### PR TITLE
fix: Handle broken pipe in release workflow

### DIFF
--- a/.github/workflows/radoub-release.yml
+++ b/.github/workflows/radoub-release.yml
@@ -177,7 +177,7 @@ jobs:
       shell: bash
       run: |
         echo "Bundle contents:"
-        find ./bundle -type f | head -50
+        find ./bundle -type f 2>/dev/null | head -50 || true
 
     # macOS: Create .app bundles
     - name: Create macOS App Bundles


### PR DESCRIPTION
## Summary

Fix radoub-release workflow failure caused by SIGPIPE error.

**Issue**: `find ./bundle -type f | head -50` fails with "Broken pipe" when using bash's `pipefail` option.

**Fix**: Add `|| true` to ignore the pipe error in display step.

## After Merge

Delete tag and re-release:
```bash
git tag -d radoub-v0.8.4
git push origin :radoub-v0.8.4
# Then run /release radoub
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)