### PR TITLE
[Radoub] Sprint: Dependabot Avalonia 11.3.13 (#2038)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,13 +5,13 @@
 
   <ItemGroup>
     <!-- Avalonia UI Framework -->
-    <PackageVersion Include="Avalonia" Version="11.3.12" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.12" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.12" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.12" />
-    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.3.12" />
-    <PackageVersion Include="Avalonia.Skia" Version="11.3.12" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.12" />
+    <PackageVersion Include="Avalonia" Version="11.3.13" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.3.13" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.13" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.13" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.3.13" />
+    <PackageVersion Include="Avalonia.Skia" Version="11.3.13" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.13" />
 
     <!-- SkiaSharp -->
     <PackageVersion Include="SkiaSharp" Version="3.119.2" />
@@ -47,7 +47,7 @@
     <PackageVersion Include="AvaloniaGraphControl" Version="0.7.0" />
 
     <!-- Testing -->
-    <PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.12" />
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.13" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />


### PR DESCRIPTION
## Summary

Bumps all Avalonia packages from 11.3.12 → 11.3.13 (patch release).

- Avalonia 11.3.12 → 11.3.13
- Avalonia.Desktop 11.3.12 → 11.3.13
- Avalonia.Themes.Fluent 11.3.12 → 11.3.13
- Avalonia.Fonts.Inter 11.3.12 → 11.3.13
- Avalonia.Controls.DataGrid 11.3.12 → 11.3.13
- Avalonia.Skia 11.3.12 → 11.3.13
- Avalonia.Diagnostics 11.3.12 → 11.3.13
- Avalonia.Headless.XUnit 11.3.12 → 11.3.13

Consolidates dependabot PRs: #2038, #2039, #2040, #2041, #2042

## Test Results

- Build: ✅ 0 errors, 3 pre-existing warnings
- Unit tests: ✅ 4,111 passed, 0 failed, 1 skipped

## Risk Assessment

| Package | Change | Risk |
|---------|--------|------|
| All Avalonia packages | 11.3.12 → 11.3.13 (patch) | Low |

## Checklist

- [x] Build passes
- [x] Unit tests pass (4,111 ✅)
- [x] All version bumps in Directory.Packages.props
- [ ] Close superseded dependabot PRs after merge

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)