### PR TITLE
[Parley] fix: macOS ARM64 build - WebView package based on RuntimeIdentifier (#314)

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -10,6 +10,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.1.48-alpha] - 2025-12-09
+
+### Fix: macOS ARM64 Build - WebView Package Resolution (#314)
+
+**Problem**: macOS ARM64 builds failing with "libEGL.dylib not found" during build step.
+
+**Root Cause**: Package reference condition used `RuntimeInformation.OSArchitecture` which detects the build machine, not the target. GitHub's macOS runners are ARM64 (M1), causing wrong package selection.
+
+**Fix**: Changed WebView package conditions to use `$(RuntimeIdentifier)` MSBuild property:
+- When building with `-r osx-arm64`, uses `WebViewControl-Avalonia-ARM64`
+- When building without RID or with x64/win, uses `WebViewControl-Avalonia`
+
+---
+
 ## [0.1.47-alpha] - 2025-12-09
 
 ### Fix: macOS Build Failure (#314)

--- a/Parley/Parley/Parley.csproj
+++ b/Parley/Parley/Parley.csproj
@@ -85,11 +85,13 @@
     <!-- Using RuntimeInformation.OSArchitecture for native builds (GitHub Actions macos-latest is ARM64) -->
   </ItemGroup>
 
-  <!-- WebView packages - architecture-specific due to CEF native libraries -->
-  <ItemGroup Condition="$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) != 'Arm64'">
+  <!-- WebView packages - include both x64 and ARM64 packages
+       NuGet/MSBuild will resolve the correct native libs based on RuntimeIdentifier
+       Using RuntimeIdentifier-based condition instead of build machine architecture -->
+  <ItemGroup Condition="'$(RuntimeIdentifier)' == '' OR !$(RuntimeIdentifier.Contains('arm64'))">
     <PackageReference Include="WebViewControl-Avalonia" Version="3.120.10" />
   </ItemGroup>
-  <ItemGroup Condition="$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) == 'Arm64'">
+  <ItemGroup Condition="$(RuntimeIdentifier.Contains('arm64'))">
     <PackageReference Include="WebViewControl-Avalonia-ARM64" Version="3.120.10" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Fixes macOS ARM64 build failure "libEGL.dylib not found"
- Changed WebView package condition from `RuntimeInformation.OSArchitecture` to `$(RuntimeIdentifier)`
- Previous condition detected build machine arch (GitHub M1 runners), not target platform

## Test plan

- [ ] Windows build succeeds
- [ ] macOS ARM64 build succeeds  
- [ ] Linux build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)