### PR TITLE
[Parley] Refactor: Split ScriptBrowserController.cs (#707)

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -15,13 +15,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Refactor: Split ScriptBrowserController.cs (#707)
 
-Split 638-line controller for maintainability:
+Split 638-line controller into focused components for maintainability:
 
-| File | Responsibility |
-|------|----------------|
-| ScriptBrowserController.cs | Core browser window management |
-| ScriptPreviewService.cs | Script preview loading and display |
-| ParameterBrowserController.cs | Parameter browser functionality |
+| File | Lines | Responsibility |
+|------|-------|----------------|
+| ScriptBrowserController.cs | 299 | Script browser window management |
+| ParameterBrowserController.cs | 290 | Parameter browser and declaration caching |
+| ScriptPreviewService.cs | 88 | Script preview loading and display |
 
 ---
 

--- a/Parley/Parley/Services/ScriptPreviewService.cs
+++ b/Parley/Parley/Services/ScriptPreviewService.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Parley.Views.Helpers;
+using Radoub.Formats.Logging;
+
+namespace DialogEditor.Services
+{
+    /// <summary>
+    /// Service for loading and displaying script content previews.
+    /// Extracted from ScriptBrowserController for single responsibility.
+    /// </summary>
+    public class ScriptPreviewService
+    {
+        private readonly SafeControlFinder _controls;
+
+        public ScriptPreviewService(SafeControlFinder controls)
+        {
+            _controls = controls ?? throw new ArgumentNullException(nameof(controls));
+        }
+
+        /// <summary>
+        /// Loads script content preview asynchronously.
+        /// </summary>
+        public async Task LoadScriptPreviewAsync(string scriptName, bool isCondition)
+        {
+            if (string.IsNullOrWhiteSpace(scriptName))
+            {
+                ClearScriptPreview(isCondition);
+                return;
+            }
+
+            try
+            {
+                var previewTextBox = isCondition
+                    ? _controls.Get<TextBox>("ConditionalScriptPreviewTextBox")
+                    : _controls.Get<TextBox>("ActionScriptPreviewTextBox");
+
+                if (previewTextBox == null)
+                {
+                    UnifiedLogger.LogApplication(LogLevel.WARN,
+                        $"LoadScriptPreviewAsync: Preview TextBox not found for {(isCondition ? "conditional" : "action")} script");
+                    return;
+                }
+
+                previewTextBox.Text = "Loading...";
+
+                var scriptContent = await ScriptService.Instance.GetScriptContentAsync(scriptName);
+
+                if (!string.IsNullOrEmpty(scriptContent))
+                {
+                    previewTextBox.Text = scriptContent;
+                    UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                        $"LoadScriptPreviewAsync: Loaded preview for {(isCondition ? "conditional" : "action")} script '{scriptName}'");
+                }
+                else
+                {
+                    previewTextBox.Text = $"// Script '{scriptName}.nss' not found or could not be loaded.\n" +
+                                          "// This may be a compiled game resource (.ncs) without source available.\n" +
+                                          "// Use nwnnsscomp to decompile .ncs files: github.com/niv/neverwinter.nim";
+                    UnifiedLogger.LogApplication(LogLevel.WARN,
+                        $"LoadScriptPreviewAsync: No content for script '{scriptName}'");
+                }
+            }
+            catch (Exception ex)
+            {
+                UnifiedLogger.LogApplication(LogLevel.ERROR,
+                    $"LoadScriptPreviewAsync: Error loading preview for '{scriptName}': {ex.Message}");
+                ClearScriptPreview(isCondition);
+            }
+        }
+
+        /// <summary>
+        /// Clears script preview content.
+        /// </summary>
+        public void ClearScriptPreview(bool isCondition)
+        {
+            var previewTextBox = isCondition
+                ? _controls.Get<TextBox>("ConditionalScriptPreviewTextBox")
+                : _controls.Get<TextBox>("ActionScriptPreviewTextBox");
+
+            if (previewTextBox != null)
+            {
+                previewTextBox.Text = $"// {(isCondition ? "Conditional" : "Action")} script preview will appear here";
+            }
+        }
+    }
+}

--- a/Parley/Parley/Views/Helpers/MainWindowControllers.cs
+++ b/Parley/Parley/Views/Helpers/MainWindowControllers.cs
@@ -9,6 +9,7 @@ namespace Parley.Views.Helpers
         public FlowchartManager Flowchart { get; set; } = null!;
         public TreeViewUIController TreeView { get; set; } = null!;
         public ScriptBrowserController ScriptBrowser { get; set; } = null!;
+        public ParameterBrowserController ParameterBrowser { get; set; } = null!;
         public QuestUIController Quest { get; set; } = null!;
         public FileMenuController FileMenu { get; set; } = null!;
         public EditMenuController EditMenu { get; set; } = null!;

--- a/Parley/Parley/Views/Helpers/MainWindowServices.cs
+++ b/Parley/Parley/Views/Helpers/MainWindowServices.cs
@@ -22,6 +22,7 @@ namespace Parley.Views.Helpers
         public PropertyPanelPopulator PropertyPopulator { get; set; } = null!;
         public PropertyAutoSaveService PropertyAutoSave { get; set; } = null!;
         public ScriptParameterUIManager ParameterUI { get; set; } = null!;
+        public ScriptPreviewService ScriptPreview { get; set; } = null!;
 
         // UI helpers
         public NodeCreationHelper NodeCreation { get; set; } = null!;

--- a/Parley/Parley/Views/Helpers/ParameterBrowserController.cs
+++ b/Parley/Parley/Views/Helpers/ParameterBrowserController.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using DialogEditor.Models;
+using DialogEditor.Services;
+using DialogEditor.Utils;
+using DialogEditor.ViewModels;
+using DialogEditor.Views;
+using Radoub.Formats.Logging;
+
+namespace Parley.Views.Helpers
+{
+    /// <summary>
+    /// Manages parameter browser UI interactions for MainWindow.
+    /// Extracted from ScriptBrowserController for single responsibility.
+    ///
+    /// Handles:
+    /// 1. Parameter browser window lifecycle
+    /// 2. Parameter declaration loading and caching
+    /// 3. Extracting existing parameters from UI panels
+    /// </summary>
+    public class ParameterBrowserController
+    {
+        private readonly SafeControlFinder _controls;
+        private readonly Func<MainViewModel> _getViewModel;
+        private readonly Func<TreeViewSafeNode?> _getSelectedNode;
+        private readonly ScriptParameterUIManager _parameterUIManager;
+
+        // Track active browser window
+        private ParameterBrowserWindow? _activeParameterBrowserWindow;
+
+        // Parameter autocomplete: Cache of script parameter declarations
+        private ScriptParameterDeclarations? _currentConditionDeclarations;
+        private ScriptParameterDeclarations? _currentActionDeclarations;
+
+        public ParameterBrowserController(
+            SafeControlFinder controls,
+            Func<MainViewModel> getViewModel,
+            Func<TreeViewSafeNode?> getSelectedNode,
+            ScriptParameterUIManager parameterUIManager)
+        {
+            _controls = controls ?? throw new ArgumentNullException(nameof(controls));
+            _getViewModel = getViewModel ?? throw new ArgumentNullException(nameof(getViewModel));
+            _getSelectedNode = getSelectedNode ?? throw new ArgumentNullException(nameof(getSelectedNode));
+            _parameterUIManager = parameterUIManager ?? throw new ArgumentNullException(nameof(parameterUIManager));
+        }
+
+        private MainViewModel ViewModel => _getViewModel();
+        private TreeViewSafeNode? SelectedNode => _getSelectedNode();
+
+        #region Parameter Browser
+
+        /// <summary>
+        /// Opens parameter browser for conditional parameters.
+        /// Always reloads declarations from current textbox to avoid caching wrong script.
+        /// </summary>
+        public async Task OnSuggestConditionsParamClickAsync()
+        {
+            var scriptTextBox = _controls.Get<TextBox>("ScriptAppearsTextBox");
+            var currentScript = scriptTextBox?.Text?.Trim();
+
+            if (!string.IsNullOrWhiteSpace(currentScript))
+            {
+                await LoadParameterDeclarationsAsync(currentScript, true);
+            }
+
+            ShowParameterBrowser(_currentConditionDeclarations, true);
+        }
+
+        /// <summary>
+        /// Opens parameter browser for action parameters.
+        /// Always reloads declarations from current textbox to avoid caching wrong script.
+        /// </summary>
+        public async Task OnSuggestActionsParamClickAsync()
+        {
+            var scriptTextBox = _controls.Get<TextBox>("ScriptActionTextBox");
+            var currentScript = scriptTextBox?.Text?.Trim();
+
+            if (!string.IsNullOrWhiteSpace(currentScript))
+            {
+                await LoadParameterDeclarationsAsync(currentScript, false);
+            }
+
+            ShowParameterBrowser(_currentActionDeclarations, false);
+        }
+
+        /// <summary>
+        /// Extracts existing parameters from the UI panel for dependency resolution.
+        /// Returns a dictionary of key-value pairs currently in the parameter panel.
+        /// </summary>
+        private Dictionary<string, string> GetExistingParametersFromPanel(bool isCondition)
+        {
+            var parameters = new Dictionary<string, string>();
+
+            try
+            {
+                var panelName = isCondition ? "ConditionsParametersPanel" : "ActionsParametersPanel";
+                var panel = _controls.Get<StackPanel>(panelName);
+
+                if (panel == null)
+                {
+                    UnifiedLogger.LogApplication(LogLevel.WARN,
+                        $"GetExistingParametersFromPanel: {panelName} not found");
+                    return parameters;
+                }
+
+                foreach (var child in panel.Children)
+                {
+                    if (child is Grid paramGrid)
+                    {
+                        var textBoxes = paramGrid.Children.OfType<TextBox>().ToList();
+                        if (textBoxes.Count >= 2)
+                        {
+                            var keyTextBox = textBoxes[0];
+                            var valueTextBox = textBoxes[1];
+
+                            if (!string.IsNullOrWhiteSpace(keyTextBox.Text))
+                            {
+                                string key = keyTextBox.Text.Trim();
+                                string value = (valueTextBox.Text ?? "").Trim();
+
+                                if (!parameters.ContainsKey(key))
+                                {
+                                    parameters[key] = value;
+                                    UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                                        $"GetExistingParametersFromPanel: Found parameter '{key}' = '{value}'");
+                                }
+                            }
+                        }
+                    }
+                }
+
+                UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                    $"GetExistingParametersFromPanel: Extracted {parameters.Count} existing parameters");
+            }
+            catch (Exception ex)
+            {
+                UnifiedLogger.LogApplication(LogLevel.ERROR,
+                    $"GetExistingParametersFromPanel: Error extracting parameters - {ex.Message}");
+            }
+
+            return parameters;
+        }
+
+        /// <summary>
+        /// Shows parameter browser window for selecting parameters (modeless - Issue #20).
+        /// </summary>
+        private void ShowParameterBrowser(ScriptParameterDeclarations? declarations, bool isCondition)
+        {
+            try
+            {
+                // Get script name from the appropriate textbox
+                string scriptName = "";
+                if (isCondition)
+                {
+                    var scriptTextBox = _controls.Get<TextBox>("ScriptAppearsTextBox");
+                    scriptName = scriptTextBox?.Text ?? "";
+                }
+                else
+                {
+                    var scriptTextBox = _controls.Get<TextBox>("ScriptActionTextBox");
+                    scriptName = scriptTextBox?.Text ?? "";
+                }
+
+                // Get existing parameters from the node for dependency resolution
+                var existingParameters = GetExistingParametersFromPanel(isCondition);
+
+                // Close existing browser if one is already open
+                CloseActiveParameterBrowser();
+
+                // Create and show modeless browser window (Issue #20)
+                var browser = new ParameterBrowserWindow();
+                browser.SetDeclarations(declarations, scriptName, isCondition, existingParameters);
+
+                // Track the window and handle cleanup when it closes
+                _activeParameterBrowserWindow = browser;
+                browser.Closed += (s, e) =>
+                {
+                    _activeParameterBrowserWindow = null;
+
+                    if (browser.DialogResult && !string.IsNullOrEmpty(browser.SelectedKey))
+                    {
+                        // Add the parameter to the appropriate panel
+                        var key = browser.SelectedKey;
+                        var value = browser.SelectedValue ?? "";
+
+                        // Find the appropriate panel
+                        var panelName = isCondition ? "ConditionsParametersPanel" : "ActionsParametersPanel";
+                        var panel = _controls.Get<StackPanel>(panelName);
+
+                        if (panel != null)
+                        {
+                            // User-initiated add from browser - focus the new row
+                            _parameterUIManager.AddParameterRow(panel, key, value, isCondition, focusNewRow: true);
+                            OnParameterChanged(isCondition);
+
+                            var paramType = isCondition ? "condition" : "action";
+                            ViewModel.StatusMessage = $"Added {paramType} parameter: {key}={value}";
+                            UnifiedLogger.LogApplication(LogLevel.INFO,
+                                $"Added parameter from browser - Type: {paramType}, Key: '{key}', Value: '{value}'");
+                        }
+                    }
+                };
+
+                browser.Show();
+            }
+            catch (Exception ex)
+            {
+                UnifiedLogger.LogApplication(LogLevel.ERROR,
+                    $"Error showing parameter browser: {ex.Message}");
+                ViewModel.StatusMessage = "Error showing parameter browser";
+            }
+        }
+
+        /// <summary>
+        /// Closes any active parameter browser window.
+        /// </summary>
+        public void CloseActiveParameterBrowser()
+        {
+            if (_activeParameterBrowserWindow != null)
+            {
+                _activeParameterBrowserWindow.Close();
+                _activeParameterBrowserWindow = null;
+            }
+        }
+
+        /// <summary>
+        /// Called when parameter values change in the UI.
+        /// Delegates to ScriptParameterUIManager for model updates.
+        /// </summary>
+        public void OnParameterChanged(bool isCondition)
+        {
+            _parameterUIManager.OnParameterChanged(isCondition, SelectedNode);
+        }
+
+        #endregion
+
+        #region Parameter Declarations
+
+        /// <summary>
+        /// Loads parameter declarations for a script asynchronously.
+        /// Caches declarations for use by parameter browser.
+        /// </summary>
+        public async Task LoadParameterDeclarationsAsync(string scriptName, bool isCondition)
+        {
+            if (string.IsNullOrWhiteSpace(scriptName))
+            {
+                if (isCondition)
+                {
+                    _currentConditionDeclarations = null;
+                }
+                else
+                {
+                    _currentActionDeclarations = null;
+                }
+                return;
+            }
+
+            try
+            {
+                var declarations = await ScriptService.Instance.GetParameterDeclarationsAsync(scriptName);
+
+                if (isCondition)
+                {
+                    _currentConditionDeclarations = declarations;
+                }
+                else
+                {
+                    _currentActionDeclarations = declarations;
+                }
+
+                if (declarations.HasDeclarations)
+                {
+                    var totalValues = declarations.ValuesByKey.Values.Sum(list => list.Count);
+                    UnifiedLogger.LogApplication(LogLevel.INFO,
+                        $"Loaded parameter declarations for {(isCondition ? "condition" : "action")} script '{scriptName}': {declarations.Keys.Count} keys, {totalValues} values");
+                }
+            }
+            catch (Exception ex)
+            {
+                UnifiedLogger.LogApplication(LogLevel.ERROR,
+                    $"Failed to load parameter declarations for '{scriptName}': {ex.Message}");
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Parley/Parley/Views/Helpers/ScriptBrowserController.cs
+++ b/Parley/Parley/Views/Helpers/ScriptBrowserController.cs
@@ -1,30 +1,25 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Styling;
 using DialogEditor.Models;
 using DialogEditor.Services;
-using Radoub.Formats.Logging;
-using DialogEditor.Utils;
 using DialogEditor.ViewModels;
-using DialogEditor.Views;
+using Radoub.Formats.Logging;
 using Radoub.UI.Views;
 
 namespace Parley.Views.Helpers
 {
     /// <summary>
-    /// Manages all script browsing UI interactions for MainWindow.
+    /// Manages script browsing UI interactions for MainWindow.
     /// Extracted from MainWindow to reduce method size and improve maintainability (Epic #457, Sprint 3).
     ///
     /// Handles:
     /// 1. Script browser dialog handlers (conditional and action scripts)
     /// 2. Script editor launching (external editor integration)
-    /// 3. Parameter browser and suggestion logic
-    /// 4. Script preview loading
-    /// 5. Parameter declarations caching
+    /// 3. Conversation-level script browsing
+    ///
+    /// Related controllers:
+    /// - ParameterBrowserController: Parameter browser and suggestion logic
+    /// - ScriptPreviewService: Script preview loading
     /// </summary>
     public class ScriptBrowserController
     {
@@ -33,36 +28,22 @@ namespace Parley.Views.Helpers
         private readonly Func<MainViewModel> _getViewModel;
         private readonly Func<TreeViewSafeNode?> _getSelectedNode;
         private readonly Action<string> _autoSaveProperty;
-        private readonly Func<bool> _isPopulatingProperties;
-        private readonly ScriptParameterUIManager _parameterUIManager;
-        private readonly Action _triggerAutoSave;
 
-        // Track active browser windows
-        private ParameterBrowserWindow? _activeParameterBrowserWindow;
-        private Radoub.UI.Views.ScriptBrowserWindow? _activeScriptBrowserWindow;
-
-        // Parameter autocomplete: Cache of script parameter declarations
-        private ScriptParameterDeclarations? _currentConditionDeclarations;
-        private ScriptParameterDeclarations? _currentActionDeclarations;
+        // Track active script browser window
+        private ScriptBrowserWindow? _activeScriptBrowserWindow;
 
         public ScriptBrowserController(
             Window window,
             SafeControlFinder controls,
             Func<MainViewModel> getViewModel,
             Func<TreeViewSafeNode?> getSelectedNode,
-            Action<string> autoSaveProperty,
-            Func<bool> isPopulatingProperties,
-            ScriptParameterUIManager parameterUIManager,
-            Action triggerAutoSave)
+            Action<string> autoSaveProperty)
         {
             _window = window ?? throw new ArgumentNullException(nameof(window));
             _controls = controls ?? throw new ArgumentNullException(nameof(controls));
             _getViewModel = getViewModel ?? throw new ArgumentNullException(nameof(getViewModel));
             _getSelectedNode = getSelectedNode ?? throw new ArgumentNullException(nameof(getSelectedNode));
             _autoSaveProperty = autoSaveProperty ?? throw new ArgumentNullException(nameof(autoSaveProperty));
-            _isPopulatingProperties = isPopulatingProperties ?? throw new ArgumentNullException(nameof(isPopulatingProperties));
-            _parameterUIManager = parameterUIManager ?? throw new ArgumentNullException(nameof(parameterUIManager));
-            _triggerAutoSave = triggerAutoSave ?? throw new ArgumentNullException(nameof(triggerAutoSave));
         }
 
         private MainViewModel ViewModel => _getViewModel();
@@ -102,7 +83,7 @@ namespace Parley.Views.Helpers
 
                 // Create and show modeless browser window (Issue #20)
                 var context = new ParleyScriptBrowserContext(ViewModel.CurrentFileName);
-                var scriptBrowser = new Radoub.UI.Views.ScriptBrowserWindow(context);
+                var scriptBrowser = new ScriptBrowserWindow(context);
 
                 // Track the window and handle cleanup when it closes
                 _activeScriptBrowserWindow = scriptBrowser;
@@ -158,7 +139,7 @@ namespace Parley.Views.Helpers
 
                 // Create and show modeless browser window (Issue #20)
                 var context = new ParleyScriptBrowserContext(ViewModel.CurrentFileName);
-                var scriptBrowser = new Radoub.UI.Views.ScriptBrowserWindow(context);
+                var scriptBrowser = new ScriptBrowserWindow(context);
 
                 // Track the window and handle cleanup when it closes
                 _activeScriptBrowserWindow = scriptBrowser;
@@ -245,7 +226,7 @@ namespace Parley.Views.Helpers
         /// <summary>
         /// Closes any active script browser window.
         /// </summary>
-        private void CloseActiveScriptBrowser()
+        public void CloseActiveScriptBrowser()
         {
             if (_activeScriptBrowserWindow != null)
             {
@@ -264,7 +245,7 @@ namespace Parley.Views.Helpers
                 CloseActiveScriptBrowser();
 
                 var context = new ParleyScriptBrowserContext(ViewModel.CurrentFileName);
-                var scriptBrowser = new Radoub.UI.Views.ScriptBrowserWindow(context);
+                var scriptBrowser = new ScriptBrowserWindow(context);
 
                 _activeScriptBrowserWindow = scriptBrowser;
                 scriptBrowser.Closed += (s, e) =>
@@ -311,326 +292,6 @@ namespace Parley.Views.Helpers
                 UnifiedLogger.LogApplication(LogLevel.ERROR, $"Error opening script browser: {ex.Message}");
                 ViewModel.StatusMessage = $"Error opening script browser: {ex.Message}";
             }
-        }
-
-        #endregion
-
-        #region Parameter Browser
-
-        /// <summary>
-        /// Opens parameter browser for conditional parameters.
-        /// Always reloads declarations from current textbox to avoid caching wrong script.
-        /// </summary>
-        public async Task OnSuggestConditionsParamClickAsync()
-        {
-            var scriptTextBox = _controls.Get<TextBox>("ScriptAppearsTextBox");
-            var currentScript = scriptTextBox?.Text?.Trim();
-
-            if (!string.IsNullOrWhiteSpace(currentScript))
-            {
-                await LoadParameterDeclarationsAsync(currentScript, true);
-            }
-
-            ShowParameterBrowser(_currentConditionDeclarations, true);
-        }
-
-        /// <summary>
-        /// Opens parameter browser for action parameters.
-        /// Always reloads declarations from current textbox to avoid caching wrong script.
-        /// </summary>
-        public async Task OnSuggestActionsParamClickAsync()
-        {
-            var scriptTextBox = _controls.Get<TextBox>("ScriptActionTextBox");
-            var currentScript = scriptTextBox?.Text?.Trim();
-
-            if (!string.IsNullOrWhiteSpace(currentScript))
-            {
-                await LoadParameterDeclarationsAsync(currentScript, false);
-            }
-
-            ShowParameterBrowser(_currentActionDeclarations, false);
-        }
-
-        /// <summary>
-        /// Extracts existing parameters from the UI panel for dependency resolution.
-        /// Returns a dictionary of key-value pairs currently in the parameter panel.
-        /// </summary>
-        private Dictionary<string, string> GetExistingParametersFromPanel(bool isCondition)
-        {
-            var parameters = new Dictionary<string, string>();
-
-            try
-            {
-                var panelName = isCondition ? "ConditionsParametersPanel" : "ActionsParametersPanel";
-                var panel = _controls.Get<StackPanel>(panelName);
-
-                if (panel == null)
-                {
-                    UnifiedLogger.LogApplication(LogLevel.WARN,
-                        $"GetExistingParametersFromPanel: {panelName} not found");
-                    return parameters;
-                }
-
-                foreach (var child in panel.Children)
-                {
-                    if (child is Grid paramGrid)
-                    {
-                        var textBoxes = paramGrid.Children.OfType<TextBox>().ToList();
-                        if (textBoxes.Count >= 2)
-                        {
-                            var keyTextBox = textBoxes[0];
-                            var valueTextBox = textBoxes[1];
-
-                            if (!string.IsNullOrWhiteSpace(keyTextBox.Text))
-                            {
-                                string key = keyTextBox.Text.Trim();
-                                string value = (valueTextBox.Text ?? "").Trim();
-
-                                if (!parameters.ContainsKey(key))
-                                {
-                                    parameters[key] = value;
-                                    UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                                        $"GetExistingParametersFromPanel: Found parameter '{key}' = '{value}'");
-                                }
-                            }
-                        }
-                    }
-                }
-
-                UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                    $"GetExistingParametersFromPanel: Extracted {parameters.Count} existing parameters");
-            }
-            catch (Exception ex)
-            {
-                UnifiedLogger.LogApplication(LogLevel.ERROR,
-                    $"GetExistingParametersFromPanel: Error extracting parameters - {ex.Message}");
-            }
-
-            return parameters;
-        }
-
-        /// <summary>
-        /// Shows parameter browser window for selecting parameters (modeless - Issue #20).
-        /// </summary>
-        private void ShowParameterBrowser(ScriptParameterDeclarations? declarations, bool isCondition)
-        {
-            try
-            {
-                // Get script name from the appropriate textbox
-                string scriptName = "";
-                if (isCondition)
-                {
-                    var scriptTextBox = _controls.Get<TextBox>("ScriptAppearsTextBox");
-                    scriptName = scriptTextBox?.Text ?? "";
-                }
-                else
-                {
-                    var scriptTextBox = _controls.Get<TextBox>("ScriptActionTextBox");
-                    scriptName = scriptTextBox?.Text ?? "";
-                }
-
-                // Get existing parameters from the node for dependency resolution
-                var existingParameters = GetExistingParametersFromPanel(isCondition);
-
-                // Close existing browser if one is already open
-                CloseActiveParameterBrowser();
-
-                // Create and show modeless browser window (Issue #20)
-                var browser = new ParameterBrowserWindow();
-                browser.SetDeclarations(declarations, scriptName, isCondition, existingParameters);
-
-                // Track the window and handle cleanup when it closes
-                _activeParameterBrowserWindow = browser;
-                browser.Closed += (s, e) =>
-                {
-                    _activeParameterBrowserWindow = null;
-
-                    if (browser.DialogResult && !string.IsNullOrEmpty(browser.SelectedKey))
-                    {
-                        // Add the parameter to the appropriate panel
-                        var key = browser.SelectedKey;
-                        var value = browser.SelectedValue ?? "";
-
-                        // Find the appropriate panel
-                        var panelName = isCondition ? "ConditionsParametersPanel" : "ActionsParametersPanel";
-                        var panel = _controls.Get<StackPanel>(panelName);
-
-                        if (panel != null)
-                        {
-                            // User-initiated add from browser - focus the new row
-                            _parameterUIManager.AddParameterRow(panel, key, value, isCondition, focusNewRow: true);
-                            OnParameterChanged(isCondition);
-
-                            var paramType = isCondition ? "condition" : "action";
-                            ViewModel.StatusMessage = $"Added {paramType} parameter: {key}={value}";
-                            UnifiedLogger.LogApplication(LogLevel.INFO,
-                                $"Added parameter from browser - Type: {paramType}, Key: '{key}', Value: '{value}'");
-                        }
-                    }
-                };
-
-                browser.Show();
-            }
-            catch (Exception ex)
-            {
-                UnifiedLogger.LogApplication(LogLevel.ERROR,
-                    $"Error showing parameter browser: {ex.Message}");
-                ViewModel.StatusMessage = "Error showing parameter browser";
-            }
-        }
-
-        /// <summary>
-        /// Closes any active parameter browser window.
-        /// </summary>
-        private void CloseActiveParameterBrowser()
-        {
-            if (_activeParameterBrowserWindow != null)
-            {
-                _activeParameterBrowserWindow.Close();
-                _activeParameterBrowserWindow = null;
-            }
-        }
-
-        /// <summary>
-        /// Called when parameter values change in the UI.
-        /// Delegates to ScriptParameterUIManager for model updates.
-        /// </summary>
-        public void OnParameterChanged(bool isCondition)
-        {
-            _parameterUIManager.OnParameterChanged(isCondition, SelectedNode);
-        }
-
-        #endregion
-
-        #region Parameter Declarations
-
-        /// <summary>
-        /// Loads parameter declarations for a script asynchronously.
-        /// Caches declarations for use by parameter browser.
-        /// </summary>
-        public async Task LoadParameterDeclarationsAsync(string scriptName, bool isCondition)
-        {
-            if (string.IsNullOrWhiteSpace(scriptName))
-            {
-                if (isCondition)
-                {
-                    _currentConditionDeclarations = null;
-                }
-                else
-                {
-                    _currentActionDeclarations = null;
-                }
-                return;
-            }
-
-            try
-            {
-                var declarations = await ScriptService.Instance.GetParameterDeclarationsAsync(scriptName);
-
-                if (isCondition)
-                {
-                    _currentConditionDeclarations = declarations;
-                }
-                else
-                {
-                    _currentActionDeclarations = declarations;
-                }
-
-                if (declarations.HasDeclarations)
-                {
-                    var totalValues = declarations.ValuesByKey.Values.Sum(list => list.Count);
-                    UnifiedLogger.LogApplication(LogLevel.INFO,
-                        $"Loaded parameter declarations for {(isCondition ? "condition" : "action")} script '{scriptName}': {declarations.Keys.Count} keys, {totalValues} values");
-                }
-            }
-            catch (Exception ex)
-            {
-                UnifiedLogger.LogApplication(LogLevel.ERROR,
-                    $"Failed to load parameter declarations for '{scriptName}': {ex.Message}");
-            }
-        }
-
-        #endregion
-
-        #region Script Preview
-
-        /// <summary>
-        /// Loads script content preview asynchronously.
-        /// </summary>
-        public async Task LoadScriptPreviewAsync(string scriptName, bool isCondition)
-        {
-            if (string.IsNullOrWhiteSpace(scriptName))
-            {
-                ClearScriptPreview(isCondition);
-                return;
-            }
-
-            try
-            {
-                var previewTextBox = isCondition
-                    ? _controls.Get<TextBox>("ConditionalScriptPreviewTextBox")
-                    : _controls.Get<TextBox>("ActionScriptPreviewTextBox");
-
-                if (previewTextBox == null)
-                {
-                    UnifiedLogger.LogApplication(LogLevel.WARN,
-                        $"LoadScriptPreviewAsync: Preview TextBox not found for {(isCondition ? "conditional" : "action")} script");
-                    return;
-                }
-
-                previewTextBox.Text = "Loading...";
-
-                var scriptContent = await ScriptService.Instance.GetScriptContentAsync(scriptName);
-
-                if (!string.IsNullOrEmpty(scriptContent))
-                {
-                    previewTextBox.Text = scriptContent;
-                    UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                        $"LoadScriptPreviewAsync: Loaded preview for {(isCondition ? "conditional" : "action")} script '{scriptName}'");
-                }
-                else
-                {
-                    previewTextBox.Text = $"// Script '{scriptName}.nss' not found or could not be loaded.\n" +
-                                          "// This may be a compiled game resource (.ncs) without source available.\n" +
-                                          "// Use nwnnsscomp to decompile .ncs files: github.com/niv/neverwinter.nim";
-                    UnifiedLogger.LogApplication(LogLevel.WARN,
-                        $"LoadScriptPreviewAsync: No content for script '{scriptName}'");
-                }
-            }
-            catch (Exception ex)
-            {
-                UnifiedLogger.LogApplication(LogLevel.ERROR,
-                    $"LoadScriptPreviewAsync: Error loading preview for '{scriptName}': {ex.Message}");
-                ClearScriptPreview(isCondition);
-            }
-        }
-
-        /// <summary>
-        /// Clears script preview content.
-        /// </summary>
-        public void ClearScriptPreview(bool isCondition)
-        {
-            var previewTextBox = isCondition
-                ? _controls.Get<TextBox>("ConditionalScriptPreviewTextBox")
-                : _controls.Get<TextBox>("ActionScriptPreviewTextBox");
-
-            if (previewTextBox != null)
-            {
-                previewTextBox.Text = $"// {(isCondition ? "Conditional" : "Action")} script preview will appear here";
-            }
-        }
-
-        #endregion
-
-        #region Cleanup
-
-        /// <summary>
-        /// Closes all active browser windows. Call on window close.
-        /// </summary>
-        public void CloseAllBrowserWindows()
-        {
-            CloseActiveScriptBrowser();
-            CloseActiveParameterBrowser();
         }
 
         #endregion

--- a/Parley/Parley/Views/MainWindow.axaml.cs
+++ b/Parley/Parley/Views/MainWindow.axaml.cs
@@ -165,10 +165,15 @@ namespace DialogEditor.Views
                 controls: _controls,
                 getViewModel: () => _viewModel,
                 getSelectedNode: () => _selectedNode,
-                autoSaveProperty: AutoSaveProperty,
-                isPopulatingProperties: () => _uiState.IsPopulatingProperties,
-                parameterUIManager: _services.ParameterUI,
-                triggerAutoSave: () => { _viewModel.HasUnsavedChanges = true; TriggerDebouncedAutoSave(); });
+                autoSaveProperty: AutoSaveProperty);
+
+            _controllers.ParameterBrowser = new ParameterBrowserController(
+                controls: _controls,
+                getViewModel: () => _viewModel,
+                getSelectedNode: () => _selectedNode,
+                parameterUIManager: _services.ParameterUI);
+
+            _services.ScriptPreview = new ScriptPreviewService(_controls);
 
             _controllers.Quest = new QuestUIController(
                 window: this,
@@ -576,8 +581,9 @@ namespace DialogEditor.Views
             // Issue #343: Close all managed windows (Settings, Flowchart)
             _windows.CloseAll();
 
-            // Close browser windows managed by ScriptBrowserController
-            _controllers.ScriptBrowser.CloseAllBrowserWindows();
+            // Close browser windows managed by controllers
+            _controllers.ScriptBrowser.CloseActiveScriptBrowser();
+            _controllers.ParameterBrowser.CloseActiveParameterBrowser();
 
             // Close plugin panel windows (Epic 3 / #225)
             _services.PluginPanel.Dispose();
@@ -1025,24 +1031,24 @@ namespace DialogEditor.Views
         }
 
         private async void OnSuggestConditionsParamClick(object? sender, RoutedEventArgs e)
