### PR TITLE
[Relique] Sprint: Preview & Settings (#1983)

### DIFF
--- a/Radoub.Formats/Radoub.Formats.Tests/BaseItemTypeServiceTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/BaseItemTypeServiceTests.cs
@@ -234,6 +234,66 @@ public class BaseItemTypeServiceTests
 
     #endregion
 
+    #region Inventory Size (Relique icon picker)
+
+    [Fact]
+    public void BaseItemTypeInfo_DefaultInventorySize_Is1x1()
+    {
+        var info = new BaseItemTypeInfo(1, "Longsword", "BASE_ITEM_LONGSWORD");
+        Assert.Equal(1, info.InvSlotWidth);
+        Assert.Equal(1, info.InvSlotHeight);
+    }
+
+    [Fact]
+    public void BaseItemTypeInfo_InventorySize_SetFromConstructor()
+    {
+        var info = new BaseItemTypeInfo(10, "Halberd", "BASE_ITEM_HALBERD",
+            invSlotWidth: 1, invSlotHeight: 3);
+        Assert.Equal(1, info.InvSlotWidth);
+        Assert.Equal(3, info.InvSlotHeight);
+    }
+
+    [Fact]
+    public void GetBaseItemTypes_From2DA_ParsesInventorySize()
+    {
+        var mockGameData = new MockGameDataService(includeSampleData: false);
+        var columns = new[] { "label", "Name", "ModelType", "Stacking", "Description",
+            "ChargesStarting", "StorePanel", "InvSlotWidth", "InvSlotHeight" };
+        var twoDA = new TwoDAFile { Columns = new System.Collections.Generic.List<string>(columns) };
+
+        // Row 0: Longsword (1x3)
+        twoDA.Rows.Add(new TwoDARow { Values = new System.Collections.Generic.List<string?>
+            { "BASE_ITEM_LONGSWORD", "****", "0", "1", "****", "****", "1", "1", "3" } });
+        // Row 1: Large Shield (2x3)
+        twoDA.Rows.Add(new TwoDARow { Values = new System.Collections.Generic.List<string?>
+            { "BASE_ITEM_LARGESHIELD", "****", "0", "1", "****", "****", "0", "2", "3" } });
+        // Row 2: Ring (missing columns → default 1x1)
+        twoDA.Rows.Add(new TwoDARow { Values = new System.Collections.Generic.List<string?>
+            { "BASE_ITEM_RING", "****", "0", "1", "****", "****", "4", "****", "****" } });
+
+        mockGameData.With2DA("baseitems", twoDA);
+
+        var service = new BaseItemTypeService(mockGameData);
+        var types = service.GetBaseItemTypes();
+
+        var longsword = types.Find(t => t.BaseItemIndex == 0);
+        Assert.NotNull(longsword);
+        Assert.Equal(1, longsword.InvSlotWidth);
+        Assert.Equal(3, longsword.InvSlotHeight);
+
+        var shield = types.Find(t => t.BaseItemIndex == 1);
+        Assert.NotNull(shield);
+        Assert.Equal(2, shield.InvSlotWidth);
+        Assert.Equal(3, shield.InvSlotHeight);
+
+        var ring = types.Find(t => t.BaseItemIndex == 2);
+        Assert.NotNull(ring);
+        Assert.Equal(1, ring.InvSlotWidth);
+        Assert.Equal(1, ring.InvSlotHeight);
+    }
+
+    #endregion
+
     #region 2DA parsing tests (from Relique)
 
     [Fact]

--- a/Radoub.Formats/Radoub.Formats/Services/BaseItemTypeService.cs
+++ b/Radoub.Formats/Radoub.Formats/Services/BaseItemTypeService.cs
@@ -101,7 +101,18 @@ public class BaseItemTypeService
             if (chargesStartingStr != null && chargesStartingStr != "****" && int.TryParse(chargesStartingStr, out var cs))
                 chargesStarting = cs;
 
-            _cachedTypes.Add(new BaseItemTypeInfo(i, displayName, label, storePanel, modelType, descriptionText, stacking, chargesStarting));
+            // Read InvSlotWidth/InvSlotHeight for inventory size rendering
+            var invSlotWidthStr = baseItems.GetValue(i, "InvSlotWidth");
+            int invSlotWidth = 1;
+            if (invSlotWidthStr != null && invSlotWidthStr != "****" && int.TryParse(invSlotWidthStr, out var isw))
+                invSlotWidth = isw;
+
+            var invSlotHeightStr = baseItems.GetValue(i, "InvSlotHeight");
+            int invSlotHeight = 1;
+            if (invSlotHeightStr != null && invSlotHeightStr != "****" && int.TryParse(invSlotHeightStr, out var ish))
+                invSlotHeight = ish;
+
+            _cachedTypes.Add(new BaseItemTypeInfo(i, displayName, label, storePanel, modelType, descriptionText, stacking, chargesStarting, invSlotWidth, invSlotHeight));
         }
 
         _cachedTypes = _cachedTypes.OrderBy(t => t.DisplayName).ToList();
@@ -280,6 +291,12 @@ public class BaseItemTypeInfo
     /// <summary>Initial charges from baseitems.2da ChargesStarting column. 0 = none, >0 = charge-based.</summary>
     public int ChargesStarting { get; }
 
+    /// <summary>Inventory slot width from baseitems.2da InvSlotWidth column. Default 1.</summary>
+    public int InvSlotWidth { get; }
+
+    /// <summary>Inventory slot height from baseitems.2da InvSlotHeight column. Default 1.</summary>
+    public int InvSlotHeight { get; }
+
     // Computed convenience properties (used by Relique)
     public bool HasColorFields => ModelType is 1 or 3;
     public bool HasArmorParts => ModelType == 3;
@@ -291,7 +308,8 @@ public class BaseItemTypeInfo
     public BaseItemTypeInfo(
         int baseItemIndex, string displayName, string label,
         int storePanel = 4, int modelType = 0, string descriptionText = "",
-        int stacking = 1, int chargesStarting = 0)
+        int stacking = 1, int chargesStarting = 0,
+        int invSlotWidth = 1, int invSlotHeight = 1)
     {
         BaseItemIndex = baseItemIndex;
         DisplayName = displayName;
@@ -301,6 +319,8 @@ public class BaseItemTypeInfo
         DescriptionText = descriptionText;
         Stacking = stacking;
         ChargesStarting = chargesStarting;
+        InvSlotWidth = invSlotWidth;
+        InvSlotHeight = invSlotHeight;
     }
 
     public override string ToString() => DisplayName;

--- a/Radoub.UI/Radoub.UI/Services/BrushManager.cs
+++ b/Radoub.UI/Radoub.UI/Services/BrushManager.cs
@@ -71,7 +71,7 @@ public static class BrushManager
             return appBrush;
 
         // Log when using fallback (helps debug theme issues)
-        UnifiedLogger.LogApplication(LogLevel.DEBUG, $"BrushManager: {key} not in theme, using fallback");
+        UnifiedLogger.LogApplication(LogLevel.WARN, $"BrushManager: {key} not in theme, using fallback");
         return fallback;
     }
 }

