### PR TITLE
[Parley] Sprint: Quality of Life & Polish (#1977)

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -9,7 +9,9 @@ All notable changes to Parley. One-line highlights per version; full details in 
 
 ### Sprint: Quality of Life & Polish
 - User-defined custom (non-color) tokens in token chooser (#1890)
-- Sound Browser overhaul — TDD refactor, correct labels, pre-scan validation (#1241)
+- Sound Browser overhaul — correct labels, defaults, mono filter persistence (#1241)
+- Fix ADPCM/DviAdpcm WAV playback (base game sounds now play correctly)
+- Fix Sound Browser validation display and list refresh after channel detection
 
 ---
 

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Parley. One-line highlights per version; full details in 
 
 ---
 
-## [0.1.162-alpha] - 2026-04-10 | PR #TBD
+## [0.1.162-alpha] - 2026-04-10 | PR #2048
 **Branch**: `parley/issue-1977`
 
 ### Sprint: Quality of Life & Polish

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Parley. One-line highlights per version; full details in 
 
 ---
 
+## [0.1.162-alpha] - 2026-04-10 | PR #TBD
+**Branch**: `parley/issue-1977`
+
+### Sprint: Quality of Life & Polish
+- User-defined custom (non-color) tokens in token chooser (#1890)
+- Sound Browser overhaul — TDD refactor, correct labels, pre-scan validation (#1241)
+
+---
+
 ## [0.1.161-alpha] - 2026-03-29 | PR #2035
 **Branch**: `parley/issue-1976`
 

--- a/Parley/Parley.Tests/Mocks/MockSettingsService.cs
+++ b/Parley/Parley.Tests/Mocks/MockSettingsService.cs
@@ -125,6 +125,7 @@ namespace Parley.Tests.Mocks
         public bool SoundBrowserIncludeGameResources { get; set; } = true;
         public bool SoundBrowserIncludeHakFiles { get; set; } = true;
         public bool SoundBrowserIncludeBifFiles { get; set; } = true;
+        public bool SoundBrowserMonoOnly { get; set; } = true;
 
         // Spell Check settings
         public bool SpellCheckEnabled { get; set; } = false;

--- a/Parley/Parley.Tests/SoundFileInfoTests.cs
+++ b/Parley/Parley.Tests/SoundFileInfoTests.cs
@@ -1,0 +1,99 @@
+using DialogEditor.Models.Sound;
+using Xunit;
+
+namespace DialogEditor.Tests;
+
+/// <summary>
+/// Tests for SoundFileInfo model — computed properties.
+/// Issue #1241: Sound Browser overhaul.
+/// </summary>
+public class SoundFileInfoTests
+{
+    [Fact]
+    public void IsCompatible_MonoValidWav_ReturnsTrue()
+    {
+        var info = new SoundFileInfo { IsMono = true, IsValidWav = true, ChannelUnknown = false };
+        Assert.True(info.IsCompatible);
+    }
+
+    [Fact]
+    public void IsCompatible_StereoValidWav_ReturnsFalse()
+    {
+        var info = new SoundFileInfo { IsMono = false, IsValidWav = true, ChannelUnknown = false };
+        Assert.False(info.IsCompatible);
+    }
+
+    [Fact]
+    public void IsCompatible_MonoInvalidWav_ReturnsFalse()
+    {
+        var info = new SoundFileInfo { IsMono = true, IsValidWav = false, ChannelUnknown = false };
+        Assert.False(info.IsCompatible);
+    }
+
+    [Fact]
+    public void IsCompatible_ChannelUnknownValidWav_ReturnsTrue()
+    {
+        var info = new SoundFileInfo { IsMono = false, ChannelUnknown = true, IsValidWav = true };
+        Assert.True(info.IsCompatible);
+    }
+
+    [Fact]
+    public void IsCompatible_ChannelUnknownInvalidWav_ReturnsFalse()
+    {
+        var info = new SoundFileInfo { IsMono = false, ChannelUnknown = true, IsValidWav = false };
+        Assert.False(info.IsCompatible);
+    }
+
+    [Fact]
+    public void IsFromHak_WithHakPathAndErfEntry_ReturnsTrue()
+    {
+        var info = new SoundFileInfo
+        {
+            HakPath = "/some/path.hak",
+            ErfEntry = new Radoub.Formats.Erf.ErfResourceEntry()
+        };
+        Assert.True(info.IsFromHak);
+    }
+
+    [Fact]
+    public void IsFromHak_WithoutErfEntry_ReturnsFalse()
+    {
+        var info = new SoundFileInfo { HakPath = "/some/path.hak" };
+        Assert.False(info.IsFromHak);
+    }
+
+    [Fact]
+    public void IsFromBif_WithBifInfo_ReturnsTrue()
+    {
+        var info = new SoundFileInfo { BifInfo = new BifSoundInfo() };
+        Assert.True(info.IsFromBif);
+    }
+
+    [Fact]
+    public void IsFromBif_WithoutBifInfo_ReturnsFalse()
+    {
+        var info = new SoundFileInfo();
+        Assert.False(info.IsFromBif);
+    }
+
+    [Fact]
+    public void IsFromArchive_HakOrBif_ReturnsTrue()
+    {
+        var hakInfo = new SoundFileInfo
+        {
+            HakPath = "/path.hak",
+            ErfEntry = new Radoub.Formats.Erf.ErfResourceEntry()
+        };
+        Assert.True(hakInfo.IsFromArchive);
+
+        var bifInfo = new SoundFileInfo { BifInfo = new BifSoundInfo() };
+        Assert.True(bifInfo.IsFromArchive);
+    }
+
+    [Fact]
+    public void IsFromArchive_LooseFile_ReturnsFalse()
+    {
+        var info = new SoundFileInfo { FullPath = "/some/file.wav" };
+        Assert.False(info.IsFromArchive);
+    }
+}

--- a/Parley/Parley/Models/Sound/SoundFileInfo.cs
+++ b/Parley/Parley/Models/Sound/SoundFileInfo.cs
@@ -67,5 +67,11 @@ namespace DialogEditor.Models.Sound
         /// These sounds use IGameDataService.FindResource() for extraction (#1240).
         /// </summary>
         public bool IsFromGameDataService { get; set; }
+
+        /// <summary>
+        /// True if this sound is compatible with NWN conversations (mono + valid WAV).
+        /// Sounds with unknown channels are considered potentially compatible.
+        /// </summary>
+        public bool IsCompatible => (IsMono || ChannelUnknown) && IsValidWav;
     }
 }

--- a/Parley/Parley/Services/EditorPreferencesService.cs
+++ b/Parley/Parley/Services/EditorPreferencesService.cs
@@ -43,9 +43,10 @@ namespace DialogEditor.Services
         private int _maxCachedScripts = 1000;
 
         // Sound Browser settings
-        private bool _soundBrowserIncludeGameResources = false;
-        private bool _soundBrowserIncludeHakFiles = false;
+        private bool _soundBrowserIncludeGameResources = true;
+        private bool _soundBrowserIncludeHakFiles = true;
         private bool _soundBrowserIncludeBifFiles = false;
+        private bool _soundBrowserMonoOnly = true;
 
         // Spell Check settings
         private bool _spellCheckEnabled = true;
@@ -73,6 +74,7 @@ namespace DialogEditor.Services
             string manifestPath,
             bool enableParameterCache, int maxCachedValuesPerParameter, int maxCachedScripts,
             bool soundBrowserIncludeGameResources, bool soundBrowserIncludeHakFiles, bool soundBrowserIncludeBifFiles,
+            bool soundBrowserMonoOnly,
             bool spellCheckEnabled)
         {
             _autoSaveEnabled = autoSaveEnabled;
@@ -100,6 +102,7 @@ namespace DialogEditor.Services
             _soundBrowserIncludeGameResources = soundBrowserIncludeGameResources;
             _soundBrowserIncludeHakFiles = soundBrowserIncludeHakFiles;
             _soundBrowserIncludeBifFiles = soundBrowserIncludeBifFiles;
+            _soundBrowserMonoOnly = soundBrowserMonoOnly;
 
             _spellCheckEnabled = spellCheckEnabled;
         }
@@ -284,6 +287,12 @@ namespace DialogEditor.Services
         {
             get => _soundBrowserIncludeBifFiles;
             set { if (SetProperty(ref _soundBrowserIncludeBifFiles, value)) SettingsChanged?.Invoke(); }
+        }
+
+        public bool SoundBrowserMonoOnly
+        {
+            get => _soundBrowserMonoOnly;
+            set { if (SetProperty(ref _soundBrowserMonoOnly, value)) SettingsChanged?.Invoke(); }
         }
 
         // Spell Check Settings

--- a/Parley/Parley/Services/Interfaces/ISettingsService.cs
+++ b/Parley/Parley/Services/Interfaces/ISettingsService.cs
@@ -102,6 +102,7 @@ namespace DialogEditor.Services
         bool SoundBrowserIncludeGameResources { get; set; }
         bool SoundBrowserIncludeHakFiles { get; set; }
         bool SoundBrowserIncludeBifFiles { get; set; }
+        bool SoundBrowserMonoOnly { get; set; }
 
         // Spell Check settings
         bool SpellCheckEnabled { get; set; }

--- a/Parley/Parley/Services/SettingsService.cs
+++ b/Parley/Parley/Services/SettingsService.cs
@@ -510,6 +510,12 @@ namespace DialogEditor.Services
             set => _editorPreferences.SoundBrowserIncludeBifFiles = value;
         }
 
+        public bool SoundBrowserMonoOnly
+        {
+            get => _editorPreferences.SoundBrowserMonoOnly;
+            set => _editorPreferences.SoundBrowserMonoOnly = value;
+        }
+
         public bool SpellCheckEnabled
         {
             get => _editorPreferences.SpellCheckEnabled;
@@ -606,6 +612,7 @@ namespace DialogEditor.Services
                             settings.SoundBrowserIncludeGameResources,
                             settings.SoundBrowserIncludeHakFiles,
                             settings.SoundBrowserIncludeBifFiles,
+                            settings.SoundBrowserMonoOnly,
                             settings.SpellCheckEnabled);
 
                         // Initialize recent creature tags (#1244)
@@ -684,6 +691,7 @@ namespace DialogEditor.Services
                     SoundBrowserIncludeGameResources = SoundBrowserIncludeGameResources,
                     SoundBrowserIncludeHakFiles = SoundBrowserIncludeHakFiles,
                     SoundBrowserIncludeBifFiles = SoundBrowserIncludeBifFiles,
+                    SoundBrowserMonoOnly = SoundBrowserMonoOnly,
                     SpellCheckEnabled = SpellCheckEnabled,
                     ManifestPath = SharedPathHelper.ContractPath(ManifestPath),
                     ExternalEditorPath = SharedPathHelper.ContractPath(ExternalEditorPath),
@@ -778,9 +786,10 @@ namespace DialogEditor.Services
             public int MaxCachedScripts { get; set; } = 1000;
 
             // Sound Browser settings
-            public bool SoundBrowserIncludeGameResources { get; set; } = false;
-            public bool SoundBrowserIncludeHakFiles { get; set; } = false;
+            public bool SoundBrowserIncludeGameResources { get; set; } = true;
+            public bool SoundBrowserIncludeHakFiles { get; set; } = true;
             public bool SoundBrowserIncludeBifFiles { get; set; } = false;
+            public bool SoundBrowserMonoOnly { get; set; } = true;
 
             // Spell Check settings
             public bool SpellCheckEnabled { get; set; } = true;

--- a/Parley/Parley/Services/SoundScanner.cs
+++ b/Parley/Parley/Services/SoundScanner.cs
@@ -309,7 +309,7 @@ namespace DialogEditor.Services
                             FullPath = bifPath,
                             IsMono = true, // Default value, but ChannelUnknown indicates not verified
                             ChannelUnknown = true, // Channel status unknown until validated
-                            Source = $"BIF:{bifName}",
+                            Source = $"Base Game:{bifName}",
                             BifInfo = new BifSoundInfo
                             {
                                 ResRef = resource.ResRef,

--- a/Parley/Parley/Views/MainWindow.ResourceBrowsing.cs
+++ b/Parley/Parley/Views/MainWindow.ResourceBrowsing.cs
@@ -45,13 +45,14 @@ namespace DialogEditor.Views
                     string newText;
                     int newCursorPos;
 
-                    // Determine if we need a space before the token
-                    // Add space if: not at start, and previous char is not whitespace
+                    // Determine if we need spaces around the token
                     var needsSpaceBefore = selStart > 0 &&
                         !char.IsWhiteSpace(currentText[selStart - 1]);
-                    var tokenToInsert = needsSpaceBefore
-                        ? " " + tokenWindow.SelectedToken
-                        : tokenWindow.SelectedToken;
+                    var needsSpaceAfter = selStart < currentText.Length &&
+                        !char.IsWhiteSpace(currentText[selStart]);
+                    var tokenToInsert = (needsSpaceBefore ? " " : "") +
+                        tokenWindow.SelectedToken +
+                        (needsSpaceAfter ? " " : "");
 
                     if (selLength > 0)
                     {
@@ -76,10 +77,13 @@ namespace DialogEditor.Views
                         _viewModel.StatusMessage = "Text updated with token";
                     }
 
-                    // Restore cursor position and focus
-                    textBox.SelectionStart = newCursorPos;
-                    textBox.SelectionEnd = newCursorPos;
-                    textBox.Focus();
+                    // Restore cursor position and focus (deferred to let dialog close complete)
+                    Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                    {
+                        textBox.Focus();
+                        textBox.SelectionStart = newCursorPos;
+                        textBox.SelectionEnd = newCursorPos;
+                    }, Avalonia.Threading.DispatcherPriority.Background);
                 }
             }
             catch (Exception ex)

