### PR TITLE
[Radoub] fix: Serialize RadoubSettings tests to prevent CI race

### DIFF
--- a/Radoub.Formats/Radoub.Formats.Tests/RadoubSettingsTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/RadoubSettingsTests.cs
@@ -10,6 +10,7 @@ namespace Radoub.Formats.Tests;
 /// Tests for RadoubSettings persistence and cross-process propagation (#1384).
 /// Verifies that settings written by one process (Trebuchet) can be read by another (child tools).
 /// </summary>
+[Collection("RadoubSettings")]
 public class RadoubSettingsTests : IDisposable
 {
     private readonly string _testDirectory;

--- a/Radoub.Formats/Radoub.Formats.Tests/Settings/RadoubSettingsTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Settings/RadoubSettingsTests.cs
@@ -3,6 +3,7 @@ using Xunit;
 
 namespace Radoub.Formats.Tests.Settings;
 
+[Collection("RadoubSettings")]
 public class BackupRetentionDaysTests
 {
     [Theory]


### PR DESCRIPTION
## Summary

Fixes intermittent `RadoubSettingsTests.CurrentModulePath_PersistsToFile` failure on windows-latest CI.

Both `RadoubSettingsTests` and `BackupRetentionDaysTests` mutate the `RadoubSettings` singleton via reflection reset. Without `[Collection]` serialization, xUnit runs them in parallel with other test classes, causing race conditions on the singleton state.

Added `[Collection("RadoubSettings")]` to both classes to ensure they run sequentially.

## Test Results

✅ 1,054 passed locally

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)