--- a/Radoub.UI/Radoub.UI/Services/ThemeManager.Resources.cs
+++ b/Radoub.UI/Radoub.UI/Services/ThemeManager.Resources.cs
@@ -46,6 +46,30 @@ public partial class ThemeManager
     }
 
     /// <summary>
+    /// Apply semantic colors (Success, Warning, Error, Info, Disabled) synchronously.
+    /// Called before the deferred Post so BrushManager can resolve these immediately
+    /// during window construction. These are custom resources that don't depend on
+    /// Fluent's variant re-derivation.
+    /// </summary>
+    private void ApplySemanticColors(IResourceDictionary resources, ThemeColors colors)
+    {
+        if (!string.IsNullOrEmpty(colors.Success))
+            resources["ThemeSuccess"] = new SolidColorBrush(Color.Parse(colors.Success)); // theme-ok
+        if (!string.IsNullOrEmpty(colors.Warning))
+            resources["ThemeWarning"] = new SolidColorBrush(Color.Parse(colors.Warning)); // theme-ok
+        if (!string.IsNullOrEmpty(colors.Error))
+            resources["ThemeError"] = new SolidColorBrush(Color.Parse(colors.Error)); // theme-ok
+        if (!string.IsNullOrEmpty(colors.Info))
+        {
+            var infoBrush = new SolidColorBrush(Color.Parse(colors.Info)); // theme-ok
+            resources["ThemeInfo"] = infoBrush;
+            resources["ThemeInfoBrush"] = infoBrush; // Alias for Trebuchet
+        }
+        if (!string.IsNullOrEmpty(colors.Disabled))
+            resources["ThemeDisabled"] = new SolidColorBrush(Color.Parse(colors.Disabled)); // theme-ok
+    }
+
+    /// <summary>
     /// Apply color values to resource dictionary.
     /// Maps theme colors to Avalonia system resources.
     /// </summary>

--- a/Radoub.UI/Radoub.UI/Services/ThemeManager.cs
+++ b/Radoub.UI/Radoub.UI/Services/ThemeManager.cs
@@ -323,9 +323,16 @@ public partial class ThemeManager
                 : ThemeVariant.Light;
             app.RequestedThemeVariant = oppositeVariant;
 
-            // Step 2: Yield to the UI thread so Avalonia processes the variant
+            // Step 2a: Apply semantic colors synchronously so BrushManager
+            // can resolve ThemeInfo/ThemeSuccess/etc. immediately — before any
+            // window constructors run. These are custom resources that don't
+            // depend on Fluent's variant re-derivation.
+            if (theme.Colors != null)
+                ApplySemanticColors(app.Resources, theme.Colors);
+
+            // Step 2b: Yield to the UI thread so Avalonia processes the variant
             // change (style detach/reattach, resource re-derivation). Then set