--- a/Parley/Parley/Views/MainWindow.ResourceBrowsing.cs
+++ b/Parley/Parley/Views/MainWindow.ResourceBrowsing.cs
@@ -24,6 +24,7 @@ namespace DialogEditor.Views
         {
             // Set flag to suppress tree refresh during token insertion
             _uiState.IsInsertingToken = true;
+            var deferredClear = false;
             try
             {
                 // Capture cursor position BEFORE opening dialog (OnFieldLostFocus fires when button clicked)
@@ -77,12 +78,23 @@ namespace DialogEditor.Views
                         _viewModel.StatusMessage = "Text updated with token";
                     }
 
-                    // Restore cursor position and focus (deferred to let dialog close complete)
+                    // Restore cursor position and focus (deferred to let dialog close complete).
+                    // Keep IsInsertingToken true until focus is restored to prevent
+                    // debounced auto-save from triggering a tree refresh that jumps to root.
+                    // See #2050 for the proper architectural fix.
+                    deferredClear = true;
                     Avalonia.Threading.Dispatcher.UIThread.Post(() =>
                     {
-                        textBox.Focus();
-                        textBox.SelectionStart = newCursorPos;
-                        textBox.SelectionEnd = newCursorPos;
+                        try
+                        {
+                            textBox.Focus();
+                            textBox.SelectionStart = newCursorPos;
+                            textBox.SelectionEnd = newCursorPos;
+                        }
+                        finally
+                        {
+                            _uiState.IsInsertingToken = false;
+                        }
                     }, Avalonia.Threading.DispatcherPriority.Background);
                 }
             }
@@ -92,7 +104,9 @@ namespace DialogEditor.Views
             }
             finally
             {
-                _uiState.IsInsertingToken = false;
+                // Only clear here if we didn't defer it to the focus restoration callback
+                if (!deferredClear)
+                    _uiState.IsInsertingToken = false;
             }
         }
 

--- a/Parley/Parley/Views/SoundBrowserWindow.axaml
+++ b/Parley/Parley/Views/SoundBrowserWindow.axaml
@@ -65,24 +65,24 @@
                        VerticalAlignment="Center"
                        FontSize="{DynamicResource FontSizeSmall}"/>
             <CheckBox x:Name="IncludeGameResourcesCheckBox"
-                      Content="Game resources"
+                      Content="User Files"
                       FontSize="{DynamicResource FontSizeSmall}"
-                      IsChecked="False"
-                      ToolTip.Tip="Include sounds from base game folders"
+                      IsChecked="True"
+                      ToolTip.Tip="Include sounds from override and user sound folders"
                       Checked="OnSourceSelectionChanged"
                       Unchecked="OnSourceSelectionChanged"/>
             <CheckBox x:Name="IncludeHakFolderCheckBox"
-                      Content="HAK files"
+                      Content="HAK Files"
                       FontSize="{DynamicResource FontSizeSmall}"
-                      IsChecked="False"
-                      ToolTip.Tip="Include sounds from HAK files in dialog directory"
+                      IsChecked="True"
+                      ToolTip.Tip="Include sounds from HAK files in dialog and hak directories"
                       Checked="OnSourceSelectionChanged"
                       Unchecked="OnSourceSelectionChanged"/>
             <CheckBox x:Name="IncludeBifFilesCheckBox"
-                      Content="BIF archives"
+                      Content="Base Game"
                       FontSize="{DynamicResource FontSizeSmall}"
                       IsChecked="False"
-                      ToolTip.Tip="Include base game sounds from BIF archives (slower)"
+                      ToolTip.Tip="Include base game sounds from KEY/BIF data files (slower)"
                       Checked="OnSourceSelectionChanged"
                       Unchecked="OnSourceSelectionChanged"/>
             <CheckBox x:Name="IncludeOtherLocationCheckBox"
@@ -131,7 +131,7 @@
                       Margin="15,0,0,0"
                       ToolTip.Tip="Disable on-selection format validation for HAK sounds (faster for large HAK collections)"/>
             <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="10">
