### PR TITLE
[Radoub] feat: Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# Dependabot configuration for Radoub toolset
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+
+version: 2
+updates:
+  # NuGet packages for Parley
+  - package-ecosystem: "nuget"
+    directory: "/Parley"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "[Parley]"
+
+  # NuGet packages for Radoub.Formats shared library
+  - package-ecosystem: "nuget"
+    directory: "/Radoub.Formats"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "[Radoub]"
+
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "ci"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Dependabot configuration for automated dependency updates (NuGet + GitHub Actions)
+
 ---
 
 ## [0.5.0] - 2025-11-28


### PR DESCRIPTION
## Summary
- Adds Dependabot for automated dependency updates
- Monitors NuGet packages in Parley and Radoub.Formats
- Monitors GitHub Actions workflow versions
- Weekly update schedule

## Configuration
PRs will be auto-labeled:
- `dependencies` + `[Parley]` for Parley packages
- `dependencies` + `[Radoub]` for shared library packages
- `dependencies` + `ci` for GitHub Actions

## Test Plan
- [ ] Verify dependabot.yml syntax valid (GitHub will validate on push)
- [ ] Check Dependabot tab appears in repo Insights after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)