### PR TITLE
[Quartermaster] Sprint: Spell System Polish (#761)

### DIFF
--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -23,12 +23,24 @@ Enhance SpellsPanel with multi-class spell slot display and polish spell editing
 
 #### Added
 
-- **Spell Slots by Class** section showing all caster classes at once
-  - Multi-class characters see spell usage for every caster class simultaneously
-  - Format: `Wizard (10): 0:4/4 | 1:3/4 | 2:2/3 | ...`
-  - Selected class highlighted in blue
-  - Non-caster classes omitted
-  - Updates when spells are added/removed
+- **Spell Slot Table** (left panel) showing spell slots/known limits per class
+  - Grid format with spell levels as rows, caster classes as columns
+  - Color-coded: gold (full), green (partial), gray (empty/unavailable)
+  - Spontaneous casters show "spells known" limits, prepared casters show spell slots
+  - Filters out feat-based abilities from slot counts
+- **Known Spells List** (left panel, below slot table)
+  - Shows ALL caster classes with their spells grouped by level
+  - Overlapping spells (same spell in multiple classes) highlighted in gold with ⬥
+  - Feat-based abilities marked with asterisk (*) in gray
+  - Selected class header highlighted in blue
+  - Scrollable for characters with many spells
+
+#### Fixed
+
+- Spell list now loads all spells from spells.2da (fixed early termination bug)
+  - Previously stopped at first gap after 100 spells
+  - Now scans up to 2000 rows with consecutive-empty detection
+  - Supports custom content (CEP, PRC, etc.)
 
 ---
 

--- a/Quartermaster/Quartermaster/Services/CreatureDisplayService.cs
+++ b/Quartermaster/Quartermaster/Services/CreatureDisplayService.cs
@@ -439,6 +439,7 @@ public class CreatureDisplayService
     public bool IsCasterClass(int classId) => Spells.IsCasterClass(classId);
     public bool IsSpontaneousCaster(int classId) => Spells.IsSpontaneousCaster(classId);
     public int[]? GetSpellSlots(int classId, int classLevel) => Spells.GetSpellSlots(classId, classLevel);
+    public int[]? GetSpellsKnownLimit(int classId, int classLevel) => Spells.GetSpellsKnownLimit(classId, classLevel);
 
     #endregion
 }

--- a/Quartermaster/Quartermaster/Views/Panels/SpellsPanel.axaml
+++ b/Quartermaster/Quartermaster/Views/Panels/SpellsPanel.axaml
@@ -2,37 +2,70 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
+             mc:Ignorable="d" d:DesignWidth="1100" d:DesignHeight="600"
              x:Class="Quartermaster.Views.Panels.SpellsPanel">
 
     <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Padding="20,20,20,20">
-        <Grid RowDefinitions="Auto,Auto,Auto,Auto,*,Auto">
-            <!-- Header -->
-            <TextBlock Grid.Row="0"
-                       Text="Spells"
-                       FontSize="20"
-                       FontWeight="Bold"/>
+        <!-- Main layout: Spell Slot Table on left, Spell List on right -->
+        <Grid ColumnDefinitions="Auto,*">
 
-            <!-- All Caster Classes Summary -->
-            <Border Grid.Row="1"
-                    x:Name="AllClassesSummaryBorder"
-                    Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
-                    CornerRadius="4"
-                    Padding="10"
-                    Margin="0,5,0,10"
-                    IsVisible="False"
-                    AutomationProperties.AutomationId="AllClassesSummarySection">
-                <StackPanel x:Name="AllClassesSummaryPanel" Spacing="4">
-                    <TextBlock Text="Spell Slots by Class"
-                               FontWeight="SemiBold"
-                               FontSize="12"
-                               Margin="0,0,0,6"/>
-                    <!-- Dynamic class summaries added here -->
-                </StackPanel>
-            </Border>
+            <!-- LEFT COLUMN: Spell Slot Table + Known Spells List -->
+            <StackPanel Grid.Column="0" Margin="0,0,15,0">
+                <!-- Spell Slot Table -->
+                <Border x:Name="SpellSlotTableBorder"
+                        Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                        CornerRadius="4"
+                        Padding="10"
+                        MinWidth="180"
+                        IsVisible="False"
+                        AutomationProperties.AutomationId="SpellSlotTableSection">
+                    <StackPanel>
+                        <TextBlock Text="Spell Slots"
+                                   FontWeight="SemiBold"
+                                   FontSize="14"
+                                   Margin="0,0,0,10"/>
+                        <!-- Dynamic table grid will be added here -->
+                        <Grid x:Name="SpellSlotTableGrid">
+                            <!-- Columns and rows populated dynamically based on caster classes -->
+                        </Grid>
+                    </StackPanel>
+                </Border>
 