-            // the real variant and apply our color overrides.
+            // the real variant and apply our full color overrides.
             var capturedTheme = theme;
             Dispatcher.UIThread.Post(() =>
             {

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.10.8-alpha] - 2026-04-09
+**Branch**: `relique/issue-1983` | **PR**: #TBD
+
+### Sprint: Preview & Settings (#1983)
+- SettingsWindow with game paths, theme/font display, and Trebuchet integration (#2009)
+- Item icon picker dialog with inventory size rendering (#1911)
+
+---
+
 ## [0.10.7-alpha] - 2026-03-29
 **Branch**: `relique/issue-1982` | **PR**: #2036
 

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.10.8-alpha] - 2026-04-09
-**Branch**: `relique/issue-1983` | **PR**: #TBD
+**Branch**: `relique/issue-1983` | **PR**: #2044
 
 ### Sprint: Preview & Settings (#1983)
 - SettingsWindow with game paths, theme/font display, and Trebuchet integration (#2009)

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Sprint: Preview & Settings (#1983)
 - SettingsWindow with game paths, theme/font display, and Trebuchet integration (#2009)
 - Item icon picker dialog with inventory size rendering (#1911)
+- Fix: Semantic theme colors (Info, Success, etc.) now apply before window construction (all tools)
 
 ---
 

--- a/Relique/Relique/Views/ItemIconPickerWindow.axaml
+++ b/Relique/Relique/Views/ItemIconPickerWindow.axaml
@@ -1,0 +1,151 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ItemEditor.Views.ItemIconPickerWindow"
+        Title="Select Icon"
+        Width="600" Height="500"
+        MinWidth="400" MinHeight="350"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource ThemeBackground}"
+        ExtendClientAreaToDecorationsHint="True"
+        ExtendClientAreaChromeHints="PreferSystemChrome"
+        ExtendClientAreaTitleBarHeightHint="30">
+
+    <Window.Styles>
+        <!-- Dark mode selection visibility fix -->
+        <Style Selector="ListBoxItem:selected /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+        <Style Selector="ListBoxItem:selected:focus /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+        <Style Selector="ListBoxItem:selected:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SystemAccentColorDark1}"/>
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+    </Window.Styles>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="30"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Custom Title Bar -->
+        <Border Grid.Row="0" Background="{DynamicResource ThemeTitleBar}"
+                x:Name="TitleBar"
+                PointerPressed="OnTitleBarPointerPressed"
+                DoubleTapped="OnTitleBarDoubleTapped">
+            <StackPanel Orientation="Horizontal"
+                        VerticalAlignment="Center"
+                        Margin="10,0,0,0"
+                        IsHitTestVisible="False">
+                <TextBlock x:Name="TitleBarText"
+                           Text="Select Icon"
+                           VerticalAlignment="Center"
+                           Foreground="{DynamicResource ThemeTitleBarForeground}"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Main Content -->
+        <Grid Grid.Row="1" Margin="10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" MinWidth="250"/>
+                <ColumnDefinition Width="10"/>
+                <ColumnDefinition Width="180"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Left Panel: Icon Grid -->
+            <Grid Grid.Column="0" Grid.Row="0">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <!-- Count Label -->
+                <TextBlock Grid.Row="0" x:Name="IconCountLabel"
+                           Text="0 icons"
+                           Margin="0,0,0,5"/>
+
+                <!-- Icon Grid -->
+                <Border Grid.Row="1"
+                        BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                        BorderThickness="1" Padding="5">
+                    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+                        <ListBox x:Name="IconListBox"
+                                 SelectionChanged="OnIconSelected"
+                                 DoubleTapped="OnIconDoubleClicked">
+                            <ListBox.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <WrapPanel Orientation="Horizontal"/>
+                                </ItemsPanelTemplate>
+                            </ListBox.ItemsPanel>
+                        </ListBox>
+                    </ScrollViewer>
+                </Border>
+            </Grid>
+
+            <!-- Right Panel: Preview -->
+            <Border Grid.Column="2" Grid.Row="0"
+                    BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                    BorderThickness="1"
+                    Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Text="Preview"
+                               FontWeight="SemiBold"
+                               Margin="10,10,10,5"/>
+
+                    <!-- Large Icon Preview -->
+                    <Border Grid.Row="1" Margin="10"
+                            Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                            CornerRadius="4">
+                        <Image x:Name="IconPreviewImage"
+                               Stretch="Uniform"
+                               VerticalAlignment="Center"
+                               HorizontalAlignment="Center"/>
+                    </Border>
+
+                    <!-- Icon Info -->
+                    <StackPanel Grid.Row="2" Margin="10,5,10,10" Spacing="2">
+                        <TextBlock x:Name="ModelNumberLabel"
+                                   Text=""
+                                   TextAlignment="Center"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <TextBlock x:Name="InventorySizeLabel"
+                                   Text=""
+                                   TextAlignment="Center"
+                                   FontSize="{DynamicResource FontSizeSmall}"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <!-- Dialog Buttons -->
+            <StackPanel Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="1"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        Margin="0,10,0,0"
+                        Spacing="10">
+                <Button Content="OK"
+                        Width="80"
+                        Click="OnOkClick"
+                        IsDefault="True"/>
+                <Button Content="Cancel"
+                        Width="80"
+                        Click="OnCancelClick"
+                        IsCancel="True"/>
+            </StackPanel>
+        </Grid>
+    </Grid>
+</Window>

--- a/Relique/Relique/Views/ItemIconPickerWindow.axaml.cs
+++ b/Relique/Relique/Views/ItemIconPickerWindow.axaml.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Radoub.Formats.Logging;
+using Radoub.Formats.Services;
+using Radoub.UI.Services;
+
+namespace ItemEditor.Views;
+
+/// <summary>
+/// Icon picker dialog for selecting item model variations.
+/// Shows all icon variations for a given base item type, rendered at correct inventory slot dimensions.
+/// </summary>
+public partial class ItemIconPickerWindow : Window
+{
+    private readonly IGameDataService? _gameDataService;
+    private readonly ItemIconService? _itemIconService;
+    private readonly int _baseItemType;
+    private readonly int _invSlotWidth;
+    private readonly int _invSlotHeight;
+    private readonly ListBox _iconListBox;
+    private readonly TextBlock _iconCountLabel;
+    private readonly TextBlock _modelNumberLabel;
+    private readonly TextBlock _inventorySizeLabel;
+    private readonly Image _iconPreviewImage;
+
+    private List<IconInfo> _icons = new();
+    private IconInfo? _selectedIcon;
+
+    private const int BaseSlotSize = 32;
+
+    /// <summary>
+    /// Parameterless constructor for XAML designer.
+    /// </summary>
+    public ItemIconPickerWindow()
+    {
+        InitializeComponent();
+        _iconListBox = this.FindControl<ListBox>("IconListBox")!;
+        _iconCountLabel = this.FindControl<TextBlock>("IconCountLabel")!;
+        _modelNumberLabel = this.FindControl<TextBlock>("ModelNumberLabel")!;
+        _inventorySizeLabel = this.FindControl<TextBlock>("InventorySizeLabel")!;
+        _iconPreviewImage = this.FindControl<Image>("IconPreviewImage")!;
+    }
+
+    /// <summary>
+    /// Creates a new icon picker for a specific base item type.
+    /// </summary>
+    public ItemIconPickerWindow(
+        IGameDataService gameDataService,
+        ItemIconService iconService,
+        int baseItemType,
+        byte currentModelPart,
+        string baseItemName,
+        int invSlotWidth,
+        int invSlotHeight) : this()
+    {
+        _gameDataService = gameDataService;
+        _itemIconService = iconService;
+        _baseItemType = baseItemType;
+        _invSlotWidth = Math.Max(1, invSlotWidth);
+        _invSlotHeight = Math.Max(1, invSlotHeight);
+
+        var titleText = this.FindControl<TextBlock>("TitleBarText");
+        if (titleText != null)
+            titleText.Text = $"Select Icon \u2014 {baseItemName}";
+        Title = $"Select Icon \u2014 {baseItemName}";
+
+        var sizeLabel = this.FindControl<TextBlock>("InventorySizeLabel");
+        if (sizeLabel != null)
+            sizeLabel.Text = $"{_invSlotWidth} \u00d7 {_invSlotHeight} slots";
+
+        LoadIcons(currentModelPart);
+    }
+
+    private void LoadIcons(byte currentModelPart)
+    {
+        if (_gameDataService == null || _itemIconService == null)
+            return;
+
+        var baseItems = _gameDataService.Get2DA("baseitems");
+        if (baseItems == null) return;
+
+        var minRangeStr = baseItems.GetValue(_baseItemType, "MinRange");
+        var maxRangeStr = baseItems.GetValue(_baseItemType, "MaxRange");
+
+        int minRange = 0, maxRange = 0;
+        if (minRangeStr != null && minRangeStr != "****") int.TryParse(minRangeStr, out minRange);
+        if (maxRangeStr != null && maxRangeStr != "****") int.TryParse(maxRangeStr, out maxRange);
+
+        int preSelectIndex = -1;
+
+        for (int modelNum = minRange; modelNum <= maxRange; modelNum++)
+        {
+            var icon = _itemIconService.GetItemIcon(_baseItemType, modelNum);
+            if (icon == null) continue;
+
+            _icons.Add(new IconInfo { ModelNumber = (byte)modelNum, Bitmap = icon });
+
+            if (modelNum == currentModelPart)
+                preSelectIndex = _icons.Count - 1;
+        }
+
+        // Fallback: try default icon (model 0) if no numbered icons found
+        if (_icons.Count == 0)
+        {
+            var defaultIcon = _itemIconService.GetItemIcon(_baseItemType);
+            if (defaultIcon != null)
+            {
+                _icons.Add(new IconInfo { ModelNumber = 0, Bitmap = defaultIcon });
+                preSelectIndex = 0;
+            }
+        }
+
+        PopulateIconGrid();
+
+        _iconCountLabel.Text = _icons.Count == 1
+            ? "1 icon"
+            : $"{_icons.Count} icons";
+
+        // Pre-select current model part
+        if (preSelectIndex >= 0 && preSelectIndex < _iconListBox.ItemCount)
+        {
+            _iconListBox.SelectedIndex = preSelectIndex;
+            _iconListBox.ScrollIntoView(preSelectIndex);
+        }
+    }
+
+    private void PopulateIconGrid()
+    {
+        _iconListBox.Items.Clear();
+
+        int cellWidth = _invSlotWidth * BaseSlotSize;
+        int cellHeight = _invSlotHeight * BaseSlotSize;
+
+        foreach (var iconInfo in _icons)
+        {
+            var image = new Image
+            {
+                Source = iconInfo.Bitmap,
+                Width = cellWidth,
+                Height = cellHeight,
+                Stretch = Stretch.Uniform
+            };
+            RenderOptions.SetBitmapInterpolationMode(image, BitmapInterpolationMode.HighQuality);
+
+            var border = new Border
+            {
+                BorderBrush = Brushes.Transparent,
+                BorderThickness = new Thickness(2),
+                Padding = new Thickness(2),
+                Margin = new Thickness(2),
+                Child = image
+            };
+
+            var item = new ListBoxItem
+            {
+                Content = border,
+                Tag = iconInfo,
+                Padding = new Thickness(0)
+            };
+            ToolTip.SetTip(item, $"Model {iconInfo.ModelNumber}");
+
+            _iconListBox.Items.Add(item);
+        }
+    }
+
+    private void OnIconSelected(object? sender, SelectionChangedEventArgs e)
+    {
+        if (_iconListBox.SelectedItem is not ListBoxItem { Tag: IconInfo info })
+        {
+            _selectedIcon = null;
+            _iconPreviewImage.Source = null;
+            _modelNumberLabel.Text = "";
+            return;
+        }
+
+        _selectedIcon = info;
+        _iconPreviewImage.Source = info.Bitmap;
+        _modelNumberLabel.Text = $"Model {info.ModelNumber}";
+    }
+
+    private void OnIconDoubleClicked(object? sender, TappedEventArgs e)
+    {
+        if (_selectedIcon != null)
+        {
+            Close(_selectedIcon.ModelNumber);
+        }
+    }
+
+    private void OnOkClick(object? sender, RoutedEventArgs e)
+    {
+        if (_selectedIcon != null)
+        {
+            Close(_selectedIcon.ModelNumber);
+        }
+        else
+        {
+            Close(null);
+        }
+    }
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e)
+    {
+        Close(null);
+    }
+
+    #region Title Bar Events
+
+    private void OnTitleBarPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            BeginMoveDrag(e);
+        }
+    }
+
+    private void OnTitleBarDoubleTapped(object? sender, TappedEventArgs e)
+    {
+        WindowState = WindowState == WindowState.Maximized
+            ? WindowState.Normal
+            : WindowState.Maximized;
+    }
+
+    #endregion
+
+    private class IconInfo
+    {
+        public byte ModelNumber { get; set; }
+        public Bitmap? Bitmap { get; set; }
+    }
+}

--- a/Relique/Relique/Views/MainWindow.EditorPopulation.cs
+++ b/Relique/Relique/Views/MainWindow.EditorPopulation.cs
@@ -371,7 +371,7 @@ public partial class MainWindow
         // Highlight selected icon
         if (isSelected)
         {
-            button.BorderBrush = Avalonia.Media.Brushes.DodgerBlue;
+            button.BorderBrush = BrushManager.GetInfoBrush(this);
             button.BorderThickness = new Thickness(2);
 
             // Update the selected icon preview
@@ -584,7 +584,7 @@ public partial class MainWindow
     {
         if (_paletteColorService == null)
         {
-            swatch.Background = Avalonia.Media.Brushes.Gray;
+            swatch.Background = BrushManager.GetDisabledBrush(this);
             return;
         }
         swatch.Background = _paletteColorService.CreateGradientBrush(paletteName, colorIndex);

--- a/Relique/Relique/Views/MainWindow.EditorPopulation.cs
+++ b/Relique/Relique/Views/MainWindow.EditorPopulation.cs
@@ -26,7 +26,6 @@ public partial class MainWindow
             ColorsPanel.IsVisible = false;
             ArmorPartsPanel.IsVisible = false;
             IconChooserPanel.IsVisible = false;
-            IconChooserGrid.Children.Clear();
             SelectedIconPreview.Source = null;
             PropertyConfigPanel.IsVisible = false;
             AssignedPropertiesList.Items.Clear();
@@ -188,7 +187,7 @@ public partial class MainWindow
         IconChooserPanel.IsVisible = showIconChooser;
         if (showIconChooser)
         {
-            PopulateIconChooser(baseItemIndex);
+            UpdateIconPreview(baseItemIndex);
         }
 
         AppearanceExpander.IsVisible = showModelParts || showColors || showArmorParts || showIconChooser;
@@ -280,11 +279,10 @@ public partial class MainWindow
         if (ArmorPartNames.Length % 2 == 1) row++;
     }
 
-    // --- Icon Chooser ---
+    // --- Icon Preview + Picker ---
 
-    private void PopulateIconChooser(int baseItemIndex)
+    private void UpdateIconPreview(int baseItemIndex)
     {
-        IconChooserGrid.Children.Clear();
         SelectedIconPreview.Source = null;
 
         if (_itemIconService == null || _itemViewModel == null)
@@ -293,106 +291,42 @@ public partial class MainWindow
             return;
         }
 
-        int iconCount = 0;
         byte currentModelPart1 = _itemViewModel.ModelPart1;
+        var icon = _itemIconService.GetItemIcon(baseItemIndex, currentModelPart1);
+        if (icon == null)
+            icon = _itemIconService.GetItemIcon(baseItemIndex);
 
-        // Use MinRange/MaxRange from baseitems.2da to limit scan (matches wizard pattern)
-        int minRange = 0, maxRange = 0;
-        if (_gameDataService != null && _gameDataService.IsConfigured)
+        if (icon != null)
         {
-            var minStr = _gameDataService.Get2DAValue("baseitems", baseItemIndex, "MinRange");
-            var maxStr = _gameDataService.Get2DAValue("baseitems", baseItemIndex, "MaxRange");
-            if (int.TryParse(minStr, out int mn)) minRange = mn;
-            if (int.TryParse(maxStr, out int mx)) maxRange = mx;
-        }
-
-        // Cap to avoid UI lag
-        if (maxRange - minRange > 300) maxRange = minRange + 300;
-
-        int start = minRange == 0 ? 1 : minRange;
-
-        for (int modelNum = start; modelNum <= maxRange; modelNum++)
-        {
-            var icon = _itemIconService.GetItemIcon(baseItemIndex, modelNum);
-            if (icon == null) continue;
-
-            iconCount++;
-            AddIconChooserButton(icon, (byte)modelNum, $"Model #{modelNum}", currentModelPart1 == modelNum);
-        }
-
-        if (iconCount == 0)
-        {
-            // No numbered icons — show the default icon (fixed icon type)
-            var defaultIcon = _itemIconService.GetItemIcon(baseItemIndex);
-            if (defaultIcon != null)
-            {
-                AddIconChooserButton(defaultIcon, 1, "Default", currentModelPart1 == 1);
-                iconCount = 1;
-            }
-        }
-
-        // If no icon in the grid matched the current selection, try to show a preview anyway
-        if (SelectedIconPreview.Source == null && _itemIconService != null)
-        {
-            var currentIcon = _itemIconService.GetItemIcon(baseItemIndex, currentModelPart1);
-            if (currentIcon != null)
-                SelectedIconPreview.Source = currentIcon;
-        }
-
-        IconChooserInfoLabel.Text = iconCount > 1
-            ? $"({iconCount} variations)"
-            : iconCount == 1
-                ? "(fixed icon)"
-                : "(no icons found)";
-    }
-
-    private void AddIconChooserButton(Bitmap icon, byte modelPart, string tooltip, bool isSelected)
-    {
-        var image = new Avalonia.Controls.Image
-        {
-            Source = icon,
-            Width = 40,
-            Height = 40,
-            Stretch = Avalonia.Media.Stretch.Uniform
-        };
-        Avalonia.Media.RenderOptions.SetBitmapInterpolationMode(image, Avalonia.Media.Imaging.BitmapInterpolationMode.HighQuality);
-
-        var button = new Button
-        {
-            Content = image,
-            Width = 48,
-            Height = 48,
-            Margin = new Thickness(2),
-            Padding = new Thickness(2),
-            Tag = modelPart
-        };
-        Avalonia.Controls.ToolTip.SetTip(button, tooltip);
-
-        // Highlight selected icon
-        if (isSelected)
-        {
-            button.BorderBrush = BrushManager.GetInfoBrush(this);
-            button.BorderThickness = new Thickness(2);
-
-            // Update the selected icon preview
             SelectedIconPreview.Source = icon;
+            IconChooserInfoLabel.Text = $"Model {currentModelPart1}";
         }
-
-        button.Click += OnIconChooserButtonClick;
-        IconChooserGrid.Children.Add(button);
+        else
+        {
+            IconChooserInfoLabel.Text = "(no icon)";
+        }
     }
 
-    private void OnIconChooserButtonClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    private async void OnBrowseIconClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
-        if (sender is not Button button || button.Tag is not byte modelPart) return;
-        if (_itemViewModel == null) return;
+        if (_gameDataService == null || _itemIconService == null || _itemViewModel == null || _currentItem == null)
+            return;
 
-        _itemViewModel.ModelPart1 = modelPart;
+        var baseItemIndex = _currentItem.BaseItem;
+        var typeInfo = _baseItemTypes?.Find(t => t.BaseItemIndex == baseItemIndex);
+        var baseItemName = typeInfo?.DisplayName ?? $"Type {baseItemIndex}";
+        int invW = typeInfo?.InvSlotWidth ?? 1;
+        int invH = typeInfo?.InvSlotHeight ?? 1;
 
-        // Refresh the icon grid to update selection highlight
-        if (_currentItem != null)
+        var picker = new ItemIconPickerWindow(
+            _gameDataService, _itemIconService, baseItemIndex,
+            _itemViewModel.ModelPart1, baseItemName, invW, invH);
+
+        var result = await picker.ShowDialog<byte?>(this);
+        if (result.HasValue)
         {
-            PopulateIconChooser(_currentItem.BaseItem);
+            _itemViewModel.ModelPart1 = result.Value;
+            UpdateIconPreview(baseItemIndex);
         }
     }
 

--- a/Relique/Relique/Views/MainWindow.MenuHandlers.cs
+++ b/Relique/Relique/Views/MainWindow.MenuHandlers.cs
@@ -153,8 +153,8 @@ public partial class MainWindow
 
     private void OnSettingsClick(object? sender, RoutedEventArgs e)
     {
-        // TODO (#1706): Settings window
-        UpdateStatus("Settings not yet implemented");
+        var settingsWindow = new SettingsWindow();
+        settingsWindow.Show(this);
     }
 
     private void OnEditSettingsFileClick(object? sender, RoutedEventArgs e)
@@ -178,39 +178,6 @@ public partial class MainWindow
             Radoub.Formats.Logging.UnifiedLogger.LogApplication(
                 Radoub.Formats.Logging.LogLevel.WARN, $"Failed to open settings file: {ex.Message}");
             UpdateStatus("Could not open settings file");
-        }
-    }
-
-    private void OnToggleUseRadoubThemeClick(object? sender, RoutedEventArgs e)
-    {
-        // Theme management moved to Trebuchet — launch settings
-        LaunchTrebuchetSettings();
-    }
-
-    private static void LaunchTrebuchetSettings()
-    {
-        try
-        {
-            var trebuchetPath = Radoub.Formats.Settings.RadoubSettings.Instance.TrebuchetPath;
-            if (!string.IsNullOrEmpty(trebuchetPath) && System.IO.File.Exists(trebuchetPath))
-            {
-                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
-                {
-                    FileName = trebuchetPath,
-                    Arguments = "--settings",
-                    UseShellExecute = false
-                });
-            }
-            else
-            {
-                Radoub.Formats.Logging.UnifiedLogger.LogApplication(
-                    Radoub.Formats.Logging.LogLevel.WARN, "Trebuchet not found — cannot open settings");
-            }
-        }
-        catch (Exception ex)
-        {
-            Radoub.Formats.Logging.UnifiedLogger.LogApplication(
-                Radoub.Formats.Logging.LogLevel.WARN, $"Could not launch Trebuchet: {ex.Message}");
         }
     }
 