-                <TextBlock Text="○ = BIF"
+                <TextBlock Text="○ = Base Game"
                            FontSize="{DynamicResource FontSizeXSmall}"
                            VerticalAlignment="Center"/>
                 <TextBlock Text="☐ = HAK"

--- a/Parley/Parley/Views/SoundBrowserWindow.axaml.cs
+++ b/Parley/Parley/Views/SoundBrowserWindow.axaml.cs
@@ -72,6 +72,7 @@ namespace DialogEditor.Views
             IncludeGameResourcesCheckBox.IsChecked = _settings.SoundBrowserIncludeGameResources;
             IncludeHakFolderCheckBox.IsChecked = _settings.SoundBrowserIncludeHakFiles;
             IncludeBifFilesCheckBox.IsChecked = _settings.SoundBrowserIncludeBifFiles;
+            MonoOnlyCheckBox.IsChecked = _settings.SoundBrowserMonoOnly;
             _isInitializing = false;
 
             _audioService.PlaybackStopped += OnPlaybackStopped;
@@ -150,7 +151,14 @@ namespace DialogEditor.Views
             }
         }
 
-        private void OnMonoFilterChanged(object? sender, RoutedEventArgs e) => UpdateSoundList();
+        private void OnMonoFilterChanged(object? sender, RoutedEventArgs e)
+        {
+            if (!_isInitializing)
+            {
+                _settings.SoundBrowserMonoOnly = MonoOnlyCheckBox?.IsChecked == true;
+            }
+            UpdateSoundList();
+        }
 
         private async void LoadSounds() => await LoadSoundsAsync();
 
@@ -386,7 +394,7 @@ namespace DialogEditor.Views
                 GameResourceSource.Override => "Override",
                 GameResourceSource.Hak => "HAK (Module)",
                 GameResourceSource.Module => "Module",
-                GameResourceSource.Bif => "BIF",
+                GameResourceSource.Bif => "Base Game",
                 _ => source.ToString()
             };
         }
@@ -441,8 +449,8 @@ namespace DialogEditor.Views
             if (sound.IsFromGameDataService)
             {
                 var channelHint = sound.ChannelUnknown ? " [?ch]" : "";
-                var icon = sound.Source?.Contains("BIF") == true ? "○" : "☐";
-                var brush = sound.Source?.Contains("BIF") == true ? ForegroundBrush : HakBrush;
+                var icon = sound.IsFromBif ? "○" : "☐";
+                var brush = sound.IsFromBif ? ForegroundBrush : HakBrush;
                 return ($"{icon} {baseName}{sourceInfo}{channelHint}", brush);
             }
             return ($"{baseName}{sourceInfo}", ForegroundBrush);
@@ -451,14 +459,14 @@ namespace DialogEditor.Views
         private void UpdateFileCountLabel(int count, bool monoOnly)
         {
             var hakCount = _filteredSounds.Count(s => s.IsFromHak || (s.IsFromGameDataService && s.Source?.Contains("HAK") == true));
-            var bifCount = _filteredSounds.Count(s => s.IsFromBif || (s.IsFromGameDataService && s.Source?.Contains("BIF") == true));
+            var bifCount = _filteredSounds.Count(s => s.IsFromBif);
             var stereoCount = _filteredSounds.Count(s => !s.IsMono && !s.ChannelUnknown);
             var unknownChannelCount = _filteredSounds.Count(s => s.ChannelUnknown);
             var invalidCount = _filteredSounds.Count(s => !s.IsValidWav);
             var countText = $"{count} sound{(count == 1 ? "" : "s")}";
 
             var details = new List<string>();
-            if (bifCount > 0) details.Add($"{bifCount} from BIF");
+            if (bifCount > 0) details.Add($"{bifCount} base game");
             if (hakCount > 0) details.Add($"{hakCount} from HAK");
             if (!monoOnly && stereoCount > 0) details.Add($"{stereoCount} stereo");
             if (monoOnly && unknownChannelCount > 0) details.Add($"{unknownChannelCount} unverified");
@@ -486,7 +494,7 @@ namespace DialogEditor.Views
                 _selectedSound = soundInfo.FileName;
                 var selIcon = soundInfo.IsFromHak ? " ☐"
                     : soundInfo.IsFromBif ? " ○"
-                    : soundInfo.IsFromGameDataService && soundInfo.Source?.Contains("BIF") == true ? " ○"
+                    : soundInfo.IsFromGameDataService && soundInfo.IsFromBif ? " ○"
                     : soundInfo.IsFromGameDataService && soundInfo.Source?.Contains("HAK") == true ? " ☐"
                     : "";
                 SelectedSoundLabel.Text = $"{soundInfo.FileName}{selIcon}";
@@ -545,7 +553,7 @@ namespace DialogEditor.Views
                     if (tempPath != null)
                     {
                         var validation = SoundValidator.Validate(tempPath, isVoiceOrSfx: true);
-                        var icon = soundInfo.Source?.Contains("BIF") == true ? "○" : "☐";
+                        var icon = soundInfo.IsFromBif ? "○" : "☐";
                         if (validation.HasIssues)
                         {
                             var issues = string.Join(", ", validation.Errors.Concat(validation.Warnings));

--- a/Parley/Parley/Views/SoundBrowserWindow.axaml.cs
+++ b/Parley/Parley/Views/SoundBrowserWindow.axaml.cs
@@ -615,7 +615,7 @@ namespace DialogEditor.Views
 
         /// <summary>
         /// Update a single item's display after validation revealed its channel info.
-        /// If the sound is now stereo and mono-only is checked, remove it from the list.
+        /// Updates the icon/text to reflect the newly-known channel status.
         /// </summary>
         private void RefreshSoundListItem(SoundFileInfo soundInfo)
         {
@@ -623,34 +623,9 @@ namespace DialogEditor.Views
             {
                 if (SoundListBox.Items[i] is ListBoxItem item && item.Tag == soundInfo)
                 {
-                    var monoOnly = MonoOnlyCheckBox?.IsChecked == true;
-                    if (monoOnly && !soundInfo.IsMono)
-                    {
-                        // Sound is stereo and mono filter is on — remove it.
-                        // Suppress SelectionChanged to avoid re-entrant validation.
-                        SoundListBox.SelectionChanged -= OnSoundSelected;
-                        try
-                        {
-                            SoundListBox.Items.RemoveAt(i);
-                            _filteredSounds.Remove(soundInfo);
-                            _selectedSound = null;
-                            _selectedSoundInfo = null;
-                            SelectedSoundLabel.Text = "(none)";
-                            PlayButton.IsEnabled = false;
-                            UpdateFileCountLabel(_filteredSounds.Count, monoOnly);
-                        }
-                        finally
-                        {
-                            SoundListBox.SelectionChanged += OnSoundSelected;
-                        }
-                    }
-                    else
-                    {
-                        // Update the display text/icon
-                        var (displayName, foreground) = GetSoundDisplayInfo(soundInfo);
-                        item.Content = displayName;
-                        item.Foreground = foreground;
-                    }
+                    var (displayName, foreground) = GetSoundDisplayInfo(soundInfo);
+                    item.Content = displayName;
+                    item.Foreground = foreground;
                     break;
                 }
             }

--- a/Parley/Parley/Views/SoundBrowserWindow.axaml.cs
+++ b/Parley/Parley/Views/SoundBrowserWindow.axaml.cs
@@ -618,10 +618,23 @@ namespace DialogEditor.Views
                     var monoOnly = MonoOnlyCheckBox?.IsChecked == true;
                     if (monoOnly && !soundInfo.IsMono)
                     {
-                        // Sound is stereo and mono filter is on — remove it
-                        SoundListBox.Items.RemoveAt(i);
-                        _filteredSounds.Remove(soundInfo);
-                        UpdateFileCountLabel(_filteredSounds.Count, monoOnly);
+                        // Sound is stereo and mono filter is on — remove it.
+                        // Suppress SelectionChanged to avoid re-entrant validation.
+                        SoundListBox.SelectionChanged -= OnSoundSelected;
+                        try
+                        {
+                            SoundListBox.Items.RemoveAt(i);
+                            _filteredSounds.Remove(soundInfo);
+                            _selectedSound = null;
+                            _selectedSoundInfo = null;
+                            SelectedSoundLabel.Text = "(none)";
+                            PlayButton.IsEnabled = false;
+                            UpdateFileCountLabel(_filteredSounds.Count, monoOnly);
+                        }
+                        finally
+                        {
+                            SoundListBox.SelectionChanged += OnSoundSelected;
+                        }
                     }
                     else
                     {

--- a/Parley/Parley/Views/SoundBrowserWindow.axaml.cs
+++ b/Parley/Parley/Views/SoundBrowserWindow.axaml.cs
@@ -513,6 +513,7 @@ namespace DialogEditor.Views
                 _selectedSoundInfo = null;
                 SelectedSoundLabel.Text = "(none)";
                 PlayButton.IsEnabled = false;
+                UpdateFileCountLabel(_filteredSounds.Count, MonoOnlyCheckBox?.IsChecked == true);
             }
         }
 
@@ -594,6 +595,43 @@ namespace DialogEditor.Views
             catch (Exception ex)
             {
                 UnifiedLogger.LogApplication(LogLevel.ERROR, $"Validation error: {ex.Message}");
+                UpdateFileCountLabel(_filteredSounds.Count, MonoOnlyCheckBox?.IsChecked == true);
+            }
+
+            // If validation changed channel info, refresh the list to update icons/filtering
+            if (!soundInfo.ChannelUnknown)
+            {
+                RefreshSoundListItem(soundInfo);
+            }
+        }
+
+        /// <summary>
+        /// Update a single item's display after validation revealed its channel info.
+        /// If the sound is now stereo and mono-only is checked, remove it from the list.
+        /// </summary>
+        private void RefreshSoundListItem(SoundFileInfo soundInfo)
+        {
+            for (int i = 0; i < SoundListBox.Items.Count; i++)
+            {
+                if (SoundListBox.Items[i] is ListBoxItem item && item.Tag == soundInfo)
+                {
+                    var monoOnly = MonoOnlyCheckBox?.IsChecked == true;
+                    if (monoOnly && !soundInfo.IsMono)
+                    {
+                        // Sound is stereo and mono filter is on — remove it
+                        SoundListBox.Items.RemoveAt(i);
+                        _filteredSounds.Remove(soundInfo);
+                        UpdateFileCountLabel(_filteredSounds.Count, monoOnly);
+                    }
+                    else
+                    {
+                        // Update the display text/icon
+                        var (displayName, foreground) = GetSoundDisplayInfo(soundInfo);
+                        item.Content = displayName;
+                        item.Foreground = foreground;
+                    }
+                    break;
+                }
             }
         }
 

--- a/Parley/Parley/Views/SoundBrowserWindow.axaml.cs
+++ b/Parley/Parley/Views/SoundBrowserWindow.axaml.cs
@@ -519,6 +519,7 @@ namespace DialogEditor.Views
 
         private void ValidateSelectedSound(SoundFileInfo soundInfo, bool skipValidation)
         {
+            var wasChannelUnknown = soundInfo.ChannelUnknown;
             try
             {
                 if (soundInfo.IsFromHak)
@@ -598,10 +599,17 @@ namespace DialogEditor.Views
                 UpdateFileCountLabel(_filteredSounds.Count, MonoOnlyCheckBox?.IsChecked == true);
             }
 
-            // If validation changed channel info, refresh the list to update icons/filtering
-            if (!soundInfo.ChannelUnknown)
+            // If validation revealed channel info for a previously unknown sound, refresh its display
+            if (wasChannelUnknown && !soundInfo.ChannelUnknown)
             {
-                RefreshSoundListItem(soundInfo);
+                try
+                {
+                    RefreshSoundListItem(soundInfo);
+                }
+                catch (Exception ex)
+                {
+                    UnifiedLogger.LogApplication(LogLevel.ERROR, $"Error refreshing sound list item: {ex.Message}");
+                }
             }
         }
 

--- a/Parley/Parley/Views/TokenSelectorWindow.axaml
+++ b/Parley/Parley/Views/TokenSelectorWindow.axaml
@@ -172,6 +172,75 @@
                 </Grid>
             </TabItem>
 
+            <!-- Custom Tokens Tab -->
+            <TabItem Header="Custom Tokens">
+                <Grid Margin="5">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <!-- Info Text -->
+                    <TextBlock Grid.Row="0" TextWrapping="Wrap" Margin="0,0,0,10"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}" FontSize="{DynamicResource FontSizeSmall}">
+                        User-defined custom tokens. Configure in ~/Radoub/custom-tokens.json
+                    </TextBlock>
+
+                    <!-- Token List -->
+                    <ListBox Grid.Row="1" x:Name="CustomTokenListBox"
+                             SelectionChanged="OnCustomTokenSelected"
+                             DoubleTapped="OnTokenDoubleClicked">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <Grid Margin="2">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+
+                                    <!-- Token name -->
+                                    <TextBlock Grid.Column="0"
+                                               Text="{Binding Name}"
+                                               VerticalAlignment="Center"/>
+
+                                    <!-- Tag preview -->
+                                    <TextBlock Grid.Column="1"
+                                               Text="{Binding TagPreview}"
+                                               Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                                               FontFamily="Consolas"
+                                               FontSize="{DynamicResource FontSizeXSmall}"
+                                               VerticalAlignment="Center"/>
+                                </Grid>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+
+                    <!-- Empty state -->
+                    <TextBlock Grid.Row="1" x:Name="CustomTokenEmptyText"
+                               Text="No custom tokens defined. Add tokens to ~/Radoub/custom-tokens.json"
+                               TextWrapping="Wrap"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                               IsVisible="True"/>
+
+                    <!-- Preview -->
+                    <Border Grid.Row="2"
+                            BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}" BorderThickness="1"
+                            Padding="10" Margin="0,10,0,0">
+                        <StackPanel>
+                            <TextBlock Text="Insert" FontWeight="Bold" Margin="0,0,0,10"/>
+                            <TextBlock x:Name="CustomTokenPreviewText"
+                                       Text="Select a token"
+                                       TextWrapping="Wrap"
+                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                                       FontFamily="Consolas"
+                                       FontSize="{DynamicResource FontSizeSmall}"/>
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </TabItem>
+
             <!-- Custom Colors Tab -->
             <TabItem Header="Custom Colors">
                 <Grid Margin="5">

