### PR TITLE
[Radoub] Sprint: Cross-Tool Service Standardization Wave 2 (#1528)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Sprint: Cross-Tool Service Standardization Wave 2 (#1528)
 
-- [ ] #1445 - Extract BaseToolSettingsService<T> into Radoub.UI
-- [ ] #1446 - Centralize RecentFilesService in Radoub.UI
-- [ ] #1447 - Centralize WindowLayoutService in Radoub.UI
+- [x] #1445 - BaseToolSettingsService<T> already extracted in Wave 1 (#1508); verified all 4 tools using it
+- [x] #1446 - Migrated Parley to use shared RecentFilesMenuHelper.Populate() from Radoub.UI
+- [x] #1447 - Migrated Parley to use WindowPositionHelper + IWindowSettings from Radoub.UI
 
 ---
 

--- a/Parley/Parley/Services/Interfaces/ISettingsService.cs
+++ b/Parley/Parley/Services/Interfaces/ISettingsService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using DialogEditor.Utils;
 using Radoub.Formats.Logging;
+using Radoub.UI.Services;
 
 namespace DialogEditor.Services
 {
@@ -10,8 +11,9 @@ namespace DialogEditor.Services
     /// Interface for Parley application settings.
     /// Provides access to user preferences, game paths, and configuration.
     /// #1230: Phase 3 - Service interface extraction for dependency injection.
+    /// #1447: Extends IWindowSettings for WindowPositionHelper compatibility.
     /// </summary>
-    public interface ISettingsService : INotifyPropertyChanged
+    public interface ISettingsService : INotifyPropertyChanged, IWindowSettings
     {
         // Recent files (delegated to RecentFilesService)
         List<string> RecentFiles { get; }
@@ -20,13 +22,6 @@ namespace DialogEditor.Services
         void RemoveRecentFile(string filePath);
         void ClearRecentFiles();
         void CleanupRecentFiles();
-
-        // Window layout (delegated to WindowLayoutService)
-        double WindowLeft { get; set; }
-        double WindowTop { get; set; }
-        double WindowWidth { get; set; }
-        double WindowHeight { get; set; }
-        bool WindowMaximized { get; set; }
 
         // Panel layout (delegated to WindowLayoutService)
         double LeftPanelWidth { get; set; }

--- a/Parley/Parley/Services/WindowPersistenceManager.cs
+++ b/Parley/Parley/Services/WindowPersistenceManager.cs
@@ -5,6 +5,7 @@ using DialogEditor.Utils;
 using DialogEditor.ViewModels;
 using System;
 using Radoub.Formats.Logging;
+using Radoub.UI.Services;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -13,8 +14,8 @@ namespace DialogEditor.Services
 {
     /// <summary>
     /// Manages window position, panel sizes, and UI state persistence.
-    /// Handles save/restore of window geometry and screen boundary validation.
-    /// Also handles startup tasks like loading command line files.
+    /// Uses WindowPositionHelper from Radoub.UI for basic position save/restore (#1447).
+    /// Adds Parley-specific panel persistence, debug settings, and startup handling.
     /// Extracted from MainWindow.axaml.cs to separate persistence concerns.
     /// </summary>
     public class WindowPersistenceManager
@@ -55,31 +56,14 @@ namespace DialogEditor.Services
         }
 
         /// <summary>
-        /// Restores window position from settings with screen validation
+        /// Restores window position from settings using shared WindowPositionHelper.
+        /// Adds async screen validation with delay to prevent saving during restore.
         /// </summary>
         public async Task RestoreWindowPositionAsync()
         {
             _isRestoringPosition = true;
-            var settings = _settings;
-            UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                $"Restoring window position: Left={settings.WindowLeft}, Top={settings.WindowTop}, Current={_window.Position.X},{_window.Position.Y}");
 
-            if (settings.WindowLeft >= 0 && settings.WindowTop >= 0)
-            {
-                var targetPos = new PixelPoint((int)settings.WindowLeft, (int)settings.WindowTop);
-
-                // Validate position is on a visible screen
-                if (IsPositionOnScreen(targetPos))
-                {
-                    _window.Position = targetPos;
-                    UnifiedLogger.LogApplication(LogLevel.DEBUG, $"Position restored to ({targetPos.X}, {targetPos.Y})");
-                }
-                else
-                {
-                    UnifiedLogger.LogApplication(LogLevel.WARN,
-                        $"Saved position ({targetPos.X}, {targetPos.Y}) is off-screen, using default");
-                }
-            }
+            WindowPositionHelper.Restore(_window, _settings, validateBounds: true);
 
             // Allow position saving after a short delay (to avoid saving the restore itself)
             await Task.Delay(500);
@@ -87,62 +71,14 @@ namespace DialogEditor.Services
         }
 
         /// <summary>
-        /// Saves current window position and size to settings
+        /// Saves current window position and size to settings using shared WindowPositionHelper.
         /// </summary>
         public void SaveWindowPosition()
         {
-            // Don't save position during initial restore
             if (_isRestoringPosition)
-            {
-                UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                    $"Position changed during restore, skipping save: ({_window.Position.X}, {_window.Position.Y})");
                 return;
-            }
 
-            var settings = _settings;
-            if (_window.Position.X >= 0 && _window.Position.Y >= 0)
-            {
-                settings.WindowLeft = _window.Position.X;
-                settings.WindowTop = _window.Position.Y;
-                UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                    $"Saved window position: ({_window.Position.X}, {_window.Position.Y})");
-            }
-
-            // Width/Height already bound to settings with TwoWay, but ensure they're saved
-            if (_window.Width > 0 && _window.Height > 0)
-            {
-                settings.WindowWidth = _window.Width;
-                settings.WindowHeight = _window.Height;
-            }
-        }
-
-        /// <summary>
-        /// Checks if a position is visible on any screen
-        /// </summary>
-        private bool IsPositionOnScreen(PixelPoint position)
-        {
-            var screens = _window.Screens.All;
-            UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                $"Checking position ({position.X}, {position.Y}) against {screens.Count} screens");
-
-            foreach (var screen in screens)
-            {
-                var bounds = screen.Bounds;
-                UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                    $"  Screen: X={bounds.X}, Y={bounds.Y}, W={bounds.Width}, H={bounds.Height}, Primary={screen.IsPrimary}");
-
-                // Check if the top-left corner is within screen bounds (with some tolerance)
-                if (position.X >= bounds.X - 50 &&
-                    position.X < bounds.X + bounds.Width &&
-                    position.Y >= bounds.Y - 50 &&
-                    position.Y < bounds.Y + bounds.Height)
-                {
-                    UnifiedLogger.LogApplication(LogLevel.DEBUG, "  Position is ON this screen");
-                    return true;
-                }
-            }
-            UnifiedLogger.LogApplication(LogLevel.DEBUG, "  Position is OFF all screens");
-            return false;
+            WindowPositionHelper.Save(_window, _settings);
         }
 
         /// <summary>

