### PR TITLE
[Radoub] fix: Update GitVersion.yml for v6.x format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Dependabot configuration for automated dependency updates (NuGet + GitHub Actions)
 
+### Fixed
+- GitVersion.yml updated to v6.x format (replaced deprecated `tag` with `label`, `is-mainline` with `is-main-branch`, updated `prevent-increment` syntax)
+
 ---
 
 ## [0.5.0] - 2025-11-28

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -2,40 +2,45 @@ mode: ContinuousDelivery
 branches:
   main:
     regex: ^main$
-    tag: ''
+    label: ''
     increment: Patch
-    prevent-increment-of-merged-branch-version: true
+    prevent-increment:
+      of-merged-branch: true
     track-merge-target: false
-    is-mainline: true
+    is-main-branch: true
   develop:
     regex: ^develop$
-    tag: alpha
+    label: alpha
     increment: Minor
-    prevent-increment-of-merged-branch-version: false
+    prevent-increment:
+      of-merged-branch: false
     track-merge-target: true
-    is-mainline: false
+    is-main-branch: false
   feature:
     regex: ^feature?[/-]
-    tag: feature
+    label: feature
     increment: Minor
-    prevent-increment-of-merged-branch-version: false
+    prevent-increment:
+      of-merged-branch: false
     track-merge-target: false
-    is-mainline: false
+    is-main-branch: false
   fix:
     regex: ^fix[/-]
-    tag: alpha
+    label: alpha
     increment: Patch
     source-branches: ['main', 'develop']
-    prevent-increment-of-merged-branch-version: false
+    prevent-increment:
+      of-merged-branch: false
     track-merge-target: false
-    is-mainline: false
+    is-main-branch: false
   pull-request:
     regex: ^(pull|pull\-requests|pr)[/-]
-    tag: pr
+    label: pr
     increment: Inherit
-    prevent-increment-of-merged-branch-version: false
+    prevent-increment:
+      of-merged-branch: false
     track-merge-target: false
-    is-mainline: false
+    is-main-branch: false
 ignore:
   sha: []
 major-version-bump-message: '\+semver:\s?(breaking|major)'


### PR DESCRIPTION
## Summary

Fixes release workflow failure due to GitVersion 6.x config format changes.

**Error**: "GitVersion output is not valid JSON" - caused by deprecated config syntax.

**Changes**:
- `tag` → `label` (GitVersion 6.x renamed this property)
- `is-mainline` → `is-main-branch`
- `prevent-increment-of-merged-branch-version: true` → `prevent-increment: of-merged-branch: true`

## Test Plan

- [ ] Merge PR to main
- [ ] Re-tag v0.1.41-alpha (delete old tag first)
- [ ] Verify release workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)