### PR TITLE
[Parley] Sprint: UX Polish & Search Fix (#1976)

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Parley. One-line highlights per version; full details in 
 
 ---
 
-## [0.1.161-alpha] - 2026-03-29 | PR #TBD
+## [0.1.161-alpha] - 2026-03-29 | PR #2035
 **Branch**: `parley/issue-1976`
 
 ### Sprint: UX Polish & Search Fix

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Parley. One-line highlights per version; full details in 
 
 ---
 
+## [0.1.161-alpha] - 2026-03-29 | PR #TBD
+**Branch**: `parley/issue-1976`
+
+### Sprint: UX Polish & Search Fix
+- Fix --mod flag not working for module search context (#1927)
+- Grey out 'Go to Parent Node' when not on a link node (#1967)
+- Toggle to show entry/reply index numbers in tree and flow views (#1921)
+
+---
+
 ## [0.1.160-alpha] - 2026-03-28 | PR #2024
 - Lazy-load TTS factory and defer ResourcePathDetector startup
 - Remove broken SVG export option

--- a/Parley/Parley.Tests/Mocks/MockSettingsService.cs
+++ b/Parley/Parley.Tests/Mocks/MockSettingsService.cs
@@ -38,6 +38,7 @@ namespace Parley.Tests.Mocks
         public int FlowchartNodeMaxLines { get; set; } = 3;
         public int FlowchartNodeWidth { get; set; } = 200;
         public bool TreeViewWordWrap { get; set; } = false;
+        public bool ShowNodeIndexNumbers { get; set; } = false;
 
         // Flowchart window
         public double FlowchartWindowLeft { get; set; } = 200;

--- a/Parley/Parley/Models/FlowchartGraph.cs
+++ b/Parley/Parley/Models/FlowchartGraph.cs
@@ -134,6 +134,12 @@ namespace DialogEditor.Models
         }
 
         /// <summary>
+        /// Issue #1921: Index prefix for debugging (e.g., "[E5] " or "[R12] ").
+        /// Derived from the node's Id which is already in E{n}/R{n} format.
+        /// </summary>
+        public string IndexPrefix => $"[{Id}] ";
+
+        /// <summary>
         /// Display text for flowchart nodes. Returns full text - truncation handled by XAML MaxLines.
         /// </summary>
         public string DisplayText

--- a/Parley/Parley/Models/TreeViewSafeNode.cs
+++ b/Parley/Parley/Models/TreeViewSafeNode.cs
@@ -205,6 +205,22 @@ namespace DialogEditor.Models
         public virtual string SpeakerTag => $"[{Speaker}]";
 
         /// <summary>
+        /// Issue #1921: Index prefix for debugging (e.g., "[E5]" or "[R12]").
+        /// Returns the node's position in the dialog's Entry/Reply list.
+        /// </summary>
+        public virtual string IndexPrefix
+        {
+            get
+            {
+                if (_originalNode?.Parent == null) return "";
+                var index = _originalNode.Parent.GetNodeIndex(_originalNode, _originalNode.Type);
+                if (index < 0) return "";
+                var typeChar = _originalNode.Type == DialogNodeType.Entry ? "E" : "R";
+                return $"[{typeChar}{index}] ";
+            }
+        }
+
+        /// <summary>
         /// Issue #877: Dialog text only (without speaker tag) for theme-colored display.
         /// </summary>
         public virtual string DialogText

--- a/Parley/Parley/Services/Interfaces/ISettingsService.cs
+++ b/Parley/Parley/Services/Interfaces/ISettingsService.cs
@@ -34,6 +34,7 @@ namespace DialogEditor.Services
         int FlowchartNodeMaxLines { get; set; }
         int FlowchartNodeWidth { get; set; }
         bool TreeViewWordWrap { get; set; }
+        bool ShowNodeIndexNumbers { get; set; }
 
         // Flowchart window (delegated to WindowLayoutService)
         double FlowchartWindowLeft { get; set; }

--- a/Parley/Parley/Services/SettingsService.cs
+++ b/Parley/Parley/Services/SettingsService.cs
@@ -409,6 +409,12 @@ namespace DialogEditor.Services
             set => _uiSettings.TreeViewWordWrap = value;
         }
 
+        public bool ShowNodeIndexNumbers
+        {
+            get => _uiSettings.ShowNodeIndexNumbers;
+            set => _uiSettings.ShowNodeIndexNumbers = value;
+        }
+
         // NPC Speaker Visual Preferences - DELEGATED to SpeakerPreferencesService (#719)
         public Dictionary<string, SpeakerPreferences> NpcSpeakerPreferences => _speakerPreferences.Preferences;
 
@@ -557,7 +563,8 @@ namespace DialogEditor.Services
                             settings.AllowScrollbarAutoHide,
                             settings.FlowchartNodeMaxLines,
                             settings.TreeViewWordWrap,
-                            settings.FlowchartNodeWidth);
+                            settings.FlowchartNodeWidth,
+                            settings.ShowNodeIndexNumbers);
 
                         // Issue #179: Migrate speaker preferences to separate file
                         _legacyNpcSpeakerPreferences = settings.NpcSpeakerPreferences;
