### PR TITLE
[Radoub] Fix: Add explicit Avalonia.Skia reference to resolve SkiaSharp version mismatch (#666)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.9.18.4] - 2025-12-30
-**Branch**: `radoub/fix/skia-version-mismatch` | **PR**: #TBD | **Issue**: #666
+**Branch**: `radoub/fix/skia-version-mismatch` | **PR**: #667 | **Issue**: #666
 
 ### Fix: SkiaSharp Transitive Version Mismatch
 


### PR DESCRIPTION
## Summary

Add explicit `Avalonia.Skia 11.3.10` reference to prevent older SkiaSharp versions from coming in transitively through dependency chains. Also removes Quartermaster from `Radoub.sln` since it's not preview-ready.

## Related Issues

- Closes #666
- Relates to #663 (Post-merge verification)

## Checklist

- [ ] Implementation complete
- [ ] Tests pass
- [ ] CHANGELOG updated with date
- [ ] Documentation updated (if needed)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)