--- a/Parley/Parley/Views/TokenSelectorWindow.axaml.cs
+++ b/Parley/Parley/Views/TokenSelectorWindow.axaml.cs
@@ -15,6 +15,7 @@ namespace DialogEditor.Views
     public partial class TokenSelectorWindow : Window
     {
         private UserColorConfig? _userColorConfig;
+        private CustomTokenConfig? _customTokenConfig;
 
         /// <summary>
         /// The token string to insert. Null if cancelled.
@@ -29,6 +30,7 @@ namespace DialogEditor.Views
             InitializeComponent();
             LoadStandardTokens();
             LoadUserColorConfig();
+            LoadCustomTokenConfig();
         }
 
         private void LoadStandardTokens()
@@ -71,6 +73,60 @@ namespace DialogEditor.Views
             }
 
             ColorListBox.ItemsSource = colors;
+        }
+
+        private void LoadCustomTokenConfig()
+        {
+            try
+            {
+                _customTokenConfig = CustomTokenConfigLoader.LoadOrCreateDefault();
+                LoadCustomTokenList();
+            }
+            catch (Exception)
+            {
+                _customTokenConfig = new CustomTokenConfig();
+                LoadCustomTokenList();
+            }
+        }
+
+        private void LoadCustomTokenList()
+        {
+            if (_customTokenConfig == null || !_customTokenConfig.Tokens.Any())
+            {
+                CustomTokenListBox.ItemsSource = null;
+                CustomTokenEmptyText.IsVisible = true;
+                return;
+            }
+
+            CustomTokenEmptyText.IsVisible = false;
+            var items = _customTokenConfig.Tokens.Select(t => new CustomTokenListItem
+            {
+                Name = t.Name,
+                TagPreview = t.IsStandalone ? t.Tag ?? "" : $"{t.OpenTag}...{t.CloseTag}",
+                Definition = t
+            }).ToList();
+
+            CustomTokenListBox.ItemsSource = items;
+        }
+
+        private void OnCustomTokenSelected(object? sender, SelectionChangedEventArgs e)
+        {
+            if (CustomTokenListBox == null || CustomTokenPreviewText == null)
+                return;
+
+            var item = CustomTokenListBox.SelectedItem as CustomTokenListItem;
+            if (item != null)
+            {
+                if (item.Definition.IsStandalone)
+                {
+                    CustomTokenPreviewText.Text = item.Definition.Tag ?? "";
+                }
+                else if (item.Definition.IsPaired)
+                {
+                    CustomTokenPreviewText.Text = $"{item.Definition.OpenTag}TEXT{item.Definition.CloseTag}";
+                }
+            }
+            UpdateTokenOutput();
         }
 
         private void OnTabSelectionChanged(object? sender, SelectionChangedEventArgs e)
@@ -226,7 +282,8 @@ namespace DialogEditor.Views
             // Guard against calls before UI is initialized
             if (TokenTabControl == null || TokenOutputTextBox == null ||
                 StandardTokenListBox == null || ActionRadio == null || HighlightRadio == null ||
-                ActionTextBox == null || SkillCheckComboBox == null || ColorListBox == null)
+                ActionTextBox == null || SkillCheckComboBox == null || ColorListBox == null ||
+                CustomTokenListBox == null)
                 return;
 
             var tabIndex = TokenTabControl.SelectedIndex;
@@ -268,11 +325,29 @@ namespace DialogEditor.Views
                         : "";
                     break;
 