@@ -648,6 +655,7 @@ namespace DialogEditor.Services
                     FlowchartNodeMaxLines = FlowchartNodeMaxLines,
                     FlowchartNodeWidth = FlowchartNodeWidth,
                     TreeViewWordWrap = TreeViewWordWrap,
+                    ShowNodeIndexNumbers = ShowNodeIndexNumbers,
                     // Issue #179: NpcSpeakerPreferences moved to SpeakerPreferences.json
                     EnableNpcTagColoring = EnableNpcTagColoring,
                     ShowDeleteConfirmation = ShowDeleteConfirmation,
@@ -736,6 +744,7 @@ namespace DialogEditor.Services
             public int FlowchartNodeMaxLines { get; set; } = 3;
             public int FlowchartNodeWidth { get; set; } = 200;
             public bool TreeViewWordWrap { get; set; } = false;
+            public bool ShowNodeIndexNumbers { get; set; } = false;
             public Dictionary<string, SpeakerPreferences>? NpcSpeakerPreferences { get; set; }
             public bool EnableNpcTagColoring { get; set; } = true;
             public bool ShowDeleteConfirmation { get; set; } = true;

--- a/Parley/Parley/Services/SettingsService.cs
+++ b/Parley/Parley/Services/SettingsService.cs
@@ -412,7 +412,11 @@ namespace DialogEditor.Services
         public bool ShowNodeIndexNumbers
         {
             get => _uiSettings.ShowNodeIndexNumbers;
-            set => _uiSettings.ShowNodeIndexNumbers = value;
+            set
+            {
+                _uiSettings.ShowNodeIndexNumbers = value;
+                OnPropertyChanged();
+            }
         }
 
         // NPC Speaker Visual Preferences - DELEGATED to SpeakerPreferencesService (#719)

--- a/Parley/Parley/Services/UISettingsService.cs
+++ b/Parley/Parley/Services/UISettingsService.cs
@@ -28,6 +28,9 @@ namespace DialogEditor.Services
         // TreeView display settings (#903)
         private bool _treeViewWordWrap = false; // Default: OFF (traditional single-line display)
 
+        // Node index display (#1921)
+        private bool _showNodeIndexNumbers = false; // Default: OFF
+
         // TreeView dynamic width (#1158) - Runtime only, not persisted
         private double _treeViewTextMaxWidth = 400; // Default fallback width
 
@@ -53,13 +56,15 @@ namespace DialogEditor.Services
             bool allowScrollbarAutoHide,
             int flowchartNodeMaxLines = 3,
             bool treeViewWordWrap = false,