--- a/Relique/Relique/Views/MainWindow.axaml
+++ b/Relique/Relique/Views/MainWindow.axaml
@@ -61,8 +61,6 @@
                 <Separator/>
                 <MenuItem x:Name="LanguageMenu" Header="_Language" AutomationProperties.AutomationId="LanguageMenu"/>
                 <Separator/>
-                <MenuItem x:Name="UseRadoubThemeMenuItem" Header="Use _Radoub Theme" Click="OnToggleUseRadoubThemeClick"/>
-                <Separator/>
                 <MenuItem Header="_Settings..." Click="OnSettingsClick"/>
                 <Separator/>
                 <MenuItem Header="Edit Settings _File..." Click="OnEditSettingsFileClick"/>
@@ -699,7 +697,7 @@
                                                 <Button Content="Remove" Click="OnRemoveVariable"/>
                                             </StackPanel>
                                             <TextBlock x:Name="VariableValidationText"
-                                                       Foreground="#FF4444"
+                                                       Foreground="{DynamicResource ThemeError}"
                                                        FontSize="11"
                                                        TextWrapping="Wrap"
                                                        IsVisible="False"/>

--- a/Relique/Relique/Views/MainWindow.axaml
+++ b/Relique/Relique/Views/MainWindow.axaml
@@ -323,19 +323,12 @@
                             <Expander x:Name="AppearanceExpander" Header="Appearance" IsExpanded="True" IsVisible="False" Margin="0,0,0,8">
                                 <StackPanel Spacing="8" Margin="0,4,0,0">
 
