### PR TITLE
[Radoub] Sprint: Infrastructure & Logging (#1184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Sprint: Infrastructure & Logging (#1184)
 
-- [ ] #935 - Implement auto-pruning for log files
-- [ ] #1072 - Add centralized log level control for all applications
+#### #935 - Log Auto-Pruning (Already Implemented)
+- All tools now use `SharedLogRetentionSessions` from RadoubSettings at startup
+- Pruning happens during `UnifiedLogger.Configure()` based on shared setting
+- Previously hardcoded `RetainSessions=10` replaced with shared config
+
+#### #1072 - Centralized Log Level Control
+- All tools now use `SharedLogLevel` from RadoubSettings at startup
+- Added TRACE level to Trebuchet's log level dropdown (needed for Parley debugging)
+- Removed redundant Logging tab from Quartermaster settings
+- Removed redundant Logging section from Manifest settings
+- Parley's Logging tab renamed to "Debug" - keeps debug panel toggle, removed log level/retention
+- All logging configuration now done via Trebuchet (central hub)
 
 **Removed from sprint:**
 - #863 - Already completed in #1190

--- a/Fence/Fence/Program.cs
+++ b/Fence/Fence/Program.cs
@@ -34,20 +34,14 @@ sealed class Program
             SafeMode.ActivateSafeMode(clearParameterCache: false, clearPluginData: false);
         }
 
-        // Initialize unified logging FIRST with defaults (before any code that might log)
+        // Initialize unified logging with shared settings
+        var sharedSettings = RadoubSettings.Instance;
         UnifiedLogger.Configure(new LoggerConfig
         {
             AppName = "Fence",
-            LogLevel = LogLevel.INFO,
-            RetainSessions = 10
+            LogLevel = sharedSettings.UseSharedLogging ? sharedSettings.SharedLogLevel : LogLevel.INFO,
+            RetainSessions = sharedSettings.SharedLogRetentionSessions
         });
-
-        // Then apply shared settings if enabled
-        var sharedSettings = RadoubSettings.Instance;
-        if (sharedSettings.UseSharedLogging)
-        {
-            UnifiedLogger.SetLogLevel(sharedSettings.SharedLogLevel);
-        }
 
         // Start GUI application
         BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);

--- a/Manifest/Manifest/Program.cs
+++ b/Manifest/Manifest/Program.cs
@@ -37,20 +37,14 @@ sealed class Program
             SafeMode.ActivateSafeMode(clearParameterCache: false, clearPluginData: false);
         }
 
-        // Initialize unified logging FIRST with defaults (before any code that might log)
+        // Initialize unified logging with shared settings
+        var sharedSettings = RadoubSettings.Instance;
         UnifiedLogger.Configure(new LoggerConfig
         {
             AppName = "Manifest",
-            LogLevel = LogLevel.INFO,
-            RetainSessions = 10
+            LogLevel = sharedSettings.UseSharedLogging ? sharedSettings.SharedLogLevel : LogLevel.INFO,
+            RetainSessions = sharedSettings.SharedLogRetentionSessions
         });
-
-        // Then apply shared settings if enabled
-        var sharedSettings = RadoubSettings.Instance;
-        if (sharedSettings.UseSharedLogging)
-        {
-            UnifiedLogger.SetLogLevel(sharedSettings.SharedLogLevel);
-        }
 
         // Start GUI application
         BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);

--- a/Manifest/Manifest/Views/SettingsWindow.axaml
+++ b/Manifest/Manifest/Views/SettingsWindow.axaml
@@ -174,29 +174,6 @@
                     </StackPanel>
                 </Border>
 
