### PR TITLE
chore: Prepare radoub v0.8.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.8.4] - 2025-12-21
-**Branch**: `radoub/chore/release-0.8.4` | **PR**: #TBD
+**Branch**: `radoub/chore/release-0.8.4` | **PR**: #500
 
 ### Bundle Release: Parley 0.1.84 + Manifest 0.8.0
 


### PR DESCRIPTION
## Summary

Prepare CHANGELOG for radoub bundle release v0.8.4.

### Included Updates
- **Parley** 0.1.76 → 0.1.84 (Conversation Simulator, Linux TTS, architecture refactoring)
- **Manifest** 0.7.0 → 0.8.0 (CLI arguments, UI polish)

## After Merge
Run `/release radoub` to create tag and trigger build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)