-            => await _controllers.ScriptBrowser.OnSuggestConditionsParamClickAsync();
+            => await _controllers.ParameterBrowser.OnSuggestConditionsParamClickAsync();
 
         private async void OnSuggestActionsParamClick(object? sender, RoutedEventArgs e)
-            => await _controllers.ScriptBrowser.OnSuggestActionsParamClickAsync();
+            => await _controllers.ParameterBrowser.OnSuggestActionsParamClickAsync();
 
         #region Script Browser Delegation Methods
-        // These methods delegate to ScriptBrowserController but are kept as instance methods
+        // These methods delegate to controllers/services but are kept as instance methods
         // because they're passed as callbacks to PropertyAutoSaveService and PropertyPanelPopulator
-        // during construction before the controller is initialized.
+        // during construction before the controllers are initialized.
 
         private Task LoadParameterDeclarationsAsync(string scriptName, bool isCondition)
-            => _controllers.ScriptBrowser.LoadParameterDeclarationsAsync(scriptName, isCondition);
+            => _controllers.ParameterBrowser.LoadParameterDeclarationsAsync(scriptName, isCondition);
 
         private Task LoadScriptPreviewAsync(string scriptName, bool isCondition)
-            => _controllers.ScriptBrowser.LoadScriptPreviewAsync(scriptName, isCondition);
+            => _services.ScriptPreview.LoadScriptPreviewAsync(scriptName, isCondition);
 
         private void ClearScriptPreview(bool isCondition)
