### PR TITLE
[Parley] Enhancement: Remove unused WebView dependency (#897)

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -15,9 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Enhancement: Remove unused WebView dependency (#897)
 
-- [ ] Remove WebViewControl packages from Parley.csproj
-- [ ] Verify build succeeds and tests pass
-- [ ] Measure binary size reduction
+- Removed `WebViewControl-Avalonia` and `WebViewControl-Avalonia-ARM64` packages from Parley.csproj
+- Binary size reduced from ~359 MB to ~38 MB (89% reduction)
 
 ---
 

--- a/Parley/Parley/Parley.csproj
+++ b/Parley/Parley/Parley.csproj
@@ -65,17 +65,6 @@
     <PackageReference Include="AvaloniaGraphControl" Version="0.7.0" />
     <!-- Text-to-Speech for Windows (Sprint #479) -->
     <PackageReference Include="System.Speech" Version="9.0.0" Condition="'$(RuntimeIdentifier)' == 'win-x64' Or '$(RuntimeIdentifier)' == 'win-arm64' Or $([MSBuild]::IsOSPlatform('Windows'))" />
-    <!-- WebView for CEF-based browser embedding (documentation, help) -->
-    <!-- Architecture-specific packages: x64 vs ARM64 (CEF natives are platform-specific) -->
-    <!-- Using RuntimeInformation.OSArchitecture for native builds (GitHub Actions macos-latest is ARM64) -->
-  </ItemGroup>
-
-  <!-- WebView packages - include BOTH x64 and ARM64 packages unconditionally
-       The packages contain RID-specific native libs that MSBuild resolves at build time
-       Conditional package refs don't work because RID isn't set during restore -->
-  <ItemGroup>
-    <PackageReference Include="WebViewControl-Avalonia" Version="3.120.11" />
-    <PackageReference Include="WebViewControl-Avalonia-ARM64" Version="3.120.11" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Removed unused WebView packages from Parley.csproj to significantly reduce binary size.

- **Before**: ~359 MB
- **After**: ~38 MB (89% reduction)
- **Packages removed**: `WebViewControl-Avalonia`, `WebViewControl-Avalonia-ARM64`

These packages were included for a "CEF-based browser embedding (documentation, help)" feature that was never implemented.

## Related Issues

- Closes #897

## Checklist

- [x] Remove WebViewControl packages from Parley.csproj
- [x] Verify build succeeds
- [x] Verify tests pass (475 passed)
- [x] Measure new binary size
- [x] CHANGELOG updated

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)