### PR TITLE
[Radoub] feat: Enhanced /release command with highlight selection (#893)

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -4,14 +4,22 @@ Create and push a version tag to trigger the GitHub Actions release workflow.
 
 ## Upfront Questions
 
-**IMPORTANT**: Gather ALL required user input at the start, then execute autonomously.
+**IMPORTANT**: Gather user input in phases, not all at once.
 
-Before creating any release, collect these answers in ONE interaction:
-
+### Phase 1: Release Type
 1. **Release Type** (if not specified in args): "Which release? [parley/manifest/radoub]"
-2. **Version Confirmation**: "Ready to release [type] v[version] from commit [hash]? [y/n]"
 
-After collecting answers, proceed through all steps without further prompts unless errors occur.
+### Phase 2: Changelog Highlights Selection
+After determining release type and reading changelog:
+1. Parse the changelog section for the version being released
+2. Present a **numbered list** of all changelog items (bullet points and headers)
+3. Ask user: "Which items are highlights? (Enter numbers, e.g., 1,3,5 or 'all' or 'none')"
+4. Selected items become **Highlights** in release notes
+5. Remaining items are auto-categorized and summarized with link to full changelog
+
+### Phase 3: Final Confirmation
+1. Show release summary with selected highlights
+2. **Version Confirmation**: "Ready to release [type] v[version] from commit [hash]? [y/n]"
 
 ## Usage
 
@@ -54,19 +62,70 @@ Before releasing:
    - Working directory must be clean
    - Confirm latest commit is what we want to release
 
-3. **Check Current Version**
+3. **Check Current Version & Parse Changelog**
    - **Parley**: Read `Parley/CHANGELOG.md`
    - **Manifest**: Read `Manifest/CHANGELOG.md`
-   - **Radoub**: Read `CHANGELOG.md` (repo-level)
+   - **Radoub**: Read `CHANGELOG.md` (repo-level) + tool changelogs
    - Look for the most recent version section (e.g., `[0.1.5-alpha]`)
    - Confirm the version hasn't been released yet
+   - Extract all items from that version's section
 
-4. **Confirm with User**
-   - Show the release type and version
+4. **Present Changelog Items for Selection**
+
+   Display items as a numbered list:
+   ```
+   ## Changelog Items for v0.1.120-alpha
+
+   1. [###] Refactor: Tech debt - Large files needing refactoring (#719)
+   2. [-] Extracted WindowLayoutService for window position, panel layout
+   3. [-] SettingsService now delegates window-related properties
+   4. [-] Removed plugin migration code (PluginSettings.json)
+   5. [-] Follows same service extraction pattern as RecentFilesService
+
+   Which items are highlights? (Enter numbers like 1,2,5 or 'all' or 'none')
+   ```
+
+   - `[###]` prefix = section header
+   - `[-]` prefix = bullet point
+
+5. **Generate Release Notes**
+
+   Based on selection, create structured release notes:
+
+   **If user selects items 1,2:**
+   ```markdown
+   ## What's New
+
+   - **Refactor: Tech debt** - Large files needing refactoring (#719)
+   - Extracted WindowLayoutService for window position, panel layout
+
+   ## Other Changes
+
+   Bug fixes, refactoring, and maintenance. See [CHANGELOG.md](link) for details.
+   ```
+
+   **If user selects 'none':**
+   ```markdown
+   ## What's New
+
+   Bug fixes and maintenance release. See [CHANGELOG.md](link) for details.
+   ```
+
+6. **Write Release Notes File**
+
+   Write the generated notes to `release-notes.md` in repo root.
+   This file is read by the workflow during release.
+
+   ```bash
+   # The workflow reads this file for the release body
+   ```
+
+7. **Confirm with User**
+   - Show the release type, version, and generated highlights
    - Show recent commits that will be included
    - Ask user to confirm: "Ready to release [type] [tag]?"
 
-5. **Create and Push Tag**
+8. **Create and Push Tag**
 
    **For Parley:**
    ```bash

--- a/.github/workflows/manifest-release.yml
+++ b/.github/workflows/manifest-release.yml
@@ -185,6 +185,48 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "tag=$TAG" >> $GITHUB_OUTPUT
 
+    - name: Extract Changelog Highlights
+      id: highlights
+      shell: bash
+      run: |
+        # Check for manually curated release notes first (created by /release command)
+        if [ -f "release-notes.md" ]; then
+          echo "Using curated release-notes.md"
+          cp release-notes.md highlights.md
+        elif [ -f "Manifest/CHANGELOG.md" ]; then
+          # Fallback: auto-extract from changelog
+          # Find the first versioned section (skip [Unreleased])
+          section=$(awk '
+            /^## \[[0-9]/ { if (found) exit; found=1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' "Manifest/CHANGELOG.md")
+
+          if [ -n "$section" ]; then
+            {
+              echo "## What's New"
+              echo ""
+              # Extract key points - lines starting with - or ###
+              echo "$section" | grep -E "^(###|- \[?x?\]?)" | head -15 | sed 's/^### /#### /'
+            } > highlights.md
+          else
+            echo "## What's New" > highlights.md
+            echo "" >> highlights.md
+            echo "_See CHANGELOG.md for details_" >> highlights.md
+          fi
+        else
+          echo "## What's New" > highlights.md
+          echo "" >> highlights.md
+          echo "_See CHANGELOG.md for details_" >> highlights.md
+        fi
+
+        # Store as multiline output
+        {
+          echo 'highlights<<EOF'
+          cat highlights.md
+          echo 'EOF'
+        } >> $GITHUB_OUTPUT
+
     - name: Download all artifacts
       uses: actions/download-artifact@v7
       with:
@@ -205,6 +247,8 @@ jobs:
           # Manifest ${{ steps.version.outputs.version }}
 
           Journal editor for Neverwinter Nights `.jrl` files.
+
+          ${{ steps.highlights.outputs.highlights }}
 
           ## Downloads
 

--- a/.github/workflows/parley-release.yml
+++ b/.github/workflows/parley-release.yml
@@ -220,6 +220,48 @@ jobs:
       id: gitversion
       uses: gittools/actions/gitversion/execute@v4
 
+    - name: Extract Changelog Highlights
+      id: highlights
+      shell: bash
+      run: |
+        # Check for manually curated release notes first (created by /release command)
+        if [ -f "release-notes.md" ]; then
+          echo "Using curated release-notes.md"
+          cp release-notes.md highlights.md
+        elif [ -f "Parley/CHANGELOG.md" ]; then
+          # Fallback: auto-extract from changelog
+          # Find the first versioned section (skip [Unreleased])
+          section=$(awk '
+            /^## \[[0-9]/ { if (found) exit; found=1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' "Parley/CHANGELOG.md")
+
+          if [ -n "$section" ]; then
+            {
+              echo "## What's New"
+              echo ""
+              # Extract key points - lines starting with - or ###
+              echo "$section" | grep -E "^(###|- \[?x?\]?)" | head -15 | sed 's/^### /#### /'
+            } > highlights.md
+          else
+            echo "## What's New" > highlights.md
+            echo "" >> highlights.md
+            echo "_See CHANGELOG.md for details_" >> highlights.md
+          fi
+        else
+          echo "## What's New" > highlights.md
+          echo "" >> highlights.md
+          echo "_See CHANGELOG.md for details_" >> highlights.md
+        fi
+
+        # Store as multiline output
+        {
+          echo 'highlights<<EOF'
+          cat highlights.md
+          echo 'EOF'
+        } >> $GITHUB_OUTPUT
+
     - name: Download all artifacts
       uses: actions/download-artifact@v7
       with:
@@ -240,6 +282,8 @@ jobs:
           # Parley ${{ steps.gitversion.outputs.semVer }}
 
           Dialog editor for Neverwinter Nights `.dlg` files.
+
+          ${{ steps.highlights.outputs.highlights }}
 
           ## Downloads
 

--- a/.github/workflows/radoub-release.yml
+++ b/.github/workflows/radoub-release.yml
@@ -202,6 +202,57 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "tag=$TAG" >> $GITHUB_OUTPUT
 
+    - name: Extract Changelog Highlights
+      id: highlights
+      shell: bash
+      run: |
+        # Check for manually curated release notes first (created by /release command)
+        if [ -f "release-notes.md" ]; then
+          echo "Using curated release-notes.md"
+          cp release-notes.md highlights.md
+        else
+          # Fallback: auto-extract from tool changelogs
+          extract_changelog_section() {
+            local file="$1"
+            local tool_name="$2"
+
+            if [ ! -f "$file" ]; then
+              echo "### $tool_name"
+              echo "_No changelog found_"
+              echo ""
+              return
+            fi
+
+            # Find the first versioned section (skip [Unreleased])
+            local section=$(awk '
+              /^## \[[0-9]/ { if (found) exit; found=1; next }
+              found && /^## \[/ { exit }
+              found { print }
+            ' "$file")
+
+            if [ -n "$section" ]; then
+              echo "### $tool_name"
+              # Extract just the key points - lines starting with - or ###
+              echo "$section" | grep -E "^(###|- \[?x?\]?)" | head -15 | sed 's/^### /#### /'
+              echo ""
+            fi
+          }
+
+          {
+            echo "## Highlights"
+            echo ""
+            extract_changelog_section "Parley/CHANGELOG.md" "Parley"
+            extract_changelog_section "Manifest/CHANGELOG.md" "Manifest"
+          } > highlights.md
+        fi
+
+        # Store as multiline output
+        {
+          echo 'highlights<<EOF'
+          cat highlights.md
+          echo 'EOF'
+        } >> $GITHUB_OUTPUT
+
     - name: Download all artifacts
       uses: actions/download-artifact@v7
       with:
@@ -222,6 +273,8 @@ jobs:
           # Radoub ${{ steps.version.outputs.version }}
 
           Bundled release containing Parley and Manifest editors with shared runtime.
+
+          ${{ steps.highlights.outputs.highlights }}
 
           ## Downloads
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Desktop.ini
 *.cache
 ~$*
 nul
+release-notes.md
 
 # Python
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Enhancement: Release workflow with curated highlights (#893)
+
+Updated `/release` command and all release workflows to support curated release highlights.
+
+**Workflow changes:**
+- All workflows check for `release-notes.md` first (curated by `/release` command)
+- Falls back to auto-extracting from CHANGELOG if no curated notes exist
+- Auto-extraction parses latest versioned section, extracts headers and bullet points
+
+**`/release` command changes:**
+- Now presents numbered list of changelog items for the version being released
+- User selects which items are "highlights" to feature prominently
+- Remaining items summarized as "Other Changes" with link to full changelog
+- Generates `release-notes.md` file consumed by workflow
+
 ---
 
 ## [0.9.31] - 2026-01-15


### PR DESCRIPTION
## Summary

- `/release` command now presents numbered list of changelog items
- User selects which items are "highlights" for release notes
- Remaining items auto-categorized as bugfix/tech-debt with changelog link
- Workflows check for `release-notes.md` first, fall back to auto-extract

Closes #893

## Test plan

- [ ] Run `/release parley` and verify changelog items are presented
- [ ] Select highlights and confirm release notes format

🤖 Generated with [Claude Code](https://claude.com/claude-code)