### PR TITLE
[Quartermaster] fix: Dragon models missing tails in appearance preview (#2057)

### DIFF
--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.77-alpha] - 2026-04-11
-**Branch**: `quartermaster/issue-2057` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2057` | **PR**: #2059
 
 ### Fix: Dragon models missing tails in appearance preview (#2057)
 - Texture-based mesh skip heuristic replaces blunt <30 vertex threshold

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.77-alpha] - 2026-04-11
+**Branch**: `quartermaster/issue-2057` | **PR**: #TBD
+
+### Fix: Dragon models missing tails in appearance preview (#2057)
+- Texture-based mesh skip heuristic replaces blunt <30 vertex threshold
+- Status line shows filtered trimesh count for diagnostic visibility
+
+---
+
 ## [0.2.76-alpha] - 2026-04-11
 **Branch**: `quartermaster/issue-1979` | **PR**: #2055
 

--- a/Quartermaster/Quartermaster.Tests/MeshSkipHeuristicTests.cs
+++ b/Quartermaster/Quartermaster.Tests/MeshSkipHeuristicTests.cs
@@ -1,0 +1,115 @@
+using Quartermaster.Controls;
+
+namespace Quartermaster.Tests;
+
+/// <summary>
+/// Tests for the texture-based mesh skip heuristic (#2057).
+/// Tiny trimeshes (&lt;30 verts) in skin models should only be skipped
+/// when they share a bitmap with a skin mesh (bone visualization overlay).
+/// Trimeshes with unique bitmaps are real geometry (tails, manes, fangs).
+/// </summary>
+public class MeshSkipHeuristicTests
+{
+    [Fact]
+    public void SharedBitmap_TinyTrimesh_IsSkipped()
+    {
+        // Bone visualization trimesh shares the skin's texture
+        var skinBitmaps = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "c_dragon_red" };
+
+        var result = MeshSkipHeuristic.ShouldSkipTrimesh(
+            hasSkins: true, isSkinMesh: false, vertexCount: 12,
+            meshBitmap: "c_dragon_red", skinBitmaps: skinBitmaps);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void UniqueBitmap_TinyTrimesh_IsKept()
+    {
+        // Tail/mane/fang trimesh has its own distinct texture — real geometry
+        var skinBitmaps = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "c_dragon_red" };
+
+        var result = MeshSkipHeuristic.ShouldSkipTrimesh(
+            hasSkins: true, isSkinMesh: false, vertexCount: 18,
+            meshBitmap: "c_dragon_tail", skinBitmaps: skinBitmaps);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void EmptyBitmap_TinyTrimesh_IsSkipped()
+    {
+        // Untextured <30 vert trimesh in skin model — likely bone viz
+        var skinBitmaps = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "c_dragon_red" };
+
+        var result = MeshSkipHeuristic.ShouldSkipTrimesh(
+            hasSkins: true, isSkinMesh: false, vertexCount: 8,
+            meshBitmap: "", skinBitmaps: skinBitmaps);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void NullBitmap_TinyTrimesh_IsSkipped()
+    {
+        var skinBitmaps = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "c_dragon_red" };
+
+        var result = MeshSkipHeuristic.ShouldSkipTrimesh(
+            hasSkins: true, isSkinMesh: false, vertexCount: 8,
+            meshBitmap: "null", skinBitmaps: skinBitmaps);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void NoSkins_TinyTrimesh_IsKept()
+    {
+        // No skin meshes in model — all trimeshes kept regardless of size
+        var skinBitmaps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var result = MeshSkipHeuristic.ShouldSkipTrimesh(
+            hasSkins: false, isSkinMesh: false, vertexCount: 12,
+            meshBitmap: "some_texture", skinBitmaps: skinBitmaps);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void LargeTrimesh_SharedBitmap_IsKept()
+    {
+        // Trimesh >= 30 verts is kept even if it shares a skin bitmap
+        var skinBitmaps = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "c_dragon_red" };
+
+        var result = MeshSkipHeuristic.ShouldSkipTrimesh(
+            hasSkins: true, isSkinMesh: false, vertexCount: 30,
+            meshBitmap: "c_dragon_red", skinBitmaps: skinBitmaps);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void SkinMesh_IsNeverSkipped()
+    {
+        // Skin meshes are never filtered by this heuristic
+        var skinBitmaps = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "c_dragon_red" };
+
+        var result = MeshSkipHeuristic.ShouldSkipTrimesh(
+            hasSkins: true, isSkinMesh: true, vertexCount: 10,
+            meshBitmap: "c_dragon_red", skinBitmaps: skinBitmaps);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void BitmapComparison_IsCaseInsensitive()
+    {
+        // Bitmap matching should be case-insensitive
+        var skinBitmaps = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "C_Dragon_Red" };
+
+        var result = MeshSkipHeuristic.ShouldSkipTrimesh(
+            hasSkins: true, isSkinMesh: false, vertexCount: 12,
+            meshBitmap: "c_dragon_red", skinBitmaps: skinBitmaps);
+
+        Assert.True(result);
+    }
+}

--- a/Quartermaster/Quartermaster/Controls/MeshSkipHeuristic.cs
+++ b/Quartermaster/Quartermaster/Controls/MeshSkipHeuristic.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+
+namespace Quartermaster.Controls;
+
+/// <summary>
+/// Texture-based heuristic for skipping tiny trimeshes in skin models (#2057).
+/// Bone visualization trimeshes share the same texture as the skin they overlap.
+/// Real geometry parts (tails, manes, fangs) have distinct textures and are kept.
+/// </summary>
+public static class MeshSkipHeuristic
+{
+    private const int TinyTrimeshThreshold = 30;
+
+    /// <summary>
+    /// Determines whether a trimesh should be skipped during rendering.
+    /// </summary>
+    /// <param name="hasSkins">Whether the model contains any skin meshes.</param>
+    /// <param name="isSkinMesh">Whether this specific mesh is a skin mesh.</param>
+    /// <param name="vertexCount">Number of vertices in the mesh.</param>
+    /// <param name="meshBitmap">The mesh's bitmap name.</param>
+    /// <param name="skinBitmaps">Set of bitmap names used by skin meshes (case-insensitive).</param>
+    /// <returns>True if the mesh should be skipped (bone visualization overlay).</returns>
+    public static bool ShouldSkipTrimesh(
+        bool hasSkins, bool isSkinMesh, int vertexCount,
+        string? meshBitmap, HashSet<string> skinBitmaps)
+    {
+        if (!hasSkins || isSkinMesh || vertexCount >= TinyTrimeshThreshold)
+            return false;
+
+        bool hasUniqueBitmap = !string.IsNullOrEmpty(meshBitmap)
+            && !meshBitmap.Equals("null", StringComparison.OrdinalIgnoreCase)
+            && !skinBitmaps.Contains(meshBitmap);
+
+        return !hasUniqueBitmap;
+    }
+}

--- a/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
+++ b/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
@@ -83,7 +83,7 @@ public class ModelPreviewGLControl : OpenGlControlBase
     /// <summary>
     /// Mesh composition info for the currently loaded model.
     /// </summary>
-    public record ModelMeshInfo(int TotalMeshes, int SkinMeshCount, int HiddenMeshCount);
+    public record ModelMeshInfo(int TotalMeshes, int SkinMeshCount, int HiddenMeshCount, int SkippedTrimeshCount);
 
     /// <summary>
     /// Raised on the UI thread after model mesh analysis completes.
@@ -106,7 +106,7 @@ public class ModelPreviewGLControl : OpenGlControlBase
             if (value == null)
             {
                 SetPreviewState(PreviewState.None);
-                MeshInfoChanged?.Invoke(this, new ModelMeshInfo(0, 0, 0));
+                MeshInfoChanged?.Invoke(this, new ModelMeshInfo(0, 0, 0, 0));
             }
             RequestNextFrameRendering();
         }
@@ -540,17 +540,26 @@ public class ModelPreviewGLControl : OpenGlControlBase
 
         int meshIndex = 0;
         int skippedMeshes = 0;
+        int skippedTrimeshes = 0;
         var allMeshes = _model.GetMeshNodes().ToList();
 
-        // #1676: CEP models often have both skin meshes (full-body geometry for animation)
-        // and trimeshes. Small trimeshes (<30 verts) in skin models are typically bone
-        // visualizations that overlap with skin geometry, causing visual artifacts.
-        // Skip them when skins are present. Keep substantial trimeshes (manes, fangs, etc.).
+        // #1676/#2057: CEP models often have both skin meshes and trimeshes. Tiny trimeshes
+        // (<30 verts) that share a skin's bitmap are bone visualizations causing artifacts.
+        // Trimeshes with unique bitmaps are real geometry (tails, manes, fangs) — keep them.
         bool hasSkins = allMeshes.Any(m => m is Radoub.Formats.Mdl.MdlSkinNode && m.Render && m.Vertices.Length > 0);
+        var skinBitmaps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (hasSkins)
         {
+            foreach (var m in allMeshes)
+            {
+                if (m is Radoub.Formats.Mdl.MdlSkinNode && m.Render && m.Vertices.Length > 0)
+                {
+                    if (!string.IsNullOrEmpty(m.Bitmap) && !m.Bitmap.Equals("null", StringComparison.OrdinalIgnoreCase))
+                        skinBitmaps.Add(m.Bitmap);
+                }
+            }
             UnifiedLogger.LogApplication(LogLevel.INFO,
-                $"  Model '{_model.Name}': Has skin meshes — will skip tiny trimeshes (<30 verts)");
+                $"  Model '{_model.Name}': Has skin meshes — will filter tiny trimeshes sharing skin textures ({string.Join(", ", skinBitmaps)})");
         }
 
         UnifiedLogger.LogApplication(LogLevel.INFO, $"  Model '{_model.Name}': {allMeshes.Count} mesh nodes: {string.Join(", ", allMeshes.Select(m => m.Name))}");
@@ -576,13 +585,15 @@ public class ModelPreviewGLControl : OpenGlControlBase
 
             bool isSkinMesh = mesh is Radoub.Formats.Mdl.MdlSkinNode;
 
-            // #1676: In models with skins, skip tiny trimeshes (<30 verts) — they're
-            // bone visualizations that overlap with skin geometry causing artifacts.
-            // Keep substantial trimeshes (manes, fangs, accessories, etc.)
-            if (hasSkins && !isSkinMesh && mesh.Vertices.Length < 30)
+            // #1676/#2057: In models with skins, skip tiny trimeshes (<30 verts) that share
+            // a skin bitmap (bone visualizations). Keep trimeshes with unique bitmaps — they're
+            // real geometry (tails, manes, fangs, accessories).
+            if (MeshSkipHeuristic.ShouldSkipTrimesh(hasSkins, isSkinMesh, mesh.Vertices.Length, mesh.Bitmap, skinBitmaps))
             {
                 skippedMeshes++;
-                UnifiedLogger.LogApplication(LogLevel.DEBUG, $"  Skipping tiny trimesh '{mesh.Name}' ({mesh.Vertices.Length} verts): bone viz in skin model");
+                skippedTrimeshes++;
+                UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                    $"  Skipping tiny trimesh '{mesh.Name}' ({mesh.Vertices.Length} verts, bitmap='{mesh.Bitmap}'): shares skin texture in skin model");
                 continue;
             }
 
@@ -800,7 +811,7 @@ public class ModelPreviewGLControl : OpenGlControlBase
         UnifiedLogger.LogApplication(LogLevel.INFO, $"UpdateMeshBuffers: model={_model?.Name ?? "null"}, {_meshDrawCalls.Count} meshes ({skippedMeshes} skipped), {vertices.Count / 8} vertices, {_indexCount / 3} triangles");
 
         // Notify listeners of mesh composition
-        var meshInfo = new ModelMeshInfo(totalMeshCount, skinMeshCount, hiddenMeshCount);
+        var meshInfo = new ModelMeshInfo(totalMeshCount, skinMeshCount, hiddenMeshCount, skippedTrimeshes);
         if (Dispatcher.UIThread.CheckAccess())
             MeshInfoChanged?.Invoke(this, meshInfo);
         else

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
@@ -2,6 +2,7 @@
 // All event wiring and handler methods
 
 using System;
+using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -398,15 +399,15 @@ public partial class AppearancePanel
             return;
         }
 
-        // Only warn about missing skins when the model has meshes but ALL are
-        // non-rendering bones (many Render=false, zero visible geometry).
-        // Part-based models often assemble trimeshes (not skin nodes) and render fine.
-        // Static models use trimeshes by design. The real skeleton-only case is when
-        // most meshes are hidden and there's no visible geometry — that's already
-        // covered by PreviewState.NotAvailable. So we only show the hidden mesh info.
+        var parts = new List<string>();
+        if (info.SkippedTrimeshCount > 0)
+            parts.Add($"{info.SkippedTrimeshCount} tiny trimeshes filtered");
         if (info.HiddenMeshCount > 0)
+            parts.Add($"{info.HiddenMeshCount} of {info.TotalMeshes} meshes hidden (Render=false)");
+
+        if (parts.Count > 0)
         {
-            _modelInfoStatusText.Text = $"\u2139 {info.HiddenMeshCount} of {info.TotalMeshes} meshes hidden (Render=false)";
+            _modelInfoStatusText.Text = $"\u2139 {string.Join(", ", parts)}";
             _modelInfoStatusText.Foreground = BrushManager.GetInfoBrush(this);
             _modelInfoStatusText.IsVisible = true;
         }


### PR DESCRIPTION
## Summary

- Replaces blunt <30 vertex threshold with texture-based mesh skip heuristic
- Tiny trimeshes sharing a skin bitmap are skipped (bone overlays); unique-bitmap trimeshes are kept (real geometry like tails, manes, fangs)
- Adds `SkippedTrimeshCount` to `ModelMeshInfo` for status line diagnostic visibility
- Extracted `MeshSkipHeuristic.ShouldSkipTrimesh()` static helper for testability

## Related Issues

- Closes #2057
- Partially addresses #2029 (mesh skip refinement tech-debt)

## Test Plan

- [x] 8 unit tests for heuristic (shared bitmap, unique bitmap, null bitmap, no skins, large trimesh, skin mesh, case insensitive)
- [x] All 1216 QM unit tests pass
- [x] Full solution builds clean
- [x] Manual: Dragon model — tail visible in preview
- [x] Manual: Dire tiger — mane and fangs visible
- [x] Manual: Lion — mane still renders (regression check)
- [x] Manual: Aribeth — no bone overlay artifacts
- [x] Manual: Status line shows filtered count

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)