### PR TITLE
Add Relique to documentation command + post-merge dev doc enforcement hook

### DIFF
--- a/.claude/commands/documentation.md
+++ b/.claude/commands/documentation.md
@@ -42,7 +42,11 @@ Developer documentation updates should be checked when:
 - Parley code changes
 - Manifest code changes
 - Quartermaster code changes
+- Fence code changes
+- Relique code changes
+- Trebuchet code changes
 - Radoub.Formats changes
+- Radoub.UI changes
 - Refactors (change relationships/references)
 
 ## Workflow
@@ -69,7 +73,9 @@ Categorize by tool:
 | `Parley/Parley/Views/` | Parley-Developer-Architecture (UI section) |
 | `Manifest/Manifest/Services/` | Manifest-Developer-Architecture |
 | `Quartermaster/Quartermaster/` | Quartermaster-Developer-Architecture |
+| `Relique/Relique/` | Relique-Developer-Architecture |
 | `Radoub.Formats/Radoub.Formats/` | Radoub-Formats |
+| `Radoub.UI/` | Radoub-UI-Developer |
 | Copy/paste logic | Parley-Developer-CopyPaste |
 | Delete behavior | Parley-Developer-Delete-Behavior |
 | Scrap system | Parley-Developer-Scrap-System |
@@ -155,7 +161,7 @@ Pages updated:
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
 git push
 ```
 


### PR DESCRIPTION
## Summary

- Added Relique, Fence, Trebuchet, and Radoub.UI to `/documentation` command triggers and wiki page mapping
- Updated Co-Authored-By to current model version
- Added Stop hook in `settings.local.json` that enforces Step 6 (dev doc updates) during `/post-merge` — prevents sessions from rationalizing away documentation work
- Created `Relique-Developer-Architecture.md` wiki page (local, not pushed)
- Updated wiki `_Sidebar.md` and `Index.md` with Relique developer docs link

Note: The post-merge.md Step 6 addition was already included in the previous sprint PR (#1834). This PR adds the remaining pieces: documentation command alignment, enforcement hook, and wiki content.

## Test plan

- [ ] Verify `/post-merge` Step 6 instructions are clear and complete
- [ ] Verify Stop hook blocks if post-merge skips documentation
- [ ] Verify Relique-Developer-Architecture wiki page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)