-                case 2: // Custom Colors
+                case 2: // Custom Tokens
+                    var customItem = CustomTokenListBox.SelectedItem as CustomTokenListItem;
+                    if (customItem != null)
+                    {
+                        if (customItem.Definition.IsStandalone)
+                        {
+                            TokenOutputTextBox.Text = customItem.Definition.Tag ?? "";
+                        }
+                        else if (customItem.Definition.IsPaired)
+                        {
+                            TokenOutputTextBox.Text = $"{customItem.Definition.OpenTag}TEXT{customItem.Definition.CloseTag}";
+                        }
+                    }
+                    else
+                    {
+                        TokenOutputTextBox.Text = "";
+                    }
+                    break;
+
+                case 3: // Custom Colors
                     var colorItem = ColorListBox.SelectedItem as ColorListItem;
                     if (colorItem != null)
                     {
-                        // For custom colors, we insert open+close with cursor position in between
                         TokenOutputTextBox.Text = $"{colorItem.OpenToken}TEXT{colorItem.CloseToken}";
                     }
                     else
@@ -313,5 +388,15 @@ namespace DialogEditor.Views
         public string OpenToken { get; set; } = "";
         public string CloseToken { get; set; } = "";
         public IBrush HexColor { get; set; } = BrushManager.GetInfoBrush();
+    }
+
+    /// <summary>
+    /// Item for the custom token list display.
+    /// </summary>
+    internal class CustomTokenListItem
+    {
+        public string Name { get; set; } = "";
+        public string TagPreview { get; set; } = "";
+        public CustomTokenDefinition Definition { get; set; } = new();
     }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/CustomTokenConfigLoaderTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/CustomTokenConfigLoaderTests.cs
