### PR TITLE
[Quartermaster] Sprint: Item Property Search (#557)

### DIFF
--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -17,10 +17,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Add item property search to ItemFilterPanel. Search/filter items by their properties.
 
-- [ ] Property search text box (searches property names/values)
-- [ ] Property type dropdown (optional - filter to specific property type)
-- [ ] Works across all item types
-- [ ] Performance acceptable with 500+ items
+#### Added
+
+- **Property Search** in ItemFilterPanel
+  - New "Properties:" text box searches item property strings
+  - Debounced input (300ms) for performance
+  - Case-insensitive search
+  - Clear button to reset property filter
+  - Filter state persisted with other filter settings
+
+#### Use Cases
+
+- Find class-restricted items: search "monk" or "wizard"
+- Find spell items by level: search "level 3"
+- Find items with specific bonuses: search "enhancement" or "+2"
+- Find damage types: search "fire" or "cold"
 
 ---
 

--- a/Radoub.UI/Radoub.UI/Controls/ItemFilterPanel.axaml
+++ b/Radoub.UI/Radoub.UI/Controls/ItemFilterPanel.axaml
@@ -58,6 +58,25 @@
                    Margin="16,0,0,0"
                    Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
       </Grid>
+
+      <!-- Row 3: Property search -->
+      <Grid ColumnDefinitions="Auto,*,Auto">
+        <TextBlock Grid.Column="0"
+                   Text="Properties:"
+                   VerticalAlignment="Center"
+                   Margin="0,0,8,0"/>
+        <TextBox x:Name="PropertySearchBox"
+                 Grid.Column="1"
+                 Watermark="Search properties (e.g., Enhancement, Monk, Fire)..."
+                 Text="{Binding PropertySearchText, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay}"/>
+        <Button x:Name="ClearPropertyButton"
+                Grid.Column="2"
+                Content="✕"
+                Width="32"
+                Margin="4,0,0,0"
+                Click="OnClearPropertySearchClick"
+                ToolTip.Tip="Clear property search"/>
+      </Grid>
     </StackPanel>
   </Border>
 </UserControl>

--- a/Radoub.UI/Radoub.UI/Models/FilterState.cs
+++ b/Radoub.UI/Radoub.UI/Models/FilterState.cs
@@ -24,4 +24,9 @@ public class FilterState
     /// Selected base item type index, or null for "All Types".
     /// </summary>
     public int? SelectedBaseItemIndex { get; set; }
+
+    /// <summary>
+    /// Property search string (searches item properties).
+    /// </summary>
+    public string? PropertySearchText { get; set; }
 }


### PR DESCRIPTION
## Summary

Add item property search to ItemFilterPanel. Search/filter items by their properties (enhancement bonuses, class restrictions, damage types, etc.).

## Changes

- New "Properties:" text box in ItemFilterPanel
- Searches resolved property strings (case-insensitive)
- Debounced input (300ms) for performance
- Clear button to reset property filter
- Filter state persisted with other filter settings

## Use Cases

- Find class-restricted items: search "monk" or "wizard"
- Find spell items by level: search "level 3"
- Find items with specific bonuses: search "enhancement" or "+2"
- Find damage types: search "fire" or "cold"

## Related Issues

- Closes #557
- Parent Epic: #546 (Shared Inventory UI Components)

## Pre-Merge Checklist

- [x] Privacy scan: PASS
- [x] Tech debt scan: PASS
- [x] Unit tests: 469 passed
- [x] CHANGELOG updated (0.1.28-alpha)
- [x] Wiki current (2026-01-04)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)