### PR TITLE
[Quartermaster] Sprint: Appearance Preview & Search (#1979)

### DIFF
--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.76-alpha] - 2026-04-11
-**Branch**: `quartermaster/issue-1979` | **PR**: #TBD
+**Branch**: `quartermaster/issue-1979` | **PR**: #2055
 
 ### Sprint: Appearance Preview & Search (#1979)
 - Show model resref in appearance list with copy context menu (#1870)

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.76-alpha] - 2026-04-11
+**Branch**: `quartermaster/issue-1979` | **PR**: #TBD
+
+### Sprint: Appearance Preview & Search (#1979)
+- Show model resref in appearance list with copy context menu (#1870)
+- Model completeness indicator below 3D preview (#1873)
+- Search creature inventory/backpack item ResRefs in Marlinspike (#1947)
+- Custom token support and Description editor for spell-checked fields (#1697)
+
+---
+
 ## [0.2.75-alpha] - 2026-03-29
 **Branch**: `radoub/issue-1817` | **PR**: #2030
 

--- a/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
+++ b/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
@@ -81,6 +81,16 @@ public class ModelPreviewGLControl : OpenGlControlBase
     public event EventHandler<PreviewState>? PreviewStateChanged;
 
     /// <summary>
+    /// Mesh composition info for the currently loaded model.
+    /// </summary>
+    public record ModelMeshInfo(int TotalMeshes, int SkinMeshCount, int HiddenMeshCount);
+
+    /// <summary>
+    /// Raised on the UI thread after model mesh analysis completes.
+    /// </summary>
+    public event EventHandler<ModelMeshInfo>? MeshInfoChanged;
+
+    /// <summary>
     /// The model to render.
     /// </summary>
     public MdlModel? Model
@@ -94,7 +104,10 @@ public class ModelPreviewGLControl : OpenGlControlBase
             _logOncePerModel = true;
             _viewController.CenterCamera();
             if (value == null)
+            {
                 SetPreviewState(PreviewState.None);
+                MeshInfoChanged?.Invoke(this, new ModelMeshInfo(0, 0, 0));
+            }
             RequestNextFrameRendering();
         }
     }
@@ -779,7 +792,19 @@ public class ModelPreviewGLControl : OpenGlControlBase
             } // else (valid bounds)
         }
 
+        // Mesh composition analysis for model completeness indicator (#1873)
+        int totalMeshCount = allMeshes.Count;
+        int skinMeshCount = allMeshes.Count(m => m is Radoub.Formats.Mdl.MdlSkinNode && m.Render && m.Vertices.Length > 0);
+        int hiddenMeshCount = allMeshes.Count(m => !m.Render);
+
         UnifiedLogger.LogApplication(LogLevel.INFO, $"UpdateMeshBuffers: model={_model?.Name ?? "null"}, {_meshDrawCalls.Count} meshes ({skippedMeshes} skipped), {vertices.Count / 8} vertices, {_indexCount / 3} triangles");
+
+        // Notify listeners of mesh composition
+        var meshInfo = new ModelMeshInfo(totalMeshCount, skinMeshCount, hiddenMeshCount);
+        if (Dispatcher.UIThread.CheckAccess())
+            MeshInfoChanged?.Invoke(this, meshInfo);
+        else
+            Dispatcher.UIThread.Post(() => MeshInfoChanged?.Invoke(this, meshInfo));
 
         // Determine preview state based on rendered geometry and emitter nodes
         if (_indexCount == 0)

--- a/Quartermaster/Quartermaster/Views/Panels/AdvancedPanel.axaml
+++ b/Quartermaster/Quartermaster/Views/Panels/AdvancedPanel.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:converters="using:Radoub.UI.Converters"
+             xmlns:controls="using:Radoub.UI.Controls"
              mc:Ignorable="d" d:DesignWidth="700" d:DesignHeight="900"
              x:Class="Quartermaster.Views.Panels.AdvancedPanel">
 
@@ -63,7 +64,7 @@
                                 <TextBlock Grid.Column="0" Text="Comment:"
                                            Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                            VerticalAlignment="Top" Margin="0,5,0,0" Width="100"/>
