### PR TITLE
[Radoub] fix: Pin dotnet/nbgv action to v0.4.2

### DIFF
--- a/.github/workflows/radoub-release.yml
+++ b/.github/workflows/radoub-release.yml
@@ -49,25 +49,25 @@ jobs:
         echo "tag=$TAG" >> $GITHUB_OUTPUT
 
     - name: Determine Parley Version
-      uses: dotnet/nbgv@master
+      uses: dotnet/nbgv@v0.4.2
       id: parley-ver
       with:
         path: Parley
 
     - name: Determine Manifest Version
-      uses: dotnet/nbgv@master
+      uses: dotnet/nbgv@v0.4.2
       id: manifest-ver
       with:
         path: Manifest
 
     - name: Determine Fence Version
-      uses: dotnet/nbgv@master
+      uses: dotnet/nbgv@v0.4.2
       id: fence-ver
       with:
         path: Fence
 
     - name: Determine Trebuchet Version
-      uses: dotnet/nbgv@master
+      uses: dotnet/nbgv@v0.4.2
       id: trebuchet-ver
       with:
         path: Trebuchet


### PR DESCRIPTION
## Summary
- `dotnet/nbgv@master` broke — now uses `dotnet tool exec` unsupported on CI runners
- Pin to `v0.4.2` (last stable release, Jan 2024)

After merge, delete the `radoub-v0.9.41` tag and re-tag to trigger a new release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)