-            => _controllers.ScriptBrowser.ClearScriptPreview(isCondition);
+            => _services.ScriptPreview.ClearScriptPreview(isCondition);
 
         // Issue #664: Population wrapper - always passes focusNewRow=false to prevent focus stealing
         private void AddParameterRow(StackPanel parent, string key, string value, bool isCondition)


### PR DESCRIPTION
## Summary

Split ScriptBrowserController.cs (638 lines) into focused components for maintainability:

| File | Lines | Responsibility |
|------|-------|----------------|
| ScriptBrowserController.cs | 299 | Script browser window management |
| ParameterBrowserController.cs | 290 | Parameter browser and declaration caching |
| ScriptPreviewService.cs | 88 | Script preview loading and display |

## Related Issues

- Closes #707

## Test Results

**Privacy Scan**: ✅ No hardcoded paths found

**Test Suite** (Windows):

| Project | Status | Passed | Failed |
|---------|--------|--------|--------|
| Radoub.Formats.Tests | ✅ | 293 | 0 |
| Radoub.UI.Tests | ✅ | 66 | 0 |
| Radoub.Dictionary.Tests | ✅ | 54 | 0 |
| Parley.Tests | ✅ | 500 | 0 |
| Manifest.Tests | ✅ | 32 | 0 |
| Quartermaster.Tests | ✅ | 25 | 0 |
| Radoub.IntegrationTests.Parley | ⚠️ | 22 | 2 |
| Radoub.IntegrationTests.Quartermaster | ✅ | 11 | 0 |

**Total**: Passed 1003, Failed 2

**Note**: 2 UI test failures are pre-existing known issues:
- BrowseScriptButton_OpensScriptBrowserWindow (#704 - known flaky)
- MultipleUndo_RevertsMultipleChanges (tolerance issue - not related to this PR)

## Checklist

- [x] Build passes
- [x] Unit tests pass (500/500 Parley tests)
- [x] CHANGELOG updated with version, PR number, and date
- [x] Wiki updated (Parley-Developer-Architecture)
- [x] No hardcoded paths
- [x] Code review completed - no technical debt introduced

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)