### PR TITLE
[Parley] Sprint: Update Parley to Use Shared GFF

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.1.70-alpha] - 2025-12-17
-**Branch**: `parley/sprint/use-shared-gff` | **PR**: #TBD
+**Branch**: `parley/sprint/use-shared-gff` | **PR**: #445
 
 ### Sprint: Update Parley to Use Shared GFF (#384)
 


### PR DESCRIPTION
## Summary

Migrate Parley's DialogEditor from local GFF parser to shared Radoub.Formats.Gff library, removing duplicate code.

## Related Issues

- Closes #384
- Parent: #379 (Epic: Shared Infrastructure)
- Builds on: PR #399 (GFF parser moved to Radoub.Formats)

## Scope

- Update DialogParser.cs, DialogBuilder.cs, DialogWriter.cs to use `Radoub.Formats.Gff`
- Remove duplicate GFF files from Parley/Parsers/
- All tests pass
- Manual smoke test: Open DLG → Edit → Save → Reopen

## Checklist

- [ ] Implementation complete
- [ ] Tests pass
- [ ] CHANGELOG updated
- [ ] Manual smoke test

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)