### PR TITLE
fix: Use RuntimeInformation for ARM64 WebView package selection

### DIFF
--- a/Parley/Parley/Parley.csproj
+++ b/Parley/Parley/Parley.csproj
@@ -73,8 +73,15 @@
     <PackageReference Include="Google.Protobuf" Version="3.29.3" />
     <!-- WebView for CEF-based browser embedding (plugin documentation, help) -->
     <!-- Architecture-specific packages: x64 vs ARM64 (CEF natives are platform-specific) -->
-    <PackageReference Include="WebViewControl-Avalonia" Version="3.120.10" Condition="'$(RuntimeIdentifier)' != 'osx-arm64'" />
-    <PackageReference Include="WebViewControl-Avalonia-ARM64" Version="3.120.10" Condition="'$(RuntimeIdentifier)' == 'osx-arm64'" />
+    <!-- Using RuntimeInformation.OSArchitecture for native builds (GitHub Actions macos-latest is ARM64) -->
+  </ItemGroup>
+
+  <!-- WebView packages - architecture-specific due to CEF native libraries -->
+  <ItemGroup Condition="$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) != 'Arm64'">
+    <PackageReference Include="WebViewControl-Avalonia" Version="3.120.10" />
+  </ItemGroup>
+  <ItemGroup Condition="$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) == 'Arm64'">
+    <PackageReference Include="WebViewControl-Avalonia-ARM64" Version="3.120.10" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Fixes macOS ARM64 build failure by using `RuntimeInformation.OSArchitecture` instead of `$(RuntimeIdentifier)` for WebView package selection
- `macos-latest` on GitHub Actions is now ARM64 (macos-14+), so native architecture detection works correctly
- This approach follows the OutSystems/WebView PR #390 pattern

## Technical Details

The `$(RuntimeIdentifier)` MSBuild property wasn't being evaluated correctly at NuGet restore time, causing the x64 WebView package to be referenced on ARM64 builds. Using `RuntimeInformation.OSArchitecture` detects the host machine's architecture at build time.

## Test Plan

- [ ] Verify macOS ARM64 build succeeds
- [ ] Verify Windows x64 build succeeds  
- [ ] Verify Linux x64 build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)