### PR TITLE
[Radoub] fix: Build project instead of solution for RID support

### DIFF
--- a/.github/workflows/parley-release.yml
+++ b/.github/workflows/parley-release.yml
@@ -77,11 +77,11 @@ jobs:
         echo "FullSemVer: ${{ steps.gitversion.outputs.fullSemVer }}"
 
     - name: Restore dependencies
-      run: dotnet restore Parley.sln -r ${{ matrix.runtime }}
+      run: dotnet restore Parley/Parley.csproj -r ${{ matrix.runtime }}
       working-directory: ./Parley
 
-    - name: Build solution
-      run: dotnet build Parley.sln --configuration Release --no-restore -r ${{ matrix.runtime }} -p:Version=${{ steps.gitversion.outputs.assemblySemVer }} -p:FileVersion=${{ steps.gitversion.outputs.assemblySemFileVer }} -p:InformationalVersion=${{ steps.gitversion.outputs.informationalVersion }}
+    - name: Build project
+      run: dotnet build Parley/Parley.csproj --configuration Release --no-restore -r ${{ matrix.runtime }} -p:Version=${{ steps.gitversion.outputs.assemblySemVer }} -p:FileVersion=${{ steps.gitversion.outputs.assemblySemFileVer }} -p:InformationalVersion=${{ steps.gitversion.outputs.informationalVersion }}
       working-directory: ./Parley
 
     - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - GitVersion.yml updated to v6.x format (replaced deprecated `tag` with `label`, `is-mainline` with `is-main-branch`, updated `prevent-increment` syntax)
-- Release workflow: Pass RuntimeIdentifier to restore/build steps (fixes conditional package references for macOS ARM64)
+- Release workflow: Build project instead of solution to support RuntimeIdentifier for platform-specific packages (macOS ARM64)
 
 ---
 

--- a/Parley/Parley/Parley.csproj
+++ b/Parley/Parley/Parley.csproj
@@ -72,7 +72,7 @@
     </PackageReference>
     <PackageReference Include="Google.Protobuf" Version="3.29.3" />
     <!-- WebView for CEF-based browser embedding (plugin documentation, help) -->
-    <!-- Platform-specific packages for native libraries -->
+    <!-- ARM64 package provides natives for Apple Silicon; base package excluded on ARM64 to prevent conflicts -->
     <PackageReference Include="WebViewControl-Avalonia" Version="3.120.10" Condition="'$(RuntimeIdentifier)' != 'osx-arm64'" />
     <PackageReference Include="WebViewControl-Avalonia-ARM64" Version="3.120.10" Condition="'$(RuntimeIdentifier)' == 'osx-arm64'" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- .NET SDK doesn't support `-r` (RuntimeIdentifier) with solution files
- Changed restore/build to target `Parley/Parley.csproj` directly
- Enables conditional package references for macOS ARM64 WebView

Fixes release workflow failure: `NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported`

🤖 Generated with [Claude Code](https://claude.com/claude-code)