### PR TITLE
[Quartermaster] fix: Filter already-known spells in LUW spell selection (#1646)

### DIFF
--- a/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.SpellSelection.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.SpellSelection.cs
@@ -219,8 +219,14 @@ public partial class LevelUpWizardWindow
         var allSpellIds = _displayService.Spells.GetSpellsForClassAtLevel(_selectedClassId, spellLevel);
         var selectedForLevel = _selectedSpellsByLevel.GetValueOrDefault(spellLevel, new List<int>());
 
-        // Get creature's existing spells to exclude
+        // Get creature's existing spells to exclude (check both SpecAbilityList and KnownSpells)
         var existingSpells = new HashSet<int>(_creature.SpecAbilityList.Select(sa => (int)sa.Spell));
+        var spellClass = _creature.ClassList.FirstOrDefault(c => c.Class == _selectedClassId);
+        if (spellClass != null && spellLevel >= 0 && spellLevel < spellClass.KnownSpells.Length)
+        {
+            foreach (var ks in spellClass.KnownSpells[spellLevel])
+                existingSpells.Add((int)ks.Spell);
+        }
 
         _availableSpellsForLevel = new List<SpellDisplayItem>();
         foreach (var spellId in allSpellIds)
@@ -368,6 +374,14 @@ public partial class LevelUpWizardWindow
     private void OnSpellAutoAssignClick(object? sender, RoutedEventArgs e)
     {
         var existingSpells = new HashSet<int>(_creature.SpecAbilityList.Select(sa => (int)sa.Spell));
+        // Also exclude spells already in KnownSpells for this class
+        var autoSpellClass = _creature.ClassList.FirstOrDefault(c => c.Class == _selectedClassId);
+        if (autoSpellClass != null)
+        {
+            foreach (var knownList in autoSpellClass.KnownSpells)
+                foreach (var ks in knownList)
+                    existingSpells.Add((int)ks.Spell);
+        }
 
         // For Wizards, limit total across all levels to free spell budget
         int totalBudget = _wizardFreeSpellsRemaining > 0 ? _wizardFreeSpellsRemaining : int.MaxValue;


### PR DESCRIPTION
## Summary

Fast follow to PR #1643 (Multi-Level Character Creation sprint).

Spell selection in LUW checked `SpecAbilityList` for existing spells, but `LevelUpApplicationService.ApplySpells()` writes to `spellClass.KnownSpells[spellLevel]`. During multi-level loops, subsequent LUW passes showed spells already picked in previous levels.

Fixed both `LoadAvailableSpellsForLevel()` and `OnSpellAutoAssignClick()` to check `KnownSpells` alongside `SpecAbilityList`.

## Related Issues

- Fixes #1646
- Follow-up to #1643 / #1492

## Test Results

- 600 unit tests passing, 0 failed
- Build: 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)