### PR TITLE
[Radoub] fix: Linux OOM killer mitigation for all tools

### DIFF
--- a/Fence/Fence/Program.cs
+++ b/Fence/Fence/Program.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using MerchantEditor.Services;
 using System;
+using System.Collections.Generic;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Settings;
 using Radoub.UI.Services;
@@ -53,8 +54,27 @@ sealed class Program
 
     // Avalonia configuration, don't remove; also used by visual designer.
     public static AppBuilder BuildAvaloniaApp()
-        => AppBuilder.Configure<App>()
+    {
+        var builder = AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .WithInterFont()
             .LogToTrace();
+
+        // Linux: Explicitly use GLX + Software rendering (no Vulkan).
+        // Vulkan GPU drivers reserve ~256GB of virtual address space, which
+        // triggers the OOM killer on memory-constrained systems.
+        if (OperatingSystem.IsLinux())
+        {
+            builder = builder.With(new X11PlatformOptions
+            {
+                RenderingMode = new List<X11RenderingMode>
+                {
+                    X11RenderingMode.Glx,
+                    X11RenderingMode.Software
+                }
+            });
+        }
+
+        return builder;
+    }
 }

--- a/Manifest/Manifest/Program.cs
+++ b/Manifest/Manifest/Program.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Manifest.Services;
 using System;
+using System.Collections.Generic;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Settings;
 using Radoub.UI.Services;
@@ -56,8 +57,27 @@ sealed class Program
 
     // Avalonia configuration, don't remove; also used by visual designer.
     public static AppBuilder BuildAvaloniaApp()
-        => AppBuilder.Configure<App>()
+    {
+        var builder = AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .WithInterFont()
             .LogToTrace();
+
+        // Linux: Explicitly use GLX + Software rendering (no Vulkan).
+        // Vulkan GPU drivers reserve ~256GB of virtual address space, which
+        // triggers the OOM killer on memory-constrained systems.
+        if (OperatingSystem.IsLinux())
+        {
+            builder = builder.With(new X11PlatformOptions
+            {
+                RenderingMode = new List<X11RenderingMode>
+                {
+                    X11RenderingMode.Glx,
+                    X11RenderingMode.Software
+                }
+            });
+        }
+
+        return builder;
+    }
 }

--- a/Parley/Parley/Program.cs
+++ b/Parley/Parley/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using DialogEditor.Services;
@@ -190,8 +191,27 @@ sealed class Program
 
     // Avalonia configuration, don't remove; also used by visual designer.
     public static AppBuilder BuildAvaloniaApp()
-        => AppBuilder.Configure<App>()
+    {
+        var builder = AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .WithInterFont()
             .LogToTrace();
+
+        // Linux: Explicitly use GLX + Software rendering (no Vulkan).
+        // Vulkan GPU drivers reserve ~256GB of virtual address space, which
+        // triggers the OOM killer on memory-constrained systems.
+        if (OperatingSystem.IsLinux())
+        {
+            builder = builder.With(new X11PlatformOptions
+            {
+                RenderingMode = new List<X11RenderingMode>
+                {
+                    X11RenderingMode.Glx,
+                    X11RenderingMode.Software
+                }
+            });
+        }
+
+        return builder;
+    }
 }

--- a/Quartermaster/Quartermaster/Program.cs
+++ b/Quartermaster/Quartermaster/Program.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Quartermaster.Services;
 using System;
+using System.Collections.Generic;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Settings;
 using Radoub.UI.Services;
@@ -67,8 +68,27 @@ sealed class Program
 
     // Avalonia configuration, don't remove; also used by visual designer.
     public static AppBuilder BuildAvaloniaApp()
