### PR TITLE
[Parley] Refactor: Split ScriptParameterUIManager.cs (#706)

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -15,10 +15,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Refactor: Split ScriptParameterUIManager.cs (#706)
 
-- Split 666-line file for maintainability
-- Extract validation logic to ParameterValidationService
-- Extract persistence logic to ParameterPersistenceService
-- Keep core row management in ScriptParameterUIManager
+Split 666-line file into focused services for maintainability:
+
+| File | Lines | Responsibility |
+|------|-------|----------------|
+| ScriptParameterUIManager.cs | 269 | Core row management, add/remove, change handling |
+| ParameterValidationService.cs | 244 | Duplicate key validation, red borders, theme colors |
+| ParameterPersistenceService.cs | 233 | UI-to-model sync, auto-trim, parameter caching |
 
 ---
 

--- a/Parley/Parley/Services/ParameterPersistenceService.cs
+++ b/Parley/Parley/Services/ParameterPersistenceService.cs
@@ -1,0 +1,233 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+using DialogEditor.Models;
+using Radoub.Formats.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DialogEditor.Services
+{
+    /// <summary>
+    /// Handles persistence of script parameters between UI and dialog model.
+    /// Extracted from ScriptParameterUIManager.cs for maintainability.
+    /// Issue #287: Proper TextBox finding regardless of Grid column assignment
+    /// </summary>
+    public class ParameterPersistenceService
+    {
+        private readonly Func<string, Control?> _findControl;
+        private readonly ParameterValidationService _validationService;
+
+        public ParameterPersistenceService(
+            Func<string, Control?> findControl,
+            ParameterValidationService validationService)
+        {
+            _findControl = findControl ?? throw new ArgumentNullException(nameof(findControl));
+            _validationService = validationService ?? throw new ArgumentNullException(nameof(validationService));
+        }
+
+        /// <summary>
+        /// Updates conditional parameters from UI to model
+        /// </summary>
+        public void UpdateConditionParamsFromUI(DialogPtr ptr, string? scriptName = null)
+        {
+            UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                $"UpdateConditionParamsFromUI: ENTRY - ptr has {ptr.ConditionParams.Count} existing params");
+
+            ptr.ConditionParams.Clear();
+            var panel = _findControl("ConditionsParametersPanel") as StackPanel;
+            if (panel == null)
+            {
+                UnifiedLogger.LogApplication(LogLevel.ERROR,
+                    "UpdateConditionParamsFromUI: ConditionsParametersPanel NOT FOUND - parameters will be empty!");
+                return;
+            }
+
+            // Get script name from UI if not provided
+            if (string.IsNullOrEmpty(scriptName))
+            {
+                var scriptTextBox = _findControl("ScriptAppearsTextBox") as TextBox;
+                scriptName = scriptTextBox?.Text;
+            }
+
+            UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                $"UpdateConditionParamsFromUI: Found ConditionsParametersPanel with {panel.Children.Count} children");
+
+            var autoTrimCheckBox = _findControl("AutoTrimConditionsCheckBox") as CheckBox;
+            bool autoTrim = autoTrimCheckBox?.IsChecked ?? true;
+
+            UnifiedLogger.LogApplication(LogLevel.DEBUG, $"UpdateConditionParamsFromUI: Auto-Trim = {autoTrim}");
+
+            ProcessParameterPanel(panel, ptr.ConditionParams, autoTrim, scriptName);
+
+            UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                $"UpdateConditionParamsFromUI: EXIT - ptr now has {ptr.ConditionParams.Count} params");
+        }
+
+        /// <summary>
+        /// Updates action parameters from UI to model
+        /// </summary>
+        public void UpdateActionParamsFromUI(DialogNode node, string? scriptName = null)
+        {
+            UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                $"UpdateActionParamsFromUI: ENTRY - node '{node.DisplayText}' has {node.ActionParams.Count} existing params");
+
+            node.ActionParams.Clear();
+            var panel = _findControl("ActionsParametersPanel") as StackPanel;
+            if (panel == null)
+            {
+                UnifiedLogger.LogApplication(LogLevel.ERROR,
+                    "UpdateActionParamsFromUI: ActionsParametersPanel NOT FOUND - parameters will be empty!");
+                return;
+            }
+
+            // Get script name from UI if not provided
+            if (string.IsNullOrEmpty(scriptName))
+            {
+                var scriptTextBox = _findControl("ScriptActionTextBox") as TextBox;
+                scriptName = scriptTextBox?.Text;
+            }
+
+            UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                $"UpdateActionParamsFromUI: Found ActionsParametersPanel with {panel.Children.Count} children");
+
+            var autoTrimCheckBox = _findControl("AutoTrimActionsCheckBox") as CheckBox;
+            bool autoTrim = autoTrimCheckBox?.IsChecked ?? true;
+
+            UnifiedLogger.LogApplication(LogLevel.DEBUG, $"UpdateActionParamsFromUI: Auto-Trim = {autoTrim}");
+
+            ProcessParameterPanel(panel, node.ActionParams, autoTrim, scriptName);
+
+            UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                $"UpdateActionParamsFromUI: EXIT - node '{node.DisplayText}' now has {node.ActionParams.Count} params");
+        }
+
+        /// <summary>
+        /// Processes a parameter panel and updates the parameter dictionary
+        /// Issue #287: Fixed to properly find TextBox children regardless of Grid column assignment
+        /// </summary>
+        public void ProcessParameterPanel(StackPanel panel, Dictionary<string, string> paramDict, bool autoTrim, string? scriptName)
+        {
+            UnifiedLogger.LogApplication(LogLevel.DEBUG, $"ProcessParameterPanel: Processing {panel.Children.Count} children");
+
+            foreach (var child in panel.Children)
+            {
+                if (child is Grid paramGrid)
+                {
+                    // Issue #287: Find TextBox children by type, not by index
+                    // Grid children order is not guaranteed to match visual column order
+                    var textBoxes = paramGrid.Children.OfType<TextBox>().ToList();
+
+                    UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                        $"ProcessParameterPanel: Grid has {paramGrid.Children.Count} children, {textBoxes.Count} TextBoxes");
+
+                    if (textBoxes.Count >= 2)
+                    {
+                        // First TextBox is key (column 0), second is value (column 2)
+                        var keyTextBox = textBoxes[0];
+                        var valueTextBox = textBoxes[1];
+
+                        UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                            $"ProcessParameterPanel: keyText='{keyTextBox.Text}', valueText='{valueTextBox.Text}'");
+
+                        if (!string.IsNullOrWhiteSpace(keyTextBox.Text))
+                        {
+                            string key = keyTextBox.Text;
+                            string value = valueTextBox.Text ?? "";
+
+                            // Apply trimming if Auto-Trim is enabled
+                            if (autoTrim)
+                            {
+                                string originalKey = key;
+                                string originalValue = value;
+
+                                key = key.Trim();
+                                value = value.Trim();
+
+                                // Update the UI textboxes to show trimmed values
+                                keyTextBox.Text = key;
+                                valueTextBox.Text = value;
+
+                                // Show visual feedback if text was actually trimmed
+                                if (originalKey != key)
+                                {
+                                    _ = ShowTrimFeedbackAsync(keyTextBox);
+                                }
+                                if (originalValue != value)
+                                {
+                                    _ = ShowTrimFeedbackAsync(valueTextBox);
+                                }
+                            }
+
+                            // Issue #287: Check for duplicate keys
+                            if (paramDict.ContainsKey(key))
+                            {
+                                UnifiedLogger.LogApplication(LogLevel.WARN,
+                                    $"ProcessParameterPanel: Duplicate key '{key}' - overwriting previous value '{paramDict[key]}' with '{value}'");
+                            }
+
+                            paramDict[key] = value;
+                            UnifiedLogger.LogApplication(LogLevel.DEBUG, $"ProcessParameterPanel: Added param '{key}' = '{value}'");
+
+                            // Cache parameter value if script name is known
+                            if (!string.IsNullOrWhiteSpace(scriptName) && !string.IsNullOrWhiteSpace(value))
+                            {
+                                ParameterCacheService.Instance.AddValue(scriptName, key, value);
+                            }
+                        }
+                        else
+                        {
+                            UnifiedLogger.LogApplication(LogLevel.DEBUG, "ProcessParameterPanel: Skipping row with empty key");
+                        }
+                    }
+                    else
+                    {
+                        UnifiedLogger.LogApplication(LogLevel.WARN,
+                            $"ProcessParameterPanel: Grid has {textBoxes.Count} TextBoxes (expected 2+)");
+                    }
+                }
+                else
+                {
+                    UnifiedLogger.LogApplication(LogLevel.WARN, $"ProcessParameterPanel: Child is not Grid, type={child.GetType().Name}");
+                }
+            }
+
+            UnifiedLogger.LogApplication(LogLevel.DEBUG, $"ProcessParameterPanel: Finished with {paramDict.Count} parameters");
+        }
+
+        /// <summary>
+        /// Shows visual feedback when parameter text is trimmed.
+        /// Briefly flashes the TextBox border to indicate successful trim operation.
+        /// Issue #141: Uses theme success color for colorblind accessibility.
+        /// </summary>
+        public async Task ShowTrimFeedbackAsync(TextBox textBox)
+        {
+            // Store original border properties
+            var originalBrush = textBox.BorderBrush;
+            var originalThickness = textBox.BorderThickness;
+
+            try
+            {
+                // Flash success border to indicate trim occurred (theme-aware for accessibility)
+                textBox.BorderBrush = _validationService.GetSuccessBrush();
+                textBox.BorderThickness = new Thickness(2);
+
+                // Wait briefly for visual feedback
+                await Task.Delay(300);
+
+                // Restore original appearance
+                textBox.BorderBrush = originalBrush;
+                textBox.BorderThickness = originalThickness;
+            }
+            catch (Exception ex)
+            {
+                UnifiedLogger.LogApplication(LogLevel.ERROR, $"ShowTrimFeedback: Error showing visual feedback - {ex.Message}");
+                // Ensure we restore original state even if error occurs
+                textBox.BorderBrush = originalBrush;
+                textBox.BorderThickness = originalThickness;
+            }
+        }
+    }
+}

