### PR TITLE
[Parley] fix: CEF subprocess missing in release builds (#314)

### DIFF
--- a/.github/workflows/parley-release.yml
+++ b/.github/workflows/parley-release.yml
@@ -96,14 +96,16 @@ jobs:
         fi
       working-directory: ./Parley
 
+    # Note: PublishSingleFile disabled because CEF subprocess (CefGlueBrowserProcess)
+    # requires its .dll files to remain separate - they can't be bundled (#314)
     - name: Publish (Self-Contained)
       if: matrix.self-contained == true
-      run: dotnet publish Parley/Parley.csproj -c Release -r ${{ matrix.runtime }} --self-contained true -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:IncludeNativeLibrariesForSelfExtract=true -p:Version=${{ steps.gitversion.outputs.assemblySemVer }} -o ./publish/${{ matrix.artifact-name }}
+      run: dotnet publish Parley/Parley.csproj -c Release -r ${{ matrix.runtime }} --self-contained true -p:PublishReadyToRun=true -p:Version=${{ steps.gitversion.outputs.assemblySemVer }} -o ./publish/${{ matrix.artifact-name }}
       working-directory: ./Parley
 
     - name: Publish (Framework-Dependent)
       if: matrix.self-contained == false
-      run: dotnet publish Parley/Parley.csproj -c Release -r ${{ matrix.runtime }} --self-contained false -p:PublishSingleFile=true -p:Version=${{ steps.gitversion.outputs.assemblySemVer }} -o ./publish/${{ matrix.artifact-name }}
+      run: dotnet publish Parley/Parley.csproj -c Release -r ${{ matrix.runtime }} --self-contained false -p:Version=${{ steps.gitversion.outputs.assemblySemVer }} -o ./publish/${{ matrix.artifact-name }}
       working-directory: ./Parley
 
     # macOS: Create .app bundle for self-contained builds

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -16,6 +16,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.1.46-alpha] - 2025-12-09
+
+### Fix: CEF Subprocess Missing in Release Builds (#314)
+
+**Problem**: Flowchart plugin crashes on launch in release builds with "Xilium.CefGlue.BrowserProcess.dll not found".
+
+**Root Cause**: `PublishSingleFile=true` bundled CEF subprocess files into the main EXE, but CEF spawns `Xilium.CefGlue.BrowserProcess.exe` as a separate process which couldn't find its DLLs.
+
+**Fix**: Removed `PublishSingleFile` from release workflow. CEF requires its subprocess files to remain as separate files. Trade-off: larger download size but plugins work correctly.
+
+---
+
 ## [0.1.45-alpha] - 2025-12-08
 
 ### Fix: WebView Crash on Close (#314)

--- a/Parley/Parley/Parley.csproj
+++ b/Parley/Parley/Parley.csproj
@@ -19,6 +19,7 @@
     <Copyright>Copyright © 2025</Copyright>
     <AssemblyName>Parley</AssemblyName>
     <RootNamespace>DialogEditor</RootNamespace>
+
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Fixes #314 (continued) - Flowchart plugin crashes in release builds.

## Problem
Release builds with `PublishSingleFile=true` bundled CEF subprocess files into the main EXE. When CEF spawns `Xilium.CefGlue.BrowserProcess.exe`, it couldn't find its required `Xilium.CefGlue.BrowserProcess.dll`.

Error: `The application to execute does not exist: '...\CefGlueBrowserProcess\Xilium.CefGlue.BrowserProcess.dll'`

## Fix
Removed `PublishSingleFile` from release workflow. CEF requires its subprocess files to remain as separate files.

## Trade-off
Download size is larger without single-file bundling, but plugins work correctly.

## Test Plan
- [ ] Build release locally without PublishSingleFile
- [ ] Verify CefGlueBrowserProcess folder has all DLLs
- [ ] Test flowchart plugin works in release build

🤖 Generated with [Claude Code](https://claude.com/claude-code)