--- a/Parley/Parley/Views/Helpers/FileMenuController.cs
+++ b/Parley/Parley/Views/Helpers/FileMenuController.cs
@@ -305,52 +305,66 @@ namespace Parley.Views.Helpers
         }
 
         /// <summary>
-        /// Handle recent file click - Load selected recent file.
+        /// Populate the recent files submenu using shared RecentFilesMenuHelper.
         /// </summary>
-        public async void OnRecentFileClick(object? sender, RoutedEventArgs e)
+        public void PopulateRecentFilesMenu()
+        {
+            var recentFilesMenuItem = _window.FindControl<MenuItem>("RecentFilesMenuItem");
+            if (recentFilesMenuItem == null)
+            {
+                UnifiedLogger.LogApplication(LogLevel.WARN, "RecentFilesMenuItem not found in XAML");
+                return;
+            }
+
+            RecentFilesMenuHelper.Populate(
+                recentFilesMenuItem,
+                _settings.RecentFiles,
+                async filePath => await HandleRecentFileClick(filePath),
+                () =>
+                {
+                    _settings.ClearRecentFiles();
+                    PopulateRecentFilesMenu();
+                });
+        }
+
+        /// <summary>
+        /// Handles loading a file from the recent files menu.
+        /// Extracted from OnRecentFileClick for use with RecentFilesMenuHelper.
+        /// </summary>
+        private async Task HandleRecentFileClick(string filePath)
         {
             try
             {
-                if (sender is MenuItem menuItem && menuItem.Tag is string filePath)
+                if (!File.Exists(filePath))
                 {
-                    // Check if file exists before trying to load
-                    if (!File.Exists(filePath))
-                    {
-                        var fileName = Path.GetFileName(filePath);
-                        var shouldRemove = await ShowConfirmDialog(
-                            "File Not Found",
-                            $"The file '{fileName}' could not be found.\n\nFull path: {UnifiedLogger.SanitizePath(filePath)}\n\nRemove from recent files?");
+                    var fileName = Path.GetFileName(filePath);
+                    var shouldRemove = await ShowConfirmDialog(
+                        "File Not Found",
+                        $"The file '{fileName}' could not be found.\n\nFull path: {UnifiedLogger.SanitizePath(filePath)}\n\nRemove from recent files?");
 
-                        if (shouldRemove)
-                        {
-                            _settings.RemoveRecentFile(filePath);
-                            _populateRecentFilesMenu();
-                        }
-                        return;
+                    if (shouldRemove)
+                    {
+                        _settings.RemoveRecentFile(filePath);
+                        _populateRecentFilesMenu();
                     }
+                    return;
+                }
 
-                    UnifiedLogger.LogApplication(LogLevel.INFO, $"Loading recent file: {UnifiedLogger.SanitizePath(filePath)}");
-                    await ViewModel.LoadDialogAsync(filePath);
+                UnifiedLogger.LogApplication(LogLevel.INFO, $"Loading recent file: {UnifiedLogger.SanitizePath(filePath)}");
+                await ViewModel.LoadDialogAsync(filePath);
 
-                    // Update module info bar
-                    UpdateModuleInfo(filePath);
+                UpdateModuleInfo(filePath);
+                _populateRecentFilesMenu();
+                _updateEmbeddedFlowchartAfterLoad();
 
-                    // Refresh recent files menu to move this file to top (#597)
-                    _populateRecentFilesMenu();
-
-                    // Update embedded flowchart
-                    _updateEmbeddedFlowchartAfterLoad();
-
-                    // Scan creatures for portrait/soundset display (#786, #915, #916)
-                    if (_scanCreaturesForModule != null)
+                if (_scanCreaturesForModule != null)
+                {
+                    var moduleDir = Path.GetDirectoryName(filePath);
+                    if (!string.IsNullOrEmpty(moduleDir))
                     {
-                        var moduleDir = Path.GetDirectoryName(filePath);
-                        if (!string.IsNullOrEmpty(moduleDir))
-                        {
-                            ViewModel.StatusMessage = "Loading creatures...";
-                            await _scanCreaturesForModule(moduleDir);
-                            ViewModel.StatusMessage = $"Opened: {Path.GetFileName(filePath)}";
-                        }
+                        ViewModel.StatusMessage = "Loading creatures...";
+                        await _scanCreaturesForModule(moduleDir);
+                        ViewModel.StatusMessage = $"Opened: {Path.GetFileName(filePath)}";
                     }
                 }
             }
@@ -358,66 +372,6 @@ namespace Parley.Views.Helpers
             {
                 ViewModel.StatusMessage = $"Error loading recent file: {ex.Message}";
                 UnifiedLogger.LogApplication(LogLevel.ERROR, $"Failed to load recent file: {ex.Message}");
-            }
-        }
-
-        /// <summary>
-        /// Populate the recent files submenu.
-        /// </summary>
-        public void PopulateRecentFilesMenu()
-        {
-            try
-            {
-                var recentFilesMenuItem = _window.FindControl<MenuItem>("RecentFilesMenuItem");
-                if (recentFilesMenuItem == null)
-                {
-                    UnifiedLogger.LogApplication(LogLevel.WARN, "RecentFilesMenuItem not found in XAML");
-                    return;
-                }
-
-                var menuItems = new System.Collections.Generic.List<object>();
-                var recentFiles = _settings.RecentFiles;
-
-                UnifiedLogger.LogApplication(LogLevel.INFO, $"PopulateRecentFilesMenu: {recentFiles.Count} recent files from settings");
-
-                if (recentFiles.Count == 0)
-                {
-                    var noFilesItem = new MenuItem { Header = "(No recent files)", IsEnabled = false };
-                    menuItems.Add(noFilesItem);
-                }
-                else
-                {
-                    foreach (var file in recentFiles)
-                    {
-                        var fileName = Path.GetFileName(file);
-                        // Escape underscores for menu display (Avalonia treats _ as mnemonic)
-                        var displayName = fileName.Replace("_", "__");
-
-                        var menuItem = new MenuItem
-                        {
-                            Header = displayName,
-                            Tag = file
-                        };
-                        menuItem.Click += OnRecentFileClick;
-                        ToolTip.SetTip(menuItem, file);
-                        menuItems.Add(menuItem);
-                    }
-
-                    menuItems.Add(new Separator());
-                    var clearItem = new MenuItem { Header = "Clear Recent Files" };
-                    clearItem.Click += (s, args) =>
-                    {
-                        _settings.ClearRecentFiles();
-                        PopulateRecentFilesMenu();
-                    };
-                    menuItems.Add(clearItem);
-                }
-
-                recentFilesMenuItem.ItemsSource = menuItems;
-            }
-            catch (Exception ex)
-            {
-                UnifiedLogger.LogApplication(LogLevel.ERROR, $"Error building recent files menu: {ex.Message}");
             }
         }
 


### PR DESCRIPTION
## Summary

Completes Wave 2 of the Cross-Tool Service Standardization epic (#1444).
Migrates Parley to use shared Radoub.UI services that were created in Wave 1 (#1508).

- #1445: `BaseToolSettingsService<T>` already extracted in Wave 1; verified Manifest, Quartermaster, Fence, Trebuchet all using it
- #1446: Parley's `FileMenuController.PopulateRecentFilesMenu()` refactored to use `RecentFilesMenuHelper.Populate()`
- #1447: Parley's `WindowPersistenceManager` refactored to use `WindowPositionHelper.Save/Restore()`; `ISettingsService` now extends `IWindowSettings`

Net: -115 lines (57 added, 172 removed)

## Related Issues

- Closes #1528
- Relates to #1444 (parent epic)
- Follows #1508 (Wave 1)

## Test Plan

- [x] All 1500 unit tests pass (Parley 671, Formats 641, UI 134, Dictionary 54)
- [x] Full solution builds with 0 warnings
- [x] Privacy scan clean
- [x] No new tech debt

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)