### PR TITLE
[Parley] Epic #39: Inline Text Editing for Dialog Nodes

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -15,7 +15,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Epic #39: UI/UX Enhancements (Issue #108)
 
-Inline text editing for dialog tree nodes - rapid dialog capture workflow.
+Inline text editing for dialog tree nodes - rapid dialog capture workflow optimized for fast-paced "Samuel L. Jackson style" conversations.
+
+### Added
+- **Inline Text Editing** for dialog tree nodes
+  - F2 key to enter edit mode (cross-platform friendly)
+  - Edit text directly in the tree view without jumping to properties panel
+  - Automatic edit mode on new node creation (Ctrl+D workflow)
+  - 10-second auto-save timer to prevent data loss
+  - Visual feedback with theme-compliant border during edit
+- **Keyboard Shortcuts for Inline Editing**
+  - Enter: Save and exit edit mode
+  - Escape: Cancel edit without saving
+  - Tab: Save and move focus to node properties
+  - Ctrl+D: Save current edit, create child node, auto-enter edit mode
+- **Smart Edit Restrictions**
+  - ROOT node cannot be edited (read-only)
+  - Link nodes (IsChild=true) cannot be edited (Aurora standard)
+  - Placeholder nodes cannot be edited
+
+### Technical
+- TreeViewSafeNode extended with IsInEditMode, EditText, and CanEdit properties
+- Custom TreeView DataTemplate with TextBlock/TextBox switching
+- NotConverter added for boolean inversion in XAML bindings
+- Separate inline edit timer to avoid conflicts with file auto-save
+- Focus management for seamless Ctrl+D rapid node creation
+
+### Known Limitations
+- Real-time sync with bulk text editor not yet implemented
+- Enter key behavior not yet configurable (always saves)
+- Inline edit TextBox focus needs refinement for template controls
 
 ---
 

--- a/Parley/Parley/Models/UIConverters.cs
+++ b/Parley/Parley/Models/UIConverters.cs
@@ -46,4 +46,31 @@ namespace DialogEditor.Models
             throw new NotImplementedException();
         }
     }
+
+    /// <summary>
+    /// Inverts a boolean value
+    /// true = false, false = true
+    /// </summary>
+    public class NotConverter : IValueConverter
+    {
+        public static readonly NotConverter Instance = new();
+
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is bool boolValue)
+            {
+                return !boolValue;
+            }
+            return true; // Default to true if not a boolean
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is bool boolValue)
+            {
+                return !boolValue;
+            }
+            return false;
+        }
+    }
 }

--- a/Parley/Parley/Views/MainWindow.axaml
+++ b/Parley/Parley/Views/MainWindow.axaml
@@ -2,6 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:DialogEditor.ViewModels"
         xmlns:models="using:DialogEditor.Models"
+        xmlns:converters="using:DialogEditor.Models"
         xmlns:services="using:DialogEditor.Services"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -208,12 +209,34 @@
                                           Width="16" Height="16"
                                           Stretch="Uniform"
                                           VerticalAlignment="Center"
-                                          Margin="0,2,0,0"/>
-                                    <!-- Node text -->
-                                    <TextBlock Text="{Binding DisplayText}"
+                                          Margin="0,2,0,0"
+                                          IsVisible="{Binding IsInEditMode, Converter={x:Static converters:NotConverter.Instance}}"/>
+                                    <!-- Node text (display mode) -->
+                                    <TextBlock Name="DisplayTextBlock"
+                                               Text="{Binding DisplayText}"
                                                TextWrapping="Wrap"
                                                Foreground="{Binding NodeColor}"
-                                               VerticalAlignment="Center"/>
+                                               VerticalAlignment="Center"
+                                               IsVisible="{Binding IsInEditMode, Converter={x:Static converters:NotConverter.Instance}}"/>
+                                    <!-- Node text (edit mode) -->
+                                    <Border Name="EditBorder"
+                                            BorderBrush="{DynamicResource SystemAccentColor}"
+                                            BorderThickness="1"
+                                            IsVisible="{Binding IsInEditMode}"
+                                            Margin="-2">
+                                        <TextBox Name="EditTextBox"
+                                                 Text="{Binding EditText}"
+                                                 MinWidth="200"
+                                                 MaxWidth="400"
+                                                 TextWrapping="Wrap"
+                                                 AcceptsReturn="False"
+                                                 Background="{DynamicResource ThemeBackground}"
+                                                 Foreground="{DynamicResource ThemeForeground}"
+                                                 BorderThickness="0"
+                                                 Padding="2"
+                                                 LostFocus="OnInlineEditLostFocus"
+                                                 KeyDown="OnInlineEditKeyDown"/>
+                                    </Border>
                                 </StackPanel>
                             </TreeDataTemplate>
                         </TreeView.DataTemplates>


### PR DESCRIPTION
## Summary
Implementing inline text editing for dialog tree nodes to support rapid dialog capture workflows. This feature enables writers to quickly capture dialog while maintaining focus in the "conversation stream" rather than jumping to the properties panel.

**Epic**: #39 - UI/UX Enhancements
**Issue**: #108 - Inline text editing
**Branch**: `parley/feat/epic-39-inline-text-v2`

## Key Features
- **F2** or **click-pause-click** to enter inline edit mode
- **Ctrl+D** saves current edit and creates new node with auto-edit
- Visual feedback with theme-compliant border colors
- 10-second auto-save timer
- Support for rapid "Samuel L. Jackson style" dialog writing

## Implementation Plan
- [ ] Phase 1: Core infrastructure (EditableTreeViewItem control)
- [ ] Phase 2: Keyboard handlers (Enter, Escape, Tab, Ctrl+D)
- [ ] Phase 3: Focus management and Ctrl+D integration
- [ ] Phase 4: Visual feedback and theme integration
- [ ] Phase 5: Settings and real-time sync with bulk editor

## Testing Focus
- Rapid Ctrl+D sequences maintain proper focus
- Performance on 500+ node dialogs
- Works across Windows/Mac/Linux
- No data loss with auto-save system

## Related Issues
Closes #108 (partially - inline editing portion)
Related to #39 (Epic 2: UI/UX Enhancements)

---
*Note: This is the final major feature for Epic #39. Previous work included theme system (#140), panel persistence (#142), and layout redesign (#107).*