@@ -1,0 +1,491 @@
+using Radoub.Formats.Tokens;
+using Xunit;
+
+namespace Radoub.Formats.Tests;
+
+/// <summary>
+/// Tests for CustomTokenConfigLoader — user-defined custom (non-color) tokens.
+/// Issue #1890: User-defined custom tokens in token chooser.
+/// </summary>
+public class CustomTokenConfigLoaderTests : IDisposable
+{
+    private readonly string _testDir;
+    private readonly string _testConfigPath;
+
+    public CustomTokenConfigLoaderTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), $"RadoubTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDir);
+        _testConfigPath = Path.Combine(_testDir, "custom-tokens.json");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDir))
+        {
+            Directory.Delete(_testDir, recursive: true);
+        }
+    }
+
+    #region Load Tests
+
+    [Fact]
+    public void Load_NonExistentFile_ReturnsEmptyConfig()
+    {
+        var result = CustomTokenConfigLoader.Load(Path.Combine(_testDir, "nonexistent.json"));
+
+        Assert.NotNull(result);
+        Assert.Empty(result.Tokens);
+    }
+
+    [Fact]
+    public void Load_ValidStandaloneToken_ParsesCorrectly()
+    {
+        var json = """
+            {
+              "tokens": [
+                { "name": "Faction Header", "type": "standalone", "tag": "<CUSTOM500>" }
+              ]
+            }
+            """;
+        File.WriteAllText(_testConfigPath, json);
+
+        var result = CustomTokenConfigLoader.Load(_testConfigPath);
+
+        Assert.Single(result.Tokens);
+        var token = result.Tokens[0];
+        Assert.Equal("Faction Header", token.Name);
+        Assert.True(token.IsStandalone);
+        Assert.Equal("<CUSTOM500>", token.Tag);
+    }
+
+    [Fact]
+    public void Load_ValidPairedToken_ParsesCorrectly()
+    {
+        var json = """
+            {
+              "tokens": [
+                { "name": "Italic", "type": "paired", "openTag": "<CUSTOM2001>", "closeTag": "<CUSTOM2000>" }
+              ]
+            }
+            """;
+        File.WriteAllText(_testConfigPath, json);
+
+        var result = CustomTokenConfigLoader.Load(_testConfigPath);
+
+        Assert.Single(result.Tokens);
+        var token = result.Tokens[0];
+        Assert.Equal("Italic", token.Name);
+        Assert.True(token.IsPaired);
+        Assert.Equal("<CUSTOM2001>", token.OpenTag);
+        Assert.Equal("<CUSTOM2000>", token.CloseTag);
+    }
+
+    [Fact]
+    public void Load_MixedTokenTypes_ParsesBoth()
+    {
+        var json = """
+            {
+              "tokens": [
+                { "name": "Faction", "type": "standalone", "tag": "<CUSTOM500>" },
+                { "name": "Bold", "type": "paired", "openTag": "<CUSTOM3001>", "closeTag": "<CUSTOM3000>" }
+              ]
+            }
+            """;
+        File.WriteAllText(_testConfigPath, json);
+
+        var result = CustomTokenConfigLoader.Load(_testConfigPath);
+
+        Assert.Equal(2, result.Tokens.Count);
+        Assert.True(result.Tokens[0].IsStandalone);
+        Assert.True(result.Tokens[1].IsPaired);
+    }
+
+    [Fact]
+    public void Load_EmptyTokensArray_ReturnsEmptyConfig()
+    {
+        File.WriteAllText(_testConfigPath, """{ "tokens": [] }""");
+
+        var result = CustomTokenConfigLoader.Load(_testConfigPath);
+
+        Assert.NotNull(result);
+        Assert.Empty(result.Tokens);
+    }
+
+    [Fact]
+    public void Load_InvalidJson_ReturnsEmptyConfig()
+    {
+        File.WriteAllText(_testConfigPath, "{ not valid json }");
+
+        var result = CustomTokenConfigLoader.Load(_testConfigPath);
+
+        Assert.NotNull(result);
+        Assert.Empty(result.Tokens);
+    }
+
+    [Fact]
+    public void Load_EmptyFile_ReturnsEmptyConfig()
+    {
+        File.WriteAllText(_testConfigPath, "");
+
+        var result = CustomTokenConfigLoader.Load(_testConfigPath);
+
+        Assert.NotNull(result);
+        Assert.Empty(result.Tokens);
+    }
+
+    [Fact]
+    public void Load_EmptyObject_ReturnsEmptyConfig()
+    {
+        File.WriteAllText(_testConfigPath, "{}");
+
+        var result = CustomTokenConfigLoader.Load(_testConfigPath);
+
+        Assert.NotNull(result);
+        Assert.Empty(result.Tokens);
+    }
+
+    #endregion
+
+    #region Validation Tests
+
+    [Fact]
+    public void Load_StandaloneWithoutTag_SkipsInvalidEntry()
+    {
+        var json = """
+            {
+              "tokens": [
+                { "name": "Missing Tag", "type": "standalone" },
+                { "name": "Valid", "type": "standalone", "tag": "<CUSTOM100>" }
+              ]
+            }
+            """;
+        File.WriteAllText(_testConfigPath, json);
+
+        var result = CustomTokenConfigLoader.Load(_testConfigPath);
+
+        Assert.Single(result.Tokens);
+        Assert.Equal("Valid", result.Tokens[0].Name);
+    }
+
+    [Fact]
+    public void Load_PairedWithoutOpenTag_SkipsInvalidEntry()
+    {
+        var json = """
+            {
+              "tokens": [
+                { "name": "Missing Open", "type": "paired", "closeTag": "<CUSTOM2000>" },
+                { "name": "Valid", "type": "standalone", "tag": "<CUSTOM100>" }
+              ]
+            }
+            """;
+        File.WriteAllText(_testConfigPath, json);
+
+        var result = CustomTokenConfigLoader.Load(_testConfigPath);
+
+        Assert.Single(result.Tokens);
+        Assert.Equal("Valid", result.Tokens[0].Name);
+    }
+
+    [Fact]
+    public void Load_PairedWithoutCloseTag_SkipsInvalidEntry()
+    {
+        var json = """
+            {
+              "tokens": [
+                { "name": "Missing Close", "type": "paired", "openTag": "<CUSTOM2001>" },
+                { "name": "Valid", "type": "standalone", "tag": "<CUSTOM100>" }
+              ]
+            }
+            """;
+        File.WriteAllText(_testConfigPath, json);
+
+        var result = CustomTokenConfigLoader.Load(_testConfigPath);
+
+        Assert.Single(result.Tokens);
+        Assert.Equal("Valid", result.Tokens[0].Name);
+    }
+
+    [Fact]
+    public void Load_InvalidTagSyntax_SkipsEntry()
+    {
+        var json = """
+            {
+              "tokens": [
+                { "name": "Bad Tag", "type": "standalone", "tag": "NotACustomTag" },
+                { "name": "Valid", "type": "standalone", "tag": "<CUSTOM100>" }
+              ]
+            }
+            """;
+        File.WriteAllText(_testConfigPath, json);
+
+        var result = CustomTokenConfigLoader.Load(_testConfigPath);
+
+        Assert.Single(result.Tokens);
+        Assert.Equal("Valid", result.Tokens[0].Name);
+    }
+
+    [Fact]
+    public void Load_InvalidTagSyntaxInPaired_SkipsEntry()
+    {
+        var json = """
+            {
+              "tokens": [
+                { "name": "Bad Paired", "type": "paired", "openTag": "invalid", "closeTag": "<CUSTOM2000>" },
+                { "name": "Valid", "type": "standalone", "tag": "<CUSTOM100>" }
+              ]
+            }
+            """;
+        File.WriteAllText(_testConfigPath, json);
+
+        var result = CustomTokenConfigLoader.Load(_testConfigPath);
+
+        Assert.Single(result.Tokens);
+        Assert.Equal("Valid", result.Tokens[0].Name);
+    }
+
+    [Fact]
+    public void Load_DuplicateNames_KeepsFirstOnly()
+    {
+        var json = """
+            {
+              "tokens": [
+                { "name": "Faction", "type": "standalone", "tag": "<CUSTOM500>" },
+                { "name": "Faction", "type": "standalone", "tag": "<CUSTOM501>" }
+              ]
+            }
+            """;
+        File.WriteAllText(_testConfigPath, json);
+
+        var result = CustomTokenConfigLoader.Load(_testConfigPath);
+
+        Assert.Single(result.Tokens);
+        Assert.Equal("<CUSTOM500>", result.Tokens[0].Tag);
+    }
+
+    [Fact]
+    public void Load_UnknownType_SkipsEntry()
+    {
+        var json = """
+            {
+              "tokens": [
+                { "name": "Unknown", "type": "macro", "tag": "<CUSTOM100>" },
+                { "name": "Valid", "type": "standalone", "tag": "<CUSTOM200>" }
+              ]
+            }
+            """;
+        File.WriteAllText(_testConfigPath, json);
+
+        var result = CustomTokenConfigLoader.Load(_testConfigPath);
+
+        Assert.Single(result.Tokens);
+        Assert.Equal("Valid", result.Tokens[0].Name);
+    }
+
+    [Fact]
+    public void Load_EmptyName_SkipsEntry()
+    {
+        var json = """
+            {
+              "tokens": [
+                { "name": "", "type": "standalone", "tag": "<CUSTOM100>" },
+                { "name": "Valid", "type": "standalone", "tag": "<CUSTOM200>" }
+              ]
+            }
+            """;
+        File.WriteAllText(_testConfigPath, json);
+
+        var result = CustomTokenConfigLoader.Load(_testConfigPath);
+
+        Assert.Single(result.Tokens);
+        Assert.Equal("Valid", result.Tokens[0].Name);
+    }
+
+    #endregion
+
+    #region Save and RoundTrip Tests
+
+    [Fact]
+    public void Save_WritesFileToPath()
+    {
+        var config = new CustomTokenConfig
+        {
+            Tokens = new List<CustomTokenDefinition>
+            {
+                new() { Name = "Test", Type = "standalone", Tag = "<CUSTOM100>" }
+            }
+        };
+
+        CustomTokenConfigLoader.Save(config, _testConfigPath);
+
+        Assert.True(File.Exists(_testConfigPath));
+        var content = File.ReadAllText(_testConfigPath);
+        Assert.Contains("Test", content);
+        Assert.Contains("CUSTOM100", content);
+    }
+
+    [Fact]
+    public void Save_CreatesDirectoryIfNeeded()
+    {
+        var nestedPath = Path.Combine(_testDir, "sub", "nested", "custom-tokens.json");
+        var config = new CustomTokenConfig();
+
+        CustomTokenConfigLoader.Save(config, nestedPath);
+
+        Assert.True(File.Exists(nestedPath));
+    }
+
+    [Fact]
+    public void RoundTrip_StandaloneToken_PreservesAllFields()
+    {
+        var original = new CustomTokenConfig
+        {
+            Tokens = new List<CustomTokenDefinition>
+            {
+                new() { Name = "Faction Header", Type = "standalone", Tag = "<CUSTOM500>" }
+            }
+        };
+
+        CustomTokenConfigLoader.Save(original, _testConfigPath);
+        var loaded = CustomTokenConfigLoader.Load(_testConfigPath);
+
+        Assert.Single(loaded.Tokens);
+        Assert.Equal("Faction Header", loaded.Tokens[0].Name);
+        Assert.Equal("standalone", loaded.Tokens[0].Type);
+        Assert.Equal("<CUSTOM500>", loaded.Tokens[0].Tag);
+    }
+
+    [Fact]
+    public void RoundTrip_PairedToken_PreservesAllFields()
+    {
+        var original = new CustomTokenConfig
+        {
+            Tokens = new List<CustomTokenDefinition>
+            {
+                new() { Name = "Italic", Type = "paired", OpenTag = "<CUSTOM2001>", CloseTag = "<CUSTOM2000>" }
+            }
+        };
+
+        CustomTokenConfigLoader.Save(original, _testConfigPath);
+        var loaded = CustomTokenConfigLoader.Load(_testConfigPath);
+
+        Assert.Single(loaded.Tokens);
+        Assert.Equal("Italic", loaded.Tokens[0].Name);
+        Assert.Equal("paired", loaded.Tokens[0].Type);
+        Assert.Equal("<CUSTOM2001>", loaded.Tokens[0].OpenTag);
+        Assert.Equal("<CUSTOM2000>", loaded.Tokens[0].CloseTag);
+    }
+
+    [Fact]
+    public void RoundTrip_MixedTokens_PreservesAll()
+    {
+        var original = new CustomTokenConfig
+        {
+            Tokens = new List<CustomTokenDefinition>
+            {
+                new() { Name = "Faction", Type = "standalone", Tag = "<CUSTOM500>" },
+                new() { Name = "Bold", Type = "paired", OpenTag = "<CUSTOM3001>", CloseTag = "<CUSTOM3000>" },
+                new() { Name = "Location", Type = "standalone", Tag = "<CUSTOM600>" }
+            }
+        };
+
+        CustomTokenConfigLoader.Save(original, _testConfigPath);
+        var loaded = CustomTokenConfigLoader.Load(_testConfigPath);
+
+        Assert.Equal(3, loaded.Tokens.Count);
+        Assert.Equal("Faction", loaded.Tokens[0].Name);
+        Assert.Equal("Bold", loaded.Tokens[1].Name);
+        Assert.Equal("Location", loaded.Tokens[2].Name);
+    }
+
+    #endregion
+
+    #region LoadOrCreateDefault Tests
+
+    [Fact]
+    public void LoadOrCreateDefault_WhenFileNotExists_CreatesEmptyConfig()
+    {
+        var path = Path.Combine(_testDir, "newdir", "custom-tokens.json");
+
+        var config = CustomTokenConfigLoader.LoadOrCreateDefault(path);
+
+        Assert.NotNull(config);
+        Assert.Empty(config.Tokens);
+        Assert.True(File.Exists(path));
+    }
+
+    [Fact]
+    public void LoadOrCreateDefault_WhenFileExists_ReturnsExisting()
+    {
+        var json = """
+            {
+              "tokens": [
+                { "name": "Test", "type": "standalone", "tag": "<CUSTOM100>" }
+              ]
+            }
+            """;
+        File.WriteAllText(_testConfigPath, json);
+
+        var config = CustomTokenConfigLoader.LoadOrCreateDefault(_testConfigPath);
+
+        Assert.Single(config.Tokens);
+        Assert.Equal("Test", config.Tokens[0].Name);
+    }
+
+    #endregion
+
+    #region GetDefaultConfigPath Tests
+
+    [Fact]
+    public void GetDefaultConfigPath_ContainsRadoubFolder()
+    {
+        var path = CustomTokenConfigLoader.GetDefaultConfigPath();
+
+        Assert.Contains("Radoub", path);
+        Assert.EndsWith("custom-tokens.json", path);
+    }
+
+    [Fact]
+    public void GetDefaultConfigPath_IsAbsolutePath()
+    {
+        var path = CustomTokenConfigLoader.GetDefaultConfigPath();
+
+        Assert.True(Path.IsPathRooted(path));
+    }
+
+    #endregion
+
+    #region CustomTokenDefinition Model Tests
+
+    [Fact]
+    public void IsStandalone_WhenTypeIsStandalone_ReturnsTrue()
+    {
+        var token = new CustomTokenDefinition { Type = "standalone" };
+        Assert.True(token.IsStandalone);
+        Assert.False(token.IsPaired);
+    }
+
+    [Fact]
+    public void IsPaired_WhenTypeIsPaired_ReturnsTrue()
+    {
+        var token = new CustomTokenDefinition { Type = "paired" };
+        Assert.True(token.IsPaired);
+        Assert.False(token.IsStandalone);
+    }
+
+    [Fact]
+    public void IsStandalone_CaseInsensitive()
+    {
+        var token = new CustomTokenDefinition { Type = "Standalone" };
+        Assert.True(token.IsStandalone);
+    }
+
+    [Fact]
+    public void IsPaired_CaseInsensitive()
+    {
+        var token = new CustomTokenDefinition { Type = "Paired" };
+        Assert.True(token.IsPaired);
+    }
+
+    #endregion
+}

