### PR TITLE
[Parley] Sprint: Parley Techdebt

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -15,7 +15,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Sprint: Parley Techdebt (#347)
 
-- TBD
+#### Refactored - Node Creation Template (#344)
+- Added `AddNodeWithUndoAndRefresh()` template method in MainViewModel
+- Refactored `AddSmartNode()`, `AddEntryNode()`, `AddPCReplyNode()` to use template
+- Reduced code duplication across node creation methods (~30 lines)
+
+#### Refactored - Path Validation Helpers (#345)
+- Added `ValidateBaseGamePath()` to ResourcePathHelper
+- Added `AutoDetectBaseGamePath()` with Steam registry and common paths
+- Added `PathValidationResult` record for UI feedback
+- Added `ValidateGamePathWithMessage()`, `ValidateBaseGamePathWithMessage()`, `ValidateModulePathWithMessage()`
+- Refactored SettingsWindow to use ResourcePathHelper methods (~70 lines removed)
 
 ---
 


### PR DESCRIPTION
## Summary

Sprint for Parley technical debt cleanup (#347).

### #344: Extract NodeCreationTemplate in MainViewModel
- Added `AddNodeWithUndoAndRefresh()` template method
- Refactored `AddSmartNode()`, `AddEntryNode()`, `AddPCReplyNode()` to use template
- Reduced ~30 lines of duplication

### #345: Extract Path Validation to ResourcePathHelper  
- Added `ValidateBaseGamePath()` and `AutoDetectBaseGamePath()`
- Added `PathValidationResult` record for UI feedback
- Added `*WithMessage()` variants for all validation methods
- Removed ~70 lines from SettingsWindow

## Related Issues

- Closes #347
- Closes #344
- Closes #345

## Changes

**Logic (3 files)**:
- `Parley/Parley/Services/ResourcePathHelper.cs` - Added base game path validation
- `Parley/Parley/ViewModels/MainViewModel.cs` - Added template method
- `Parley/Parley/Views/SettingsWindow.axaml.cs` - Refactored to use helpers

**Docs (1 file)**:
- `Parley/CHANGELOG.md` - Updated with sprint details

## Test Results

- Unit Tests: ✅ 424 passed, 16 skipped
- Build: ✅ No warnings or errors

## Checklist

- [x] Build passes
- [x] Tests pass  
- [x] CHANGELOG updated
- [x] No hardcoded paths
- [x] PR number in CHANGELOG

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)