-                                <TextBox Grid.Column="1"
+                                <controls:SpellCheckTextBox Grid.Column="1"
                                          x:Name="CommentTextBox"
                                          AcceptsReturn="True"
                                          TextWrapping="Wrap"

--- a/Quartermaster/Quartermaster/Views/Panels/AdvancedPanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AdvancedPanel.axaml.cs
@@ -11,6 +11,8 @@ using Quartermaster.Views.Dialogs;
 using Radoub.Formats.Gff;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Utc;
+using Radoub.UI.Controls;
+using Radoub.UI.Services;
 
 namespace Quartermaster.Views.Panels;
 
@@ -19,7 +21,7 @@ public partial class AdvancedPanel : BasePanelControl
     // Identity section
     private TextBox? _templateResRefTextBox;
     private TextBox? _tagTextBox;
-    private TextBox? _commentTextBox;
+    private Radoub.UI.Controls.SpellCheckTextBox? _commentTextBox;
     private Button? _copyResRefButton;
     private Button? _copyTagButton;
     private Button? _renameResRefButton;
@@ -81,7 +83,7 @@ public partial class AdvancedPanel : BasePanelControl
         // Identity section
         _templateResRefTextBox = this.FindControl<TextBox>("TemplateResRefTextBox");
         _tagTextBox = this.FindControl<TextBox>("TagTextBox");
-        _commentTextBox = this.FindControl<TextBox>("CommentTextBox");
+        _commentTextBox = this.FindControl<Radoub.UI.Controls.SpellCheckTextBox>("CommentTextBox");
         _copyResRefButton = this.FindControl<Button>("CopyResRefButton");
         _copyTagButton = this.FindControl<Button>("CopyTagButton");
         _renameResRefButton = this.FindControl<Button>("RenameResRefButton");
@@ -125,7 +127,10 @@ public partial class AdvancedPanel : BasePanelControl
         if (_tagTextBox != null)
             _tagTextBox.TextChanged += OnTagTextChanged;
         if (_commentTextBox != null)
+        {
             _commentTextBox.TextChanged += OnCommentTextChanged;
+            WireTokenMenu(_commentTextBox);
+        }
 
         WireUpFlagCheckboxes();
         WireUpBehaviorCombos();
@@ -727,6 +732,21 @@ public partial class AdvancedPanel : BasePanelControl
             vm.PropertyChanged -= OnVariablePropertyChanged;
         }
         Variables.Clear();
+    }
+
+    #endregion
+
+    #region Token Support
+
+    private readonly QuickTokenService _quickTokenService = new();
+
+    private void WireTokenMenu(SpellCheckTextBox? textBox)
+    {
+        if (textBox == null) return;
+        textBox.ContextMenuExtras = menu =>
+            TokenContextMenu.AppendTokenMenu(menu, textBox, () =>
+                TokenInsertionHelper.OpenTokenWindow(textBox, this.VisualRoot as Avalonia.Controls.Window),
+                _quickTokenService);
     }
 
     #endregion

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.DataLoading.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.DataLoading.cs
@@ -71,14 +71,14 @@ public partial class AppearancePanel
             var baseName = app.IsPartBased && !app.Name.Contains("(Dynamic)")
                 ? $"(Dynamic) {app.Name}"
                 : app.Name;
-            // Show appearance ID in display, model name in tooltip for debugging
             var modelRef = !string.IsNullOrEmpty(app.Race) ? app.Race : app.Label;
-            var displayText = $"[{app.AppearanceId}] {baseName}";
+            var displayText = $"[{app.AppearanceId}] {baseName} ({modelRef})";
             var item = new ListBoxItem
             {
                 Content = displayText,
                 Tag = app.AppearanceId
             };
+            item.ContextMenu = CreateAppearanceCopyMenu(app.AppearanceId, baseName, modelRef);
             Avalonia.Controls.ToolTip.SetTip(item, $"ID: {app.AppearanceId} | Model: {modelRef} | Type: {(app.IsPartBased ? "Part-Based" : "Static")} | Label: {app.Label}");
             _appearanceListBox.Items.Add(item);
         }
