### PR TITLE
[Radoub] fix: Correct dependabot label names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
-      - "[Parley]"
+      - "parley"
 
   # NuGet packages for Radoub.Formats shared library
   - package-ecosystem: "nuget"
@@ -19,7 +19,7 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
-      - "[Radoub]"
+      - "radoub"
 
   # GitHub Actions workflows
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- Fixed label names to match existing repo labels
- `[Parley]` → `parley`
- `[Radoub]` → `radoub`
- Created `dependencies` and `ci` labels

## Test Plan
- [x] Labels exist in repo
- [ ] Future dependabot PRs get correct labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)