-            int flowchartNodeWidth = 200)
+            int flowchartNodeWidth = 200,
+            bool showNodeIndexNumbers = false)
         {
             _flowchartLayout = flowchartLayout ?? "Floating";
             _allowScrollbarAutoHide = allowScrollbarAutoHide;
             _flowchartNodeMaxLines = Math.Max(1, Math.Min(6, flowchartNodeMaxLines));
             _treeViewWordWrap = treeViewWordWrap;
             _flowchartNodeWidth = Math.Max(100, Math.Min(400, flowchartNodeWidth));
+            _showNodeIndexNumbers = showNodeIndexNumbers;
         }
 
         // FontSize, FontFamily, IsDarkTheme, CurrentThemeId, UseSharedTheme removed
@@ -147,6 +152,24 @@ namespace DialogEditor.Services
                 {
                     SettingsChanged?.Invoke();
                     UnifiedLogger.LogUI(LogLevel.INFO, $"TreeView word wrap set to {value}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Show entry/reply index numbers in tree and flow views (#1921).
+        /// When enabled, nodes are prefixed with [E5] or [R12] for debugging.
+        /// Default: OFF.
+        /// </summary>
+        public bool ShowNodeIndexNumbers
+        {
+            get => _showNodeIndexNumbers;
+            set
+            {
+                if (SetProperty(ref _showNodeIndexNumbers, value))
+                {
+                    SettingsChanged?.Invoke();
+                    UnifiedLogger.LogUI(LogLevel.INFO, $"Show node index numbers set to {value}");
                 }
             }
         }

--- a/Parley/Parley/Views/FlowchartPanel.axaml
+++ b/Parley/Parley/Views/FlowchartPanel.axaml
@@ -3,6 +3,7 @@
              xmlns:agc="clr-namespace:AvaloniaGraphControl;assembly=AvaloniaGraphControl"
              xmlns:vm="using:DialogEditor.ViewModels"
              xmlns:models="using:DialogEditor.Models"
+             xmlns:services="using:DialogEditor.Services"
              x:Class="DialogEditor.Views.FlowchartPanel">
 
     <Design.DataContext>
@@ -150,6 +151,11 @@
                                     </MultiBinding>
                                 </Border.BorderThickness>
                                 <StackPanel Spacing="2">
+                                    <!-- Issue #1921: Node index prefix (e.g., [E5] [R12]) -->
+                                    <TextBlock Text="{Binding IndexPrefix}"
+                                               IsVisible="{Binding Source={x:Static services:SettingsService.Instance}, Path=ShowNodeIndexNumbers}"
+                                               FontSize="{DynamicResource FontSizeXSmall}"
+                                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
                                     <!-- Speaker label - slightly smaller than global font (#905) -->
                                     <TextBlock Text="{Binding Speaker}"
                                                FontSize="{DynamicResource GlobalFontSize}"

--- a/Parley/Parley/Views/FlowchartPanel.axaml
+++ b/Parley/Parley/Views/FlowchartPanel.axaml
@@ -123,7 +123,7 @@
                                         <MenuItem Header="Go to Link Target" InputGesture="Ctrl+J" Tag="GoToLinkTarget" Click="OnContextMenuItemClick"
                                                   IsVisible="{Binding IsLink}"/>
                                         <MenuItem Header="Go to Parent Node" InputGesture="Ctrl+J" Tag="GoToParent" Click="OnContextMenuItemClick"
-                                                  IsVisible="{Binding !IsLink}"/>
+                                                  IsVisible="{Binding !IsLink}" IsEnabled="False"/>
                                     </ContextMenu>
                                 </Border.ContextMenu>
                                 <Border.Background>

--- a/Parley/Parley/Views/MainWindow.NodeHandlers.cs
+++ b/Parley/Parley/Views/MainWindow.NodeHandlers.cs
@@ -267,6 +267,13 @@ namespace DialogEditor.Views
         private void OnGoToParentNodeClick(object? sender, RoutedEventArgs e)
             => _controllers.TreeView.OnGoToParentNodeClick(sender, e);
 
+        private void OnTreeViewContextMenuOpening(object? sender, System.ComponentModel.CancelEventArgs e)
+        {
+            var treeView = this.FindControl<TreeView>("DialogTreeView");
+            var selectedNode = treeView?.SelectedItem as TreeViewSafeNode;
+            GoToParentNodeMenuItem.IsEnabled = selectedNode?.IsChild == true;
+        }
+
         #endregion
 
         #region ViewModel Property Changed

--- a/Parley/Parley/Views/MainWindow.NodeHandlers.cs
+++ b/Parley/Parley/Views/MainWindow.NodeHandlers.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -271,7 +272,14 @@ namespace DialogEditor.Views
         {
             var treeView = this.FindControl<TreeView>("DialogTreeView");
             var selectedNode = treeView?.SelectedItem as TreeViewSafeNode;
-            GoToParentNodeMenuItem.IsEnabled = selectedNode?.IsChild == true;
+            if (sender is ContextMenu contextMenu)
+            {
+                var menuItem = contextMenu.Items
+                    .OfType<MenuItem>()
+                    .FirstOrDefault(m => m.Header?.ToString() == "Go to Parent Node");
+                if (menuItem != null)
+                    menuItem.IsEnabled = selectedNode?.IsChild == true;
+            }
         }
 
         #endregion

--- a/Parley/Parley/Views/MainWindow.TreeOps.cs
+++ b/Parley/Parley/Views/MainWindow.TreeOps.cs
@@ -64,6 +64,7 @@ namespace DialogEditor.Views
 
         private void OnShowNodeIndexChanged(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
+            _viewModel.RefreshTreeViewColors();
             var enabled = _services.Settings.ShowNodeIndexNumbers;
             _viewModel.StatusMessage = enabled ? "Node index numbers shown" : "Node index numbers hidden";
             UnifiedLogger.LogUI(LogLevel.INFO, $"Show node index numbers toggled: {enabled}");

--- a/Parley/Parley/Views/MainWindow.TreeOps.cs
+++ b/Parley/Parley/Views/MainWindow.TreeOps.cs
@@ -62,6 +62,13 @@ namespace DialogEditor.Views
             UnifiedLogger.LogUI(LogLevel.INFO, $"TreeView word wrap toggled: {enabled}");
         }
 
+        private void OnShowNodeIndexChanged(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            var enabled = _services.Settings.ShowNodeIndexNumbers;
+            _viewModel.StatusMessage = enabled ? "Node index numbers shown" : "Node index numbers hidden";
+            UnifiedLogger.LogUI(LogLevel.INFO, $"Show node index numbers toggled: {enabled}");
+        }
+
         private void ExpandAllTreeViewItems(TreeView treeView)
         {
             // Avalonia approach: Work directly with ViewModel data

--- a/Parley/Parley/Views/MainWindow.axaml
+++ b/Parley/Parley/Views/MainWindow.axaml
@@ -274,7 +274,7 @@
                                         <MenuItem Header="Expand Subnodes" InputGesture="Ctrl+E" Click="OnExpandSubnodesClick"/>
                                         <MenuItem Header="Collapse Subnodes" InputGesture="Ctrl+W" Click="OnCollapseSubnodesClick"/>
                                         <Separator/>
-                                        <MenuItem x:Name="GoToParentNodeMenuItem" Header="Go to Parent Node" InputGesture="Ctrl+J" Click="OnGoToParentNodeClick"/>
+                                        <MenuItem Header="Go to Parent Node" InputGesture="Ctrl+J" Click="OnGoToParentNodeClick"/>
                                     </ContextMenu>
                                 </TreeView.ContextMenu>
                                 <TreeView.Styles>

--- a/Parley/Parley/Views/MainWindow.axaml
+++ b/Parley/Parley/Views/MainWindow.axaml
@@ -233,6 +233,12 @@
                                           Checked="OnWordWrapChanged"
                                           Unchecked="OnWordWrapChanged"
                                           ToolTip.Tip="Wrap long dialog text in tree view (#903)"/>
+                                <CheckBox x:Name="ShowIndexCheckBox" Content="Index #"
+                                          IsChecked="{Binding Source={x:Static services:SettingsService.Instance}, Path=ShowNodeIndexNumbers, Mode=TwoWay}"
+                                          VerticalAlignment="Center"
+                                          Checked="OnShowNodeIndexChanged"
+                                          Unchecked="OnShowNodeIndexChanged"
+                                          ToolTip.Tip="Show entry/reply index numbers [E5] [R12] (#1921)"/>
                             </StackPanel>
 
                             <!-- Search Bar (Ctrl+F) -->
@@ -297,6 +303,11 @@
                                                   Stretch="Uniform"
                                                   VerticalAlignment="Center"
                                                   Margin="0,2,0,0"/>
+                                            <!-- Issue #1921: Node index prefix (e.g., [E5] [R12]) -->
+                                            <TextBlock Text="{Binding IndexPrefix}"
+                                                       IsVisible="{Binding Source={x:Static services:SettingsService.Instance}, Path=ShowNodeIndexNumbers}"
+                                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                                       VerticalAlignment="Center"/>
                                             <!-- Issue #877: Speaker tag (colored) + dialog text (theme color) -->
                                             <TextBlock Text="{Binding SpeakerTag}"
                                                        Foreground="{Binding NodeColor}"

--- a/Parley/Parley/Views/MainWindow.axaml
+++ b/Parley/Parley/Views/MainWindow.axaml
@@ -235,6 +235,7 @@
                                           ToolTip.Tip="Wrap long dialog text in tree view (#903)"/>
                                 <CheckBox x:Name="ShowIndexCheckBox" Content="Index #"
                                           IsChecked="{Binding Source={x:Static services:SettingsService.Instance}, Path=ShowNodeIndexNumbers, Mode=TwoWay}"
+                                          Margin="8,0,0,0"
                                           VerticalAlignment="Center"
                                           Checked="OnShowNodeIndexChanged"
                                           Unchecked="OnShowNodeIndexChanged"

--- a/Parley/Parley/Views/MainWindow.axaml
+++ b/Parley/Parley/Views/MainWindow.axaml
@@ -252,7 +252,7 @@
                                       DragDrop.AllowDrop="True"
                                       Padding="0,0,12,20">
                                 <TreeView.ContextMenu>
-                                    <ContextMenu>
+                                    <ContextMenu Opening="OnTreeViewContextMenuOpening">
                                         <MenuItem Header="Add Node" InputGesture="Ctrl+D" Click="OnAddSmartNodeClick"/>
                                         <MenuItem Header="Add Sibling Node" InputGesture="Ctrl+Shift+D" Click="OnAddSiblingNodeClick"/>
                                         <MenuItem Header="Delete Node" InputGesture="Delete" Click="OnDeleteNodeClick"/>
@@ -268,7 +268,7 @@
                                         <MenuItem Header="Expand Subnodes" InputGesture="Ctrl+E" Click="OnExpandSubnodesClick"/>
                                         <MenuItem Header="Collapse Subnodes" InputGesture="Ctrl+W" Click="OnCollapseSubnodesClick"/>
                                         <Separator/>
-                                        <MenuItem Header="Go to Parent Node" InputGesture="Ctrl+J" Click="OnGoToParentNodeClick"/>
+                                        <MenuItem x:Name="GoToParentNodeMenuItem" Header="Go to Parent Node" InputGesture="Ctrl+J" Click="OnGoToParentNodeClick"/>
                                     </ContextMenu>
                                 </TreeView.ContextMenu>
                                 <TreeView.Styles>


### PR DESCRIPTION
## Summary

- Grey out 'Go to Parent Node' when not on a link node (#1967)
- Toggle to show entry/reply index numbers in tree and flow views (#1921)
- Fix crash on right-click child link in TreeView context menu

Note: #1968 (SVG export removal) and #1927 (--mod flag) were completed in prior PRs.

## Related Issues

- Closes #1976
- Closes #1967
- Closes #1921

## Test Results

- Privacy scan: ✅
- Tech debt: ✅
- Unit tests: ✅ 726 passed
- Theme scan: ⚠️ 3 pre-existing warnings (not from this PR)

## Checklist

- [x] Implementation complete
- [x] Tests passing
- [x] CHANGELOG updated
- [x] MockSettingsService updated

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)