### PR TITLE
[Parley] Refactor: Create ServiceCoordinator (#526)

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -15,7 +15,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Refactor: Create ServiceCoordinator (#526)
 
-Consolidate MainWindow's 24 service dependencies into a ServiceCoordinator class.
+Consolidate MainWindow's 24 service dependencies into organized container classes.
+
+#### Added
+- `Views/Helpers/MainWindowServices.cs` - Container for 15 service dependencies:
+  - Core: Audio, Creature
+  - Plugin: Plugin, PluginPanel
+  - Property: PropertyPopulator, PropertyAutoSave, ParameterUI
+  - UI: NodeCreation, ResourceBrowser, KeyboardShortcuts
+  - Window: DebugLogging, WindowPersistence, PluginSelectionSync
+  - TreeView/Dialog: DragDrop, Dialog
+- `Views/Helpers/MainWindowControllers.cs` - Container for 6 controller dependencies:
+  - Flowchart, TreeView, ScriptBrowser, Quest, FileMenu, EditMenu
+
+#### Changed
+- MainWindow field count reduced from 24 to 6 (ViewModel, Controls, Windows, Services, Controllers, UiState)
+- Removed verbose development comments (Phase 0/1/2 notes)
+- MainWindow reduced by ~49 lines
 
 ---
 

--- a/Parley/Parley/Views/Helpers/MainWindowControllers.cs
+++ b/Parley/Parley/Views/Helpers/MainWindowControllers.cs
@@ -1,0 +1,16 @@
+namespace Parley.Views.Helpers
+{
+    /// <summary>
+    /// Container for MainWindow's UI controller dependencies.
+    /// Controllers coordinate complex UI interactions.
+    /// </summary>
+    public class MainWindowControllers
+    {
+        public FlowchartManager Flowchart { get; set; } = null!;
+        public TreeViewUIController TreeView { get; set; } = null!;
+        public ScriptBrowserController ScriptBrowser { get; set; } = null!;
+        public QuestUIController Quest { get; set; } = null!;
+        public FileMenuController FileMenu { get; set; } = null!;
+        public EditMenuController EditMenu { get; set; } = null!;
+    }
+}

--- a/Parley/Parley/Views/Helpers/MainWindowServices.cs
+++ b/Parley/Parley/Views/Helpers/MainWindowServices.cs
@@ -1,0 +1,50 @@
+using DialogEditor.Services;
+using DialogEditor.Plugins;
+using Parley.Services;
+
+namespace Parley.Views.Helpers
+{
+    /// <summary>
+    /// Container for MainWindow's service dependencies.
+    /// Reduces field count and provides organized access to services.
+    /// </summary>
+    public class MainWindowServices
+    {
+        // Core services
+        public AudioService Audio { get; }
+        public CreatureService Creature { get; }
+
+        // Plugin services
+        public PluginManager Plugin { get; }
+        public PluginPanelManager PluginPanel { get; set; } = null!;
+
+        // Property services
+        public PropertyPanelPopulator PropertyPopulator { get; set; } = null!;
+        public PropertyAutoSaveService PropertyAutoSave { get; set; } = null!;
+        public ScriptParameterUIManager ParameterUI { get; set; } = null!;
+
+        // UI helpers
+        public NodeCreationHelper NodeCreation { get; set; } = null!;
+        public ResourceBrowserManager ResourceBrowser { get; set; } = null!;
+        public KeyboardShortcutManager KeyboardShortcuts { get; }
+
+        // Window services
+        public DebugAndLoggingHandler DebugLogging { get; set; } = null!;
+        public WindowPersistenceManager WindowPersistence { get; set; } = null!;
+        public PluginSelectionSyncHelper PluginSelectionSync { get; set; } = null!;
+
+        // TreeView and dialog services
+        public TreeViewDragDropService DragDrop { get; }
+        public DialogFactory Dialog { get; set; } = null!;
+
+        public MainWindowServices()
+        {
+            // Services with no dependencies
+            Audio = new AudioService();
+            Creature = new CreatureService();
+            Plugin = new PluginManager();
+            KeyboardShortcuts = new KeyboardShortcutManager();
+            DragDrop = new TreeViewDragDropService();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Consolidate MainWindow's 24 service dependencies into organized container classes.

Closes #526

## Changes

**Added**:
- `Views/Helpers/MainWindowServices.cs` - Container for 15 service dependencies
- `Views/Helpers/MainWindowControllers.cs` - Container for 6 controller dependencies

**Changed**:
- MainWindow field count reduced from 24 to 6
- Removed verbose development comments (Phase 0/1/2 notes)
- MainWindow reduced by ~49 lines

**Documentation**:
- Wiki: Updated Parley-Developer-Architecture.md with MainWindow Organization section

## Test Results

**Privacy Scan**: ✅ No hardcoded paths found

**Test Suite**: Windows

| Project | Status | Passed | Failed |
|---------|--------|--------|--------|
| Radoub.Formats.Tests | ✅ | 165 | 0 |
| Radoub.Dictionary.Tests | ✅ | 54 | 0 |
| Parley.Tests | ✅ | 490 | 0 |
| Manifest.Tests | ✅ | 32 | 0 |
| Radoub.UITests | ⚠️ | 23 | 1 |

**Total**: Passed 764, Failed 1

**Note**: UI test failure (`NewFile_CreatesBlankDialog`) is a known flaky test unrelated to these changes.

## Checklist

- [x] Build passes
- [x] Unit tests pass (741/741)
- [x] UI tests pass (23/24 - 1 known flaky)
- [x] CHANGELOG updated with date
- [x] Wiki updated (Parley-Developer-Architecture.md)
- [x] No hardcoded paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)