-                <!-- Logging Settings -->
-                <Border BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}" BorderThickness="1" Padding="10" CornerRadius="5">
-                    <StackPanel Spacing="8">
-                        <TextBlock Text="Logging" FontWeight="Bold"/>
-
-                        <!-- Log Level -->
-                        <StackPanel Orientation="Horizontal" Spacing="10">
-                            <TextBlock Text="Log Level:" VerticalAlignment="Center"/>
-                            <ComboBox x:Name="LogLevelComboBox" SelectionChanged="OnLogLevelChanged" MinWidth="100"/>
-                        </StackPanel>
-
-                        <!-- Log Retention -->
-                        <TextBlock Text="Log Retention (sessions to keep)" Margin="0,10,0,0"/>
-                        <Grid ColumnDefinitions="*,Auto">
-                            <Slider x:Name="LogRetentionSlider" Grid.Column="0"
-                                   Minimum="1" Maximum="10" Value="3"
-                                   TickFrequency="1" IsSnapToTickEnabled="True"
-                                   ValueChanged="OnLogRetentionChanged"/>
-                            <TextBlock x:Name="LogRetentionLabel" Grid.Column="1"
-                                      Text="3" Margin="10,0,0,0" VerticalAlignment="Center" MinWidth="30"/>
-                        </Grid>
-                    </StackPanel>
-                </Border>
             </StackPanel>
         </ScrollViewer>
 

--- a/Manifest/Manifest/Views/SettingsWindow.axaml.cs
+++ b/Manifest/Manifest/Views/SettingsWindow.axaml.cs
@@ -50,13 +50,6 @@ public partial class SettingsWindow : Window
         // Load font family list
         LoadFontFamilyList();
 
-        // Load log level
-        LoadLogLevelList();
-
-        // Load log retention
-        LogRetentionSlider.Value = settings.LogRetentionSessions;
-        LogRetentionLabel.Text = settings.LogRetentionSessions.ToString();
-
         // Load spell check settings
         LoadSpellCheckSettings();
 
@@ -224,45 +217,6 @@ public partial class SettingsWindow : Window
                 // Invalid font family - use default
             }
         }
-    }
-
-    private void LoadLogLevelList()
-    {
-        LogLevelComboBox.Items.Clear();
-
-        foreach (LogLevel level in Enum.GetValues<LogLevel>())
-        {
-            var item = new ComboBoxItem
-            {
-                Content = level.ToString(),
-                Tag = level
-            };
-            LogLevelComboBox.Items.Add(item);
-
-            if (level == SettingsService.Instance.CurrentLogLevel)
-            {
-                LogLevelComboBox.SelectedItem = item;
-            }
-        }
-    }
-
-    private void OnLogLevelChanged(object? sender, SelectionChangedEventArgs e)
-    {
-        if (_isLoading) return;
-
-        if (LogLevelComboBox.SelectedItem is ComboBoxItem item && item.Tag is LogLevel level)
-        {
-            SettingsService.Instance.CurrentLogLevel = level;
-        }
-    }
-
-    private void OnLogRetentionChanged(object? sender, Avalonia.Controls.Primitives.RangeBaseValueChangedEventArgs e)
-    {
-        if (_isLoading) return;
-
-        var value = (int)LogRetentionSlider.Value;
-        LogRetentionLabel.Text = value.ToString();
-        SettingsService.Instance.LogRetentionSessions = value;
     }
 
     private void OnCloseClick(object? sender, RoutedEventArgs e)

--- a/Parley/Parley/Program.cs
+++ b/Parley/Parley/Program.cs
@@ -120,20 +120,14 @@ sealed class Program
             SafeMode.ActivateSafeMode(clearParameterCache: true, clearPluginData: true);
         }
 
-        // Initialize unified logging FIRST with defaults (before any code that might log)
+        // Initialize unified logging with shared settings
+        var sharedSettings = RadoubSettings.Instance;
         UnifiedLogger.Configure(new LoggerConfig
         {
             AppName = "Parley",
-            LogLevel = LogLevel.INFO,
-            RetainSessions = 10
+            LogLevel = sharedSettings.UseSharedLogging ? sharedSettings.SharedLogLevel : LogLevel.INFO,
+            RetainSessions = sharedSettings.SharedLogRetentionSessions
         });
-
-        // Then apply shared settings if enabled
-        var sharedSettings = RadoubSettings.Instance;
-        if (sharedSettings.UseSharedLogging)
-        {
-            UnifiedLogger.SetLogLevel(sharedSettings.SharedLogLevel);
-        }
 
         // Start GUI application
         BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);