-            <!-- Class Radio Buttons (Class 1-8) -->
-            <Border Grid.Row="2"
+                <!-- Known Spells List (grouped by level) -->
+                <Border x:Name="KnownSpellsListBorder"
+                        Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                        CornerRadius="4"
+                        Padding="10"
+                        Margin="0,10,0,0"
+                        MinWidth="180"
+                        MaxHeight="400"
+                        IsVisible="False"
+                        AutomationProperties.AutomationId="KnownSpellsListSection">
+                    <StackPanel>
+                        <TextBlock Text="Known Spells"
+                                   FontWeight="SemiBold"
+                                   FontSize="14"
+                                   Margin="0,0,0,10"/>
+                        <!-- Scrollable list of known spells grouped by level -->
+                        <ScrollViewer MaxHeight="350" VerticalScrollBarVisibility="Auto">
+                            <StackPanel x:Name="KnownSpellsListPanel">
+                                <!-- Dynamically populated with spell names grouped by level -->
+                            </StackPanel>
+                        </ScrollViewer>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+
+            <!-- RIGHT COLUMN: Original spell panel content -->
+            <Grid Grid.Column="1" RowDefinitions="Auto,Auto,Auto,*,Auto">
+                <!-- Header -->
+                <TextBlock Grid.Row="0"
+                           Text="Spells"
+                           FontSize="20"
+                           FontWeight="Bold"/>
+
+                <!-- Class Radio Buttons (Class 1-8) -->
+                <Border Grid.Row="1"
                     Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
                     CornerRadius="4"
                     Padding="10"
@@ -81,7 +114,7 @@
             </Border>
 
             <!-- Filter Toolbar -->
-            <Grid Grid.Row="3" ColumnDefinitions="*,Auto,Auto,Auto" Margin="0,0,0,10">
+            <Grid Grid.Row="2" ColumnDefinitions="*,Auto,Auto,Auto" Margin="0,0,0,10">
                 <!-- Search Box -->
                 <Grid Grid.Column="0" ColumnDefinitions="*,Auto">
                     <TextBox x:Name="SearchTextBox"
@@ -154,7 +187,7 @@
             </Grid>
 
             <!-- Spells List -->
-            <Grid Grid.Row="4" RowDefinitions="Auto,*,Auto,Auto">
+            <Grid Grid.Row="3" RowDefinitions="Auto,*,Auto,Auto">
                 <!-- Header Row -->
                 <Border Grid.Row="0"
                         Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
@@ -281,7 +314,7 @@
             </Grid>
 
             <!-- Footer with Meta-Magic and Actions -->
-            <Grid Grid.Row="5" ColumnDefinitions="*,Auto" Margin="0,10,0,0">
+            <Grid Grid.Row="4" ColumnDefinitions="*,Auto" Margin="0,10,0,0">
                 <!-- Meta-Magic Expander (placeholder) -->
                 <Expander Grid.Column="0"
                           Header="Meta-Magic Feats"
@@ -322,6 +355,7 @@
                             ToolTip.Tip="Load class spell list (not yet implemented)"
                             AutomationProperties.AutomationId="LoadSpellListButton"/>
                 </StackPanel>
+            </Grid>
             </Grid>
         </Grid>
     </Border>

--- a/Quartermaster/Quartermaster/Views/Panels/SpellsPanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/SpellsPanel.axaml.cs
@@ -25,8 +25,10 @@ public partial class SpellsPanel : UserControl
     public event EventHandler? SpellsChanged;
 
     // UI Controls
-    private Border? _allClassesSummaryBorder;
-    private StackPanel? _allClassesSummaryPanel;
+    private Border? _spellSlotTableBorder;
+    private Grid? _spellSlotTableGrid;
+    private Border? _knownSpellsListBorder;
+    private StackPanel? _knownSpellsListPanel;
     private TextBlock? _spellSlotSummaryText;
     private TextBox? _searchTextBox;
     private Button? _clearSearchButton;
