### PR TITLE
[Parley] Refactor: Remove legacy DialogBuilder.cs

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -13,9 +13,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [0.1.101-alpha] - 2025-12-27
 **Branch**: `parley/refactor/remove-dialogbuilder` | **PR**: #605
 
-### Refactor: Remove legacy DialogBuilder.cs (#599)
+### Refactor: DialogBuilder.cs Investigation (#599)
 
-Investigation and potential removal of DialogBuilder.cs (700 lines) in favor of Radoub.Formats.Dlg.DlgWriter.
+**Outcome:** DialogBuilder.cs is NOT a duplicate of DlgWriter - they serve different architectural layers.
+
+| Component | Purpose |
+|-----------|---------|
+| `DlgReader/DlgWriter` (Radoub.Formats) | Raw DLG format I/O |
+| `DialogBuilder` (Parley) | Converts GFF → Parley domain model with TLK resolution, pointer linking, link registry |
+
+**Why DialogBuilder is needed:**
+- Preserves `OriginalGffStruct.Type` for byte-perfect round-trip editing
+- Resolves TLK StrRef values to display text
+- Links `DialogPtr.Node` references for tree traversal
+- Integrates with Parley's `LinkRegistry` for reference tracking
+
+**Removed:**
+- `ConvertGlobalToLocalIndex()` (60 lines) - dead code, never called
 
 ---
 

--- a/Parley/Parley/Parsers/DialogBuilder.cs
+++ b/Parley/Parley/Parsers/DialogBuilder.cs
@@ -540,70 +540,7 @@ namespace DialogEditor.Parsers
             }
         }
 
-        public uint ConvertGlobalToLocalIndex(uint globalIndex, DialogNodeType? expectedTargetType, Dialog? dialog)
-        {
-            // If no dialog context or no target type, assume it's already a local index
-            if (dialog == null || expectedTargetType == null)
-            {
-                return globalIndex;
-            }
-
-            try
-            {
-                // Calculate the base struct indices based on GFF struct layout:
-                // Root(0) ? All Entries(1+) ? All Replies(E+1+) ? All Starts(E+R+1+) ? All Pointers(E+R+S+1+)
-
-                uint entryBaseIndex = 1; // Entries start at struct 1
-                uint replyBaseIndex = 1 + (uint)dialog.Entries.Count; // Replies start after entries
-                uint startBaseIndex = 1 + (uint)dialog.Entries.Count + (uint)dialog.Replies.Count; // Starts after replies
-
-                switch (expectedTargetType)
-                {
-                    case DialogNodeType.Entry:
-                        // Check if this is a global struct index first (in the expected Entry global range)
-                        if (globalIndex >= entryBaseIndex && globalIndex < replyBaseIndex)
-                        {
-                            uint localIndex = globalIndex - entryBaseIndex;
-                            UnifiedLogger.LogParser(LogLevel.TRACE, $"?? Entry conversion: global {globalIndex} ? local {localIndex} (base: {entryBaseIndex})");
-                            return localIndex;
-                        }
-
-                        // Special case: If globalIndex is within the Entry count, it might be a local index already
-                        if (globalIndex < dialog.Entries.Count)
-                        {
-                            UnifiedLogger.LogParser(LogLevel.TRACE, $"?? Entry index {globalIndex} appears to be local (< {dialog.Entries.Count}), using as-is");
-                            return globalIndex;
-                        }
-                        break;
-
-                    case DialogNodeType.Reply:
-                        // Check if this is a global struct index first (in the expected Reply global range)
-                        if (globalIndex >= replyBaseIndex && globalIndex < startBaseIndex)
-                        {
-                            uint localIndex = globalIndex - replyBaseIndex;
-                            UnifiedLogger.LogParser(LogLevel.TRACE, $"?? Reply conversion: global {globalIndex} ? local {localIndex} (base: {replyBaseIndex})");
-                            return localIndex;
-                        }
-
-                        // Special case: If globalIndex is within the Reply count, it might be a local index already
-                        if (globalIndex < dialog.Replies.Count)
-                        {
-                            UnifiedLogger.LogParser(LogLevel.TRACE, $"?? Reply index {globalIndex} appears to be local (< {dialog.Replies.Count}), using as-is");
-                            return globalIndex;
-                        }
-                        break;
-                }
-
-                // If conversion doesn't apply or is out of range, log a warning and return as-is
-                UnifiedLogger.LogParser(LogLevel.WARN, $"?? Index conversion failed: global {globalIndex} for {expectedTargetType} (Entry base: {entryBaseIndex}, Reply base: {replyBaseIndex})");
-                return globalIndex;
-            }
-            catch (Exception ex)
-            {
-                UnifiedLogger.LogParser(LogLevel.ERROR, $"?? Index conversion error: {ex.Message}");
-                return globalIndex;
-            }
-        }
+        // 2025-12-27: Removed ConvertGlobalToLocalIndex (60 lines) - dead code, never called (#599)
 
         public DialogPtr? BuildDialogPtrFromStruct(GffStruct ptrStruct, Dialog? parentDialog, DialogNodeType? expectedTargetType = null)
         {


### PR DESCRIPTION
## Summary

Investigation of DialogBuilder.cs (700 lines) to determine if it duplicates Radoub.Formats.Dlg.DlgWriter.

**Finding:** DialogBuilder is NOT a duplicate - they serve different architectural layers:

| Component | Purpose |
|-----------|---------|
| `DlgReader/DlgWriter` (Radoub.Formats) | Raw DLG format I/O |
| `DialogBuilder` (Parley) | Converts GFF → Parley domain model |

**Why DialogBuilder is needed:**
- Preserves `OriginalGffStruct.Type` for byte-perfect round-trip editing
- Resolves TLK StrRef values to display text
- Links `DialogPtr.Node` references for tree traversal
- Integrates with Parley's `LinkRegistry` for reference tracking

**Changes:**
- Removed `ConvertGlobalToLocalIndex()` (60 lines) - dead code, never called

## Related Issues

- Closes #599

## Checklist

- [x] Investigation complete
- [x] Dead code removed
- [x] Tests pass (500/500)
- [x] CHANGELOG updated

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)