@@ -344,12 +344,14 @@ public partial class AppearancePanel
             }
         }
 
-        // Still not found, add it
-        _appearanceListBox.Items.Add(new ListBoxItem
+        // Still not found, add it with consistent format
+        var fallbackItem = new ListBoxItem
         {
-            Content = $"Appearance {appearanceId}",
+            Content = $"[{appearanceId}] Appearance {appearanceId}",
             Tag = appearanceId
-        });
+        };
+        fallbackItem.ContextMenu = CreateAppearanceCopyMenu(appearanceId, $"Appearance {appearanceId}", "");
+        _appearanceListBox.Items.Add(fallbackItem);
         _appearanceListBox.SelectedIndex = _appearanceListBox.Items.Count - 1;
     }
 

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
@@ -385,6 +385,44 @@ public partial class AppearancePanel
         }
     }
 
+    private ContextMenu CreateAppearanceCopyMenu(ushort id, string name, string resref)
+    {
+        var menu = new ContextMenu();
+
+        var copyAll = new MenuItem { Header = "Copy Appearance Info" };
+        copyAll.Click += async (_, _) => await CopyToClipboard($"[{id}] {name} ({resref})");
+        menu.Items.Add(copyAll);
+
+        var copyName = new MenuItem { Header = "Copy Name" };
+        copyName.Click += async (_, _) => await CopyToClipboard(name);
+        menu.Items.Add(copyName);
+
+        var copyResRef = new MenuItem { Header = "Copy ResRef" };
+        copyResRef.Click += async (_, _) => await CopyToClipboard(resref);
+        menu.Items.Add(copyResRef);
+
+        var copyId = new MenuItem { Header = "Copy ID" };
+        copyId.Click += async (_, _) => await CopyToClipboard(id.ToString());
+        menu.Items.Add(copyId);
+
+        return menu;
+    }
+
+    private async System.Threading.Tasks.Task CopyToClipboard(string text)
+    {
+        try
+        {
+            var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+            if (clipboard != null)
+                await clipboard.SetTextAsync(text);
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"AppearancePanel: Clipboard copy failed: {ex.Message}");
+        }
+    }
+
     // 3D Preview control handlers
     private void OnRotateLeftClicked(object? sender, RoutedEventArgs e)
     {

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
@@ -398,7 +398,12 @@ public partial class AppearancePanel
             return;
         }
 
-        if (info.SkinMeshCount == 0 && info.TotalMeshes > 0)
+        // Only warn about missing skin meshes for part-based appearances.
+        // Static models (bat, dragon, etc.) use trimeshes and never have skin meshes.
+        var isPartBased = _currentCreature != null &&
+            (_displayService?.IsPartBasedAppearance(_currentCreature.AppearanceType) ?? false);
+
+        if (info.SkinMeshCount == 0 && isPartBased)
         {
             _modelInfoStatusText.Text = "\u26a0 No skin meshes \u2014 model may appear as skeleton only";
             _modelInfoStatusText.Foreground = BrushManager.GetWarningBrush(this);
@@ -407,7 +412,7 @@ public partial class AppearancePanel
         else if (info.HiddenMeshCount > 0)
         {
             _modelInfoStatusText.Text = $"\u2139 {info.HiddenMeshCount} of {info.TotalMeshes} meshes hidden (Render=false)";
-            _modelInfoStatusText.Foreground = Avalonia.Media.Brushes.Gray;
+            _modelInfoStatusText.Foreground = BrushManager.GetInfoBrush(this);
             _modelInfoStatusText.IsVisible = true;
         }
         else

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
@@ -70,7 +70,10 @@ public partial class AppearancePanel
 
         // 3D Preview state overlay
         if (_modelPreviewGL != null)
+        {
             _modelPreviewGL.PreviewStateChanged += OnPreviewStateChanged;
+            _modelPreviewGL.MeshInfoChanged += OnMeshInfoChanged;
+        }
 
         // 3D Preview button events
         if (_rotateLeftButton != null)
@@ -382,6 +385,34 @@ public partial class AppearancePanel
             default:
                 _previewStateOverlay.IsVisible = false;
                 break;
+        }
+    }
+
+    private void OnMeshInfoChanged(object? sender, ModelPreviewGLControl.ModelMeshInfo info)
+    {
+        if (_modelInfoStatusText == null) return;
+
+        if (info.TotalMeshes == 0)
+        {
+            _modelInfoStatusText.IsVisible = false;
+            return;
+        }
+
+        if (info.SkinMeshCount == 0 && info.TotalMeshes > 0)
+        {
+            _modelInfoStatusText.Text = "\u26a0 No skin meshes \u2014 model may appear as skeleton only";
+            _modelInfoStatusText.Foreground = BrushManager.GetWarningBrush(this);
+            _modelInfoStatusText.IsVisible = true;
+        }
+        else if (info.HiddenMeshCount > 0)
+        {
+            _modelInfoStatusText.Text = $"\u2139 {info.HiddenMeshCount} of {info.TotalMeshes} meshes hidden (Render=false)";
+            _modelInfoStatusText.Foreground = Avalonia.Media.Brushes.Gray;
+            _modelInfoStatusText.IsVisible = true;
+        }
+        else
+        {
+            _modelInfoStatusText.IsVisible = false;
         }
     }
 

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
@@ -398,18 +398,13 @@ public partial class AppearancePanel
             return;
         }
 
