### PR TITLE
[Parley] Refactor: Extract MainWindow Constructor Initialization (#522)

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -18,7 +18,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Reduce MainWindow.axaml.cs constructor from 140+ lines to focused initialization methods.
 
 #### Changed
-- (Work in progress)
+- Extract constructor into 5 focused initialization methods:
+  - `InitializeServices()` - Core services and helpers
+  - `InitializeControllers()` - UI controllers
+  - `InitializeLogging()` - Logging infrastructure
+  - `RegisterEventHandlers()` - Event subscriptions
+  - `SetupUILayout()` - UI configuration
+- Extract inline event handlers to named methods:
+  - `OnWindowOpened()` - Window opened handler
+  - `OnWindowPropertyChanged()` - Window property change handler
+  - `OnDebugMessagesCollectionChanged()` - Debug message scroll handler
+- Constructor reduced from ~225 lines to 22 lines
 
 ---
 


### PR DESCRIPTION
## Summary

Refactor MainWindow.axaml.cs constructor from ~225 lines to 22 lines by extracting initialization into focused methods.

Closes #522

## Changes

### Extracted Methods
- `InitializeServices()` - Core services and helpers
- `InitializeControllers()` - UI controllers  
- `InitializeLogging()` - Logging infrastructure
- `RegisterEventHandlers()` - Event subscriptions
- `SetupUILayout()` - UI configuration

### Extracted Event Handlers
- `OnWindowOpened()` - Window opened handler
- `OnWindowPropertyChanged()` - Window property change handler
- `OnDebugMessagesCollectionChanged()` - Debug message scroll handler

## Test Results

**Privacy Scan**: ✅ No hardcoded paths found

**Test Suite**: Windows

| Project | Status | Passed | Failed |
|---------|--------|--------|--------|
| Radoub.Formats.Tests | ✅ | 165 | 0 |
| Radoub.Dictionary.Tests | ✅ | 54 | 0 |
| Parley.Tests | ✅ | 490 | 0 |
| Manifest.Tests | ✅ | 32 | 0 |
| Radoub.UITests | ✅ | 24 | 0 |

**Total**: Passed 765, Failed 0

## Checklist
- [x] Build passes (0 warnings, 0 errors)
- [x] All tests pass
- [x] CHANGELOG updated
- [x] No hardcoded paths
- [x] Constructor readable and maintainable

🤖 Generated with [Claude Code](https://claude.com/claude-code)