### PR TITLE
[Radoub] fix: Handle broken pipe in bundle release workflow

### DIFF
--- a/.github/workflows/radoub-release.yml
+++ b/.github/workflows/radoub-release.yml
@@ -68,7 +68,7 @@ jobs:
       shell: bash
       run: |
         echo "Bundle contents:"
-        ls -la ./publish/Radoub/ | head -30
+        ls -la ./publish/Radoub/ | head -30 || true
         echo ""
         echo "Total size:"
         du -sh ./publish/Radoub/ || dir ./publish/Radoub/


### PR DESCRIPTION
## Summary

Fix macOS release workflow failure caused by broken pipe in `ls | head` command.

## Problem

The `radoub-v0.9.18` release failed because on macOS, `ls -la | head -30` returns exit code 1 when the pipe closes early (after 30 lines). GitHub Actions treats this as a failure.

Error from logs:
```
ls: stdout: Undefined error: 0
##[error]Process completed with exit code 1.
```

## Fix

Add `|| true` to ignore the cosmetic broken pipe error:
```yaml
ls -la ./publish/Radoub/ | head -30 || true
```

## Testing

This is a workflow-only change. The fix allows the display step to succeed even if `head` closes the pipe early.

## After Merge

Re-tag and release:
```bash
git tag radoub-v0.9.18.1
git push origin radoub-v0.9.18.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)