### PR TITLE
fix: Pin .NET SDK to 9.x for macOS ARM64 build

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "9.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## Summary

macOS ARM64 build failing with `libvk_swiftshader.dylib` not found error.

**Root cause**: GitHub macOS-latest runner now has .NET SDK 10.0.101 pre-installed, which is taking precedence and has different native library handling.

**Fix**: Add `global.json` to pin SDK to 9.x series.

## After Merge

Delete tag and re-release:
```bash
git tag -d radoub-v0.8.4
git push origin :radoub-v0.8.4
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)