### PR TITLE
[Quartermaster] Feat: Appearance panel diagnostic improvements (#1761)

### DIFF
--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -19,7 +19,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [0.2.63-alpha] - 2026-03-20
 **Branch**: `quartermaster/issue-1761` | **PR**: #1872
 
-### Fix: Wraith spectre 2 (hooded) and wraith allp 2 — bones only, no skin mesh (#1761)
+### Appearance Panel Diagnostic Improvements (#1761)
+
+- Show appearance ID prefix `[ID]` in appearance list for quick identification
+- Add tooltip on each appearance entry showing model name (RACE), type, and label
+- Log display text alongside appearance ID on selection change
+- Log wraith/spectre 2DA rows at startup to trace model name mapping
+- Investigation: "bones only" wraith models are a CEP 2DA data issue, not a rendering bug (see #1873)
 
 ---
 

--- a/Quartermaster/Quartermaster/Services/AppearanceService.cs
+++ b/Quartermaster/Quartermaster/Services/AppearanceService.cs
@@ -105,10 +105,23 @@ public class AppearanceService
             if (string.IsNullOrEmpty(modelResRef) || modelResRef == "****")
                 modelResRef = label;
 
+            var name = GetAppearanceName((ushort)i);
+
+            // Log wraith/spectre rows to debug model name mapping (#1761)
+            if (label.IndexOf("wraith", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                label.IndexOf("spectre", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                (name.IndexOf("wraith", StringComparison.OrdinalIgnoreCase) >= 0) ||
+                (name.IndexOf("spectre", StringComparison.OrdinalIgnoreCase) >= 0))
+            {
+                UnifiedLogger.LogApplication(LogLevel.INFO,
+                    $"[Appearance2DA] Row {i}: LABEL='{label}', RACE='{race}', MODELTYPE='{modelType}', " +
+                    $"name='{name}'");
+            }
+
             appearances.Add(new AppearanceInfo
             {
                 AppearanceId = (ushort)i,
-                Name = GetAppearanceName((ushort)i),
+                Name = name,
                 Label = label,
                 IsPartBased = isPartBased,
                 Race = race ?? "",

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.DataLoading.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.DataLoading.cs
@@ -67,14 +67,19 @@ public partial class AppearancePanel
         _appearanceListBox.Items.Clear();
         foreach (var app in filtered)
         {
-            var displayText = app.IsPartBased && !app.Name.Contains("(Dynamic)")
+            var baseName = app.IsPartBased && !app.Name.Contains("(Dynamic)")
                 ? $"(Dynamic) {app.Name}"
                 : app.Name;
-            _appearanceListBox.Items.Add(new ListBoxItem
+            // Show appearance ID in display, model name in tooltip for debugging
+            var modelRef = !string.IsNullOrEmpty(app.Race) ? app.Race : app.Label;
+            var displayText = $"[{app.AppearanceId}] {baseName}";
+            var item = new ListBoxItem
             {
                 Content = displayText,
                 Tag = app.AppearanceId
-            });
+            };
+            Avalonia.Controls.ToolTip.SetTip(item, $"ID: {app.AppearanceId} | Model: {modelRef} | Type: {(app.IsPartBased ? "Part-Based" : "Static")} | Label: {app.Label}");
+            _appearanceListBox.Items.Add(item);
         }
 
         // Restore selection if still present

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
@@ -88,7 +88,7 @@ public partial class AppearancePanel
             if (item.Tag is ushort appearanceId)
             {
                 UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                    $"AppearancePanel: Appearance changed to {appearanceId}");
+                    $"AppearancePanel: Appearance changed to {appearanceId}, displayText='{item.Content}'");
                 var isPartBased = _displayService?.IsPartBasedAppearance(appearanceId) ?? false;
                 UpdateBodyPartsEnabledState(isPartBased);
 


### PR DESCRIPTION
## Summary

- Show appearance ID prefix `[ID]` in appearance list for quick identification
- Add tooltip on each appearance entry showing model name (RACE), type, and label
- Enhanced selection logging with display text for debugging
- Wraith/spectre 2DA row logging at startup to trace model name mapping

Investigation of #1761 found the "bones only" wraith models are a **CEP 2DA data issue** — rows 156/187 have RACE pointing to skeleton-only models (`cyan_spectre`/`cyan_wraith`) despite labels saying "Hooded One." See #1873 for follow-up.

## Related Issues

- Closes #1761 (resolved as CEP data issue, not rendering bug)
- Created #1873 (incomplete model indicator enhancement)

## Tests

✅ 1130 unit tests pass
✅ Privacy scan clean
✅ No tech debt

## Pre-Merge Checklist

### Tests
| Check | Status |
|-------|--------|
| Privacy scan | ✅ Clean |
| Tech debt | ✅ No large files |
| Unit tests | ✅ 1130 passed |
| UI tests | ⏭️ Skipped (display text / logging changes only) |

### Validation
| Check | Status |
|-------|--------|
| CHANGELOG | ✅ Version 0.2.63-alpha, PR #1872, date 2026-03-20 |
| Wiki | ✅ Current (2026-03-20) |

### Status
**Ready**: ✅

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)