--- a/Parley/Parley/Views/Controllers/LoggingSettingsController.cs
+++ b/Parley/Parley/Views/Controllers/LoggingSettingsController.cs
@@ -1,18 +1,16 @@
 using System;
-using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
 using DialogEditor.Services;
-using Radoub.Formats.Logging;
 
 namespace DialogEditor.Views.Controllers
 {
     /// <summary>
-    /// Controller for Logging settings section in SettingsWindow.
-    /// Handles: Log level, retention, debug panel visibility.
+    /// Controller for Debug settings section in SettingsWindow.
+    /// Handles: Debug panel visibility.
+    /// Note: Log level and retention are now centralized in Trebuchet (RadoubSettings).
     /// </summary>
     public class LoggingSettingsController
     {
@@ -29,26 +27,7 @@ namespace DialogEditor.Views.Controllers
         {
             var settings = SettingsService.Instance;
 
-            var logLevelComboBox = _window.FindControl<ComboBox>("LogLevelComboBox");
-            var logRetentionSlider = _window.FindControl<Slider>("LogRetentionSlider");
-            var logRetentionLabel = _window.FindControl<TextBlock>("LogRetentionLabel");
             var showDebugPanelCheckBox = _window.FindControl<CheckBox>("ShowDebugPanelCheckBox");
-
-            if (logLevelComboBox != null)
-            {
-                logLevelComboBox.ItemsSource = Enum.GetValues(typeof(LogLevel)).Cast<LogLevel>().ToList();
-                logLevelComboBox.SelectedItem = settings.CurrentLogLevel;
-            }
-
-            if (logRetentionSlider != null)
-            {
-                logRetentionSlider.Value = settings.LogRetentionSessions;
-            }
-
-            if (logRetentionLabel != null)
-            {
-                logRetentionLabel.Text = $"{settings.LogRetentionSessions} sessions";
-            }
 
             if (showDebugPanelCheckBox != null)
             {
@@ -60,38 +39,11 @@ namespace DialogEditor.Views.Controllers
         {
             var settings = SettingsService.Instance;
 
-            var logLevelComboBox = _window.FindControl<ComboBox>("LogLevelComboBox");
-            var logRetentionSlider = _window.FindControl<Slider>("LogRetentionSlider");
             var showDebugPanelCheckBox = _window.FindControl<CheckBox>("ShowDebugPanelCheckBox");
-
-            if (logLevelComboBox?.SelectedItem is LogLevel logLevel)
-            {
-                settings.CurrentLogLevel = logLevel;
-            }
-
-            if (logRetentionSlider != null)
-            {
-                settings.LogRetentionSessions = (int)logRetentionSlider.Value;
-            }
 
             if (showDebugPanelCheckBox != null)
             {
                 settings.DebugWindowVisible = showDebugPanelCheckBox.IsChecked ?? false;
-            }
-        }
-
-        public void OnLogLevelChanged(object? sender, SelectionChangedEventArgs e)
-        {
-            if (_isInitializing()) return;
-            // Log level change is handled in ApplySettings
-        }
-
-        public void OnLogRetentionChanged(object? sender, RangeBaseValueChangedEventArgs e)
-        {
-            var logRetentionLabel = _window.FindControl<TextBlock>("LogRetentionLabel");
-            if (logRetentionLabel != null && sender is Slider slider)
-            {
-                logRetentionLabel.Text = $"{(int)slider.Value} sessions";
             }
         }
 

--- a/Parley/Parley/Views/SettingsWindow.axaml
+++ b/Parley/Parley/Views/SettingsWindow.axaml
@@ -320,35 +320,10 @@
                 </ScrollViewer>
             </TabItem>
 
-            <!-- Logging Tab -->
-            <TabItem Header="Logging">
+            <!-- Debug Tab -->
+            <TabItem Header="Debug">
                 <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                     <StackPanel Margin="10,10,20,10" Spacing="15">
-                        <!-- Log Level -->
-                        <Border BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}" BorderThickness="1" Padding="10" CornerRadius="5">
-                            <StackPanel Spacing="8">
-                                <TextBlock Text="Log Level" FontWeight="Bold"/>
-                                <ComboBox x:Name="LogLevelComboBox" SelectionChanged="OnLogLevelChanged"/>
-                            </StackPanel>
-                        </Border>
-
-                        <!-- Log Retention -->
-                        <Border BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}" BorderThickness="1" Padding="10" CornerRadius="5">
-                            <StackPanel Spacing="8">
-                                <TextBlock Text="Log Retention" FontWeight="Bold"/>
-                                <TextBlock Text="Number of recent sessions to keep (default: 3)"
-                                          FontSize="11" Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"/>
-                                <Grid ColumnDefinitions="*,Auto">
-                                    <Slider x:Name="LogRetentionSlider" Grid.Column="0"
-                                           Minimum="1" Maximum="10" Value="3"
-                                           TickFrequency="1" IsSnapToTickEnabled="True"
-                                           ValueChanged="OnLogRetentionChanged"/>
-                                    <TextBlock x:Name="LogRetentionLabel" Grid.Column="1"
-                                              Text="3 sessions" Margin="10,0,0,0" VerticalAlignment="Center"/>
-                                </Grid>
-                            </StackPanel>
-                        </Border>
-
                         <!-- Debug Panel Visibility -->
                         <Border BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}" BorderThickness="1" Padding="10" CornerRadius="5">
                             <StackPanel Spacing="8">
@@ -360,6 +335,13 @@
                                 <TextBlock Text="Display the debug console tab in the main window"
                                           FontSize="11" Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}" Margin="25,0,0,0"/>
                             </StackPanel>
