### PR TITLE
[Parley] fix: macOS ARM64 WebView native library build error

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Bump Avalonia packages to 11.3.9 (from 11.3.6)
 
+### Fixed
+- macOS ARM64 build: Use `WebViewControl-Avalonia-ARM64` package for Apple Silicon builds (fixes missing dylib errors)
+
 ---
 
 ## [0.1.41-alpha] - 2025-12-07

--- a/Parley/Parley/Parley.csproj
+++ b/Parley/Parley/Parley.csproj
@@ -71,7 +71,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Google.Protobuf" Version="3.29.3" />
-    <PackageReference Include="WebViewControl-Avalonia" Version="3.120.10" />
+    <!-- WebView for CEF-based browser embedding (plugin documentation, help) -->
+    <!-- Platform-specific packages for native libraries -->
+    <PackageReference Include="WebViewControl-Avalonia" Version="3.120.10" Condition="'$(RuntimeIdentifier)' != 'osx-arm64'" />
+    <PackageReference Include="WebViewControl-Avalonia-ARM64" Version="3.120.10" Condition="'$(RuntimeIdentifier)' == 'osx-arm64'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Fixes macOS ARM64 release build failure caused by missing ANGLE libraries.

**Error**: `Could not copy the file libvk_swiftshader.dylib because it was not found`

**Root Cause**: `WebViewControl-Avalonia` package only includes x64 native libraries. Apple Silicon (ARM64) requires the dedicated `WebViewControl-Avalonia-ARM64` package.

**Fix**: Conditional package reference based on runtime identifier:
- `osx-arm64` → `WebViewControl-Avalonia-ARM64`
- All others → `WebViewControl-Avalonia`

## Test Plan

- [ ] Merge and re-tag v0.1.41-alpha
- [ ] Verify macOS ARM64 build completes

## References
- [WebViewControl-Avalonia-ARM64 NuGet](https://www.nuget.org/packages/WebViewControl-Avalonia-ARM64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)