-        // Only warn about missing skin meshes for part-based appearances.
-        // Static models (bat, dragon, etc.) use trimeshes and never have skin meshes.
-        var isPartBased = _currentCreature != null &&
-            (_displayService?.IsPartBasedAppearance(_currentCreature.AppearanceType) ?? false);
-
-        if (info.SkinMeshCount == 0 && isPartBased)
-        {
-            _modelInfoStatusText.Text = "\u26a0 No skin meshes \u2014 model may appear as skeleton only";
-            _modelInfoStatusText.Foreground = BrushManager.GetWarningBrush(this);
-            _modelInfoStatusText.IsVisible = true;
-        }
-        else if (info.HiddenMeshCount > 0)
+        // Only warn about missing skins when the model has meshes but ALL are
+        // non-rendering bones (many Render=false, zero visible geometry).
+        // Part-based models often assemble trimeshes (not skin nodes) and render fine.
+        // Static models use trimeshes by design. The real skeleton-only case is when
+        // most meshes are hidden and there's no visible geometry — that's already
+        // covered by PreviewState.NotAvailable. So we only show the hidden mesh info.
+        if (info.HiddenMeshCount > 0)
         {
             _modelInfoStatusText.Text = $"\u2139 {info.HiddenMeshCount} of {info.TotalMeshes} meshes hidden (Render=false)";
             _modelInfoStatusText.Foreground = BrushManager.GetInfoBrush(this);

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
@@ -325,7 +325,7 @@
 
                     <!-- Model Info Status Line (#1873) -->
                     <TextBlock Grid.Row="2" x:Name="ModelInfoStatusText"
-                               FontSize="11" Padding="10,4"
+                               FontSize="{DynamicResource FontSizeSmall}" Padding="10,4"
                                Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                IsVisible="False"/>
 

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
@@ -295,7 +295,7 @@
                     BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
                     BorderThickness="1,0,0,0"
                     Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
-                <Grid RowDefinitions="Auto,*,Auto">
+                <Grid RowDefinitions="Auto,*,Auto,Auto">
                     <!-- Preview Header -->
                     <Border Grid.Row="0" Padding="10"
                             BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
@@ -323,8 +323,14 @@
                         </Grid>
                     </Border>
 
+                    <!-- Model Info Status Line (#1873) -->
+                    <TextBlock Grid.Row="2" x:Name="ModelInfoStatusText"
+                               FontSize="11" Padding="10,4"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                               IsVisible="False"/>
+
                     <!-- Preview Controls -->
-                    <Border Grid.Row="2" Padding="10"
+                    <Border Grid.Row="3" Padding="10"
                             BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
                             BorderThickness="0,1,0,0">
                         <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
@@ -70,6 +70,7 @@ public partial class AppearancePanel : UserControl
     private ModelPreviewGLControl? _modelPreviewGL;
     private Border? _previewStateOverlay;
     private TextBlock? _previewStateText;
+    private TextBlock? _modelInfoStatusText;
     private Button? _rotateLeftButton;
     private Button? _rotateRightButton;
     private Button? _resetViewButton;
@@ -153,6 +154,7 @@ public partial class AppearancePanel : UserControl
         _modelPreviewGL = this.FindControl<ModelPreviewGLControl>("ModelPreviewGL");
         _previewStateOverlay = this.FindControl<Border>("PreviewStateOverlay");
         _previewStateText = this.FindControl<TextBlock>("PreviewStateText");
+        _modelInfoStatusText = this.FindControl<TextBlock>("ModelInfoStatusText");
         _rotateLeftButton = this.FindControl<Button>("RotateLeftButton");
         _rotateRightButton = this.FindControl<Button>("RotateRightButton");
         _resetViewButton = this.FindControl<Button>("ResetViewButton");

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/UtcSearchProviderTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/UtcSearchProviderTests.cs
@@ -263,6 +263,95 @@ public class UtcSearchProviderTests
         Assert.Equal("Deity", match.Location as string);
     }
 
+    // --- Inventory/Equipment Search (#1947) ---
+
+    private static UtcFile CreateTestUtcWithInventory()
+    {
+        var utc = CreateTestUtc();
+        utc.EquipItemList = new List<EquippedItem>
+        {
+            new() { Slot = EquipmentSlots.RightHand, EquipRes = "nw_wswdg001" },
+            new() { Slot = EquipmentSlots.Chest, EquipRes = "nw_aarcl006" },
+            new() { Slot = EquipmentSlots.Head, EquipRes = "nw_arhe001" }
+        };
+        utc.ItemList = new List<InventoryItem>
+        {
+            new() { InventoryRes = "nw_it_gem001", Repos_PosX = 0, Repos_PosY = 0 },
+            new() { InventoryRes = "nw_it_mpotion003", Repos_PosX = 1, Repos_PosY = 0 },
+            new() { InventoryRes = "nw_wswdg001", Repos_PosX = 2, Repos_PosY = 0 }
+        };
+        return utc;
+    }
+
+    [Fact]
+    public void Search_FindsEquippedItemResRef()
+    {
+        var provider = new UtcSearchProvider();
+        var gff = UtcToGff(CreateTestUtcWithInventory());
+        var criteria = new SearchCriteria { Pattern = "nw_wswdg001" };
+
+        var matches = provider.Search(gff, criteria);
+
+        Assert.Contains(matches, m =>
+            m.Field.Name == "EquipRes" &&
+            (m.Location as string)!.Contains("Right Hand"));
+    }
+
+    [Fact]
+    public void Search_FindsBackpackItemResRef()
+    {
+        var provider = new UtcSearchProvider();
+        var gff = UtcToGff(CreateTestUtcWithInventory());
+        var criteria = new SearchCriteria { Pattern = "nw_it_gem001" };
+
+        var matches = provider.Search(gff, criteria);
+
+        Assert.Contains(matches, m =>
+            m.Field.Name == "InventoryRes" &&
+            (m.Location as string)!.Contains("Backpack"));
+    }
+
+    [Fact]
+    public void Search_NoMatch_ReturnsNoInventoryResults()
+    {
+        var provider = new UtcSearchProvider();
+        var gff = UtcToGff(CreateTestUtcWithInventory());
+        var criteria = new SearchCriteria { Pattern = "nonexistent_item" };
+
+        var matches = provider.Search(gff, criteria);
+
+        Assert.DoesNotContain(matches, m =>
+            m.Field.Name == "EquipRes" || m.Field.Name == "InventoryRes");
+    }
+
+    [Fact]
+    public void Search_FindsSameResRefInEquipmentAndBackpack()
+    {
+        var provider = new UtcSearchProvider();
+        var gff = UtcToGff(CreateTestUtcWithInventory());
+        // nw_wswdg001 is in both equipped (Right Hand) and backpack
+        var criteria = new SearchCriteria { Pattern = "nw_wswdg001" };
+
+        var matches = provider.Search(gff, criteria);
+
+        var equipMatch = matches.Where(m => m.Field.Name == "EquipRes").ToList();
+        var backpackMatch = matches.Where(m => m.Field.Name == "InventoryRes").ToList();
+        Assert.NotEmpty(equipMatch);
+        Assert.NotEmpty(backpackMatch);
+    }
+
+    [Fact]
+    public void Search_CaseInsensitive_FindsInventoryItem()
+    {
+        var provider = new UtcSearchProvider();
+        var gff = UtcToGff(CreateTestUtcWithInventory());
+        var criteria = new SearchCriteria { Pattern = "NW_IT_GEM001", CaseSensitive = false };
+
+        var matches = provider.Search(gff, criteria);
+
+        Assert.Contains(matches, m => m.Field.Name == "InventoryRes");
+    }
+
     [Fact]
     public void FileType_IsUtc()
     {

--- a/Radoub.Formats/Radoub.Formats/Search/Providers/UtcSearchProvider.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Providers/UtcSearchProvider.cs
@@ -44,6 +44,10 @@ public class UtcSearchProvider : SearchProviderBase, IFileSearchProvider
     // Variable field
     private static readonly FieldDefinition VarTableField = new() { Name = "Local Variables", GffPath = "VarTable", FieldType = SearchFieldType.Variable, Category = SearchFieldCategory.Variable, Description = "Local variable names and string values" };
 
+    // Equipment/Inventory fields (#1947)
+    private static readonly FieldDefinition EquipResField = new() { Name = "EquipRes", GffPath = "EquipRes", FieldType = SearchFieldType.ResRef, Category = SearchFieldCategory.Identity, Description = "Equipped item ResRef", IsReplaceable = false };
+    private static readonly FieldDefinition InventoryResField = new() { Name = "InventoryRes", GffPath = "InventoryRes", FieldType = SearchFieldType.ResRef, Category = SearchFieldCategory.Identity, Description = "Backpack item ResRef", IsReplaceable = false };
+
     public ushort FileType => ResourceTypes.Utc;
 
     public IReadOnlyList<string> Extensions => new[] { ".utc", ".bic" };
@@ -111,6 +115,27 @@ public class UtcSearchProvider : SearchProviderBase, IFileSearchProvider
         // Local variables
         if (criteria.MatchesField(VarTableField))
             matches.AddRange(SearchVarTable(gffFile.RootStruct, VarTableField, regex, "VarTable"));
+
+        // Equipment (#1947)
+        if (criteria.MatchesField(EquipResField))
+        {
+            foreach (var equip in utc.EquipItemList)
+            {
+                var slotName = Utc.EquipmentSlots.GetSlotName(equip.Slot);
+                var location = $"Equipment > {slotName} > EquipRes";
+                matches.AddRange(SearchString(equip.EquipRes, EquipResField, regex, location));
+            }
+        }
+
+        // Backpack inventory (#1947)
+        if (criteria.MatchesField(InventoryResField))
+        {
+            for (int i = 0; i < utc.ItemList.Count; i++)
+            {
+                var location = $"Backpack > Item {i} > InventoryRes";
+                matches.AddRange(SearchString(utc.ItemList[i].InventoryRes, InventoryResField, regex, location));
+            }
+        }
 
         return matches;
     }


### PR DESCRIPTION
## Summary

Model preview improvements and Marlinspike search integration for Quartermaster.

- Appearance list shows `[ID] Name (resref)` with right-click copy menu (#1870)
- Model completeness status line below 3D preview — shows hidden mesh count (#1873)
- Search creature inventory/backpack item ResRefs in Marlinspike (#1947)
- Comment field upgraded to SpellCheckTextBox with token insert support (#1697)

## Related Issues

- Closes #1979
- Closes #1870
- Closes #1873
- Closes #1947
- Closes #1697

## Tests

- 2,792 passed, 0 failed ✅
- Privacy scan: clean
- Tech debt: ModelPreviewGLControl.cs 897 lines (warning, tracked in #2029)
- 5 new UtcSearchProvider tests for inventory/equipment search

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)