-                                    <!-- Icon/Portrait Chooser -->
+                                    <!-- Icon Preview + Browse Button -->
                                     <StackPanel x:Name="IconChooserPanel" IsVisible="False">
-                                        <DockPanel Margin="0,0,0,4">
-                                            <TextBlock Text="Item Icon" FontWeight="SemiBold" DockPanel.Dock="Left"/>
-                                            <TextBlock x:Name="IconChooserInfoLabel"
-                                                       Margin="8,0,0,0"
-                                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
-                                                       DockPanel.Dock="Left"/>
-                                        </DockPanel>
-                                        <Grid ColumnDefinitions="Auto,8,*" Margin="0,0,0,4">
+                                        <TextBlock Text="Item Icon" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                                        <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,0,0,4">
                                             <!-- Selected icon preview -->
-                                            <Border Grid.Column="0"
-                                                    BorderBrush="{DynamicResource ThemeAccent}"
+                                            <Border BorderBrush="{DynamicResource ThemeAccent}"
                                                     BorderThickness="2" CornerRadius="4"
                                                     Width="72" Height="72"
                                                     VerticalAlignment="Top">
@@ -344,17 +337,14 @@
                                                        Stretch="Uniform"
                                                        RenderOptions.BitmapInterpolationMode="HighQuality"/>
                                             </Border>
