### PR TITLE
[Radoub] chore: Scan NuGet packages for known vulnerabilities (#1257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Chore: Scan NuGet Packages for Known Vulnerabilities (#1257)
 
+- Ran `dotnet list package --vulnerable --include-transitive` against all projects
+- Found 1 vulnerability: `System.Drawing.Common` 5.0.2 (Critical, CVE-2021-24112 RCE) — transitive via FlaUI 4.0.0 in `Radoub.IntegrationTests` only
+- Upgraded FlaUI.Core and FlaUI.UIA3 from 4.0.0 → 5.0.0, resolving the vulnerable transitive dependency
+- All other projects (Parley, Manifest, Quartermaster, Fence, Trebuchet, Radoub.Formats, Radoub.UI) are clean
+
 ---
 
 ## [0.9.59] - 2026-02-02

--- a/Radoub.IntegrationTests/Radoub.IntegrationTests.csproj
+++ b/Radoub.IntegrationTests/Radoub.IntegrationTests.csproj
@@ -21,8 +21,8 @@
     </PackageReference>
 
     <!-- FlaUI for GUI automation -->
-    <PackageReference Include="FlaUI.Core" Version="4.0.0" />
-    <PackageReference Include="FlaUI.UIA3" Version="4.0.0" />
+    <PackageReference Include="FlaUI.Core" Version="5.0.0" />
+    <PackageReference Include="FlaUI.UIA3" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Scanned all NuGet dependencies for known CVEs. Found and fixed 1 vulnerability.

- Closes #1257

## Changes

- `System.Drawing.Common` 5.0.2 (Critical, CVE-2021-24112 RCE) — transitive via FlaUI 4.0.0 in `Radoub.IntegrationTests`
- Upgraded FlaUI.Core and FlaUI.UIA3 from 4.0.0 → 5.0.0, resolving the vulnerable transitive dependency
- All other projects clean: Parley, Manifest, Quartermaster, Fence, Trebuchet, Radoub.Formats, Radoub.UI

## Test plan

- [x] `dotnet list package --vulnerable --include-transitive` returns clean
- [x] `dotnet build Radoub.sln` passes (0 errors)
- [x] Integration test project compiles with FlaUI 5.0 (API compatible)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)