### PR TITLE
[Parley] fix: Include both WebView packages for cross-platform builds (#314)

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -10,6 +10,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.1.49-alpha] - 2025-12-09
+
+### Fix: macOS ARM64 Build - Include Both WebView Packages (#314)
+
+**Problem**: macOS ARM64 builds failing with "libEGL.dylib not found". Conditional package references based on `$(RuntimeIdentifier)` don't work because RID isn't set during NuGet restore.
+
+**Fix**: Include BOTH `WebViewControl-Avalonia` (x64) and `WebViewControl-Avalonia-ARM64` packages unconditionally. MSBuild resolves the correct RID-specific native libraries at build time.
+
+---
+
 ## [0.1.48-alpha] - 2025-12-09
 
 ### Fix: macOS ARM64 Build - WebView Package Resolution (#314)

--- a/Parley/Parley/Parley.csproj
+++ b/Parley/Parley/Parley.csproj
@@ -85,13 +85,11 @@
     <!-- Using RuntimeInformation.OSArchitecture for native builds (GitHub Actions macos-latest is ARM64) -->
   </ItemGroup>
 
-  <!-- WebView packages - include both x64 and ARM64 packages
-       NuGet/MSBuild will resolve the correct native libs based on RuntimeIdentifier
-       Using RuntimeIdentifier-based condition instead of build machine architecture -->
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == '' OR !$(RuntimeIdentifier.Contains('arm64'))">
+  <!-- WebView packages - include BOTH x64 and ARM64 packages unconditionally
+       The packages contain RID-specific native libs that MSBuild resolves at build time
+       Conditional package refs don't work because RID isn't set during restore -->
+  <ItemGroup>
     <PackageReference Include="WebViewControl-Avalonia" Version="3.120.10" />
-  </ItemGroup>
-  <ItemGroup Condition="$(RuntimeIdentifier.Contains('arm64'))">
     <PackageReference Include="WebViewControl-Avalonia-ARM64" Version="3.120.10" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Includes BOTH WebViewControl-Avalonia (x64) and WebViewControl-Avalonia-ARM64 packages
- Conditional package refs don't work because RID isn't set during NuGet restore
- MSBuild resolves correct RID-specific native libs at build time

## Test plan

- [ ] Windows build succeeds
- [ ] macOS ARM64 build succeeds
- [ ] Linux build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)