-                                            <!-- Icon grid -->
-                                            <Border Grid.Column="2"
-                                                    BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
-                                                    BorderThickness="1" CornerRadius="4"
-                                                    MinHeight="60" MaxHeight="180"
-                                                    Padding="4">
-                                                <ScrollViewer>
-                                                    <WrapPanel x:Name="IconChooserGrid" Margin="2"/>
-                                                </ScrollViewer>
-                                            </Border>
-                                        </Grid>
+                                            <StackPanel VerticalAlignment="Center" Spacing="4">
+                                                <TextBlock x:Name="IconChooserInfoLabel"
+                                                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                                                <Button Content="Browse..."
+                                                        Click="OnBrowseIconClick"
+                                                        Padding="10,5"/>
+                                            </StackPanel>
+                                        </StackPanel>
                                     </StackPanel>
 
                                     <!-- Model Parts (ModelType 0/1/2) -->

--- a/Relique/Relique/Views/NewItemWizardWindow.axaml.cs
+++ b/Relique/Relique/Views/NewItemWizardWindow.axaml.cs
@@ -401,7 +401,7 @@ public partial class NewItemWizardWindow : Window
 
         if (_selectedModelPart1 == modelPart)
         {
-            button.BorderBrush = new SolidColorBrush(Colors.DodgerBlue);
+            button.BorderBrush = BrushManager.GetInfoBrush(this);
             button.BorderThickness = new Thickness(2);
         }
 

--- a/Relique/Relique/Views/SettingsWindow.axaml
+++ b/Relique/Relique/Views/SettingsWindow.axaml
@@ -1,0 +1,144 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="550" d:DesignHeight="500"
+        x:Class="ItemEditor.Views.SettingsWindow"
+        Title="Settings - Relique"
+        Width="550" Height="500"
+        WindowStartupLocation="CenterOwner"
+        CanResize="True">
+
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <TextBlock Grid.Row="0" Text="Settings" FontSize="{DynamicResource FontSizeLarge}" FontWeight="Bold" Margin="0,0,0,10"/>
+
+        <!-- Settings Content -->
+        <TabControl x:Name="SettingsTabControl" Grid.Row="1">
+            <!-- Resource Paths Tab -->
+            <TabItem Header="Resource Paths">
+                <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                    <StackPanel Margin="10" Spacing="15">
+                        <!-- Module Configuration -->
+                        <Border BorderBrush="{DynamicResource ThemeBorder}" BorderThickness="1" Padding="10" CornerRadius="5">
+                            <StackPanel Spacing="8">
+                                <TextBlock Text="Module Configuration" FontWeight="Bold"/>
+                                <TextBlock Text="Module selection is managed through Trebuchet (the Radoub launcher). All tools share the same active module."
+                                          TextWrapping="Wrap" FontSize="{DynamicResource FontSizeSmall}" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+
+                                <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto">
+                                    <TextBlock Grid.Column="0" Text="Active Module: " VerticalAlignment="Center" Margin="0,0,8,0"/>
+                                    <TextBlock x:Name="CurrentModuleText" Grid.Column="1"
+                                              Text="(checking...)"
+                                              VerticalAlignment="Center"
+                                              TextTrimming="CharacterEllipsis"/>
+                                </Grid>
+
+                                <Button x:Name="ConfigureInTrebuchetButton"
+                                       Content="Configure in Trebuchet..."
+                                       Click="OnConfigureInTrebuchetClick"
+                                       HorizontalAlignment="Left" Padding="10,5"/>
+                                <TextBlock x:Name="TrebuchetStatusText"
+                                          FontSize="{DynamicResource FontSizeSmall}"
+                                          Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Base Game Installation Path -->
+                        <Border BorderBrush="{DynamicResource ThemeBorder}" BorderThickness="1" Padding="10" CornerRadius="5">
+                            <StackPanel Spacing="8">
+                                <TextBlock Text="Base Game Installation Path (Optional)" FontWeight="Bold"/>
+                                <TextBlock Text="Path to Neverwinter Nights game installation (e.g., Steam: steamapps\common\Neverwinter Nights)"
+                                          TextWrapping="Wrap" FontSize="{DynamicResource FontSizeSmall}" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+
+                                <Grid ColumnDefinitions="*,Auto,Auto">
+                                    <TextBox x:Name="BaseGamePathTextBox" Grid.Column="0"
+                                            Watermark="C:\Program Files (x86)\Steam\steamapps\common\Neverwinter Nights"/>
+                                    <Button Grid.Column="1" Content="Browse..." Click="OnBrowseBaseGamePathClick"
+                                           Margin="5,0,0,0" Padding="10,5"/>
+                                    <Button Grid.Column="2" Content="Auto-Detect" Click="OnAutoDetectBaseGamePathClick"
+                                           Margin="5,0,0,0" Padding="10,5"/>
+                                </Grid>
+
+                                <TextBlock x:Name="BaseGamePathValidation" Foreground="{DynamicResource ThemeSuccess}" FontSize="{DynamicResource FontSizeSmall}"/>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- User Data Directory Path -->
+                        <Border BorderBrush="{DynamicResource ThemeBorder}" BorderThickness="1" Padding="10" CornerRadius="5">
+                            <StackPanel Spacing="8">
+                                <TextBlock Text="User Data Directory Path" FontWeight="Bold"/>
+                                <TextBlock Text="Path to user data directory (Documents\Neverwinter Nights - contains modules, custom items, etc.)"
+                                          TextWrapping="Wrap" FontSize="{DynamicResource FontSizeSmall}" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+
+                                <Grid ColumnDefinitions="*,Auto,Auto">
+                                    <TextBox x:Name="GamePathTextBox" Grid.Column="0"
+                                            Watermark="C:\Users\[user]\Documents\Neverwinter Nights"/>
+                                    <Button Grid.Column="1" Content="Browse..." Click="OnBrowseGamePathClick"
+                                           Margin="5,0,0,0" Padding="10,5"/>
+                                    <Button Grid.Column="2" Content="Auto-Detect" Click="OnAutoDetectGamePathClick"
+                                           Margin="5,0,0,0" Padding="10,5"/>
+                                </Grid>
+
+                                <TextBlock x:Name="GamePathValidation" Foreground="{DynamicResource ThemeSuccess}" FontSize="{DynamicResource FontSizeSmall}"/>
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
+            <!-- UI Settings Tab -->
+            <TabItem Header="UI Settings">
+                <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                    <StackPanel Margin="10" Spacing="15">
+                        <!-- Theme & Font (managed by Trebuchet) -->
+                        <Border BorderBrush="{DynamicResource ThemeBorder}" BorderThickness="1" Padding="10" CornerRadius="5">
+                            <StackPanel Spacing="8">
+                                <TextBlock Text="Theme &amp; Font" FontWeight="Bold"/>
+                                <TextBlock Text="Theme and font settings are managed centrally in Trebuchet."
+                                          TextWrapping="Wrap" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+
+                                <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto" Margin="0,4,0,0">
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Theme: " VerticalAlignment="Center" Margin="0,0,8,4"/>
+                                    <TextBlock x:Name="CurrentThemeText" Grid.Row="0" Grid.Column="1" Text="(checking...)" VerticalAlignment="Center" Margin="0,0,0,4"/>
+
+                                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Font Size: " VerticalAlignment="Center" Margin="0,0,8,4"/>
+                                    <TextBlock x:Name="CurrentFontSizeText" Grid.Row="1" Grid.Column="1" Text="(checking...)" VerticalAlignment="Center" Margin="0,0,0,4"/>
+
+                                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Font Family: " VerticalAlignment="Center" Margin="0,0,8,0"/>
+                                    <TextBlock x:Name="CurrentFontFamilyText" Grid.Row="2" Grid.Column="1" Text="(checking...)" VerticalAlignment="Center"/>
+                                </Grid>
+
+                                <Button Content="Manage in Trebuchet..."
+                                       Click="OnManageThemeInTrebuchetClick"
+                                       HorizontalAlignment="Left" Padding="10,5" Margin="0,4,0,0"/>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Relique Options -->
+                        <Border BorderBrush="{DynamicResource ThemeBorder}" BorderThickness="1" Padding="10" CornerRadius="5">
+                            <StackPanel Spacing="8">
+                                <TextBlock Text="Relique Options" FontWeight="Bold"/>
+
+                                <CheckBox x:Name="OpenInEditorCheckBox"
+                                         Content="Open item in editor after creating with wizard"
+                                         Click="OnOpenInEditorCheckBoxClick"/>
+                            </StackPanel>
+                        </Border>
+
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+        </TabControl>
+
+        <!-- Close Button -->
+        <Button Grid.Row="2" Content="Close" Click="OnCloseClick"
+               HorizontalAlignment="Right" Margin="0,10,0,0" Padding="20,8"/>
+    </Grid>
+</Window>