+                        </Border>
+
+                        <!-- Note about centralized logging -->
+                        <Border BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}" BorderThickness="1" Padding="10" CornerRadius="5"
+                               Background="{DynamicResource ThemeSidebar}" Opacity="0.7">
+                            <TextBlock Text="Log level and retention are configured in Trebuchet (Radoub launcher) and apply to all tools."
+                                      TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
                         </Border>
                     </StackPanel>
                 </ScrollViewer>

--- a/Parley/Parley/Views/SettingsWindow.axaml.cs
+++ b/Parley/Parley/Views/SettingsWindow.axaml.cs
@@ -331,13 +331,7 @@ namespace DialogEditor.Views
 
         #endregion
 
-        #region Logging Settings Handlers (delegated to controller)
-
-        private void OnLogLevelChanged(object? sender, SelectionChangedEventArgs e)
-            => _loggingSettingsController?.OnLogLevelChanged(sender, e);
-
-        private void OnLogRetentionChanged(object? sender, RangeBaseValueChangedEventArgs e)
-            => _loggingSettingsController?.OnLogRetentionChanged(sender, e);
+        #region Debug Settings Handlers (delegated to controller)
 
         private void OnShowDebugPanelChanged(object? sender, RoutedEventArgs e)
             => _loggingSettingsController?.OnShowDebugPanelChanged(sender, e);

--- a/Quartermaster/Quartermaster/Program.cs
+++ b/Quartermaster/Quartermaster/Program.cs
@@ -34,20 +34,14 @@ sealed class Program
             SafeMode.ActivateSafeMode(clearParameterCache: false, clearPluginData: false);
         }
 
-        // Initialize unified logging FIRST with defaults (before any code that might log)
+        // Initialize unified logging with shared settings
+        var sharedSettings = RadoubSettings.Instance;
         UnifiedLogger.Configure(new LoggerConfig
         {
             AppName = "Quartermaster",
-            LogLevel = LogLevel.INFO,
-            RetainSessions = 10
+            LogLevel = sharedSettings.UseSharedLogging ? sharedSettings.SharedLogLevel : LogLevel.INFO,
+            RetainSessions = sharedSettings.SharedLogRetentionSessions
         });
-
-        // Then apply shared settings if enabled
-        var sharedSettings = RadoubSettings.Instance;
-        if (sharedSettings.UseSharedLogging)
-        {
-            UnifiedLogger.SetLogLevel(sharedSettings.SharedLogLevel);
-        }
 
         // Set up global exception handlers to catch crashes
         AppDomain.CurrentDomain.UnhandledException += (sender, e) =>