--- a/Radoub.Formats/Radoub.Formats/Tokens/CustomTokenConfig.cs
+++ b/Radoub.Formats/Radoub.Formats/Tokens/CustomTokenConfig.cs
@@ -1,0 +1,51 @@
+namespace Radoub.Formats.Tokens;
+
+/// <summary>
+/// Runtime model for user-defined custom (non-color) tokens.
+/// Loaded from ~/Radoub/custom-tokens.json
+/// </summary>
+public class CustomTokenConfig
+{
+    public List<CustomTokenDefinition> Tokens { get; set; } = new();
+}
+
+/// <summary>
+/// A single custom token definition — standalone or paired.
+/// </summary>
+public class CustomTokenDefinition
+{
+    /// <summary>
+    /// Display name shown in the token chooser UI.
+    /// </summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>
+    /// Token type: "standalone" or "paired".
+    /// </summary>
+    public string Type { get; set; } = "standalone";
+
+    /// <summary>
+    /// The CUSTOM tag for standalone tokens (e.g., "&lt;CUSTOM500&gt;").
+    /// </summary>
+    public string? Tag { get; set; }
+
+    /// <summary>
+    /// The opening CUSTOM tag for paired tokens (e.g., "&lt;CUSTOM2001&gt;").
+    /// </summary>
+    public string? OpenTag { get; set; }
+
+    /// <summary>
+    /// The closing CUSTOM tag for paired tokens (e.g., "&lt;CUSTOM2000&gt;").
+    /// </summary>
+    public string? CloseTag { get; set; }
+
+    /// <summary>
+    /// Whether this is a standalone token (single tag insert).
+    /// </summary>
+    public bool IsStandalone => Type?.Equals("standalone", StringComparison.OrdinalIgnoreCase) == true;
+
+    /// <summary>
+    /// Whether this is a paired token (open/close wrapping).
+    /// </summary>
+    public bool IsPaired => Type?.Equals("paired", StringComparison.OrdinalIgnoreCase) == true;
+}

--- a/Radoub.Formats/Radoub.Formats/Tokens/CustomTokenConfigLoader.cs
+++ b/Radoub.Formats/Radoub.Formats/Tokens/CustomTokenConfigLoader.cs
@@ -1,0 +1,159 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Radoub.Formats.Logging;
+
+namespace Radoub.Formats.Tokens;
+
+/// <summary>
+/// Loads user-defined custom (non-color) token configurations.
+/// Configuration file location: ~/Radoub/custom-tokens.json
+/// </summary>
+public static class CustomTokenConfigLoader
+{
+    private const string ConfigFileName = "custom-tokens.json";
+    private const string RadoubFolderName = "Radoub";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private static readonly Regex CustomTagPattern = new(@"^<CUSTOM\d+>$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Get the default configuration file path.
+    /// </summary>
+    public static string GetDefaultConfigPath()
+    {
+        var homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(homeDir, RadoubFolderName, ConfigFileName);
+    }
+
+    /// <summary>
+    /// Load configuration from a specific path.
+    /// Returns empty config if file doesn't exist or is invalid.
+    /// </summary>
+    public static CustomTokenConfig Load(string path)
+    {
+        if (!File.Exists(path))
+            return new CustomTokenConfig();
+
+        try
+        {
+            var json = File.ReadAllText(path);
+            if (string.IsNullOrWhiteSpace(json))
+                return new CustomTokenConfig();
+
+            var fileConfig = JsonSerializer.Deserialize<CustomTokenConfig>(json, JsonOptions);
+            if (fileConfig == null)
+                return new CustomTokenConfig();
+
+            fileConfig.Tokens = ValidateTokens(fileConfig.Tokens);
+            return fileConfig;
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.Log(LogLevel.WARN, $"Failed to load custom token config: {ex.Message}", "CustomTokenConfigLoader", "Tokens");
+            return new CustomTokenConfig();
+        }
+    }
+
+    /// <summary>
+    /// Load configuration from the default path, creating empty default if not exists.
+    /// </summary>
+    public static CustomTokenConfig LoadOrCreateDefault()
+    {
+        return LoadOrCreateDefault(GetDefaultConfigPath());
+    }
+
+    /// <summary>
+    /// Load configuration from a specific path, creating empty default if not exists.
+    /// </summary>
+    public static CustomTokenConfig LoadOrCreateDefault(string path)
+    {
+        if (File.Exists(path))
+            return Load(path);
+
+        var config = new CustomTokenConfig();
+        Save(config, path);
+        return config;
+    }
+
+    /// <summary>
+    /// Save configuration to a specific path.
+    /// </summary>
+    public static void Save(CustomTokenConfig config, string path)
+    {
+        var json = JsonSerializer.Serialize(config, JsonOptions);
+
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        File.WriteAllText(path, json);
+    }
+
+    private static List<CustomTokenDefinition> ValidateTokens(List<CustomTokenDefinition> tokens)
+    {
+        var validated = new List<CustomTokenDefinition>();
+        var seenNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var token in tokens)
+        {
+            if (string.IsNullOrWhiteSpace(token.Name))
+            {
+                UnifiedLogger.Log(LogLevel.WARN, "Skipping custom token with empty name", "CustomTokenConfigLoader", "Tokens");
+                continue;
+            }
+
+            if (!seenNames.Add(token.Name))
+            {
+                UnifiedLogger.Log(LogLevel.WARN, $"Skipping duplicate custom token name: '{token.Name}'", "CustomTokenConfigLoader", "Tokens");
+                continue;
+            }
+
+            if (!token.IsStandalone && !token.IsPaired)
+            {
+                UnifiedLogger.Log(LogLevel.WARN, $"Skipping custom token '{token.Name}' with unknown type: '{token.Type}'", "CustomTokenConfigLoader", "Tokens");
+                continue;
+            }
+
+            if (token.IsStandalone)
+            {
+                if (string.IsNullOrWhiteSpace(token.Tag) || !IsValidCustomTag(token.Tag))
+                {
+                    UnifiedLogger.Log(LogLevel.WARN, $"Skipping standalone token '{token.Name}' with invalid tag: '{token.Tag}'", "CustomTokenConfigLoader", "Tokens");
+                    continue;
+                }
+            }
+
+            if (token.IsPaired)
+            {
+                if (string.IsNullOrWhiteSpace(token.OpenTag) || !IsValidCustomTag(token.OpenTag))
+                {
+                    UnifiedLogger.Log(LogLevel.WARN, $"Skipping paired token '{token.Name}' with invalid openTag: '{token.OpenTag}'", "CustomTokenConfigLoader", "Tokens");
+                    continue;
+                }
+                if (string.IsNullOrWhiteSpace(token.CloseTag) || !IsValidCustomTag(token.CloseTag))
+                {
+                    UnifiedLogger.Log(LogLevel.WARN, $"Skipping paired token '{token.Name}' with invalid closeTag: '{token.CloseTag}'", "CustomTokenConfigLoader", "Tokens");
+                    continue;
+                }
+            }
+
+            validated.Add(token);
+        }
+
+        return validated;
+    }
+
+    private static bool IsValidCustomTag(string tag)
+    {
+        return CustomTagPattern.IsMatch(tag);
+    }
+}