--- a/Relique/Relique/Views/SettingsWindow.axaml.cs
+++ b/Relique/Relique/Views/SettingsWindow.axaml.cs
@@ -1,0 +1,306 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Platform.Storage;
+using ItemEditor.Services;
+using Radoub.Formats.Common;
+using Radoub.Formats.Logging;
+using Radoub.Formats.Settings;
+using Radoub.UI.Services;
+using System;
+using System.IO;
+
+namespace ItemEditor.Views;
+
+public partial class SettingsWindow : Window
+{
+    private bool _isInitializing = true;
+
+    public SettingsWindow()
+    {
+        InitializeComponent();
+
+        LoadSettings();
+
+        _isInitializing = false;
+    }
+
+    private void LoadSettings()
+    {
+        LoadModuleConfiguration();
+        LoadResourcePaths();
+        LoadThemeInfo();
+        LoadReliqueOptions();
+    }
+
+    #region Module Configuration
+
+    private void LoadModuleConfiguration()
+    {
+        var modulePath = RadoubSettings.Instance.CurrentModulePath;
+        if (RadoubSettings.IsValidModulePath(modulePath))
+        {
+            string? workingDir = modulePath;
+            if (File.Exists(modulePath) && modulePath.EndsWith(".mod", StringComparison.OrdinalIgnoreCase))
+            {
+                var moduleName = Path.GetFileNameWithoutExtension(modulePath);
+                var moduleDir = Path.GetDirectoryName(modulePath);
+                if (!string.IsNullOrEmpty(moduleDir))
+                {
+                    var candidate = Path.Combine(moduleDir, moduleName);
+                    if (Directory.Exists(candidate))
+                        workingDir = candidate;
+                }
+            }
+
+            string? displayName = null;
+            if (!string.IsNullOrEmpty(workingDir) && Directory.Exists(workingDir))
+            {
+                var ifoPath = Path.Combine(workingDir, "module.ifo");
+                if (File.Exists(ifoPath))
+                {
+                    try
+                    {
+                        var ifo = Radoub.Formats.Ifo.IfoReader.Read(ifoPath);
+                        displayName = ifo.ModuleName.GetDefault();
+                    }
+                    catch { /* fall through to path-based name */ }
+                }
+            }
+
+            CurrentModuleText.Text = displayName ?? Path.GetFileName(modulePath);
+            CurrentModuleText.Foreground = BrushManager.GetInfoBrush(this);
+        }
+        else
+        {
+            CurrentModuleText.Text = "No module selected";
+            CurrentModuleText.Foreground = BrushManager.GetWarningBrush(this);
+        }
+    }
+
+    private void OnConfigureInTrebuchetClick(object? sender, RoutedEventArgs e)
+    {
+        LaunchTrebuchetSettings("Trebuchet launched. Restart Relique after changing module.");
+    }
+
+    #endregion
+
+    #region Resource Paths
+
+    private void LoadResourcePaths()
+    {
+        var sharedSettings = RadoubSettings.Instance;
+        BaseGamePathTextBox.Text = sharedSettings.BaseGameInstallPath;
+        GamePathTextBox.Text = sharedSettings.NeverwinterNightsPath;
+
+        ValidateBaseGamePath();
+        ValidateGamePath();
+    }
+
+    private async void OnBrowseBaseGamePathClick(object? sender, RoutedEventArgs e)
+    {
+        var folders = await StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = "Select NWN Game Installation Folder",
+            AllowMultiple = false
+        });
+
+        if (folders.Count > 0)
+        {
+            BaseGamePathTextBox.Text = folders[0].Path.LocalPath;
+            RadoubSettings.Instance.BaseGameInstallPath = folders[0].Path.LocalPath;
+            ValidateBaseGamePath();
+        }
+    }
+
+    private void OnAutoDetectBaseGamePathClick(object? sender, RoutedEventArgs e)
+    {
+        var detected = ResourcePathDetector.AutoDetectBaseGamePath();
+        if (!string.IsNullOrEmpty(detected))
+        {
+            BaseGamePathTextBox.Text = detected;
+            RadoubSettings.Instance.BaseGameInstallPath = detected;
+            ValidateBaseGamePath();
+        }
+        else
+        {
+            BaseGamePathValidation.Text = "Could not auto-detect game path";
+            BaseGamePathValidation.Foreground = GetWarningBrush();
+        }
+    }
+
+    private async void OnBrowseGamePathClick(object? sender, RoutedEventArgs e)
+    {
+        var folders = await StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = "Select NWN User Data Folder",
+            AllowMultiple = false
+        });
+
+        if (folders.Count > 0)
+        {
+            GamePathTextBox.Text = folders[0].Path.LocalPath;
+            RadoubSettings.Instance.NeverwinterNightsPath = folders[0].Path.LocalPath;
+            ValidateGamePath();
+        }
+    }
+
+    private void OnAutoDetectGamePathClick(object? sender, RoutedEventArgs e)
+    {
+        var detected = ResourcePathDetector.AutoDetectGamePath();
+        if (!string.IsNullOrEmpty(detected))
+        {
+            GamePathTextBox.Text = detected;
+            RadoubSettings.Instance.NeverwinterNightsPath = detected;
+            ValidateGamePath();
+        }
+        else
+        {
+            GamePathValidation.Text = "Could not auto-detect user data path";
+            GamePathValidation.Foreground = GetWarningBrush();
+        }
+    }
+
+    private void ValidateBaseGamePath()
+    {
+        var path = BaseGamePathTextBox.Text;
+        if (string.IsNullOrEmpty(path))
+        {
+            BaseGamePathValidation.Text = "";
+            return;
+        }
+
+        if (Directory.Exists(path))
+        {
+            var dataPath = Path.Combine(path, "data");
+            var keyFile = Path.Combine(path, "data", "nwn_base.key");
+
+            if (Directory.Exists(dataPath) || File.Exists(keyFile))
+            {
+                BaseGamePathValidation.Text = "\u2713 Valid NWN installation detected";
+                BaseGamePathValidation.Foreground = GetSuccessBrush();
+            }
+            else
+            {
+                BaseGamePathValidation.Text = "\u26A0 Directory exists but may not be NWN installation";
+                BaseGamePathValidation.Foreground = GetWarningBrush();
+            }
+        }
+        else
+        {
+            BaseGamePathValidation.Text = "\u2717 Directory does not exist";
+            BaseGamePathValidation.Foreground = GetErrorBrush();
+        }
+    }
+
+    private void ValidateGamePath()
+    {
+        var path = GamePathTextBox.Text;
+        if (string.IsNullOrEmpty(path))
+        {
+            GamePathValidation.Text = "";
+            return;
+        }
+
+        if (Directory.Exists(path))
+        {
+            var modulesPath = Path.Combine(path, "modules");
+            if (Directory.Exists(modulesPath))
+            {
+                GamePathValidation.Text = "\u2713 Valid NWN user data directory";
+                GamePathValidation.Foreground = GetSuccessBrush();
+            }
+            else
+            {
+                GamePathValidation.Text = "\u26A0 Directory exists but no modules folder found";
+                GamePathValidation.Foreground = GetWarningBrush();
+            }
+        }
+        else
+        {
+            GamePathValidation.Text = "\u2717 Directory does not exist";
+            GamePathValidation.Foreground = GetErrorBrush();
+        }
+    }
+
+    #endregion
+
+    #region Theme Info
+
+    private void LoadThemeInfo()
+    {
+        var settings = RadoubSettings.Instance;
+
+        var themeId = settings.SharedThemeId;
+        CurrentThemeText.Text = string.IsNullOrEmpty(themeId) ? "Default" : themeId;
+
+        CurrentFontSizeText.Text = $"{settings.SharedFontSize}pt";
+        CurrentFontFamilyText.Text = settings.SharedFontFamily;
+    }
+
+    private void OnManageThemeInTrebuchetClick(object? sender, RoutedEventArgs e)
+    {
+        LaunchTrebuchetSettings("Trebuchet launched. Theme changes apply after restart.");
+    }
+
+    #endregion
+
+    #region Relique Options
+
+    private void LoadReliqueOptions()
+    {
+        OpenInEditorCheckBox.IsChecked = SettingsService.Instance.OpenInEditorAfterCreate;
+    }
+
+    private void OnOpenInEditorCheckBoxClick(object? sender, RoutedEventArgs e)
+    {
+        if (_isInitializing) return;
+        SettingsService.Instance.OpenInEditorAfterCreate = OpenInEditorCheckBox.IsChecked == true;
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private void LaunchTrebuchetSettings(string successMessage)
+    {
+        var trebuchetPath = RadoubSettings.Instance.TrebuchetPath;
+
+        if (string.IsNullOrEmpty(trebuchetPath) || !File.Exists(trebuchetPath))
+        {
+            TrebuchetStatusText.Text = "Trebuchet not found. Launch Trebuchet once to register its path.";
+            TrebuchetStatusText.Foreground = BrushManager.GetWarningBrush(this);
+            return;
+        }
+
+        try
+        {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = trebuchetPath,
+                Arguments = "--settings",
+                UseShellExecute = false
+            });
+
+            TrebuchetStatusText.Text = successMessage;
+            TrebuchetStatusText.Foreground = BrushManager.GetInfoBrush(this);
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.ERROR, $"Failed to launch Trebuchet: {ex.Message}");
+            TrebuchetStatusText.Text = $"Failed to launch Trebuchet: {ex.Message}";
+            TrebuchetStatusText.Foreground = BrushManager.GetErrorBrush(this);
+        }
+    }
+
+    private IBrush GetSuccessBrush() => BrushManager.GetSuccessBrush(this);
+    private IBrush GetWarningBrush() => BrushManager.GetWarningBrush(this);
+    private IBrush GetErrorBrush() => BrushManager.GetErrorBrush(this);
+
+    #endregion
+
+    private void OnCloseClick(object? sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+}


