### PR TITLE
[CreatureEditor] Feat: Load UTI Items from BIF Archives (#579)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Part of Epic #544 (Creature Editor Tool).
 
 #### Added (CreatureEditor)
-- UTI loading from BIF archives (base game items)
+- **GameDataService integration** - Enables BIF/Override/TLK lookups for base game items
+- **UTI loading from BIF archives** - Base game items (e.g., `nw_it_torch001`) now load full data
+- **ItemViewModelFactory usage** - Proper name resolution via baseitems.2da and TLK strings
+- **Resource resolution order**: Module directory → Override → HAK → BIF archives
+
+#### Changed (CreatureEditor)
+- `CreatePlaceholderItem` now uses GameDataService for BIF lookups when module file not found
+- Item display names resolved via TLK instead of showing ResRef placeholders
+- Base item types resolved via baseitems.2da lookups
 
 ---
 


### PR DESCRIPTION
## Summary

Load UTI data from BIF archives to support base game items (e.g., `nw_it_torch001`, `nw_it_mpotion001`).

Integrates GameDataService into CreatureEditor for BIF/Override/TLK lookups. Base game items now load full data with proper name resolution via baseitems.2da and TLK strings.

## Changes

**CreatureEditor**:
- Added `IGameDataService` and `ItemViewModelFactory` integration
- Updated `CreatePlaceholderItem` to search: Module directory → Override → HAK → BIF
- Item names resolved via TLK, base types via baseitems.2da

## Related Issues

- Closes #579
- Part of Epic #544 (Creature Editor Tool)

## Test Results

**Privacy Scan**: ✅ No hardcoded paths found

**Test Suite**: Windows

| Project | Status | Passed | Failed |
|---------|--------|--------|--------|
| Radoub.Formats.Tests | ✅ | 274 | 0 |
| Radoub.UI.Tests | ✅ | 66 | 0 |
| Radoub.Dictionary.Tests | ✅ | 54 | 0 |
| Parley.Tests | ✅ | 492 | 0 |
| Manifest.Tests | ✅ | 32 | 0 |
| Radoub.IntegrationTests | ✅ | 38 | 0 |

**Total**: Passed 956, Failed 0

## Checklist
- [x] Build passes
- [x] Tests pass (956/956)
- [x] CHANGELOG updated
- [x] No hardcoded paths

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)