### PR TITLE
fix: Remove hardcoded path from JrlReaderTests

### DIFF
--- a/Radoub.Formats/Radoub.Formats.Tests/JrlReaderTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/JrlReaderTests.cs
@@ -223,7 +223,14 @@ public class JrlReaderTests
     public void Read_XP2Chapter2ModuleJrl_DumpsContents()
     {
         // Manual test to analyze real JRL file structure
-        var filePath = @"C:\Users\Sheri\Documents\Neverwinter Nights\modules\XP2_Chapter2\module.jrl";
+        // Use NWN_MODULES environment variable or skip
+        var nwnModules = Environment.GetEnvironmentVariable("NWN_MODULES");
+        if (string.IsNullOrEmpty(nwnModules))
+        {
+            Assert.Fail("Set NWN_MODULES environment variable to your modules folder");
+            return;
+        }
+        var filePath = Path.Combine(nwnModules, "XP2_Chapter2", "module.jrl");
 
         if (!File.Exists(filePath))
         {


### PR DESCRIPTION
## Summary

Privacy fix found during post-merge check of PR #511.

Removed hardcoded user path from `JrlReaderTests.cs` - now uses `NWN_MODULES` environment variable for manual test file location.

## Changes

- `JrlReaderTests.cs:226` - Use environment variable instead of hardcoded `C:\Users\...` path

## Test Results

All tests pass (765 total):
- Radoub.Formats.Tests: 165 ✅
- Radoub.Dictionary.Tests: 54 ✅
- Parley.Tests: 490 ✅
- Manifest.Tests: 32 ✅
- Radoub.UITests: 24 ✅

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)