--- a/Parley/Parley/Services/ParameterValidationService.cs
+++ b/Parley/Parley/Services/ParameterValidationService.cs
@@ -1,0 +1,244 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Radoub.Formats.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DialogEditor.Services
+{
+    /// <summary>
+    /// Handles duplicate key validation and visual feedback for script parameter UI.
+    /// Extracted from ScriptParameterUIManager.cs for maintainability.
+    /// Issue #287: Duplicate key validation
+    /// Issue #141: Theme-aware error/success colors for colorblind accessibility
+    /// </summary>
+    public class ParameterValidationService
+    {
+        private readonly Action<string> _setStatusMessage;
+
+        public ParameterValidationService(Action<string> setStatusMessage)
+        {
+            _setStatusMessage = setStatusMessage ?? throw new ArgumentNullException(nameof(setStatusMessage));
+        }
+
+        /// <summary>
+        /// Validates that a key is not duplicated in the parameter panel.
+        /// Issue #287: Prevents duplicate keys which would cause data loss.
+        /// Red border stays until the duplicate is corrected.
+        /// Issue #141: Fixed to clear ALL red borders when duplicate is resolved.
+        /// </summary>
+        public void ValidateDuplicateKeys(StackPanel parent, TextBox currentKeyTextBox, bool isCondition)
+        {
+            string currentKey = currentKeyTextBox.Text?.Trim() ?? "";
+
+            // If key is empty, clear any warning state and revalidate all to clear orphaned red borders
+            if (string.IsNullOrWhiteSpace(currentKey))
+            {
+                ClearDuplicateWarning(currentKeyTextBox);
+                RevalidateAllKeys(parent, isCondition);
+                return;
+            }
+
+            int duplicateCount = 0;
+            var allKeyTextBoxes = new List<TextBox>();
+
+            foreach (var child in parent.Children)
+            {
+                if (child is Grid paramGrid)
+                {
+                    var textBoxes = paramGrid.Children.OfType<TextBox>().ToList();
+                    if (textBoxes.Count >= 1)
+                    {
+                        var keyTextBox = textBoxes[0];
+                        string key = keyTextBox.Text?.Trim() ?? "";
+
+                        if (key.Equals(currentKey, StringComparison.Ordinal))
+                        {
+                            duplicateCount++;
+                            allKeyTextBoxes.Add(keyTextBox);
+                        }
+                    }
+                }
+            }
+
+            if (duplicateCount > 1)
+            {
+                // Show warning - duplicate key detected (use theme error color for accessibility)
+                var errorBrush = GetErrorBrush();
+                currentKeyTextBox.BorderBrush = errorBrush;
+                currentKeyTextBox.BorderThickness = new Thickness(2);
+
+                // Also mark all other textboxes with the same key
+                foreach (var tb in allKeyTextBoxes)
+                {
+                    tb.BorderBrush = errorBrush;
+                    tb.BorderThickness = new Thickness(2);
+                }
+
+                _setStatusMessage($"⚠️ Duplicate key '{currentKey}' - only one value will be saved!");
+
+                UnifiedLogger.LogApplication(LogLevel.WARN,
+                    $"Duplicate key detected: '{currentKey}' appears {duplicateCount} times in {(isCondition ? "condition" : "action")} parameters");
+            }
+            else
+            {
+                // No duplicate for current key - clear warning on this textbox
+                ClearDuplicateWarning(currentKeyTextBox);
+
+                // Issue #141: Revalidate ALL keys to clear orphaned red borders
+                // When a duplicate is resolved by editing one key, the other key's
+                // textbox still has a red border that needs to be cleared
+                RevalidateAllKeys(parent, isCondition);
+            }
+        }
+
+        /// <summary>
+        /// Revalidates all key textboxes in the panel to clear orphaned red borders.
+        /// Issue #141: Called when a key changes to ensure previously-duplicate keys get cleared.
+        /// </summary>
+        public void RevalidateAllKeys(StackPanel parent, bool isCondition)
+        {
+            // Build a count of each key to find actual duplicates
+            var keyCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+            var keyTextBoxes = new Dictionary<string, List<TextBox>>(StringComparer.Ordinal);
+
+            foreach (var child in parent.Children)
+            {
+                if (child is Grid paramGrid)
+                {
+                    var textBoxes = paramGrid.Children.OfType<TextBox>().ToList();
+                    if (textBoxes.Count >= 1)
+                    {
+                        var keyTextBox = textBoxes[0];
+                        string key = keyTextBox.Text?.Trim() ?? "";
+
+                        if (!string.IsNullOrWhiteSpace(key))
+                        {
+                            if (!keyCounts.ContainsKey(key))
+                            {
+                                keyCounts[key] = 0;
+                                keyTextBoxes[key] = new List<TextBox>();
+                            }
+                            keyCounts[key]++;
+                            keyTextBoxes[key].Add(keyTextBox);
+                        }
+                        else
+                        {
+                            // Empty key - clear any red border
+                            ClearDuplicateWarning(keyTextBox);
+                        }
+                    }
+                }
+            }
+
+            // Now update visual state for each key
+            // Get theme error brush once for efficiency
+            var errorBrush = GetErrorBrush();
+
+            foreach (var kvp in keyCounts)
+            {
+                string key = kvp.Key;
+                int count = kvp.Value;
+
+                if (count > 1)
+                {
+                    // Still a duplicate - use theme error color
+                    foreach (var tb in keyTextBoxes[key])
+                    {
+                        tb.BorderBrush = errorBrush;
+                        tb.BorderThickness = new Thickness(2);
+                    }
+                }
+                else
+                {
+                    // Not a duplicate (anymore) - clear error border
+                    foreach (var tb in keyTextBoxes[key])
+                    {
+                        ClearDuplicateWarning(tb);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the theme-aware error brush for validation errors.
+        /// Falls back to red if theme error color is not available.
+        /// Issue #141: Uses theme colors for colorblind accessibility.
+        /// </summary>
+        public IBrush GetErrorBrush()
+        {
+            var app = Application.Current;
+            if (app?.Resources.TryGetResource("ThemeError", ThemeVariant.Default, out var errorBrush) == true
+                && errorBrush is IBrush brush)
+            {
+                return brush;
+            }
+            // Fallback to standard red
+            return Brushes.Red;
+        }
+
+        /// <summary>
+        /// Gets the theme-aware success brush for validation success feedback.
+        /// Falls back to green if theme success color is not available.
+        /// Issue #141: Uses theme colors for colorblind accessibility.
+        /// </summary>
+        public IBrush GetSuccessBrush()
+        {
+            var app = Application.Current;
+            if (app?.Resources.TryGetResource("ThemeSuccess", ThemeVariant.Default, out var successBrush) == true
+                && successBrush is IBrush brush)
+            {
+                return brush;
+            }
+            // Fallback to standard green
+            return Brushes.LightGreen;
+        }
+
+        /// <summary>
+        /// Clears the duplicate key warning visual state from a TextBox.
+        /// </summary>
+        public void ClearDuplicateWarning(TextBox textBox)
+        {
+            // Only clear if currently showing error border (duplicate warning)
+            // Check for both theme error brush and fallback red
+            if (textBox.BorderThickness.Top >= 2)
+            {
+                textBox.BorderBrush = null; // Reset to default theme
+                textBox.BorderThickness = new Thickness(1);
+            }
+        }
+
+        /// <summary>
+        /// Issue #289: Checks if a parameter panel has duplicate keys.
+        /// Called by MainWindow before saving to prevent data corruption.
+        /// </summary>
+        public bool HasDuplicateKeys(StackPanel panel)
+        {
+            var keys = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var child in panel.Children)
+            {
+                if (child is Grid paramGrid)
+                {
+                    var textBoxes = paramGrid.Children.OfType<TextBox>().ToList();
+                    if (textBoxes.Count >= 1)
+                    {
+                        string key = textBoxes[0].Text?.Trim() ?? "";
+                        if (!string.IsNullOrWhiteSpace(key))
+                        {
+                            if (!keys.Add(key))
+                            {
+                                // Duplicate found
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Split `ScriptParameterUIManager.cs` (666 lines) into focused services for maintainability:

| File | Lines | Responsibility |
|------|-------|----------------|
| ScriptParameterUIManager.cs | 269 | Core row management, add/remove, change handling |
| ParameterValidationService.cs | 244 | Duplicate key validation, red borders, theme colors |
| ParameterPersistenceService.cs | 233 | UI-to-model sync, auto-trim, parameter caching |

## Related Issues

- Closes #706

## Test Results

**Privacy Scan**: ✅ No hardcoded paths found

| Project | Status | Passed | Failed |
|---------|--------|--------|--------|
| Radoub.Formats.Tests | ✅ | 293 | 0 |
| Radoub.UI.Tests | ✅ | 66 | 0 |
| Radoub.Dictionary.Tests | ✅ | 54 | 0 |
| Parley.Tests | ✅ | 500 | 0 |
| Manifest.Tests | ✅ | 32 | 0 |
| Quartermaster.Tests | ✅ | 25 | 0 |
| Radoub.IntegrationTests.Parley | ⚠️ | 23 | 1 |
| Radoub.IntegrationTests.Quartermaster | ✅ | 11 | 0 |

**Total**: Passed 1004, Failed 1

**Note**: Failed test `MultipleUndo_RevertsMultipleChanges` is pre-existing (tracked in #705), unrelated to this refactoring.

## Checklist

- [x] Build passes
- [x] Unit tests pass (500/500)
- [x] CHANGELOG updated
- [x] No hardcoded paths
- [x] All files under 500 lines
- [x] No TODOs in changed files

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)