### PR TITLE
[Radoub] fix: 3D model preview not rendering on Linux (#2074)

### DIFF
--- a/Fence/Fence/Program.cs
+++ b/Fence/Fence/Program.cs
@@ -60,15 +60,18 @@ sealed class Program
             .WithInterFont()
             .LogToTrace();
 
-        // Linux: Explicitly use GLX + Software rendering (no Vulkan).
+        // Linux: Explicitly set rendering modes (no Vulkan).
         // Vulkan GPU drivers reserve ~256GB of virtual address space, which
         // triggers the OOM killer on memory-constrained systems.
+        // EGL is needed for OpenGlControlBase on Wayland/XWayland where GLX
+        // contexts may not initialize for offscreen GL controls (#2074).
         if (OperatingSystem.IsLinux())
         {
             builder = builder.With(new X11PlatformOptions
             {
                 RenderingMode = new List<X11RenderingMode>
                 {
+                    X11RenderingMode.Egl,
                     X11RenderingMode.Glx,
                     X11RenderingMode.Software
                 }

--- a/Manifest/Manifest/Program.cs
+++ b/Manifest/Manifest/Program.cs
@@ -63,15 +63,18 @@ sealed class Program
             .WithInterFont()
             .LogToTrace();
 
-        // Linux: Explicitly use GLX + Software rendering (no Vulkan).
+        // Linux: Explicitly set rendering modes (no Vulkan).
         // Vulkan GPU drivers reserve ~256GB of virtual address space, which
         // triggers the OOM killer on memory-constrained systems.
+        // EGL is needed for OpenGlControlBase on Wayland/XWayland where GLX
+        // contexts may not initialize for offscreen GL controls (#2074).
         if (OperatingSystem.IsLinux())
         {
             builder = builder.With(new X11PlatformOptions
             {
                 RenderingMode = new List<X11RenderingMode>
                 {
+                    X11RenderingMode.Egl,
                     X11RenderingMode.Glx,
                     X11RenderingMode.Software
                 }

--- a/Parley/Parley/Program.cs
+++ b/Parley/Parley/Program.cs
@@ -197,15 +197,18 @@ sealed class Program
             .WithInterFont()
             .LogToTrace();
 
-        // Linux: Explicitly use GLX + Software rendering (no Vulkan).
+        // Linux: Explicitly set rendering modes (no Vulkan).
         // Vulkan GPU drivers reserve ~256GB of virtual address space, which
         // triggers the OOM killer on memory-constrained systems.
+        // EGL is needed for OpenGlControlBase on Wayland/XWayland where GLX
+        // contexts may not initialize for offscreen GL controls (#2074).
         if (OperatingSystem.IsLinux())
         {
             builder = builder.With(new X11PlatformOptions
             {
                 RenderingMode = new List<X11RenderingMode>
                 {
+                    X11RenderingMode.Egl,
                     X11RenderingMode.Glx,
                     X11RenderingMode.Software
                 }

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.78-alpha] - 2026-04-12
-**Branch**: `quartermaster/issue-2074` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2074` | **PR**: #2076
 
 ### Fix: 3D model preview not rendering on Linux (#2074)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.78-alpha] - 2026-04-12
+**Branch**: `quartermaster/issue-2074` | **PR**: #TBD
+
+### Fix: 3D model preview not rendering on Linux (#2074)
+
+---
+
 ## [0.2.77-alpha] - 2026-04-11
 **Branch**: `quartermaster/issue-2057` | **PR**: #2059
 

--- a/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
+++ b/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
@@ -285,8 +285,16 @@ public class ModelPreviewGLControl : OpenGlControlBase
             // Create Silk.NET GL context from Avalonia's proc address loader
             _gl = GL.GetApi(gl.GetProcAddress);
 
+            // Detect whether this is an OpenGL ES context (ANGLE on Windows)
+            // or desktop OpenGL (GLX on Linux) — shaders need different version preambles.
+            var versionString = _gl.GetStringS(StringName.Version) ?? "";
+            var isOpenGLES = versionString.Contains("OpenGL ES", StringComparison.OrdinalIgnoreCase);
+            var renderer = _gl.GetStringS(StringName.Renderer) ?? "unknown";
+            UnifiedLogger.LogApplication(LogLevel.INFO,
+                $"GL context: {versionString} | Renderer: {renderer} | ES={isOpenGLES}");
+
             // Compile and link shaders via manager
-            _shaderManager = new OpenGLShaderManager(_gl);
+            _shaderManager = new OpenGLShaderManager(_gl, isOpenGLES);
             _shaderManager.CreateProgram();
 
             // Create VAO/VBO/EBO

--- a/Quartermaster/Quartermaster/Controls/OpenGLShaderManager.cs
+++ b/Quartermaster/Quartermaster/Controls/OpenGLShaderManager.cs
@@ -15,14 +15,17 @@ namespace Quartermaster.Controls;
 public class OpenGLShaderManager
 {
     private readonly GL _gl;
+    private readonly bool _isOpenGLES;
     private uint _shaderProgram;
     private bool _loggedUniforms;
 
-    // Shader source code - GLSL ES 300 for ANGLE compatibility on Windows
-    // Avalonia uses ANGLE which provides OpenGL ES, not desktop OpenGL
-    public const string VertexShaderSource = @"#version 300 es
-precision highp float;
+    // Shader source split into version preamble + shared body.
+    // Windows (ANGLE) provides OpenGL ES → needs "#version 300 es" + precision qualifier.
+    // Linux (GLX) provides desktop OpenGL → needs "#version 330 core", no precision qualifier.
+    private const string VersionEs = "#version 300 es\nprecision highp float;\n";
+    private const string VersionDesktop = "#version 330 core\n";
 
+    private const string VertexShaderBody = @"
 layout (location = 0) in vec3 aPosition;
 layout (location = 1) in vec3 aNormal;
 layout (location = 2) in vec2 aTexCoord;
@@ -44,9 +47,7 @@ void main()
 }
 ";
 
-    public const string FragmentShaderSource = @"#version 300 es
-precision highp float;
-
+    private const string FragmentShaderBody = @"
 out vec4 FragColor;
 
 in vec3 FragPos;
@@ -88,9 +89,10 @@ void main()
 
     public uint ShaderProgram => _shaderProgram;
 
-    public OpenGLShaderManager(GL gl)
+    public OpenGLShaderManager(GL gl, bool isOpenGLES)
     {
         _gl = gl;
+        _isOpenGLES = isOpenGLES;
     }
 
     /// <summary>
@@ -98,8 +100,9 @@ void main()
     /// </summary>
     public bool CreateProgram()
     {
-        var vertexShader = CompileShader(ShaderType.VertexShader, VertexShaderSource);
-        var fragmentShader = CompileShader(ShaderType.FragmentShader, FragmentShaderSource);
+        var preamble = _isOpenGLES ? VersionEs : VersionDesktop;
+        var vertexShader = CompileShader(ShaderType.VertexShader, preamble + VertexShaderBody);
+        var fragmentShader = CompileShader(ShaderType.FragmentShader, preamble + FragmentShaderBody);
 
         _shaderProgram = _gl.CreateProgram();
         _gl.AttachShader(_shaderProgram, vertexShader);

--- a/Quartermaster/Quartermaster/Program.cs
+++ b/Quartermaster/Quartermaster/Program.cs
@@ -74,15 +74,18 @@ sealed class Program
             .WithInterFont()
             .LogToTrace();
 
-        // Linux: Explicitly use GLX + Software rendering (no Vulkan).
+        // Linux: Explicitly set rendering modes (no Vulkan).
         // Vulkan GPU drivers reserve ~256GB of virtual address space, which
         // triggers the OOM killer on memory-constrained systems.
+        // EGL is needed for OpenGlControlBase on Wayland/XWayland where GLX
+        // contexts may not initialize for offscreen GL controls (#2074).
         if (OperatingSystem.IsLinux())
         {
             builder = builder.With(new X11PlatformOptions
             {
                 RenderingMode = new List<X11RenderingMode>
                 {
+                    X11RenderingMode.Egl,
                     X11RenderingMode.Glx,
                     X11RenderingMode.Software
                 }

--- a/Relique/Relique/Program.cs
+++ b/Relique/Relique/Program.cs
@@ -60,15 +60,18 @@ sealed class Program
             .WithInterFont()
             .LogToTrace();
 
-        // Linux: Explicitly use GLX + Software rendering (no Vulkan).
+        // Linux: Explicitly set rendering modes (no Vulkan).
         // Vulkan GPU drivers reserve ~256GB of virtual address space, which
         // triggers the OOM killer on memory-constrained systems.
+        // EGL is needed for OpenGlControlBase on Wayland/XWayland where GLX
+        // contexts may not initialize for offscreen GL controls (#2074).
         if (OperatingSystem.IsLinux())
         {
             builder = builder.With(new X11PlatformOptions
             {
                 RenderingMode = new List<X11RenderingMode>
                 {
+                    X11RenderingMode.Egl,
                     X11RenderingMode.Glx,
                     X11RenderingMode.Software
                 }

--- a/Trebuchet/Trebuchet/Program.cs
+++ b/Trebuchet/Trebuchet/Program.cs
@@ -68,15 +68,18 @@ sealed class Program
             .WithInterFont()
             .LogToTrace();
 
-        // Linux: Explicitly use GLX + Software rendering (no Vulkan).
+        // Linux: Explicitly set rendering modes (no Vulkan).
         // Vulkan GPU drivers reserve ~256GB of virtual address space, which
         // triggers the OOM killer on memory-constrained systems.
+        // EGL is needed for OpenGlControlBase on Wayland/XWayland where GLX
+        // contexts may not initialize for offscreen GL controls (#2074).
         if (OperatingSystem.IsLinux())
         {
             builder = builder.With(new X11PlatformOptions
             {
                 RenderingMode = new List<X11RenderingMode>
                 {
+                    X11RenderingMode.Egl,
                     X11RenderingMode.Glx,
                     X11RenderingMode.Software
                 }


### PR DESCRIPTION
## Summary

- Fix 3D model preview panel rendering blank on Linux (Wayland/XWayland)
- Root cause: GLX contexts do not initialize for Avalonia OpenGlControlBase on Wayland/XWayland sessions
- Added X11RenderingMode.Egl as primary rendering mode for all 6 tools on Linux
- Added desktop GL / ES shader dual-compatibility so OpenGL preview works regardless of context type
- Verified working on Linux (Wayland + Hyper-V virtual GPU) and Windows (no regression)

## Changes

| File | Change |
|------|--------|
| */Program.cs (6 tools) | Add EGL to X11 rendering mode list |
| OpenGLShaderManager.cs | Dual shader preamble (ES 300 / desktop 330 core) |
| ModelPreviewGLControl.cs | GL context type detection + diagnostic logging |
| Quartermaster/CHANGELOG.md | Version 0.2.78-alpha entry |

## Related Issues

- Closes #2074

## Testing

- [x] All 4,243 unit tests pass (9 test projects)
- [x] Full solution builds (0 errors)
- [x] Privacy scan clean
- [x] Verified rendering on Linux (Wayland/XWayland + Hyper-V)
- [x] Verified no regression on Windows