### PR TITLE
[Trebuchet] Sprint: ERF Importer & Marlinspike UTM Search (#2067)

### DIFF
--- a/Radoub.UI/Radoub.UI.Tests/Services/ItemResolutionServiceTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/ItemResolutionServiceTests.cs
@@ -1,45 +1,37 @@
-using MerchantEditor.Services;
+using Radoub.UI.Services;
+using Xunit;
 
-namespace Fence.Tests;
+namespace Radoub.UI.Tests.Services;
 
 public class ItemResolutionServiceTests
 {
     [Fact]
     public void ResolveItem_NullResRef_ReturnsNull()
     {
-        // Arrange
         var service = new ItemResolutionService(null);
 
-        // Act
         var result = service.ResolveItem(null!);
 
-        // Assert
         Assert.Null(result);
     }
 
     [Fact]
     public void ResolveItem_EmptyResRef_ReturnsNull()
     {
-        // Arrange
         var service = new ItemResolutionService(null);
 
-        // Act
         var result = service.ResolveItem(string.Empty);
 
-        // Assert
         Assert.Null(result);
     }
 
     [Fact]
     public void ResolveItem_NonExistentItem_ReturnsFallbackData()
     {
-        // Arrange
         var service = new ItemResolutionService(null);
 
-        // Act
         var result = service.ResolveItem("nonexistent_item");
 
-        // Assert
         Assert.NotNull(result);
         Assert.Equal("nonexistent_item", result.ResRef);
         Assert.Equal("nonexistent_item", result.Tag);
@@ -52,29 +44,23 @@ public class ItemResolutionServiceTests
     [Fact]
     public void ResolveItem_SameResRefTwice_ReturnsCachedData()
     {
-        // Arrange
         var service = new ItemResolutionService(null);
 
-        // Act
         var result1 = service.ResolveItem("test_item");
         var result2 = service.ResolveItem("test_item");
 
-        // Assert
-        Assert.Same(result1, result2); // Same instance = cached
+        Assert.Same(result1, result2);
     }
 
     [Fact]
     public void ResolveItem_CaseInsensitive_ReturnsCachedData()
     {
-        // Arrange
         var service = new ItemResolutionService(null);
 
-        // Act
         var result1 = service.ResolveItem("Test_Item");
         var result2 = service.ResolveItem("TEST_ITEM");
         var result3 = service.ResolveItem("test_item");
 
-        // Assert
         Assert.Same(result1, result2);
         Assert.Same(result2, result3);
     }
@@ -82,57 +68,69 @@ public class ItemResolutionServiceTests
     [Fact]
     public void ClearCache_AfterResolve_ForcesFreshLoad()
     {
-        // Arrange
         var service = new ItemResolutionService(null);
         var result1 = service.ResolveItem("test_item");
 
-        // Act
         service.ClearCache();
         var result2 = service.ResolveItem("test_item");
 
-        // Assert
         Assert.NotNull(result1);
         Assert.NotNull(result2);
-        Assert.NotSame(result1, result2); // Different instance after cache clear
-        Assert.Equal(result1.ResRef, result2.ResRef); // Same data
+        Assert.NotSame(result1, result2);
+        Assert.Equal(result1.ResRef, result2.ResRef);
     }
 
     [Fact]
     public void SetCurrentFilePath_Null_ClearsModuleDirectory()
     {
-        // Arrange
         var service = new ItemResolutionService(null);
 
-        // Act & Assert - should not throw
         service.SetCurrentFilePath(null);
     }
 
     [Fact]
     public void SetCurrentFilePath_ValidPath_ClearsCacheAndSetsDirectory()
     {
-        // Arrange
         var service = new ItemResolutionService(null);
         var result1 = service.ResolveItem("test_item");
 
-        // Act
         service.SetCurrentFilePath(@"C:\test\module\store.utm");
         var result2 = service.ResolveItem("test_item");
 
-        // Assert
-        Assert.NotSame(result1, result2); // Cache was cleared
+        Assert.NotSame(result1, result2);
+    }
+
+    [Fact]
+    public void SetModuleDirectory_SetsDirectoryAndClearsCache()
+    {
+        var service = new ItemResolutionService(null);
+        var result1 = service.ResolveItem("test_item");
+
+        service.SetModuleDirectory(@"C:\test\module");
+        var result2 = service.ResolveItem("test_item");
+
+        Assert.NotSame(result1, result2);
+    }
+
+    [Fact]
+    public void SetModuleDirectory_Null_DoesNotThrow()
+    {
+        var service = new ItemResolutionService(null);
+
+        service.SetModuleDirectory(null);
+
+        var result = service.ResolveItem("test_item");
+        Assert.NotNull(result);
     }
 
     [Fact]
     public void ResolveItems_MultipleResRefs_ResolvesAll()
     {
-        // Arrange
         var service = new ItemResolutionService(null);
         var resRefs = new[] { "item1", "item2", "item3" };
 
-        // Act
         var results = service.ResolveItems(resRefs);
 
-        // Assert
         Assert.Equal(3, results.Count);
         Assert.True(results.ContainsKey("item1"));
         Assert.True(results.ContainsKey("item2"));
@@ -142,27 +140,21 @@ public class ItemResolutionServiceTests
     [Fact]
     public void ResolveItems_EmptyList_ReturnsEmptyDictionary()
     {
-        // Arrange
         var service = new ItemResolutionService(null);
 
-        // Act
         var results = service.ResolveItems(Array.Empty<string>());
 
-        // Assert
         Assert.Empty(results);
     }
 
     [Fact]
     public void ResolveItems_WithNullResRefs_SkipsNulls()
     {
-        // Arrange
         var service = new ItemResolutionService(null);
         var resRefs = new[] { "item1", null!, "", "item2" };
 
-        // Act
         var results = service.ResolveItems(resRefs);
 
-        // Assert
         Assert.Equal(2, results.Count);
         Assert.True(results.ContainsKey("item1"));
         Assert.True(results.ContainsKey("item2"));
@@ -173,125 +165,98 @@ public class ItemResolutionServiceTests
     [Fact]
     public void ResolvedItemData_CalculateSellPrice_100Markup_ReturnsBaseCost()
     {
-        // Arrange
         var data = CreateResolvedItemData(baseCost: 100);
 
-        // Act
         var sellPrice = data.CalculateSellPrice(100);
 
-        // Assert
         Assert.Equal(100, sellPrice);
     }
 
     [Fact]
     public void ResolvedItemData_CalculateSellPrice_150Markup_Returns150Percent()
     {
-        // Arrange
         var data = CreateResolvedItemData(baseCost: 100);
 
-        // Act
         var sellPrice = data.CalculateSellPrice(150);
 
-        // Assert
         Assert.Equal(150, sellPrice);
     }
 
     [Fact]
     public void ResolvedItemData_CalculateSellPrice_RoundsUp()
     {
-        // Arrange
         var data = CreateResolvedItemData(baseCost: 10);
 
-        // Act
-        var sellPrice = data.CalculateSellPrice(115); // 10 * 1.15 = 11.5
+        var sellPrice = data.CalculateSellPrice(115);
 
-        // Assert
-        Assert.Equal(12, sellPrice); // Ceiling rounds up
+        Assert.Equal(12, sellPrice);
     }
 
     [Fact]
     public void ResolvedItemData_CalculateBuyPrice_100Markdown_ReturnsBaseCost()
     {
-        // Arrange
         var data = CreateResolvedItemData(baseCost: 100);
 
-        // Act
         var buyPrice = data.CalculateBuyPrice(100);
 
-        // Assert
         Assert.Equal(100, buyPrice);
     }
 
     [Fact]
     public void ResolvedItemData_CalculateBuyPrice_50Markdown_ReturnsHalf()
     {
-        // Arrange
         var data = CreateResolvedItemData(baseCost: 100);
 
-        // Act
         var buyPrice = data.CalculateBuyPrice(50);
 
-        // Assert
         Assert.Equal(50, buyPrice);
     }
 
     [Fact]
     public void ResolvedItemData_CalculateBuyPrice_RoundsDown()
     {
-        // Arrange
         var data = CreateResolvedItemData(baseCost: 10);
 
-        // Act
-        var buyPrice = data.CalculateBuyPrice(55); // 10 * 0.55 = 5.5
+        var buyPrice = data.CalculateBuyPrice(55);
 
-        // Assert
-        Assert.Equal(5, buyPrice); // Floor rounds down
+        Assert.Equal(5, buyPrice);
     }
 
     [Fact]
     public void ResolvedItemData_CalculateBuyPrice_ZeroBaseCost_ReturnsZero()
     {
-        // Arrange
         var data = CreateResolvedItemData(baseCost: 0);
 
-        // Act
         var buyPrice = data.CalculateBuyPrice(50);
 
-        // Assert
         Assert.Equal(0, buyPrice);
     }
 
     [Theory]
-    [InlineData(100, 125, 125)]  // Standard markup
-    [InlineData(100, 200, 200)]  // Double price
-    [InlineData(50, 150, 75)]    // 150% of 50
-    [InlineData(1000, 100, 1000)] // No markup
+    [InlineData(100, 125, 125)]
+    [InlineData(100, 200, 200)]
+    [InlineData(50, 150, 75)]
+    [InlineData(1000, 100, 1000)]
     public void ResolvedItemData_CalculateSellPrice_VariousScenarios(int baseCost, int markup, int expected)
     {
-        // Arrange
         var data = CreateResolvedItemData(baseCost: baseCost);
 
-        // Act
         var sellPrice = data.CalculateSellPrice(markup);
 
-        // Assert
         Assert.Equal(expected, sellPrice);
     }
 
     [Theory]
-    [InlineData(100, 50, 50)]   // Half price
-    [InlineData(100, 25, 25)]   // Quarter price
-    [InlineData(1000, 75, 750)] // 75% of 1000
-    [InlineData(100, 100, 100)] // Full price
+    [InlineData(100, 50, 50)]
+    [InlineData(100, 25, 25)]
+    [InlineData(1000, 75, 750)]
+    [InlineData(100, 100, 100)]
     public void ResolvedItemData_CalculateBuyPrice_VariousScenarios(int baseCost, int markdown, int expected)
     {
-        // Arrange
         var data = CreateResolvedItemData(baseCost: baseCost);
 
-        // Act
         var buyPrice = data.CalculateBuyPrice(markdown);
 
-        // Assert
         Assert.Equal(expected, buyPrice);
     }
 
@@ -302,17 +267,14 @@ public class ItemResolutionServiceTests
     [Fact]
     public void ResolvedItemData_PropertiesDisplay_DefaultsToEmpty()
     {
-        // Arrange & Act
         var data = CreateResolvedItemData(baseCost: 100);
 
-        // Assert
         Assert.Equal(string.Empty, data.PropertiesDisplay);
     }
 
     [Fact]
     public void ResolvedItemData_PropertiesDisplay_CanBeSet()
     {
-        // Arrange & Act
         var data = new ResolvedItemData
         {
             ResRef = "test_item",
@@ -327,20 +289,16 @@ public class ItemResolutionServiceTests
             PropertiesDisplay = "Enhancement Bonus +1; Damage Bonus Fire 1d6"
         };
 
-        // Assert
         Assert.Equal("Enhancement Bonus +1; Damage Bonus Fire 1d6", data.PropertiesDisplay);
     }
 
     [Fact]
     public void ResolveItem_FallbackData_HasEmptyPropertiesDisplay()
     {
-        // Arrange
         var service = new ItemResolutionService(null);
 
-        // Act
         var result = service.ResolveItem("nonexistent_item");
 
-        // Assert
         Assert.NotNull(result);
         Assert.Equal(string.Empty, result.PropertiesDisplay);
     }
@@ -356,7 +314,7 @@ public class ItemResolutionServiceTests
             ResRef = "test_item",
             Tag = "TEST_TAG",
             DisplayName = "Test Item",
-            BaseItemType = 4, // Longsword
+            BaseItemType = 4,
             BaseItemTypeName = "Longsword",
             BaseCost = baseCost,
             StackSize = 1,

--- a/Radoub.UI/Radoub.UI.Tests/Services/ItemResolutionServiceWithGameDataTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/ItemResolutionServiceWithGameDataTests.cs
@@ -1,7 +1,8 @@
-using MerchantEditor.Services;
 using Radoub.TestUtilities.Mocks;
+using Radoub.UI.Services;
+using Xunit;
 
-namespace Fence.Tests;
+namespace Radoub.UI.Tests.Services;
 
 /// <summary>
 /// Tests for ItemResolutionService with a configured MockGameDataService.
@@ -23,32 +24,24 @@ public class ItemResolutionServiceWithGameDataTests
 
     private void SetupBaseItemsData()
     {
-        // baseitems.2da for GetBaseItemTypeName resolution
-        // Row 1: Longsword with valid TLK
         _mockGameData.Set2DAValue("baseitems", 1, "label", "BASE_ITEM_LONGSWORD");
         _mockGameData.Set2DAValue("baseitems", 1, "Name", "600");
 
-        // Row 16: Armor with valid TLK
         _mockGameData.Set2DAValue("baseitems", 16, "label", "BASE_ITEM_ARMOR");
         _mockGameData.Set2DAValue("baseitems", 16, "Name", "601");
 
-        // Row 24: Ring with no TLK string (falls back to label)
         _mockGameData.Set2DAValue("baseitems", 24, "label", "BASE_ITEM_RING");
         _mockGameData.Set2DAValue("baseitems", 24, "Name", "602");
 
-        // Row 46: Potions with BadStrRef TLK (falls back to label)
         _mockGameData.Set2DAValue("baseitems", 46, "label", "BASE_ITEM_POTIONS");
         _mockGameData.Set2DAValue("baseitems", 46, "Name", "603");
 
-        // Row 100: Custom item, Name = "****" (falls back to label)
         _mockGameData.Set2DAValue("baseitems", 100, "label", "BASE_ITEM_CUSTOM_SWORD");
         _mockGameData.Set2DAValue("baseitems", 100, "Name", "****");
 
-        // TLK strings
         _mockGameData.SetTlkString(600, "Long Sword");
         _mockGameData.SetTlkString(601, "Armor");
-        // 602 not set — returns null
-        _mockGameData.SetTlkString(603, "BadStrRef"); // Invalid TLK value
+        _mockGameData.SetTlkString(603, "BadStrRef");
     }
 
     #region GetBaseItemTypeName via Fallback Data
@@ -56,8 +49,6 @@ public class ItemResolutionServiceWithGameDataTests
     [Fact]
     public void ResolveItem_WithGameData_FallbackIncludesBaseItemTypeName()
     {
-        // When UTI is not found (FindResource returns null), we still get fallback data
-        // The base item type name should still be resolved from 2DA when possible
         var service = new ItemResolutionService(_mockGameData);
 
         var result = service.ResolveItem("nonexistent_sword");
@@ -65,7 +56,6 @@ public class ItemResolutionServiceWithGameDataTests
         Assert.NotNull(result);
         Assert.Equal("nonexistent_sword", result.ResRef);
         Assert.Equal(-1, result.BaseItemType);
-        // Fallback uses "Unknown" regardless of game data
         Assert.Equal("Unknown", result.BaseItemTypeName);
     }
 
@@ -91,8 +81,6 @@ public class ItemResolutionServiceWithGameDataTests
     [Fact]
     public void ResolveItem_WithConfiguredGameData_StillReturnsFallbackWhenNotFound()
     {
-        // MockGameDataService.FindResource always returns null
-        // So even with configured game data, items not found on disk get fallback
         var service = new ItemResolutionService(_mockGameData);
 
         var result = service.ResolveItem("missing_item");
@@ -207,7 +195,6 @@ public class ItemResolutionServiceWithGameDataTests
     {
         var service = new ItemResolutionService(_mockGameData);
         service.SetCurrentFilePath(null);
-        // Should work fine
         var result = service.ResolveItem("test_item");
         Assert.NotNull(result);
     }

--- a/Radoub.UI/Radoub.UI/Services/ItemResolutionService.cs
+++ b/Radoub.UI/Radoub.UI/Services/ItemResolutionService.cs
@@ -5,10 +5,9 @@ using Radoub.Formats.Common;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Services;
 using Radoub.Formats.Uti;
-using Radoub.UI.Services;
 using Radoub.UI.ViewModels;
 
-namespace MerchantEditor.Services;
+namespace Radoub.UI.Services;
 
 /// <summary>
 /// Service for resolving item data from UTI files.
@@ -29,7 +28,6 @@ public class ItemResolutionService
         _tlkService = tlkService;
         _itemViewModelFactory = itemViewModelFactory;
 
-        // Log configuration status on creation
         if (_gameDataService == null)
         {
             UnifiedLogger.LogApplication(LogLevel.WARN, "ItemResolutionService: GameDataService is null - BIF lookup disabled");
@@ -51,7 +49,17 @@ public class ItemResolutionService
     public void SetCurrentFilePath(string? filePath)
     {
         _moduleDirectory = string.IsNullOrEmpty(filePath) ? null : Path.GetDirectoryName(filePath);
-        ClearCache(); // Clear cache when file context changes
+        ClearCache();
+        UnifiedLogger.LogApplication(LogLevel.DEBUG, $"ItemResolutionService: Module directory set to: {_moduleDirectory ?? "(none)"}");
+    }
+
+    /// <summary>
+    /// Sets the module directory directly for item resolution.
+    /// </summary>
+    public void SetModuleDirectory(string? directory)
+    {
+        _moduleDirectory = directory;
+        ClearCache();
         UnifiedLogger.LogApplication(LogLevel.DEBUG, $"ItemResolutionService: Module directory set to: {_moduleDirectory ?? "(none)"}");
     }
 
@@ -65,7 +73,6 @@ public class ItemResolutionService
         if (string.IsNullOrEmpty(resRef))
             return null;
 
-        // Check cache first
         if (_cache.TryGetValue(resRef, out var cached))
             return cached;
 
@@ -159,16 +166,9 @@ public class ItemResolutionService
 
         try
         {
-            // Get display name with full resolution chain
             var displayName = ResolveDisplayName(uti, resRef);
-
-            // Get base item type name
             var baseItemTypeName = GetBaseItemTypeName(uti.BaseItem);
-
-            // Get base cost from UTI
             var baseCost = (int)uti.Cost;
-
-            // Resolve item properties display string
             var propertiesDisplay = _itemViewModelFactory?.GetPropertiesDisplay(uti.Properties) ?? string.Empty;
 
             return new ResolvedItemData
@@ -195,7 +195,6 @@ public class ItemResolutionService
 
     private string ResolveDisplayName(UtiFile uti, string resRef)
     {
-        // Use TlkService for language-aware resolution (#1361)
         if (_tlkService != null)
         {
             var resolved = _tlkService.ResolveLocString(uti.LocalizedName);
@@ -204,7 +203,6 @@ public class ItemResolutionService
         }
         else
         {
-            // Fallback: no TlkService available - use basic resolution
             var defaultString = uti.LocalizedName.GetDefault();
             if (TlkHelper.IsValidTlkString(defaultString))
                 return defaultString!;
@@ -217,11 +215,9 @@ public class ItemResolutionService
             }
         }
 
-        // Fall back to ResRef from UTI
         if (!string.IsNullOrEmpty(uti.TemplateResRef))
             return uti.TemplateResRef;
 
-        // Final fallback to the resRef we were looking for
         return resRef;
     }
 
@@ -230,7 +226,6 @@ public class ItemResolutionService
         if (_gameDataService == null)
             return $"Type {baseItemIndex}";
 
-        // Try to get name from baseitems.2da
         var nameStrRef = _gameDataService.Get2DAValue("baseitems", baseItemIndex, "Name");
         if (!string.IsNullOrEmpty(nameStrRef) && nameStrRef != "****")
         {
@@ -239,7 +234,6 @@ public class ItemResolutionService
                 return name!;
         }
 
-        // Fall back to label
         var label = _gameDataService.Get2DAValue("baseitems", baseItemIndex, "label");
         if (!string.IsNullOrEmpty(label) && label != "****")
         {

--- a/Radoub.UI/Radoub.UI/Services/Search/ModuleSearchService.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/ModuleSearchService.cs
@@ -38,6 +38,11 @@ public class ModuleSearchService
     {
     }
 
+    public ModuleSearchService(Func<string, string?>? utmItemNameResolver)
+        : this(SearchProviderFactory.CreateDefault(utmItemNameResolver))
+    {
+    }
+
     public ModuleSearchService(SearchProviderFactory factory)
     {
         _factory = factory ?? throw new ArgumentNullException(nameof(factory));

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.30.0-alpha] - 2026-04-11
+**Branch**: `trebuchet/issue-2067` | **PR**: #TBD
+
+### Sprint: ERF Importer & Marlinspike UTM Search (#2067)
+
+- Promote ItemResolutionService to shared Radoub.UI library (#2014)
+- Wire item name resolver into Marlinspike UTM search (#2014)
+- ERF import wizard for selective resource extraction into module (#2016)
+
+---
+
 ## [1.29.0-alpha] - 2026-04-11
 **Branch**: `radoub/issue-2069` | **PR**: #2070
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [1.30.0-alpha] - 2026-04-11
-**Branch**: `trebuchet/issue-2067` | **PR**: #TBD
+**Branch**: `trebuchet/issue-2067` | **PR**: #2071
 
 ### Sprint: ERF Importer & Marlinspike UTM Search (#2067)
 

--- a/Trebuchet/Trebuchet.Tests/ErfImportServiceTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ErfImportServiceTests.cs
@@ -109,6 +109,7 @@ public class ErfImportServiceTests : IDisposable
         var result = await _service.ImportResourcesAsync(_erfPath, erf.Resources, _targetDir, overwriteExisting: false);
 
         Assert.Equal(3, result.ImportedCount);
+        Assert.Equal(0, result.OverwrittenCount);
         Assert.Equal(0, result.SkippedCount);
         Assert.Equal(0, result.ErrorCount);
         Assert.True(File.Exists(Path.Combine(_targetDir, "test_script.ncs")));
@@ -126,6 +127,7 @@ public class ErfImportServiceTests : IDisposable
         var result = await _service.ImportResourcesAsync(_erfPath, erf.Resources, _targetDir, overwriteExisting: false);
 
         Assert.Equal(2, result.ImportedCount);
+        Assert.Equal(0, result.OverwrittenCount);
         Assert.Equal(1, result.SkippedCount);
         // Verify the existing file was NOT overwritten
         var actual = await File.ReadAllBytesAsync(Path.Combine(_targetDir, "test_item.uti"));
@@ -140,9 +142,10 @@ public class ErfImportServiceTests : IDisposable
 
         var result = await _service.ImportResourcesAsync(_erfPath, erf.Resources, _targetDir, overwriteExisting: true);
 
-        Assert.Equal(3, result.ImportedCount);
+        Assert.Equal(2, result.ImportedCount);
+        Assert.Equal(1, result.OverwrittenCount);
+        Assert.Equal(3, result.TotalWritten);
         Assert.Equal(0, result.SkippedCount);
-        // Verify the file was overwritten (original ERF content, not 0xFF 0xFF)
         var actual = await File.ReadAllBytesAsync(Path.Combine(_targetDir, "test_item.uti"));
         Assert.NotEqual(new byte[] { 0xFF, 0xFF }, actual);
     }

--- a/Trebuchet/Trebuchet.Tests/ErfImportServiceTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ErfImportServiceTests.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Radoub.Formats.Common;
+using Radoub.Formats.Erf;
+using RadoubLauncher.Services;
+using Xunit;
+
+namespace Trebuchet.Tests;
+
+public class ErfImportServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _targetDir;
+    private readonly string _erfPath;
+    private readonly ErfImportService _service;
+
+    public ErfImportServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "ErfImportTest_" + Guid.NewGuid().ToString("N")[..8]);
+        _targetDir = Path.Combine(_tempDir, "module");
+        Directory.CreateDirectory(_targetDir);
+        _erfPath = Path.Combine(_tempDir, "test.erf");
+        _service = new ErfImportService();
+
+        CreateTestErf();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    private void CreateTestErf()
+    {
+        var erf = new ErfFile { FileType = "ERF ", FileVersion = "V1.0" };
+        var resourceData = new Dictionary<(string ResRef, ushort Type), byte[]>();
+
+        AddResource(erf, resourceData, "test_script", ResourceTypes.Ncs, new byte[] { 0x4E, 0x43, 0x53, 0x20 });
+        AddResource(erf, resourceData, "test_item", ResourceTypes.Uti, new byte[] { 0x47, 0x46, 0x46, 0x20 });
+        AddResource(erf, resourceData, "test_store", ResourceTypes.Utm, new byte[] { 0x47, 0x46, 0x46, 0x20, 0x01 });
+
+        ErfWriter.Write(erf, _erfPath, resourceData);
+    }
+
+    private static void AddResource(ErfFile erf, Dictionary<(string ResRef, ushort Type), byte[]> data,
+        string resRef, ushort type, byte[] content)
+    {
+        erf.Resources.Add(new ErfResourceEntry
+        {
+            ResRef = resRef,
+            ResourceType = type,
+            ResId = (uint)erf.Resources.Count,
+            Size = (uint)content.Length
+        });
+        data[(resRef, type)] = content;
+    }
+
+    #region DetectConflicts
+
+    [Fact]
+    public void DetectConflicts_NoExistingFiles_ReturnsEmpty()
+    {
+        var erf = ErfReader.ReadMetadataOnly(_erfPath);
+
+        var conflicts = _service.DetectConflicts(erf.Resources, _targetDir);
+
+        Assert.Empty(conflicts);
+    }
+
+    [Fact]
+    public void DetectConflicts_WithExistingFile_ReturnsConflict()
+    {
+        File.WriteAllBytes(Path.Combine(_targetDir, "test_item.uti"), new byte[] { 0x00 });
+        var erf = ErfReader.ReadMetadataOnly(_erfPath);
+
+        var conflicts = _service.DetectConflicts(erf.Resources, _targetDir);
+
+        Assert.Single(conflicts);
+        Assert.Contains("test_item", conflicts);
+    }
+
+    [Fact]
+    public void DetectConflicts_MultipleConflicts_ReturnsAll()
+    {
+        File.WriteAllBytes(Path.Combine(_targetDir, "test_item.uti"), new byte[] { 0x00 });
+        File.WriteAllBytes(Path.Combine(_targetDir, "test_store.utm"), new byte[] { 0x00 });
+        var erf = ErfReader.ReadMetadataOnly(_erfPath);
+
+        var conflicts = _service.DetectConflicts(erf.Resources, _targetDir);
+
+        Assert.Equal(2, conflicts.Count);
+        Assert.Contains("test_item", conflicts);
+        Assert.Contains("test_store", conflicts);
+    }
+
+    #endregion
+
+    #region ImportResourcesAsync
+
+    [Fact]
+    public async Task ImportResources_AllNew_ImportsAll()
+    {
+        var erf = ErfReader.ReadMetadataOnly(_erfPath);
+
+        var result = await _service.ImportResourcesAsync(_erfPath, erf.Resources, _targetDir, overwriteExisting: false);
+
+        Assert.Equal(3, result.ImportedCount);
+        Assert.Equal(0, result.SkippedCount);
+        Assert.Equal(0, result.ErrorCount);
+        Assert.True(File.Exists(Path.Combine(_targetDir, "test_script.ncs")));
+        Assert.True(File.Exists(Path.Combine(_targetDir, "test_item.uti")));
+        Assert.True(File.Exists(Path.Combine(_targetDir, "test_store.utm")));
+    }
+
+    [Fact]
+    public async Task ImportResources_ConflictWithoutOverwrite_SkipsConflicting()
+    {
+        var existingContent = new byte[] { 0xFF, 0xFF };
+        File.WriteAllBytes(Path.Combine(_targetDir, "test_item.uti"), existingContent);
+        var erf = ErfReader.ReadMetadataOnly(_erfPath);
+
+        var result = await _service.ImportResourcesAsync(_erfPath, erf.Resources, _targetDir, overwriteExisting: false);
+
+        Assert.Equal(2, result.ImportedCount);
+        Assert.Equal(1, result.SkippedCount);
+        // Verify the existing file was NOT overwritten
+        var actual = await File.ReadAllBytesAsync(Path.Combine(_targetDir, "test_item.uti"));
+        Assert.Equal(existingContent, actual);
+    }
+
+    [Fact]
+    public async Task ImportResources_ConflictWithOverwrite_OverwritesConflicting()
+    {
+        File.WriteAllBytes(Path.Combine(_targetDir, "test_item.uti"), new byte[] { 0xFF, 0xFF });
+        var erf = ErfReader.ReadMetadataOnly(_erfPath);
+
+        var result = await _service.ImportResourcesAsync(_erfPath, erf.Resources, _targetDir, overwriteExisting: true);
+
+        Assert.Equal(3, result.ImportedCount);
+        Assert.Equal(0, result.SkippedCount);
+        // Verify the file was overwritten (original ERF content, not 0xFF 0xFF)
+        var actual = await File.ReadAllBytesAsync(Path.Combine(_targetDir, "test_item.uti"));
+        Assert.NotEqual(new byte[] { 0xFF, 0xFF }, actual);
+    }
+
+    [Fact]
+    public async Task ImportResources_EmptyList_ReturnsZeroCounts()
+    {
+        var result = await _service.ImportResourcesAsync(_erfPath, Array.Empty<ErfResourceEntry>(), _targetDir, overwriteExisting: false);
+
+        Assert.Equal(0, result.ImportedCount);
+        Assert.Equal(0, result.SkippedCount);
+        Assert.Equal(0, result.ErrorCount);
+    }
+
+    [Fact]
+    public async Task ImportResources_Cancellation_ThrowsOperationCanceled()
+    {
+        var erf = ErfReader.ReadMetadataOnly(_erfPath);
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            _service.ImportResourcesAsync(_erfPath, erf.Resources, _targetDir, overwriteExisting: false, cancellationToken: cts.Token));
+    }
+
+    [Fact]
+    public async Task ImportResources_ReportsProgress()
+    {
+        var erf = ErfReader.ReadMetadataOnly(_erfPath);
+        var progressReports = new List<ImportProgress>();
+        var progress = new Progress<ImportProgress>(p => progressReports.Add(p));
+
+        await _service.ImportResourcesAsync(_erfPath, erf.Resources, _targetDir, overwriteExisting: false, progress: progress);
+
+        // Progress may be reported asynchronously, so allow a small delay
+        await Task.Delay(100);
+        Assert.True(progressReports.Count >= 1);
+    }
+
+    [Fact]
+    public async Task ImportResources_SelectiveImport_OnlyImportsSpecified()
+    {
+        var erf = ErfReader.ReadMetadataOnly(_erfPath);
+        var selected = new List<ErfResourceEntry> { erf.Resources[0] }; // Only test_script
+
+        var result = await _service.ImportResourcesAsync(_erfPath, selected, _targetDir, overwriteExisting: false);
+
+        Assert.Equal(1, result.ImportedCount);
+        Assert.True(File.Exists(Path.Combine(_targetDir, "test_script.ncs")));
+        Assert.False(File.Exists(Path.Combine(_targetDir, "test_item.uti")));
+        Assert.False(File.Exists(Path.Combine(_targetDir, "test_store.utm")));
+    }
+
+    #endregion
+}

--- a/Trebuchet/Trebuchet.Tests/ErfImportViewModelTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ErfImportViewModelTests.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Radoub.Formats.Common;
+using Radoub.Formats.Erf;
+using RadoubLauncher.ViewModels;
+using Xunit;
+
+namespace Trebuchet.Tests;
+
+public class ErfImportViewModelTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _targetDir;
+    private readonly string _erfPath;
+
+    public ErfImportViewModelTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "ErfVmTest_" + Guid.NewGuid().ToString("N")[..8]);
+        _targetDir = Path.Combine(_tempDir, "module");
+        Directory.CreateDirectory(_targetDir);
+        _erfPath = Path.Combine(_tempDir, "test.erf");
+
+        CreateTestErf();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    private void CreateTestErf()
+    {
+        var erf = new ErfFile { FileType = "ERF ", FileVersion = "V1.0" };
+        var resourceData = new Dictionary<(string ResRef, ushort Type), byte[]>();
+
+        AddResource(erf, resourceData, "script_01", ResourceTypes.Ncs, new byte[] { 0x01, 0x02 });
+        AddResource(erf, resourceData, "script_02", ResourceTypes.Ncs, new byte[] { 0x03, 0x04 });
+        AddResource(erf, resourceData, "item_01", ResourceTypes.Uti, new byte[] { 0x05, 0x06 });
+        AddResource(erf, resourceData, "store_01", ResourceTypes.Utm, new byte[] { 0x07, 0x08 });
+
+        ErfWriter.Write(erf, _erfPath, resourceData);
+    }
+
+    private static void AddResource(ErfFile erf, Dictionary<(string ResRef, ushort Type), byte[]> data,
+        string resRef, ushort type, byte[] content)
+    {
+        erf.Resources.Add(new ErfResourceEntry
+        {
+            ResRef = resRef,
+            ResourceType = type,
+            ResId = (uint)erf.Resources.Count,
+            Size = (uint)content.Length
+        });
+        data[(resRef, type)] = content;
+    }
+
+    #region LoadErf
+
+    [Fact]
+    public async Task LoadErf_PopulatesResources()
+    {
+        var vm = new ErfImportViewModel(_targetDir);
+
+        await vm.LoadErfAsync(_erfPath);
+
+        Assert.True(vm.IsErfLoaded);
+        Assert.Equal(4, vm.TotalCount);
+        Assert.Equal(4, vm.FilteredResources.Count);
+    }
+
+    [Fact]
+    public async Task LoadErf_DetectsConflicts()
+    {
+        File.WriteAllBytes(Path.Combine(_targetDir, "item_01.uti"), new byte[] { 0x00 });
+        var vm = new ErfImportViewModel(_targetDir);
+
+        await vm.LoadErfAsync(_erfPath);
+
+        var conflicting = vm.FilteredResources.Where(r => r.ExistsInModule).ToList();
+        Assert.Single(conflicting);
+        Assert.Equal("item_01", conflicting[0].ResRef);
+    }
+
+    [Fact]
+    public async Task LoadErf_PopulatesTypeFilters()
+    {
+        var vm = new ErfImportViewModel(_targetDir);
+
+        await vm.LoadErfAsync(_erfPath);
+
+        Assert.Contains("All Types", vm.TypeFilters);
+        Assert.Contains("Script (compiled)", vm.TypeFilters);
+        Assert.Contains("Item", vm.TypeFilters);
+        Assert.Contains("Store", vm.TypeFilters);
+    }
+
+    #endregion
+
+    #region Filtering
+
+    [Fact]
+    public async Task SearchFilter_ByResRef_FiltersCorrectly()
+    {
+        var vm = new ErfImportViewModel(_targetDir);
+        await vm.LoadErfAsync(_erfPath);
+
+        vm.SearchText = "script";
+
+        Assert.Equal(2, vm.FilteredResources.Count);
+        Assert.All(vm.FilteredResources, r => Assert.Contains("script", r.ResRef));
+    }
+
+    [Fact]
+    public async Task TypeFilter_ByType_FiltersCorrectly()
+    {
+        var vm = new ErfImportViewModel(_targetDir);
+        await vm.LoadErfAsync(_erfPath);
+
+        vm.SelectedTypeFilter = "Item";
+
+        Assert.Single(vm.FilteredResources);
+        Assert.Equal("item_01", vm.FilteredResources[0].ResRef);
+    }
+
+    [Fact]
+    public async Task CombinedFilter_SearchAndType_FiltersCorrectly()
+    {
+        var vm = new ErfImportViewModel(_targetDir);
+        await vm.LoadErfAsync(_erfPath);
+
+        vm.SelectedTypeFilter = "Script (compiled)";
+        vm.SearchText = "02";
+
+        Assert.Single(vm.FilteredResources);
+        Assert.Equal("script_02", vm.FilteredResources[0].ResRef);
+    }
+
+    [Fact]
+    public async Task SearchFilter_CaseInsensitive()
+    {
+        var vm = new ErfImportViewModel(_targetDir);
+        await vm.LoadErfAsync(_erfPath);
+
+        vm.SearchText = "SCRIPT";
+
+        Assert.Equal(2, vm.FilteredResources.Count);
+    }
+
+    #endregion
+
+    #region Selection
+
+    [Fact]
+    public async Task AllResourcesSelectedByDefault()
+    {
+        var vm = new ErfImportViewModel(_targetDir);
+        await vm.LoadErfAsync(_erfPath);
+
+        Assert.Equal(4, vm.SelectedCount);
+    }
+
+    [Fact]
+    public async Task DeselectAll_DeselectsAll()
+    {
+        var vm = new ErfImportViewModel(_targetDir);
+        await vm.LoadErfAsync(_erfPath);
+
+        vm.DeselectAll();
+
+        Assert.Equal(0, vm.SelectedCount);
+        Assert.False(vm.CanImport);
+    }
+
+    [Fact]
+    public async Task SelectAll_AfterDeselect_SelectsAll()
+    {
+        var vm = new ErfImportViewModel(_targetDir);
+        await vm.LoadErfAsync(_erfPath);
+        vm.DeselectAll();
+
+        vm.SelectAll();
+
+        Assert.Equal(4, vm.SelectedCount);
+    }
+
+    [Fact]
+    public async Task SelectAll_RespectsFilter()
+    {
+        var vm = new ErfImportViewModel(_targetDir);
+        await vm.LoadErfAsync(_erfPath);
+        vm.DeselectAll();
+        vm.SearchText = "script";
+
+        vm.SelectAll();
+
+        // Only filtered items should be selected
+        Assert.Equal(2, vm.SelectedCount);
+    }
+
+    #endregion
+
+    #region Import
+
+    [Fact]
+    public async Task Import_CreatesFilesInTargetDirectory()
+    {
+        var vm = new ErfImportViewModel(_targetDir);
+        await vm.LoadErfAsync(_erfPath);
+
+        var result = await vm.ImportAsync();
+
+        Assert.NotNull(result);
+        Assert.Equal(4, result.ImportedCount);
+        Assert.True(File.Exists(Path.Combine(_targetDir, "script_01.ncs")));
+        Assert.True(File.Exists(Path.Combine(_targetDir, "item_01.uti")));
+    }
+
+    [Fact]
+    public async Task CanImport_FalseWhenNoResourcesSelected()
+    {
+        var vm = new ErfImportViewModel(_targetDir);
+        await vm.LoadErfAsync(_erfPath);
+        vm.DeselectAll();
+
+        Assert.False(vm.CanImport);
+    }
+
+    [Fact]
+    public async Task CanImport_FalseWhenNotLoaded()
+    {
+        var vm = new ErfImportViewModel(_targetDir);
+
+        Assert.False(vm.CanImport);
+    }
+
+    #endregion
+}

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
@@ -27,6 +27,7 @@ public partial class MarlinspikePanel : UserControl
     private Window? _parentWindow;
     private ModuleSearchService? _searchService;
     private BatchReplaceService? _batchReplaceService;
+    private ItemResolutionService? _itemResolutionService;
     private TlkService? _tlkService;
     private CancellationTokenSource? _searchCts;
 
@@ -68,7 +69,17 @@ public partial class MarlinspikePanel : UserControl
 
     private void EnsureServices()
     {
-        _searchService ??= new ModuleSearchService();
+        if (_searchService == null)
+        {
+            var gameDataService = _mainViewModel?.ModuleEditorViewModel?.GameDataService;
+            _itemResolutionService = new ItemResolutionService(gameDataService);
+            var modulePath = ModulePath.GetWorkingDirectory(RadoubSettings.Instance.CurrentModulePath);
+            if (!string.IsNullOrEmpty(modulePath))
+                _itemResolutionService.SetModuleDirectory(modulePath);
+
+            _searchService = new ModuleSearchService(
+                resRef => _itemResolutionService?.ResolveItem(resRef)?.DisplayName);
+        }
         _batchReplaceService ??= new BatchReplaceService(new BackupService());
         EnsureTlkResolver();
     }
@@ -335,6 +346,8 @@ public partial class MarlinspikePanel : UserControl
     /// </summary>
     public void OnModuleChanged()
     {
+        _itemResolutionService = null;
+        _searchService = null;
         _viewModel?.ClearResults();
         ResultsTree.ItemsSource = null;
         DurationText.Text = "";

--- a/Trebuchet/Trebuchet/Services/ErfImportService.cs
+++ b/Trebuchet/Trebuchet/Services/ErfImportService.cs
@@ -58,7 +58,9 @@ public class ErfImportService
                 CurrentResRef = entry.ResRef
             });
 
-            if (File.Exists(targetPath) && !overwriteExisting)
+            var fileExists = File.Exists(targetPath);
+
+            if (fileExists && !overwriteExisting)
             {
                 result.SkippedCount++;
                 processed++;
@@ -69,7 +71,17 @@ public class ErfImportService
             {
                 var data = await Task.Run(() => ErfReader.ExtractResource(erfPath, entry), cancellationToken);
                 await File.WriteAllBytesAsync(targetPath, data, cancellationToken);
-                result.ImportedCount++;
+
+                if (fileExists)
+                {
+                    result.OverwrittenCount++;
+                    UnifiedLogger.LogApplication(LogLevel.INFO, $"ERF import: overwrote {fileName}");
+                }
+                else
+                {
+                    result.ImportedCount++;
+                    UnifiedLogger.LogApplication(LogLevel.INFO, $"ERF import: imported {fileName}");
+                }
             }
             catch (OperationCanceledException)
             {
@@ -92,9 +104,11 @@ public class ErfImportService
 public class ErfImportResult
 {
     public int ImportedCount { get; set; }
+    public int OverwrittenCount { get; set; }
     public int SkippedCount { get; set; }
     public int ErrorCount { get; set; }
     public List<(string ResRef, string Error)> Errors { get; set; } = new();
+    public int TotalWritten => ImportedCount + OverwrittenCount;
 }
 
 public class ImportProgress

--- a/Trebuchet/Trebuchet/Services/ErfImportService.cs
+++ b/Trebuchet/Trebuchet/Services/ErfImportService.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Radoub.Formats.Common;
+using Radoub.Formats.Erf;
+using Radoub.Formats.Logging;
+
+namespace RadoubLauncher.Services;
+
+public class ErfImportService
+{
+    /// <summary>
+    /// Detect which resources already exist in the target directory.
+    /// </summary>
+    public HashSet<string> DetectConflicts(IReadOnlyList<ErfResourceEntry> entries, string targetDirectory)
+    {
+        var conflicts = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entry in entries)
+        {
+            var extension = ResourceTypes.GetExtension(entry.ResourceType);
+            var filePath = Path.Combine(targetDirectory, entry.ResRef + extension);
+            if (File.Exists(filePath))
+                conflicts.Add(entry.ResRef);
+        }
+
+        return conflicts;
+    }
+
+    /// <summary>
+    /// Import selected resources from an ERF archive into the target directory.
+    /// </summary>
+    public async Task<ErfImportResult> ImportResourcesAsync(
+        string erfPath,
+        IReadOnlyList<ErfResourceEntry> entries,
+        string targetDirectory,
+        bool overwriteExisting,
+        IProgress<ImportProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var result = new ErfImportResult();
+        int processed = 0;
+
+        foreach (var entry in entries)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var extension = ResourceTypes.GetExtension(entry.ResourceType);
+            var fileName = entry.ResRef + extension;
+            var targetPath = Path.Combine(targetDirectory, fileName);
+
+            progress?.Report(new ImportProgress
+            {
+                Current = processed + 1,
+                Total = entries.Count,
+                CurrentResRef = entry.ResRef
+            });
+
+            if (File.Exists(targetPath) && !overwriteExisting)
+            {
+                result.SkippedCount++;
+                processed++;
+                continue;
+            }
+
+            try
+            {
+                var data = await Task.Run(() => ErfReader.ExtractResource(erfPath, entry), cancellationToken);
+                await File.WriteAllBytesAsync(targetPath, data, cancellationToken);
+                result.ImportedCount++;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                UnifiedLogger.LogApplication(LogLevel.WARN, $"Failed to import {fileName}: {ex.Message}");
+                result.Errors.Add((entry.ResRef, ex.Message));
+                result.ErrorCount++;
+            }
+
+            processed++;
+        }
+
+        return result;
+    }
+}
+
+public class ErfImportResult
+{
+    public int ImportedCount { get; set; }
+    public int SkippedCount { get; set; }
+    public int ErrorCount { get; set; }
+    public List<(string ResRef, string Error)> Errors { get; set; } = new();
+}
+
+public class ImportProgress
+{
+    public int Current { get; init; }
+    public int Total { get; init; }
+    public string CurrentResRef { get; init; } = string.Empty;
+}

--- a/Trebuchet/Trebuchet/ViewModels/ErfImportViewModel.cs
+++ b/Trebuchet/Trebuchet/ViewModels/ErfImportViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -59,6 +60,7 @@ public partial class ErfImportViewModel : ObservableObject
         {
             ErfFilePath = path;
             StatusText = "Loading ERF metadata...";
+            UnifiedLogger.LogApplication(LogLevel.INFO, $"ERF import: loading {Path.GetFileName(path)}");
 
             var erf = await Task.Run(() => ErfReader.ReadMetadataOnly(path));
             var conflicts = _importService.DetectConflicts(erf.Resources, _moduleDirectory);
@@ -164,6 +166,9 @@ public partial class ErfImportViewModel : ObservableObject
             .Where(r => r.IsSelected)
             .Select(r => r.Entry)
             .ToList();
+
+        UnifiedLogger.LogApplication(LogLevel.INFO,
+            $"ERF import: starting — {selected.Count} resources, overwrite={OverwriteExisting}");
 
         _importCts?.Cancel();
         _importCts = new CancellationTokenSource();

--- a/Trebuchet/Trebuchet/ViewModels/ErfImportViewModel.cs
+++ b/Trebuchet/Trebuchet/ViewModels/ErfImportViewModel.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Radoub.Formats.Erf;
+using Radoub.Formats.Logging;
+using RadoubLauncher.Services;
+
+namespace RadoubLauncher.ViewModels;
+
+public partial class ErfImportViewModel : ObservableObject
+{
+    private readonly ErfImportService _importService = new();
+    private readonly string _moduleDirectory;
+    private CancellationTokenSource? _importCts;
+    private List<ErfResourceViewModel> _allResources = new();
+
+    [ObservableProperty]
+    private string _erfFilePath = string.Empty;
+
+    [ObservableProperty]
+    private string _searchText = string.Empty;
+
+    [ObservableProperty]
+    private string _selectedTypeFilter = "All Types";
+
+    [ObservableProperty]
+    private bool _overwriteExisting;
+
+    [ObservableProperty]
+    private bool _isImporting;
+
+    [ObservableProperty]
+    private string _statusText = string.Empty;
+
+    [ObservableProperty]
+    private bool _isErfLoaded;
+
+    public ObservableCollection<ErfResourceViewModel> FilteredResources { get; } = new();
+    public ObservableCollection<string> TypeFilters { get; } = new() { "All Types" };
+
+    public int SelectedCount => _allResources.Count(r => r.IsSelected);
+    public int TotalCount => _allResources.Count;
+
+    public bool CanImport => IsErfLoaded && !IsImporting && SelectedCount > 0;
+
+    public ErfImportViewModel(string moduleDirectory)
+    {
+        _moduleDirectory = moduleDirectory;
+    }
+
+    public async Task LoadErfAsync(string path)
+    {
+        try
+        {
+            ErfFilePath = path;
+            StatusText = "Loading ERF metadata...";
+
+            var erf = await Task.Run(() => ErfReader.ReadMetadataOnly(path));
+            var conflicts = _importService.DetectConflicts(erf.Resources, _moduleDirectory);
+
+            _allResources = erf.Resources.Select(entry =>
+            {
+                var vm = new ErfResourceViewModel(entry);
+                vm.ExistsInModule = conflicts.Contains(entry.ResRef);
+                vm.PropertyChanged += (_, e) =>
+                {
+                    if (e.PropertyName == nameof(ErfResourceViewModel.IsSelected))
+                    {
+                        OnPropertyChanged(nameof(SelectedCount));
+                        OnPropertyChanged(nameof(CanImport));
+                    }
+                };
+                return vm;
+            }).ToList();
+
+            TypeFilters.Clear();
+            TypeFilters.Add("All Types");
+            foreach (var label in _allResources.Select(r => r.TypeLabel).Distinct().OrderBy(l => l))
+                TypeFilters.Add(label);
+
+            SelectedTypeFilter = "All Types";
+            IsErfLoaded = true;
+            ApplyFilter();
+            StatusText = $"Loaded {_allResources.Count} resources ({conflicts.Count} already exist in module)";
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.ERROR, $"Failed to load ERF: {ex.Message}");
+            StatusText = $"Error loading ERF: {ex.Message}";
+            IsErfLoaded = false;
+        }
+    }
+
+    partial void OnSearchTextChanged(string value) => ApplyFilter();
+    partial void OnSelectedTypeFilterChanged(string value) => ApplyFilter();
+
+    partial void OnIsImportingChanged(bool value)
+    {
+        OnPropertyChanged(nameof(CanImport));
+    }
+
+    partial void OnIsErfLoadedChanged(bool value)
+    {
+        OnPropertyChanged(nameof(CanImport));
+    }
+
+    public void ApplyFilter()
+    {
+        FilteredResources.Clear();
+
+        foreach (var resource in _allResources)
+        {
+            if (!MatchesFilter(resource))
+                continue;
+            FilteredResources.Add(resource);
+        }
+
+        OnPropertyChanged(nameof(SelectedCount));
+        OnPropertyChanged(nameof(CanImport));
+    }
+
+    private bool MatchesFilter(ErfResourceViewModel resource)
+    {
+        if (!string.IsNullOrEmpty(SearchText) &&
+            !resource.ResRef.Contains(SearchText, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (SelectedTypeFilter != "All Types" && resource.TypeLabel != SelectedTypeFilter)
+            return false;
+
+        return true;
+    }
+
+    [RelayCommand]
+    public void SelectAll()
+    {
+        foreach (var resource in FilteredResources)
+            resource.IsSelected = true;
+    }
+
+    [RelayCommand]
+    public void DeselectAll()
+    {
+        foreach (var resource in FilteredResources)
+            resource.IsSelected = false;
+    }
+
+    [RelayCommand]
+    public void CancelImport()
+    {
+        _importCts?.Cancel();
+    }
+
+    public async Task<ErfImportResult?> ImportAsync()
+    {
+        if (!CanImport) return null;
+
+        var selected = _allResources
+            .Where(r => r.IsSelected)
+            .Select(r => r.Entry)
+            .ToList();
+
+        _importCts?.Cancel();
+        _importCts = new CancellationTokenSource();
+        var token = _importCts.Token;
+
+        IsImporting = true;
+
+        var progress = new Progress<ImportProgress>(p =>
+        {
+            StatusText = $"Importing {p.Current} of {p.Total}: {p.CurrentResRef}...";
+        });
+
+        try
+        {
+            var result = await _importService.ImportResourcesAsync(
+                ErfFilePath, selected, _moduleDirectory, OverwriteExisting, progress, token);
+
+            var parts = new List<string> { $"Imported {result.ImportedCount} resources" };
+            if (result.SkippedCount > 0)
+                parts.Add($"{result.SkippedCount} skipped (already exist)");
+            if (result.ErrorCount > 0)
+                parts.Add($"{result.ErrorCount} errors");
+            StatusText = string.Join(", ", parts);
+
+            return result;
+        }
+        catch (OperationCanceledException)
+        {
+            StatusText = "Import cancelled.";
+            return null;
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.ERROR, $"ERF import failed: {ex.Message}");
+            StatusText = $"Import failed: {ex.Message}";
+            return null;
+        }
+        finally
+        {
+            IsImporting = false;
+        }
+    }
+}

--- a/Trebuchet/Trebuchet/ViewModels/ErfImportViewModel.cs
+++ b/Trebuchet/Trebuchet/ViewModels/ErfImportViewModel.cs
@@ -181,12 +181,16 @@ public partial class ErfImportViewModel : ObservableObject
             var result = await _importService.ImportResourcesAsync(
                 ErfFilePath, selected, _moduleDirectory, OverwriteExisting, progress, token);
 
-            var parts = new List<string> { $"Imported {result.ImportedCount} resources" };
+            var parts = new List<string>();
+            if (result.ImportedCount > 0)
+                parts.Add($"{result.ImportedCount} imported");
+            if (result.OverwrittenCount > 0)
+                parts.Add($"{result.OverwrittenCount} overwritten");
             if (result.SkippedCount > 0)
                 parts.Add($"{result.SkippedCount} skipped (already exist)");
             if (result.ErrorCount > 0)
                 parts.Add($"{result.ErrorCount} errors");
-            StatusText = string.Join(", ", parts);
+            StatusText = parts.Count > 0 ? string.Join(", ", parts) : "No resources imported";
 
             return result;
         }

--- a/Trebuchet/Trebuchet/ViewModels/ErfResourceViewModel.cs
+++ b/Trebuchet/Trebuchet/ViewModels/ErfResourceViewModel.cs
@@ -1,0 +1,62 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using Radoub.Formats.Common;
+using Radoub.Formats.Erf;
+
+namespace RadoubLauncher.ViewModels;
+
+public partial class ErfResourceViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private bool _isSelected = true;
+
+    public string ResRef { get; }
+    public ushort ResourceType { get; }
+    public string TypeExtension { get; }
+    public string TypeLabel { get; }
+    public long Size { get; }
+    public string FormattedSize { get; }
+    public bool ExistsInModule { get; set; }
+    public ErfResourceEntry Entry { get; }
+
+    public ErfResourceViewModel(ErfResourceEntry entry)
+    {
+        Entry = entry;
+        ResRef = entry.ResRef;
+        ResourceType = entry.ResourceType;
+        TypeExtension = ResourceTypes.GetExtension(entry.ResourceType);
+        TypeLabel = GetTypeLabel(entry.ResourceType);
+        Size = entry.Size;
+        FormattedSize = FormatSize(entry.Size);
+    }
+
+    private static string GetTypeLabel(ushort type) => type switch
+    {
+        ResourceTypes.Ncs => "Script (compiled)",
+        ResourceTypes.Nss => "Script (source)",
+        ResourceTypes.Utc => "Creature",
+        ResourceTypes.Uti => "Item",
+        ResourceTypes.Utm => "Store",
+        ResourceTypes.Utp => "Placeable",
+        ResourceTypes.Utd => "Door",
+        ResourceTypes.Utt => "Trigger",
+        ResourceTypes.Ute => "Encounter",
+        ResourceTypes.Utw => "Waypoint",
+        ResourceTypes.Uts => "Sound",
+        ResourceTypes.Dlg => "Dialog",
+        ResourceTypes.Jrl => "Journal",
+        ResourceTypes.Are => "Area",
+        ResourceTypes.Git => "Area Instance",
+        ResourceTypes.Ifo => "Module Info",
+        ResourceTypes.Fac => "Factions",
+        ResourceTypes.Itp => "Palette",
+        ResourceTypes.TwoDA => "2DA",
+        _ => ResourceTypes.GetExtension(type).TrimStart('.').ToUpperInvariant()
+    };
+
+    private static string FormatSize(long bytes) => bytes switch
+    {
+        < 1024 => $"{bytes} B",
+        < 1024 * 1024 => $"{bytes / 1024.0:F1} KB",
+        _ => $"{bytes / (1024.0 * 1024.0):F1} MB"
+    };
+}

--- a/Trebuchet/Trebuchet/ViewModels/MainWindowViewModel.cs
+++ b/Trebuchet/Trebuchet/ViewModels/MainWindowViewModel.cs
@@ -27,6 +27,7 @@ public partial class MainWindowViewModel : ObservableObject
     private System.Threading.Timer? _lockPollTimer;
     private Window? _parentWindow;
     private ModuleEditorViewModel? _moduleEditorViewModel;
+    public ModuleEditorViewModel? ModuleEditorViewModel => _moduleEditorViewModel;
     private FactionEditorViewModel? _factionEditorViewModel;
 
     [ObservableProperty]

--- a/Trebuchet/Trebuchet/ViewModels/MainWindowViewModel.cs
+++ b/Trebuchet/Trebuchet/ViewModels/MainWindowViewModel.cs
@@ -127,6 +127,8 @@ public partial class MainWindowViewModel : ObservableObject
     /// </summary>
     public bool CanBuildModule => IsModuleValid && !string.IsNullOrEmpty(RadoubSettings.Instance.CurrentModulePath) && !IsModFileLocked;
 
+    public bool IsModuleUnpacked => HasUnpackedWorkingDirectory();
+
     /// <summary>
     /// Can compile scripts when a module is selected and compiler is available.
     /// Works even when .mod is locked — compilation writes to the working directory.
@@ -590,6 +592,7 @@ public partial class MainWindowViewModel : ObservableObject
             OnPropertyChanged(nameof(CanTestModule));
             OnPropertyChanged(nameof(CanLoadModule));
             OnPropertyChanged(nameof(CanBuildModule));
+            OnPropertyChanged(nameof(IsModuleUnpacked));
             BuildModuleCommand.NotifyCanExecuteChanged();
         }
 

--- a/Trebuchet/Trebuchet/Views/ErfImportWindow.axaml
+++ b/Trebuchet/Trebuchet/Views/ErfImportWindow.axaml
@@ -1,0 +1,132 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:RadoubLauncher.ViewModels"
+        x:Class="RadoubLauncher.Views.ErfImportWindow"
+        x:DataType="vm:ErfImportViewModel"
+        Title="Import ERF"
+        Width="700" Height="550"
+        MinWidth="500" MinHeight="400"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False">
+
+    <DockPanel Margin="12">
+
+        <!-- Top: File Selection -->
+        <DockPanel DockPanel.Dock="Top" Margin="0,0,0,8">
+            <Button DockPanel.Dock="Right"
+                    Content="Browse..."
+                    Click="OnBrowseClick"
+                    Padding="12,6"
+                    Margin="8,0,0,0"/>
+            <TextBlock DockPanel.Dock="Left"
+                       Text="ERF File:"
+                       VerticalAlignment="Center"
+                       Margin="0,0,8,0"/>
+            <TextBox Text="{Binding ErfFilePath}"
+                     IsReadOnly="True"
+                     VerticalAlignment="Center"/>
+        </DockPanel>
+
+        <!-- Filter Row -->
+        <DockPanel DockPanel.Dock="Top" Margin="0,0,0,4">
+            <CheckBox DockPanel.Dock="Right"
+                      Content="Overwrite existing"
+                      IsChecked="{Binding OverwriteExisting}"
+                      VerticalAlignment="Center"
+                      Margin="12,0,0,0"/>
+            <ComboBox DockPanel.Dock="Right"
+                      ItemsSource="{Binding TypeFilters}"
+                      SelectedItem="{Binding SelectedTypeFilter}"
+                      Width="160"
+                      VerticalAlignment="Center"
+                      Margin="8,0,0,0"/>
+            <TextBlock DockPanel.Dock="Left"
+                       Text="Filter:"
+                       VerticalAlignment="Center"
+                       Margin="0,0,8,0"/>
+            <TextBox Text="{Binding SearchText}"
+                     Watermark="Search ResRef..."
+                     VerticalAlignment="Center"/>
+        </DockPanel>
+
+        <!-- Bottom: Status and Buttons -->
+        <DockPanel DockPanel.Dock="Bottom" Margin="0,8,0,0">
+            <StackPanel DockPanel.Dock="Right"
+                        Orientation="Horizontal"
+                        Spacing="8">
+                <Button Content="Select All"
+                        Command="{Binding SelectAllCommand}"
+                        Padding="12,6"/>
+                <Button Content="None"
+                        Command="{Binding DeselectAllCommand}"
+                        Padding="12,6"/>
+                <Button Content="Cancel"
+                        Click="OnCancelClick"
+                        IsCancel="True"
+                        Padding="12,6"/>
+                <Button Content="Import"
+                        Click="OnImportClick"
+                        IsEnabled="{Binding CanImport}"
+                        Padding="16,6"
+                        FontWeight="SemiBold"/>
+            </StackPanel>
+            <TextBlock Text="{Binding StatusText}"
+                       VerticalAlignment="Center"
+                       TextTrimming="CharacterEllipsis"
+                       Margin="0,0,8,0"/>
+        </DockPanel>
+
+        <!-- Selection Count -->
+        <TextBlock DockPanel.Dock="Bottom"
+                   Margin="0,4,0,0"
+                   Opacity="0.7">
+            <TextBlock.Text>
+                <MultiBinding StringFormat="Selected: {0} of {1}">
+                    <Binding Path="SelectedCount"/>
+                    <Binding Path="TotalCount"/>
+                </MultiBinding>
+            </TextBlock.Text>
+        </TextBlock>
+
+        <!-- Resource List -->
+        <DataGrid ItemsSource="{Binding FilteredResources}"
+                  AutoGenerateColumns="False"
+                  CanUserSortColumns="True"
+                  CanUserReorderColumns="False"
+                  CanUserResizeColumns="True"
+                  IsReadOnly="False"
+                  GridLinesVisibility="Horizontal"
+                  SelectionMode="Extended"
+                  Margin="0,4,0,0">
+            <DataGrid.Columns>
+                <DataGridCheckBoxColumn Header=""
+                                        Binding="{Binding IsSelected}"
+                                        Width="40"/>
+                <DataGridTextColumn Header="ResRef"
+                                    Binding="{Binding ResRef}"
+                                    IsReadOnly="True"
+                                    Width="*"/>
+                <DataGridTextColumn Header="Type"
+                                    Binding="{Binding TypeLabel}"
+                                    IsReadOnly="True"
+                                    Width="120"/>
+                <DataGridTextColumn Header="Size"
+                                    Binding="{Binding FormattedSize}"
+                                    IsReadOnly="True"
+                                    Width="80"/>
+                <DataGridTemplateColumn Header="Status" Width="90" IsReadOnly="True">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate x:DataType="vm:ErfResourceViewModel">
+                            <TextBlock Text="⚠ Exists"
+                                       IsVisible="{Binding ExistsInModule}"
+                                       Foreground="{DynamicResource WarningBrush}"
+                                       VerticalAlignment="Center"
+                                       Margin="4,0"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+
+    </DockPanel>
+</Window>

--- a/Trebuchet/Trebuchet/Views/ErfImportWindow.axaml
+++ b/Trebuchet/Trebuchet/Views/ErfImportWindow.axaml
@@ -29,11 +29,6 @@
 
         <!-- Filter Row -->
         <DockPanel DockPanel.Dock="Top" Margin="0,0,0,4">
-            <CheckBox DockPanel.Dock="Right"
-                      Content="Overwrite existing"
-                      IsChecked="{Binding OverwriteExisting}"
-                      VerticalAlignment="Center"
-                      Margin="12,0,0,0"/>
             <ComboBox DockPanel.Dock="Right"
                       ItemsSource="{Binding TypeFilters}"
                       SelectedItem="{Binding SelectedTypeFilter}"
@@ -64,6 +59,10 @@
                         Click="OnCancelClick"
                         IsCancel="True"
                         Padding="12,6"/>
+                <CheckBox Content="Overwrite existing"
+                          IsChecked="{Binding OverwriteExisting}"
+                          VerticalAlignment="Center"
+                          Margin="0,0,4,0"/>
                 <Button Content="Import"
                         Click="OnImportClick"
                         IsEnabled="{Binding CanImport}"

--- a/Trebuchet/Trebuchet/Views/ErfImportWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/ErfImportWindow.axaml.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
+using RadoubLauncher.ViewModels;
+
+namespace RadoubLauncher.Views;
+
+public partial class ErfImportWindow : Window
+{
+    private ErfImportViewModel? _viewModel;
+
+    public ErfImportWindow()
+    {
+        InitializeComponent();
+    }
+
+    public void Initialize(string moduleDirectory)
+    {
+        _viewModel = new ErfImportViewModel(moduleDirectory);
+        DataContext = _viewModel;
+    }
+
+    private async void OnBrowseClick(object? sender, RoutedEventArgs e)
+    {
+        if (_viewModel == null) return;
+
+        var storage = GetTopLevel(this)?.StorageProvider;
+        if (storage == null) return;
+
+        var erfFilter = new FilePickerFileType("ERF Archives")
+        {
+            Patterns = new[] { "*.erf", "*.hak", "*.mod", "*.sav" }
+        };
+
+        var files = await storage.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Select ERF Archive",
+            FileTypeFilter = new[] { erfFilter },
+            AllowMultiple = false
+        });
+
+        if (files.Count > 0)
+        {
+            var path = files[0].TryGetLocalPath();
+            if (!string.IsNullOrEmpty(path))
+                await _viewModel.LoadErfAsync(path);
+        }
+    }
+
+    private async void OnImportClick(object? sender, RoutedEventArgs e)
+    {
+        if (_viewModel == null) return;
+
+        var result = await _viewModel.ImportAsync();
+        if (result != null && result.ErrorCount == 0 && result.ImportedCount > 0)
+        {
+            // Auto-close on successful import with no errors
+        }
+    }
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e)
+    {
+        if (_viewModel?.IsImporting == true)
+        {
+            _viewModel.CancelImport();
+        }
+        else
+        {
+            Close();
+        }
+    }
+}

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml
@@ -96,6 +96,11 @@
                             IsEnabled="{Binding CanBuildModule}"
                             Padding="8,4"
                             ToolTip.Tip="Save IFO changes and pack working directory into .mod file"/>
