### PR TITLE
[Parley] feat: Add StrRef/TLK support to LocString

### DIFF
--- a/Documentation/Research/Epic380_ManifestCore_Research.md
+++ b/Documentation/Research/Epic380_ManifestCore_Research.md
@@ -1,0 +1,155 @@
+# Research: Manifest Core Epic #380
+
+**Date**: 2025-12-14
+**Issue**: #380
+**Status**: Research Complete
+
+## Summary
+
+Manifest is a standalone journal editor for NWN `.jrl` files. The infrastructure is ready: `Radoub.Formats.Jrl` provides read/write capability (validated with 16 tests). The application shell follows DialogEditor patterns for consistent UX.
+
+## Key Findings
+
+### Shared Library Ready
+
+`Radoub.Formats.Jrl` (created in Epic #379) provides:
+- `JrlReader.Read(path|stream|buffer)` - Parse JRL files
+- `JrlWriter.Write(jrl)` - Write JRL files
+- `JrlFile`, `JournalCategory`, `JournalEntry`, `JrlLocString` - Data models
+- Full round-trip tested (16 tests pass)
+
+**No additional library work needed for core functionality.**
+
+### DialogEditor Patterns to Reuse
+
+| Component | DialogEditor Location | Manifest Adaptation |
+|-----------|----------------------|---------------------|
+| Settings Service | `Services/SettingsService.cs` | Copy, change paths to `~/Radoub/Manifest/` |
+| Unified Logger | `Services/UnifiedLogger.cs` | Copy, change paths to `~/Radoub/Manifest/Logs/` |
+| Theme System | `Themes/*.axaml` | Reuse directly (shared Radoub themes) |
+| Recent Files | SettingsService | Same pattern |
+| Dirty State | `MainWindow.axaml.cs` | Same pattern |
+
+### Project Structure
+
+```
+Manifest/
+├── Manifest/
+│   ├── App.axaml(.cs)
+│   ├── Program.cs
+│   ├── Manifest.csproj
+│   ├── Models/
+│   │   └── ViewModels.cs        # Category/Entry view models
+│   ├── Services/
+│   │   ├── SettingsService.cs   # Adapted from DialogEditor
+│   │   └── UnifiedLogger.cs     # Adapted from DialogEditor
+│   ├── Views/
+│   │   ├── MainWindow.axaml(.cs)
+│   │   └── SettingsWindow.axaml(.cs)
+│   └── Themes/                   # Link to shared Radoub themes
+├── Manifest.Tests/
+│   └── ...
+├── CHANGELOG.md
+├── CLAUDE.md
+└── README.md
+```
+
+### UI Design
+
+Based on BioWare's original Journal Editor:
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ File  Edit  Help                                               │
+├────────────────────────────────────────────────────────────────┤
+│ [+Category] [+Entry] [Delete] [Save]                           │
+├────────────────────────────────────────────────────────────────┤
+│ ▼ Main Quest                           │                       │
+│   ├─ [1] Find the artifact             │                       │
+│   ├─ [2] Return to village             │                       │
+│   └─ [10] Quest complete ✓             │                       │
+│ ▼ Side Quest A                         │                       │
+│   └─ [1] Talk to merchant              │                       │
+│ ▶ Side Quest B                         │                       │
+├────────────────────────────────────────┼───────────────────────┤
+│ Properties: Entry [2]                                          │
+│                                                                │
+│ ID:    [2      ]  ☐ Finish Category                            │
+│ Text:  ┌────────────────────────────────────────────────┐      │
+│        │ Return to the village elder with the artifact. │      │
+│        │                                                │      │
+│        └────────────────────────────────────────────────┘      │
+│                                                                │
+│                               [Apply] [OK] [Cancel]            │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### Sprint Breakdown
+
+**Sprint 1: Application Shell** (Foundation)
+- Project structure mirroring DialogEditor
+- SettingsService adapted for `~/Radoub/Manifest/`
+- UnifiedLogger adapted for `~/Radoub/Manifest/Logs/`
+- Basic MainWindow with placeholder tree
+- File > Open/Save dialogs
+- Effort: Medium
+
+**Sprint 2: File I/O** (Critical Path)
+- Open JRL via JrlReader
+- Display categories/entries in TreeView
+- Save JRL via JrlWriter
+- Dirty state tracking
+- Effort: Medium
+
+**Sprint 3: Category Editing**
+- Category property panel (Name, Tag, Comment, Priority, XP)
+- Add/Delete category
+- Category reordering
+- Effort: Medium
+
+**Sprint 4: Entry Editing**
+- Entry property panel (ID, Text, End flag)
+- Add/Delete entry
+- Entry reordering
+- Auto-increment ID for new entries
+- Effort: Medium
+
+## Recommendation
+
+**Approach**: Start with Sprint 1 (Application Shell) to establish foundation.
+
+**Key Decisions**:
+1. Use `Radoub.Formats.Jrl` types directly (no conversion like DialogEditor does)
+2. Shared theme system with DialogEditor (both reference same theme files)
+3. Separate settings file (`ManifestSettings.json`) from DialogEditor
+
+**Dependencies**:
+- Epic #379 complete ✅ (JRL reader/writer ready)
+- No external library dependencies beyond Avalonia
+
+## Open Questions
+
+1. **Shared services**: Should Logger/Settings be extracted to `Radoub.Common` for reuse?
+   - Pro: Less code duplication
+   - Con: Adds complexity, coupling between apps
+   - Recommendation: Copy for now, extract if a third tool is added
+
+2. **Theme sharing**: Link to DialogEditor themes or copy?
+   - Recommendation: Both apps reference `Radoub/Themes/` shared directory
+
+3. **StrRef/TLK support**: Issue #403 tracks adding TLK lookup
+   - Not blocking for MVP - can display embedded strings only
+
+## Resources
+
+- `Radoub.Formats.Jrl/` - JRL reader/writer (source)
+- `Parley/Parley/Services/` - Settings, Logger patterns
+- BioWare GFF Spec - `Documentation/Bioware_Aurora_GFF.md`
+
+## Code References
+
+- [JrlFile.cs](../../Radoub.Formats/Radoub.Formats/Jrl/JrlFile.cs) - Data models
+- [JrlReader.cs](../../Radoub.Formats/Radoub.Formats/Jrl/JrlReader.cs) - Reader implementation
+- [JrlWriter.cs](../../Radoub.Formats/Radoub.Formats/Jrl/JrlWriter.cs) - Writer implementation
+- [SettingsService.cs](../../Parley/Parley/Services/SettingsService.cs) - Pattern to adapt
+- [UnifiedLogger.cs](../../Parley/Parley/Services/UnifiedLogger.cs) - Pattern to adapt

--- a/Parley/Parley/Models/DialogStructures.cs
+++ b/Parley/Parley/Models/DialogStructures.cs
@@ -37,10 +37,23 @@ namespace DialogEditor.Models
     {
         [JsonProperty("Strings")]
         public Dictionary<int, string> Strings { get; set; } = new();
-        
+
+        /// <summary>
+        /// String reference into TLK file (0xFFFFFFFF = no reference).
+        /// 2025-12-14: Added for internationalization support (Issue #403)
+        /// </summary>
+        [JsonProperty("StrRef")]
+        public uint StrRef { get; set; } = 0xFFFFFFFF;
+
         [JsonIgnore]
         public string DefaultText { get; set; } = string.Empty;
-        
+
+        /// <summary>
+        /// True if this string references a TLK entry
+        /// </summary>
+        [JsonIgnore]
+        public bool HasStrRef => StrRef != 0xFFFFFFFF;
+
         public void Add(int languageId, string text, bool feminine = false)
         {
             var key = feminine ? languageId + 1000 : languageId;
@@ -48,19 +61,19 @@ namespace DialogEditor.Models
             if (languageId == 0 && !feminine)
                 DefaultText = text;
         }
-        
+
         public string? Get(int languageId = 0, bool feminine = false)
         {
             var key = feminine ? languageId + 1000 : languageId;
             return Strings.TryGetValue(key, out var text) ? text : null;
         }
-        
+
         public string GetDefault() => Get(0) ?? string.Empty;
-        
+
         public Dictionary<int, string> GetAllStrings() => new(Strings);
-        
+
         [JsonIgnore]
-        public bool IsEmpty => Strings.Count == 0;
+        public bool IsEmpty => Strings.Count == 0 && !HasStrRef;
     }
 
     public class DialogPtr

--- a/Parley/Parley/Services/JournalService.cs
+++ b/Parley/Parley/Services/JournalService.cs
@@ -111,14 +111,18 @@ namespace DialogEditor.Services
         }
 
         /// <summary>
-        /// Convert JrlLocString to DialogEditor LocString
+        /// Convert JrlLocString to DialogEditor LocString.
+        /// 2025-12-14: Now preserves StrRef for TLK internationalization (Issue #403)
         /// </summary>
         private LocString? ConvertLocString(JrlLocString jrlLocString)
         {
             if (jrlLocString.IsEmpty)
                 return null;
 
-            var locString = new LocString();
+            var locString = new LocString
+            {
+                StrRef = jrlLocString.StrRef
+            };
 
             foreach (var kvp in jrlLocString.Strings)
             {


### PR DESCRIPTION
## Summary
Adds StrRef support to DialogEditor's LocString for TLK internationalization.
Closes #403

## Changes
- `LocString.StrRef`: TLK file reference (0xFFFFFFFF = no reference)
- `LocString.HasStrRef`: convenience property for checking TLK reference
- `LocString.IsEmpty`: updated to consider StrRef
- `JournalService.ConvertLocString()`: now preserves StrRef from JRL files

## Test Results
- ✅ 461 DialogEditor tests pass

## Related
- Issue #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)