### PR TITLE
[Parley] Fix: Sound Browser test needs module context (#701)

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.1.111-alpha] - 2026-01-10
-**Branch**: `parley/issue-701` | **PR**: #TBD
+**Branch**: `parley/issue-701` | **PR**: #846
 
 ### Fix: Sound Browser test needs module context (#701)
 


### PR DESCRIPTION
## Summary

Sound Browser test (`BrowseSoundButton_OpensSoundBrowserWindow`) fails because:
- Button is found and clicked ✅
- Sound Browser window doesn't open (or opens empty and closes immediately)
- Sound Browser requires game/module context to find sounds

## Investigation Needed

- Check if Sound Browser opens but immediately closes when no sounds available
- Check if Sound Browser requires game resources path configured
- May need a test scenario with sound files or mock module

## Related Issues

- Closes #701
- Part of browser window testing initiative (#441)
- Related to Sprint #699

## Checklist

- [ ] Implementation complete
- [ ] Tests added/updated
- [ ] CHANGELOG updated with date
- [ ] Documentation updated (if needed)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)