--- a/Quartermaster/Quartermaster/Views/Dialogs/SettingsWindow.axaml
+++ b/Quartermaster/Quartermaster/Views/Dialogs/SettingsWindow.axaml
@@ -192,39 +192,6 @@
                 </ScrollViewer>
             </TabItem>
 
-            <!-- Logging Tab -->
-            <TabItem Header="Logging">
-                <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-                    <StackPanel Margin="10" Spacing="15">
-                        <!-- Log Level -->
-                        <Border BorderBrush="{DynamicResource ThemeBorder}" BorderThickness="1" Padding="10" CornerRadius="5">
-                            <StackPanel Spacing="8">
-                                <TextBlock Text="Log Level" FontWeight="Bold"/>
-                                <TextBlock Text="Set the minimum log level for messages to be recorded."
-                                          FontSize="{DynamicResource FontSizeSmall}" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
-                                <ComboBox x:Name="LogLevelComboBox" SelectionChanged="OnLogLevelChanged"/>
-                            </StackPanel>
-                        </Border>
-
-                        <!-- Log Retention -->
-                        <Border BorderBrush="{DynamicResource ThemeBorder}" BorderThickness="1" Padding="10" CornerRadius="5">
-                            <StackPanel Spacing="8">
-                                <TextBlock Text="Log Retention" FontWeight="Bold"/>
-                                <TextBlock Text="Number of recent sessions to keep (default: 3)"
-                                          FontSize="{DynamicResource FontSizeSmall}" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
-                                <Grid ColumnDefinitions="*,Auto">
-                                    <Slider x:Name="LogRetentionSlider" Grid.Column="0"
-                                           Minimum="1" Maximum="10" Value="3"
-                                           TickFrequency="1" IsSnapToTickEnabled="True"
-                                           ValueChanged="OnLogRetentionChanged"/>
-                                    <TextBlock x:Name="LogRetentionLabel" Grid.Column="1"
-                                              Text="3 sessions" Margin="10,0,0,0" VerticalAlignment="Center"/>
-                                </Grid>
-                            </StackPanel>
-                        </Border>
-                    </StackPanel>
-                </ScrollViewer>
-            </TabItem>
         </TabControl>
 
         <!-- Action Buttons -->

--- a/Quartermaster/Quartermaster/Views/Dialogs/SettingsWindow.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/SettingsWindow.axaml.cs
@@ -53,7 +53,6 @@ public partial class SettingsWindow : Window
     {
         LoadResourcePathSettings();
         LoadUISettings();
-        LoadLoggingSettings();
     }
 
     #region Resource Paths
@@ -541,64 +540,6 @@ public partial class SettingsWindow : Window
                 UnifiedLogger.LogApplication(LogLevel.DEBUG, $"Invalid font family for preview: {ex.Message}");
             }
         }
-    }
-
-    #endregion
-
-    #region Logging Settings
-
-    private void LoadLoggingSettings()
-    {
-        var settings = SettingsService.Instance;
-
-        // Log Level
-        var logLevelComboBox = this.FindControl<ComboBox>("LogLevelComboBox");
-        if (logLevelComboBox != null)
-        {
-            logLevelComboBox.ItemsSource = Enum.GetValues(typeof(LogLevel)).Cast<LogLevel>().ToList();
-            logLevelComboBox.SelectedItem = settings.CurrentLogLevel;
-        }
-
-        // Log Retention
-        var logRetentionSlider = this.FindControl<Slider>("LogRetentionSlider");
-        var logRetentionLabel = this.FindControl<TextBlock>("LogRetentionLabel");
-        if (logRetentionSlider != null)
-        {
-            logRetentionSlider.Value = settings.LogRetentionSessions;
-            if (logRetentionLabel != null)
-            {
-                logRetentionLabel.Text = $"{settings.LogRetentionSessions} sessions";
-            }
-        }
-    }
-
-    private void OnLogLevelChanged(object? sender, SelectionChangedEventArgs e)
-    {
-        if (_isInitializing) return;
-
-        var comboBox = sender as ComboBox;
-        if (comboBox?.SelectedItem is LogLevel level)
-        {
-            SettingsService.Instance.CurrentLogLevel = level;
-            UnifiedLogger.LogApplication(LogLevel.INFO, $"Log level changed to: {level}");
-        }
-    }
-
-    private void OnLogRetentionChanged(object? sender, RangeBaseValueChangedEventArgs e)
-    {
-        if (_isInitializing) return;
-
-        var slider = sender as Slider;
-        if (slider == null) return;
-
-        var retention = (int)slider.Value;
-        var logRetentionLabel = this.FindControl<TextBlock>("LogRetentionLabel");
-        if (logRetentionLabel != null)
-        {
-            logRetentionLabel.Text = $"{retention} sessions";
-        }
-
-        SettingsService.Instance.LogRetentionSessions = retention;
     }
 
     #endregion