--- a/Radoub.UI/Radoub.UI/Services/AudioService.cs
+++ b/Radoub.UI/Radoub.UI/Services/AudioService.cs
@@ -160,10 +160,25 @@ internal class WindowsAudioPlayer : IAudioPlayer
 
             if (IsRiffWav(firstBytes))
             {
-                // Use WaveFileReader for WAV files - better ADPCM codec support
-                _waveStream = new NAudio.Wave.WaveFileReader(filePath);
-                UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                    $"Using WaveFileReader for {Path.GetFileName(filePath)} - Format: {_waveStream.WaveFormat}");
+                // Use WaveFileReader for WAV files
+                var reader = new NAudio.Wave.WaveFileReader(filePath);
+
+                // IMA ADPCM and other non-PCM formats need conversion to PCM for WaveOutEvent
+                if (reader.WaveFormat.Encoding != NAudio.Wave.WaveFormatEncoding.Pcm &&
+                    reader.WaveFormat.Encoding != NAudio.Wave.WaveFormatEncoding.IeeeFloat)
+                {
+                    var pcmFormat = new NAudio.Wave.WaveFormat(
+                        reader.WaveFormat.SampleRate, 16, reader.WaveFormat.Channels);
+                    _waveStream = new NAudio.Wave.WaveFormatConversionStream(pcmFormat, reader);
+                    UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                        $"Converted {reader.WaveFormat.Encoding} to PCM for {Path.GetFileName(filePath)}");
+                }
+                else
+                {
+                    _waveStream = reader;
+                    UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                        $"Using WaveFileReader for {Path.GetFileName(filePath)} - Format: {reader.WaveFormat}");
+                }
             }
             else if (IsBmu(firstBytes))
             {

--- a/Radoub.UI/Radoub.UI/Views/TokenSelectorWindow.axaml
+++ b/Radoub.UI/Radoub.UI/Views/TokenSelectorWindow.axaml
@@ -172,6 +172,75 @@
                 </Grid>
             </TabItem>
 
+            <!-- Custom Tokens Tab -->
+            <TabItem Header="Custom Tokens">
+                <Grid Margin="5">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <!-- Info Text -->
+                    <TextBlock Grid.Row="0" TextWrapping="Wrap" Margin="0,0,0,10"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}" FontSize="{DynamicResource FontSizeSmall}">
+                        User-defined custom tokens. Configure in ~/Radoub/custom-tokens.json
+                    </TextBlock>
+
+                    <!-- Token List -->
+                    <ListBox Grid.Row="1" x:Name="CustomTokenListBox"
+                             SelectionChanged="OnCustomTokenSelected"
+                             DoubleTapped="OnTokenDoubleClicked">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <Grid Margin="2">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+
+                                    <!-- Token name -->
+                                    <TextBlock Grid.Column="0"
+                                               Text="{Binding Name}"
+                                               VerticalAlignment="Center"/>
+
+                                    <!-- Tag preview -->
+                                    <TextBlock Grid.Column="1"
+                                               Text="{Binding TagPreview}"
+                                               Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                                               FontFamily="Consolas"
+                                               FontSize="{DynamicResource FontSizeXSmall}"
+                                               VerticalAlignment="Center"/>
+                                </Grid>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+
+                    <!-- Empty state -->
+                    <TextBlock Grid.Row="1" x:Name="CustomTokenEmptyText"
+                               Text="No custom tokens defined. Add tokens to ~/Radoub/custom-tokens.json"
+                               TextWrapping="Wrap"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                               IsVisible="True"/>
+
+                    <!-- Preview -->
+                    <Border Grid.Row="2"
+                            BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}" BorderThickness="1"
+                            Padding="10" Margin="0,10,0,0">
+                        <StackPanel>
+                            <TextBlock Text="Insert" FontWeight="Bold" Margin="0,0,0,10"/>
+                            <TextBlock x:Name="CustomTokenPreviewText"
+                                       Text="Select a token"
+                                       TextWrapping="Wrap"
+                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                                       FontFamily="Consolas"
+                                       FontSize="{DynamicResource FontSizeSmall}"/>
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </TabItem>
+
             <!-- Custom Colors Tab -->
             <TabItem Header="Custom Colors">
                 <Grid Margin="5">

--- a/Radoub.UI/Radoub.UI/Views/TokenSelectorWindow.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Views/TokenSelectorWindow.axaml.cs
@@ -24,11 +24,14 @@ namespace Radoub.UI.Views
         /// <summary>
         /// Initializes the token selector window.
         /// </summary>
+        private CustomTokenConfig? _customTokenConfig;
+
         public TokenSelectorWindow()
         {
             InitializeComponent();
             LoadStandardTokens();
             LoadUserColorConfig();
+            LoadCustomTokenConfig();
         }
 
         private void LoadStandardTokens()
@@ -71,6 +74,61 @@ namespace Radoub.UI.Views
             }
 
             ColorListBox.ItemsSource = colors;
+        }
+
+        private void LoadCustomTokenConfig()
+        {
+            try
+            {
+                _customTokenConfig = CustomTokenConfigLoader.LoadOrCreateDefault();
+                LoadCustomTokenList();
+            }
+            catch (Exception ex)
+            {
+                UnifiedLogger.Log(LogLevel.WARN, $"Failed to load custom token config: {ex.Message}", "TokenSelectorWindow", "Tokens");
+                _customTokenConfig = new CustomTokenConfig();
+                LoadCustomTokenList();
+            }
+        }
+
+        private void LoadCustomTokenList()
+        {
+            if (_customTokenConfig == null || !_customTokenConfig.Tokens.Any())
+            {
+                CustomTokenListBox.ItemsSource = null;
+                CustomTokenEmptyText.IsVisible = true;
+                return;
+            }
+
+            CustomTokenEmptyText.IsVisible = false;
+            var items = _customTokenConfig.Tokens.Select(t => new CustomTokenListItem
+            {
+                Name = t.Name,
+                TagPreview = t.IsStandalone ? t.Tag ?? "" : $"{t.OpenTag}...{t.CloseTag}",
+                Definition = t
+            }).ToList();
+
+            CustomTokenListBox.ItemsSource = items;
+        }
+
+        private void OnCustomTokenSelected(object? sender, SelectionChangedEventArgs e)
+        {
+            if (CustomTokenListBox == null || CustomTokenPreviewText == null)
+                return;
+
+            var item = CustomTokenListBox.SelectedItem as CustomTokenListItem;
+            if (item != null)
+            {
+                if (item.Definition.IsStandalone)
+                {
+                    CustomTokenPreviewText.Text = item.Definition.Tag ?? "";
+                }
+                else if (item.Definition.IsPaired)
+                {
+                    CustomTokenPreviewText.Text = $"{item.Definition.OpenTag}TEXT{item.Definition.CloseTag}";
+                }
+            }
+            UpdateTokenOutput();
         }
 
         private void OnTabSelectionChanged(object? sender, SelectionChangedEventArgs e)
@@ -226,7 +284,8 @@ namespace Radoub.UI.Views
             // Guard against calls before UI is initialized
             if (TokenTabControl == null || TokenOutputTextBox == null ||
                 StandardTokenListBox == null || ActionRadio == null || HighlightRadio == null ||
-                ActionTextBox == null || SkillCheckComboBox == null || ColorListBox == null)
+                ActionTextBox == null || SkillCheckComboBox == null || ColorListBox == null ||
+                CustomTokenListBox == null)
                 return;
 
             var tabIndex = TokenTabControl.SelectedIndex;
@@ -268,11 +327,29 @@ namespace Radoub.UI.Views
                         : "";
                     break;
 
-                case 2: // Custom Colors
+                case 2: // Custom Tokens
+                    var customItem = CustomTokenListBox.SelectedItem as CustomTokenListItem;
+                    if (customItem != null)
+                    {
+                        if (customItem.Definition.IsStandalone)
+                        {
+                            TokenOutputTextBox.Text = customItem.Definition.Tag ?? "";
+                        }
+                        else if (customItem.Definition.IsPaired)
+                        {
+                            TokenOutputTextBox.Text = $"{customItem.Definition.OpenTag}TEXT{customItem.Definition.CloseTag}";
+                        }
+                    }
+                    else
+                    {
+                        TokenOutputTextBox.Text = "";
+                    }
+                    break;
+
+                case 3: // Custom Colors
                     var colorItem = ColorListBox.SelectedItem as ColorListItem;
                     if (colorItem != null)
                     {
-                        // For custom colors, we insert open+close with cursor position in between
                         TokenOutputTextBox.Text = $"{colorItem.OpenToken}TEXT{colorItem.CloseToken}";
                     }
                     else
@@ -313,5 +390,15 @@ namespace Radoub.UI.Views
         public string OpenToken { get; set; } = "";
         public string CloseToken { get; set; } = "";
         public IBrush HexColor { get; set; } = Brushes.White;
+    }
+
+    /// <summary>
+    /// Item for the custom token list display.
+    /// </summary>
+    internal class CustomTokenListItem
+    {
+        public string Name { get; set; } = "";
+        public string TagPreview { get; set; } = "";
+        public CustomTokenDefinition Definition { get; set; } = new();
     }
 }


### PR DESCRIPTION
## Summary

Sprint covering QoL improvements, audio fixes, and tech-debt cleanup for Parley.

### Work Items

- [x] #1961 — Lazy-load TTS factory and defer ResourcePathDetector (completed in prior work)
- [x] #1890 — User-defined custom (non-color) tokens in token chooser
- [x] #1241 — Sound Browser overhaul: relabel, defaults, mono filter persistence
- ~~#1889 — Per-module color token profiles~~ (deferred — over-engineering)

### Additional Fixes (found during testing)

- Fix ADPCM/DviAdpcm WAV playback — base game sounds now play correctly
- Fix Sound Browser validation display not clearing on deselect
- Fix Sound Browser list refresh after channel validation reveals stereo
- Fix Sound Browser crash when stereo sound removed from mono-only list
- Token insert adds trailing space and defers focus restoration
- Created #2050 for proper tree refresh coordinator (architectural fix)

## Related Issues

- Closes #1977
- Closes #1890
- Closes #1241
- Related: #2049 (side-by-side view positioning)
- Related: #2050 (tree refresh coordinator)

## Tests

- 2315 passed, 1 pre-existing failure (`CustomTlkPath_PersistsToFile` — unrelated)
- 29 new `CustomTokenConfigLoader` tests
- 11 new `SoundFileInfo` model tests
- Privacy scan: clean
- Tech debt: `SoundBrowserWindow.axaml.cs` 811 lines (warning only)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)