### PR TITLE
[Radoub] fix: Pass RuntimeIdentifier to restore/build in release workflow

### DIFF
--- a/.github/workflows/parley-release.yml
+++ b/.github/workflows/parley-release.yml
@@ -77,11 +77,11 @@ jobs:
         echo "FullSemVer: ${{ steps.gitversion.outputs.fullSemVer }}"
 
     - name: Restore dependencies
-      run: dotnet restore Parley.sln
+      run: dotnet restore Parley.sln -r ${{ matrix.runtime }}
       working-directory: ./Parley
 
     - name: Build solution
-      run: dotnet build Parley.sln --configuration Release --no-restore -p:Version=${{ steps.gitversion.outputs.assemblySemVer }} -p:FileVersion=${{ steps.gitversion.outputs.assemblySemFileVer }} -p:InformationalVersion=${{ steps.gitversion.outputs.informationalVersion }}
+      run: dotnet build Parley.sln --configuration Release --no-restore -r ${{ matrix.runtime }} -p:Version=${{ steps.gitversion.outputs.assemblySemVer }} -p:FileVersion=${{ steps.gitversion.outputs.assemblySemFileVer }} -p:InformationalVersion=${{ steps.gitversion.outputs.informationalVersion }}
       working-directory: ./Parley
 
     - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - GitVersion.yml updated to v6.x format (replaced deprecated `tag` with `label`, `is-mainline` with `is-main-branch`, updated `prevent-increment` syntax)
+- Release workflow: Pass RuntimeIdentifier to restore/build steps (fixes conditional package references for macOS ARM64)
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes macOS ARM64 release build failure (attempt #2).

**Problem**: The conditional package reference in `Parley.csproj`:
```xml
<PackageReference Include="WebViewControl-Avalonia" Condition="'$(RuntimeIdentifier)' != 'osx-arm64'" />
<PackageReference Include="WebViewControl-Avalonia-ARM64" Condition="'$(RuntimeIdentifier)' == 'osx-arm64'" />
```

Only works when `RuntimeIdentifier` is passed during restore/build, not just at publish time.

**Previous fix**: Added conditional package reference (PR #294)
**This fix**: Pass `-r ${{ matrix.runtime }}` to `dotnet restore` and `dotnet build`

## Changes
- `dotnet restore Parley.sln` → `dotnet restore Parley.sln -r ${{ matrix.runtime }}`
- `dotnet build ... --no-restore` → `dotnet build ... --no-restore -r ${{ matrix.runtime }}`

## Test Plan
- [ ] Merge and re-tag v0.1.41-alpha
- [ ] Verify macOS ARM64 build completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)