### PR DESCRIPTION
## Summary

- SettingsWindow with editable game paths, read-only theme/font display, and "Manage in Trebuchet" button (#2009, supersedes #1913, #1914)
- Item icon picker dialog with inventory size rendering — icons render at correct inventory slot proportions (#1911, absorbs #1902)
- Fix: Semantic theme colors (ThemeInfo, ThemeSuccess, etc.) now applied synchronously before window construction — fixes tritanopia and other color-blind themes falling back to DodgerBlue

## Issue Housekeeping

- Close #1975 — already implemented
- Close #1974 — already implemented
- Close #1913 — superseded by #2009
- Close #1914 — superseded by #2009
- Close #1902 — absorbed into #1911

## Related Issues

- Closes #1983
- Closes #2009
- Closes #1911

## Pre-Merge Checklist

**Branch**: `relique/issue-1983`
**Tool**: Relique + Radoub.Formats + Radoub.UI (shared)

### Tests
| Check | Status |
|-------|--------|
| Privacy scan | ✅ No hardcoded paths |
| Tech debt | ✅ No large files |
| Hardcoded theme values | ⚠️ 37 pre-existing (FontSize in AXAML — not introduced by this PR) |
| Radoub.Formats tests | ✅ 1084 passed |
| Radoub.UI tests | ✅ 412 passed |
| Radoub.Dictionary tests | ✅ 54 passed |
| Relique tests | ✅ 253 passed |
| **Total** | ✅ **1803 passed, 0 failed** |
| UI tests | ⏭️ Skipped (no FlaUI tests for Relique) |

### Validation
| Check | Status |
|-------|--------|
| CHANGELOG | ✅ Versioned section with PR number |
| [Unreleased] section | ✅ Empty |
| Wiki | ✅ Current (2026-03-31) |
| Release notes | ✅ Updated |

### Blast Radius
| Tool | Build | Notes |
|------|-------|-------|
| Relique | ✅ | Primary target |
| Fence | ✅ | Uses BaseItemTypeService (new fields have defaults) |
| All tools | ✅ | Radoub.sln builds clean (3 pre-existing warnings) |

## Test plan

- [x] All unit tests pass (1803/1803)
- [x] Privacy scan clean
- [x] Fence builds with shared library change
- [x] Manual: Settings window opens, game paths editable
- [x] Manual: "Manage in Trebuchet" launches Trebuchet
- [x] Manual: Icon picker shows correct inventory proportions
- [x] Manual: Theme colors correct on tritanopia theme

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)