### PR TITLE
[Radoub] fix: Use WebViewControl-Avalonia-ARM64 for Apple Silicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - GitVersion.yml updated to v6.x format (replaced deprecated `tag` with `label`, `is-mainline` with `is-main-branch`, updated `prevent-increment` syntax)
-- Release workflow: Build project instead of solution to support RuntimeIdentifier for platform-specific packages (macOS ARM64)
+- Release workflow: Build project instead of solution to support RuntimeIdentifier for platform-specific packages
+- macOS ARM64: Use conditional package references for WebView-Avalonia vs WebView-Avalonia-ARM64
 
 ---
 

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Bump Avalonia packages to 11.3.9 (from 11.3.6)
 
 ### Fixed
-- macOS ARM64 build: Use `WebViewControl-Avalonia-ARM64` package for Apple Silicon builds (fixes missing dylib errors)
+- macOS ARM64 build: Use `WebViewControl-Avalonia-ARM64` package for Apple Silicon (conditional package reference based on RuntimeIdentifier)
 
 ---
 

--- a/Parley/Parley/Parley.csproj
+++ b/Parley/Parley/Parley.csproj
@@ -72,7 +72,7 @@
     </PackageReference>
     <PackageReference Include="Google.Protobuf" Version="3.29.3" />
     <!-- WebView for CEF-based browser embedding (plugin documentation, help) -->
-    <!-- ARM64 package provides natives for Apple Silicon; base package excluded on ARM64 to prevent conflicts -->
+    <!-- Architecture-specific packages: x64 vs ARM64 (CEF natives are platform-specific) -->
     <PackageReference Include="WebViewControl-Avalonia" Version="3.120.10" Condition="'$(RuntimeIdentifier)' != 'osx-arm64'" />
     <PackageReference Include="WebViewControl-Avalonia-ARM64" Version="3.120.10" Condition="'$(RuntimeIdentifier)' == 'osx-arm64'" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
Based on [OutSystems/WebView#318](https://github.com/OutSystems/WebView/issues/318) and [PR#390](https://github.com/OutSystems/WebView/pull/390/files):

- Use conditional package references based on `$(RuntimeIdentifier)`
- `WebViewControl-Avalonia` for x64 platforms  
- `WebViewControl-Avalonia-ARM64` for osx-arm64

## Changes
- `Parley.csproj`: Conditional package reference for WebView packages
- Reverted the DISABLE_WEBVIEW conditional compilation approach

## Why this should work now
The workflow builds `Parley.csproj` directly (not the solution) with `-r ${{ matrix.runtime }}`, so `$(RuntimeIdentifier)` is properly set at restore/build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)