@@ -67,8 +69,10 @@ public partial class SpellsPanel : UserControl
         AvaloniaXamlLoader.Load(this);
 
         // Find UI controls
-        _allClassesSummaryBorder = this.FindControl<Border>("AllClassesSummaryBorder");
-        _allClassesSummaryPanel = this.FindControl<StackPanel>("AllClassesSummaryPanel");
+        _spellSlotTableBorder = this.FindControl<Border>("SpellSlotTableBorder");
+        _spellSlotTableGrid = this.FindControl<Grid>("SpellSlotTableGrid");
+        _knownSpellsListBorder = this.FindControl<Border>("KnownSpellsListBorder");
+        _knownSpellsListPanel = this.FindControl<StackPanel>("KnownSpellsListPanel");
         _spellSlotSummaryText = this.FindControl<TextBlock>("SpellSlotSummaryText");
         _searchTextBox = this.FindControl<TextBox>("SearchTextBox");
         _clearSearchButton = this.FindControl<Button>("ClearSearchButton");
@@ -312,17 +316,11 @@ public partial class SpellsPanel : UserControl
         // Load all spells from spells.2da
         LoadAllSpells(classEntry.Class);
 
-        UnifiedLogger.LogUI(LogLevel.INFO, $"SpellsPanel.LoadSpellsForClass: About to ApplyFilters...");
-
         // Apply filters
         ApplyFilters();
 
-        UnifiedLogger.LogUI(LogLevel.INFO, $"SpellsPanel.LoadSpellsForClass: About to UpdateSummary...");
-
         // Update summary
         UpdateSummary();
-
-        UnifiedLogger.LogUI(LogLevel.INFO, $"SpellsPanel.LoadSpellsForClass: Done, returning to caller");
     }
 
     private void LoadAllSpells(int classId)
@@ -330,27 +328,16 @@ public partial class SpellsPanel : UserControl
         if (_displayService == null) return;
 
         var allSpellIds = _displayService.GetAllSpellIds();
-        UnifiedLogger.LogUI(LogLevel.INFO, $"SpellsPanel.LoadAllSpells: Loading {allSpellIds.Count} spells for class {classId}");
 
-        int count = 0;
         foreach (var spellId in allSpellIds)
         {
             var vm = CreateSpellViewModel(spellId, classId);
             if (vm != null)
                 _allSpells.Add(vm);
-            count++;
-            if (count % 100 == 0)
-            {
-                UnifiedLogger.LogUI(LogLevel.INFO, $"SpellsPanel.LoadAllSpells: Processed {count}/{allSpellIds.Count} spells");
-            }
         }
-
-        UnifiedLogger.LogUI(LogLevel.INFO, $"SpellsPanel.LoadAllSpells: Finished loading {_allSpells.Count} valid spells, now sorting...");
 
         // Sort by name
         _allSpells = _allSpells.OrderBy(s => s.SpellName).ToList();
-
-        UnifiedLogger.LogUI(LogLevel.INFO, $"SpellsPanel.LoadAllSpells: Done sorting");
     }
 
     private SpellListViewModel? CreateSpellViewModel(int spellId, int classId)
@@ -737,92 +724,369 @@ public partial class SpellsPanel : UserControl
         // Update all caster classes summary
         UpdateAllClassesSummary();
 
+        // Update known spells list
+        UpdateKnownSpellsList();
+
         // Update selected class spell slot summary
         UpdateSpellSlotSummary();
     }
 
     /// <summary>