-        => AppBuilder.Configure<App>()
+    {
+        var builder = AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .WithInterFont()
             .LogToTrace();
+
+        // Linux: Explicitly use GLX + Software rendering (no Vulkan).
+        // Vulkan GPU drivers reserve ~256GB of virtual address space, which
+        // triggers the OOM killer on memory-constrained systems.
+        if (OperatingSystem.IsLinux())
+        {
+            builder = builder.With(new X11PlatformOptions
+            {
+                RenderingMode = new List<X11RenderingMode>
+                {
+                    X11RenderingMode.Glx,
+                    X11RenderingMode.Software
+                }
+            });
+        }
+
+        return builder;
+    }
 }

--- a/Relique/Relique/Program.cs
+++ b/Relique/Relique/Program.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using ItemEditor.Services;
 using System;
+using System.Collections.Generic;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Settings;
 using Radoub.UI.Services;
@@ -53,8 +54,27 @@ sealed class Program
 
     // Avalonia configuration, don't remove; also used by visual designer.
     public static AppBuilder BuildAvaloniaApp()
-        => AppBuilder.Configure<App>()
+    {
+        var builder = AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .WithInterFont()
             .LogToTrace();
+
+        // Linux: Explicitly use GLX + Software rendering (no Vulkan).
+        // Vulkan GPU drivers reserve ~256GB of virtual address space, which
+        // triggers the OOM killer on memory-constrained systems.
+        if (OperatingSystem.IsLinux())
+        {
+            builder = builder.With(new X11PlatformOptions
+            {
+                RenderingMode = new List<X11RenderingMode>
+                {
+                    X11RenderingMode.Glx,
+                    X11RenderingMode.Software
+                }
+            });
+        }
+
+        return builder;
+    }
 }

--- a/Trebuchet/Trebuchet/Program.cs
+++ b/Trebuchet/Trebuchet/Program.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using RadoubLauncher.Services;
 using System;
+using System.Collections.Generic;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Settings;
 using Radoub.UI.Services;
@@ -61,8 +62,27 @@ sealed class Program
 
     // Avalonia configuration, don't remove; also used by visual designer.
     public static AppBuilder BuildAvaloniaApp()
-        => AppBuilder.Configure<App>()
+    {
+        var builder = AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .WithInterFont()
             .LogToTrace();
+
+        // Linux: Explicitly use GLX + Software rendering (no Vulkan).
+        // Vulkan GPU drivers reserve ~256GB of virtual address space, which
+        // triggers the OOM killer on memory-constrained systems.
+        if (OperatingSystem.IsLinux())
+        {
+            builder = builder.With(new X11PlatformOptions
+            {
+                RenderingMode = new List<X11RenderingMode>
+                {
+                    X11RenderingMode.Glx,
+                    X11RenderingMode.Software
+                }
+            });
+        }
+
+        return builder;
+    }
 }


### PR DESCRIPTION
## Summary

- All six Radoub tools (Parley, Trebuchet, Quartermaster, Fence, Manifest, Relique) were being killed by the Linux OOM killer on memory-constrained systems (8GB RAM)
- Each .NET 9 process reserved ~277GB of virtual address space, causing the OOM killer to aggressively target them (`oom_score_adj=200` from systemd user slice)
- Added explicit `X11PlatformOptions` configuration to all tools' `BuildAvaloniaApp()` methods, specifying GLX + Software rendering on Linux (no Vulkan)
- This future-proofs against Avalonia changing its default rendering mode and documents the rendering intent

## Additional recommendation

For systems with <16GB RAM, also set `vm.overcommit_memory=1` at the OS level:
```bash
echo "vm.overcommit_memory=1" | sudo tee /etc/sysctl.d/99-overcommit.conf
sudo sysctl -p /etc/sysctl.d/99-overcommit.conf
```

## Test plan

- [ ] Release build on Linux: `dotnet build Radoub.sln --configuration Release`
- [ ] Launch Trebuchet from terminal — no "Killed" message
- [ ] Launch Parley from Trebuchet — stays running, no OOM kill
- [ ] Verify rendering looks correct (GLX mode)
- [ ] Confirm Windows builds unaffected (conditional Linux-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)