--- a/Trebuchet/Trebuchet/Program.cs
+++ b/Trebuchet/Trebuchet/Program.cs
@@ -34,20 +34,14 @@ sealed class Program
             SafeMode.ActivateSafeMode(clearParameterCache: false, clearPluginData: false);
         }
 
-        // Initialize unified logging FIRST with defaults (before any code that might log)
+        // Initialize unified logging with shared settings
+        var sharedSettings = RadoubSettings.Instance;
         UnifiedLogger.Configure(new LoggerConfig
         {
             AppName = "Trebuchet",
-            LogLevel = LogLevel.INFO,
-            RetainSessions = 10
+            LogLevel = sharedSettings.UseSharedLogging ? sharedSettings.SharedLogLevel : LogLevel.INFO,
+            RetainSessions = sharedSettings.SharedLogRetentionSessions
         });
-
-        // Then apply shared settings if enabled
-        var sharedSettings = RadoubSettings.Instance;
-        if (sharedSettings.UseSharedLogging)
-        {
-            UnifiedLogger.SetLogLevel(sharedSettings.SharedLogLevel);
-        }
 
         // Start GUI application
         BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);

--- a/Trebuchet/Trebuchet/ViewModels/SettingsWindowViewModel.cs
+++ b/Trebuchet/Trebuchet/ViewModels/SettingsWindowViewModel.cs
@@ -101,7 +101,7 @@ public partial class SettingsWindowViewModel : ObservableObject
 
     public ObservableCollection<string> AvailableLogLevels { get; } = new()
     {
-        "DEBUG", "INFO", "WARN", "ERROR"
+        "TRACE", "DEBUG", "INFO", "WARN", "ERROR"
     };
 
     public ObservableCollection<string> AvailableLanguages { get; } = new()


### PR DESCRIPTION
## Summary

Centralized logging configuration across all Radoub tools. Log level and retention are now controlled exclusively from Trebuchet settings - per-tool logging UI removed.

## Changes

### All 5 Tools (Program.cs)
- Use `SharedLogRetentionSessions` from RadoubSettings at startup
- Use `SharedLogLevel` from RadoubSettings at startup
- Pruning happens during `UnifiedLogger.Configure()` based on shared config

### Trebuchet
- Added TRACE level to log level dropdown (needed for Parley debugging)

### Quartermaster
- Removed redundant Logging tab from settings

### Manifest
- Removed redundant Logging section from settings

### Parley
- Renamed Logging tab to "Debug" - keeps debug panel toggle only
- Added info note directing users to Trebuchet for log settings

## Work Items

- [x] #935 - Implement auto-pruning for log files (wired to shared config)
- [x] #1072 - Add centralized log level control for all applications

**Removed from sprint:**
- #863 - Already completed in #1190
- #874 - Blocked (Aurora doesn't track ability points reliably)

## Related Issues

Closes #1184, closes #935, closes #1072

## Pre-Merge Checklist

- [x] No uncommitted changes
- [x] No unpushed commits
- [x] Unit tests pass (1531 passed)
- [x] Integration tests: 2 pre-existing failures (Parley Scrap tab), unrelated to changes
- [x] CHANGELOG finalized: v0.9.57 with date

## Files Changed (14)
- 5 Program.cs files (Parley, Manifest, Quartermaster, Fence, Trebuchet)
- 3 Settings window files (Quartermaster, Manifest, Parley)
- 1 Settings controller (Parley)
- 1 ViewModel (Trebuchet)
- 1 CHANGELOG

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)