-    /// Updates the all-classes spell slot summary section.
-    /// Shows spell slots for each caster class in the creature.
+    /// Updates the spell slot table on the left side.
+    /// Shows a grid with spell levels as rows and caster classes as columns.
     /// </summary>
     private void UpdateAllClassesSummary()
     {
-        if (_allClassesSummaryPanel == null || _allClassesSummaryBorder == null) return;
+        if (_spellSlotTableGrid == null || _spellSlotTableBorder == null) return;
 
-        // Clear existing class summaries (keep the header)
-        while (_allClassesSummaryPanel.Children.Count > 1)
-        {
-            _allClassesSummaryPanel.Children.RemoveAt(_allClassesSummaryPanel.Children.Count - 1);
-        }
+        // Clear existing content
+        _spellSlotTableGrid.Children.Clear();
+        _spellSlotTableGrid.ColumnDefinitions.Clear();
+        _spellSlotTableGrid.RowDefinitions.Clear();
 
         if (_currentCreature == null || _displayService == null)
         {
-            _allClassesSummaryBorder.IsVisible = false;
+            _spellSlotTableBorder.IsVisible = false;
             return;
         }
 
-        var casterClasses = new List<(int classIndex, string className, int classLevel, int[] slots, CreatureClass classEntry)>();
+        var casterClasses = new List<(int classIndex, string className, int classLevel, int[] limits, CreatureClass classEntry, bool isSpontaneous)>();
 
         // Find all caster classes
         for (int i = 0; i < _currentCreature.ClassList.Count; i++)
         {
             var classEntry = _currentCreature.ClassList[i];
             var className = _displayService.GetClassName(classEntry.Class) ?? $"Class {classEntry.Class}";
-            var slots = _displayService.GetSpellSlots(classEntry.Class, classEntry.ClassLevel);
+            var isSpontaneous = _displayService.IsSpontaneousCaster(classEntry.Class);
 
-            // Check if this class has spell slots or has spell data
-            bool hasSpellSlots = slots != null && slots.Any(s => s > 0);
+            // For spontaneous casters, use spells known limit; for prepared casters, use spell slots
+            var limits = isSpontaneous
+                ? _displayService.GetSpellsKnownLimit(classEntry.Class, classEntry.ClassLevel)
+                : _displayService.GetSpellSlots(classEntry.Class, classEntry.ClassLevel);
+
+            // Check if this class has spell slots/limits or has spell data
+            bool hasSpellLimits = limits != null && limits.Any(s => s > 0);
             bool hasSpellData = classEntry.KnownSpells.Any(list => list.Count > 0) ||
                                 classEntry.MemorizedSpells.Any(list => list.Count > 0);
 
-            if (hasSpellSlots || hasSpellData)
+            if (hasSpellLimits || hasSpellData)
             {
-                casterClasses.Add((i, className, classEntry.ClassLevel, slots ?? new int[10], classEntry));
+                casterClasses.Add((i, className, classEntry.ClassLevel, limits ?? new int[10], classEntry, isSpontaneous));
             }
         }
 
         if (casterClasses.Count == 0)
         {
-            _allClassesSummaryBorder.IsVisible = false;
+            _spellSlotTableBorder.IsVisible = false;
             return;
         }
 
-        _allClassesSummaryBorder.IsVisible = true;
+        _spellSlotTableBorder.IsVisible = true;
 
-        // Add a summary line for each caster class
-        foreach (var (classIndex, className, classLevel, slots, classEntry) in casterClasses)
+        // Find all spell levels that have limits across any class
+        var activeLevels = new List<int>();
+        for (int level = 0; level <= 9; level++)
         {
-            var slotParts = new List<string>();
+            if (casterClasses.Any(c => c.limits[level] > 0))
+            {
+                activeLevels.Add(level);
+            }
+        }
 
+        if (activeLevels.Count == 0)
+        {
+            _spellSlotTableBorder.IsVisible = false;
+            return;
+        }
+
+        // Build grid structure: first column for level labels, then one column per class
+        // Row 0 = header row with class names
+        // Rows 1+ = spell levels
+
+        // Add column definitions: Label column + one per class
+        _spellSlotTableGrid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        foreach (var _ in casterClasses)
+        {
+            _spellSlotTableGrid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
+        }
+
+        // Add row definitions: header + one per active level
+        _spellSlotTableGrid.RowDefinitions.Add(new RowDefinition(GridLength.Auto)); // Header
+        foreach (var _ in activeLevels)
+        {
+            _spellSlotTableGrid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
+        }
+
+        // Add header row - "Lvl" label in first column
+        var lvlHeader = new TextBlock
+        {
+            Text = "Lvl",
+            FontWeight = Avalonia.Media.FontWeight.SemiBold,
+            FontSize = 12,
+            Margin = new Avalonia.Thickness(0, 0, 10, 4),
+            HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center
+        };
+        Grid.SetRow(lvlHeader, 0);
+        Grid.SetColumn(lvlHeader, 0);
+        _spellSlotTableGrid.Children.Add(lvlHeader);
+
+        // Add class name headers
+        for (int col = 0; col < casterClasses.Count; col++)
+        {
+            var (classIndex, className, classLevel, _, _, _) = casterClasses[col];
+            var isSelected = classIndex == _selectedClassIndex;
+
+            var classHeader = new TextBlock
+            {
+                Text = className,
+                FontWeight = Avalonia.Media.FontWeight.SemiBold,
+                FontSize = 12,
+                Margin = new Avalonia.Thickness(4, 0, 4, 4),
+                HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+                Foreground = isSelected
+                    ? new SolidColorBrush(Color.FromRgb(100, 180, 255))
+                    : this.FindResource("SystemControlForegroundBaseHighBrush") as IBrush
+                      ?? Brushes.White
+            };
+            Grid.SetRow(classHeader, 0);
+            Grid.SetColumn(classHeader, col + 1);
+            _spellSlotTableGrid.Children.Add(classHeader);
+        }
+
+        // Add data rows for each spell level
+        for (int rowIdx = 0; rowIdx < activeLevels.Count; rowIdx++)
+        {
+            int spellLevel = activeLevels[rowIdx];
+            int gridRow = rowIdx + 1; // +1 for header
+
+            // Level label
+            var levelLabel = new TextBlock
+            {
+                Text = spellLevel.ToString(),
+                FontSize = 12,
+                FontWeight = Avalonia.Media.FontWeight.SemiBold,
+                Margin = new Avalonia.Thickness(0, 2, 10, 2),
+                HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
+            };
+            Grid.SetRow(levelLabel, gridRow);
+            Grid.SetColumn(levelLabel, 0);
+            _spellSlotTableGrid.Children.Add(levelLabel);
+
+            // Slot/known counts for each class
+            for (int col = 0; col < casterClasses.Count; col++)
+            {
+                var (classIndex, className, _, limits, classEntry, isSpontaneous) = casterClasses[col];
+                int totalLimit = limits[spellLevel];
+
+                // Only count spells that are actual class spells (not feat-based abilities like Barbarian Rage)
+                // Filter to spells that have a valid level for this class in spells.2da
+                int usedCount = 0;
+                foreach (var knownSpell in classEntry.KnownSpells[spellLevel])
+                {
+                    var spellInfo = _displayService.GetSpellInfo(knownSpell.Spell);
+                    int classSpellLevel = spellInfo?.GetLevelForClass(classEntry.Class) ?? -1;
+
+                    // Only count spells that are valid for this class (filter out feat-based abilities)
+                    if (spellInfo != null && classSpellLevel >= 0)
+                    {
+                        usedCount++;
+                    }
+                }
+
+                var isSelected = classIndex == _selectedClassIndex;
+
+                string cellText;
+                IBrush cellColor;
+
+                if (totalLimit <= 0)
+                {
+                    cellText = "-";
+                    cellColor = new SolidColorBrush(Colors.Gray);
+                }
+                else if (usedCount >= totalLimit)
+                {
+                    // Full - show in gold/yellow
+                    cellText = $"{usedCount}/{totalLimit}";
+                    cellColor = new SolidColorBrush(Colors.Gold);
+                }
+                else if (usedCount > 0)
+                {
+                    // Partial - show in green
+                    cellText = $"{usedCount}/{totalLimit}";
+                    cellColor = new SolidColorBrush(Colors.LightGreen);
+                }
+                else
+                {
+                    // Empty - normal color
+                    cellText = $"0/{totalLimit}";
+                    cellColor = isSelected
+                        ? new SolidColorBrush(Color.FromRgb(100, 180, 255))
+                        : this.FindResource("SystemControlForegroundBaseMediumBrush") as IBrush
+                          ?? new SolidColorBrush(Colors.Gray);
+                }
+
+                var slotCell = new TextBlock
+                {
+                    Text = cellText,
+                    FontSize = 12,
+                    Margin = new Avalonia.Thickness(4, 2, 4, 2),
+                    HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+                    VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+                    Foreground = cellColor
+                };
+                Grid.SetRow(slotCell, gridRow);
+                Grid.SetColumn(slotCell, col + 1);
+                _spellSlotTableGrid.Children.Add(slotCell);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Updates the known spells list panel below the spell slot table.
+    /// Shows spell names grouped by class and level for ALL caster classes.
+    /// Highlights overlapping spells that appear in multiple classes.
+    /// </summary>
+    private void UpdateKnownSpellsList()
+    {
+        if (_knownSpellsListPanel == null || _knownSpellsListBorder == null) return;
+
+        _knownSpellsListPanel.Children.Clear();
+
+        if (_currentCreature == null || _displayService == null)
+        {
+            _knownSpellsListBorder.IsVisible = false;
+            return;
+        }
+
+        // First pass: collect all known spells and count occurrences across classes
+        var spellOccurrences = new Dictionary<int, List<string>>(); // spellId -> list of class names
+        var casterClasses = new List<(int classIndex, string className, CreatureClass classEntry)>();
+
+        for (int i = 0; i < _currentCreature.ClassList.Count; i++)
+        {
+            var classEntry = _currentCreature.ClassList[i];
+            var className = _displayService.GetClassName(classEntry.Class) ?? $"Class {classEntry.Class}";
+
+            bool hasSpells = classEntry.KnownSpells.Any(list => list.Count > 0);
+            if (!hasSpells) continue;
+
+            casterClasses.Add((i, className, classEntry));
+
+            // Track spell occurrences
             for (int level = 0; level <= 9; level++)
             {
-                int totalSlots = slots[level];
-                if (totalSlots <= 0) continue;
+                foreach (var spell in classEntry.KnownSpells[level])
+                {
+                    if (!spellOccurrences.ContainsKey(spell.Spell))
+                        spellOccurrences[spell.Spell] = new List<string>();
+                    spellOccurrences[spell.Spell].Add(className);
+                }
+            }
+        }
 
-                // Count known/memorized spells at this level
-                int usedSlots = classEntry.KnownSpells[level].Count;
+        if (casterClasses.Count == 0)
+        {
+            _knownSpellsListBorder.IsVisible = false;
+            return;
+        }
 
-                slotParts.Add($"{level}:{usedSlots}/{totalSlots}");
+        bool hasAnySpells = false;
+
+        // Build spell list grouped by class, then by level
+        foreach (var (classIndex, className, classEntry) in casterClasses)
+        {
+            bool classHasSpells = false;
+
+            // Check if this class has any spells
+            for (int level = 0; level <= 9; level++)
+            {
+                if (classEntry.KnownSpells[level].Count > 0)
+                {
+                    classHasSpells = true;
+                    break;
+                }
             }
 
-            var slotsText = slotParts.Count > 0
-                ? string.Join(" | ", slotParts)
-                : "(no spell slots at current level)";
+            if (!classHasSpells) continue;
 
-            // Create the summary TextBlock
-            var summaryText = new TextBlock
+            hasAnySpells = true;
+            var isSelectedClass = classIndex == _selectedClassIndex;
+
+            // Class header
+            var classHeader = new TextBlock
             {
-                Text = $"{className} ({classLevel}): {slotsText}",
-                FontSize = 11,
-                Foreground = classIndex == _selectedClassIndex
-                    ? new SolidColorBrush(Color.FromRgb(100, 180, 255))  // Highlight selected class
-                    : this.FindResource("SystemControlForegroundBaseMediumBrush") as IBrush
-                      ?? new SolidColorBrush(Colors.Gray),
-                TextWrapping = Avalonia.Media.TextWrapping.Wrap
+                Text = className,
+                FontWeight = Avalonia.Media.FontWeight.Bold,
+                FontSize = 12,
+                Foreground = isSelectedClass
+                    ? new SolidColorBrush(Color.FromRgb(100, 180, 255))
+                    : this.FindResource("SystemControlForegroundBaseHighBrush") as IBrush ?? Brushes.White,
+                Margin = new Avalonia.Thickness(0, hasAnySpells && _knownSpellsListPanel.Children.Count > 0 ? 12 : 0, 0, 6)
             };
+            _knownSpellsListPanel.Children.Add(classHeader);
 
-            _allClassesSummaryPanel.Children.Add(summaryText);
+            // Spells grouped by level
+            for (int level = 0; level <= 9; level++)
+            {
+                var knownAtLevel = classEntry.KnownSpells[level];
+                if (knownAtLevel.Count == 0) continue;
+
+                // Level header
+                var levelHeader = new TextBlock
+                {
+                    Text = level == 0 ? "  Cantrips" : $"  Level {level}",
+                    FontWeight = Avalonia.Media.FontWeight.SemiBold,
+                    FontSize = 10,
+                    Foreground = new SolidColorBrush(Colors.Gray),
+                    Margin = new Avalonia.Thickness(0, 4, 0, 2)
+                };
+                _knownSpellsListPanel.Children.Add(levelHeader);
+
+                // Spell names
+                foreach (var spell in knownAtLevel)
+                {
+                    var spellName = _displayService.GetSpellName(spell.Spell);
+                    var spellInfo = _displayService.GetSpellInfo(spell.Spell);
+                    int classSpellLevel = spellInfo?.GetLevelForClass(classEntry.Class) ?? -1;
+
+                    // Check if spell appears in multiple classes (overlap)
+                    bool isOverlap = spellOccurrences.TryGetValue(spell.Spell, out var occurrences) && occurrences.Count > 1;
+
+                    // Show spell name with indicators
+                    var displayName = spellName;
+                    IBrush foreground;
+
+                    if (classSpellLevel < 0)
+                    {
+                        // Not a standard class spell (e.g., feat-based ability)
+                        displayName = $"{spellName} *";
+                        foreground = new SolidColorBrush(Colors.Gray);
+                    }
+                    else if (isOverlap)
+                    {
+                        // Spell appears in multiple classes - highlight in gold
+                        displayName = $"{spellName} ⬥";
+                        foreground = new SolidColorBrush(Colors.Gold);
+                    }
+                    else
+                    {
+                        foreground = this.FindResource("SystemControlForegroundBaseHighBrush") as IBrush ?? Brushes.White;
+                    }
+
+                    var spellLabel = new TextBlock
+                    {
+                        Text = $"    {displayName}",
+                        FontSize = 11,
+                        Foreground = foreground,
+                        Margin = new Avalonia.Thickness(0, 1, 0, 1)
+                    };
+                    _knownSpellsListPanel.Children.Add(spellLabel);
+                }
+            }
         }
+
+        _knownSpellsListBorder.IsVisible = hasAnySpells;
     }
 
     private void UpdateSpellSlotSummary()
@@ -898,14 +1162,21 @@ public partial class SpellsPanel : UserControl
         _currentCreature = null;
         _selectedClassIndex = 0;
 
-        // Hide all-classes summary
-        if (_allClassesSummaryBorder != null)
-            _allClassesSummaryBorder.IsVisible = false;
-        if (_allClassesSummaryPanel != null)
+        // Hide spell slot table
+        if (_spellSlotTableBorder != null)
+            _spellSlotTableBorder.IsVisible = false;
+        if (_spellSlotTableGrid != null)
         {
-            while (_allClassesSummaryPanel.Children.Count > 1)
-                _allClassesSummaryPanel.Children.RemoveAt(_allClassesSummaryPanel.Children.Count - 1);
+            _spellSlotTableGrid.Children.Clear();
+            _spellSlotTableGrid.ColumnDefinitions.Clear();
+            _spellSlotTableGrid.RowDefinitions.Clear();
         }
+
+        // Hide known spells list
+        if (_knownSpellsListBorder != null)
+            _knownSpellsListBorder.IsVisible = false;
+        if (_knownSpellsListPanel != null)
+            _knownSpellsListPanel.Children.Clear();
 
         SetText(_spellSlotSummaryText, "");
 


### PR DESCRIPTION
## Summary

Sprint to enhance SpellsPanel with complete spell management capabilities.

- Add spell slot table showing all caster classes at once
- Add known spells list showing all classes with overlap detection
- Fix spell loading to support full spells.2da range and custom content

## Related Issues

- Closes #761
- Closes #758 - Spell slot summary
- Closes #737 - Add/Remove Known Spells  
- Closes #738 - Add/Remove Memorized Spells

## Pre-Merge Checklist

**Branch**: `quartermaster/issue-761`
**Tool**: Quartermaster

### Tests
| Check | Status |
|-------|--------|
| Privacy scan | ✅ Pass |
| Tech debt | ⚠️ SpellsPanel.axaml.cs (1232 lines) |
| Unit tests | ✅ 27 passed |
| UI tests | ⏭️ Skipped (unit only) |

### Validation
| Check | Status |
|-------|--------|
| CHANGELOG | ✅ v0.1.29-alpha dated 2026-01-04 |
| Wiki | ✅ Current (2026-01-04) |

### Status
**Ready**: ✅ Ready to merge (1 warning - tech debt noted)

## Checklist

- [x] Implementation complete
- [x] Tests pass (27/27)
- [x] CHANGELOG updated with date
- [x] Multi-class characters show correct spell slots per class
- [x] Known spells list shows all classes with overlap detection
- [x] Spell loading fixed for full spells.2da range

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)