+                    <Button Content="Import ERF..."
+                            Click="OnImportErfClick"
+                            IsVisible="{Binding IsModuleUnpacked}"
+                            Padding="8,4"
+                            ToolTip.Tip="Import resources from an ERF, HAK, or MOD archive"/>
                     <!-- Build warning indicator -->
                     <TextBlock Text="⚠"
                                Foreground="{DynamicResource ThemeWarning}"

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
@@ -278,4 +278,19 @@ public partial class MainWindow : Window
     }
 
     #endregion
+
+    #region ERF Import
+
+    private void OnImportErfClick(object? sender, RoutedEventArgs e)
+    {
+        var modulePath = RadoubLauncher.Services.ModulePathHelper.GetWorkingDirectory(
+            Radoub.Formats.Settings.RadoubSettings.Instance.CurrentModulePath);
+        if (string.IsNullOrEmpty(modulePath)) return;
+
+        var window = new ErfImportWindow();
+        window.Initialize(modulePath);
+        window.Show(this);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

- Promote `ItemResolutionService` from Fence to shared `Radoub.UI` library for cross-tool reuse
- Wire item name resolver into Marlinspike UTM search — search by display name (e.g., "Club") not just ResRef
- ERF import wizard for selective resource extraction from .erf/.hak/.mod/.sav archives into modules

## Related Issues

- Closes #2067
- Closes #2016
- Closes #2014
- Follow-up: #2072 (stale search index after import)

## Test Results

| Suite | Result |
|-------|--------|
| Radoub.Formats.Tests | ✅ 1141 passed |
| Radoub.UI.Tests | ✅ 455 passed |
| Radoub.Dictionary.Tests | ✅ 54 passed |
| Trebuchet.Tests | ✅ 128 passed |
| **Total** | **1778 passed, 0 failed** |

## Manual Testing

- ✅ ERF import: browse, load, filter, select, import, overwrite — all confirmed
- ✅ Overwrite logging confirmed in session log
- ✅ Fence item resolution still works after service move
- ✅ Marlinspike ResRef search still works
- ✅ Marlinspike item display name search works

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)