### PR TITLE
[Radoub] docs: Release notes for radoub-v0.9.43

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -2,30 +2,49 @@
 
 ### Highlights
 
-- **Parley**: FlowView now shows 📋 symbol for nodes with quest tags, theme cleanup across browser windows (#1563)
+**Marlinspike Search & Replace** — Module-wide find & replace across all 17 GFF file types, now available as a Trebuchet workspace tab and via Ctrl+F/H in every tool.
+
+**ERF Import Wizard** — Extract resources from .erf/.hak/.mod/.sav archives into your module with search, type filtering, and conflict detection.
+
+### New Tools in This Release
+
+**Quartermaster** (Alpha) — NPC and character editor for .utc/.bic files. Make backups before using — this still needs a lot of work, but constructive feedback is welcome.
+
+**Relique** (Alpha) — Item blueprint editor for .uti files.
 
 ### Parley
 
-Visual & UX polish sprint: FlowView quest tag icons, hardcoded brush cleanup in browser windows, and test stability fixes. Bug squash sprint: delete file from browser panel, character picker persistence, file splits. Test quality improvement: replaced 35 anti-pattern tests with 40 behavioral tests.
+Drag-and-drop reorder/reparent in flowchart view. Improved focus handling and tree refresh coordination.
+
+### Bug Fixes
+
+- **Quartermaster**: Fix saving throws not updated after level-up
+- **Quartermaster**: Fix Rogue short swords flagged as requiring Martial proficiency
+- **Quartermaster**: Fix crash loading c_kocrachn model (unbounded MDL recursion)
+- **Fence**: Fix loading UTM setting dirty flag without changes
+- **Parley**: Fix NPC-to-NPC links visual bug
+- **Parley**: Fix --mod flag not working for module search context
+- **Marlinspike**: Fix VarTable replace silently failing
 
 ### Radoub (Shared)
 
-Dependabot dependency updates, status bar & title bar standardization across all tools, TDD audit followup with 142 new service tests, cross-tool service standardization (Waves 1 & 2), document lifecycle standardization, Claude Code hooks for CLAUDE.md enforcement.
+- File locking prevents data corruption when the same file is open in multiple tools
+- Service consolidation across all tools (~1,600 lines removed)
+- New GFF parsers: UTP (Placeable), UTD (Door), ARE (Area)
 
 ## Tool Versions
 
 | Tool | Version | Maturity |
 |------|---------|----------|
-| Parley | v0.2.11-alpha | Beta |
-| Manifest | v0.16.9-alpha | Beta |
-| Fence | v0.2.11-alpha | Alpha |
-| Trebuchet | v1.19.11-alpha | Alpha |
-
-**Note**: Quartermaster is not included in this release (active development).
+| Parley | 0.2.37-alpha | Beta |
+| Manifest | 0.16.25-alpha | Beta |
+| Quartermaster | 0.2.93-alpha | Alpha (NEW) |
+| Fence | 0.2.40-alpha | Alpha |
+| Trebuchet | 1.19.34-alpha | Alpha |
+| Relique | 0.1.23-alpha | Alpha (NEW) |
 
 ## Downloads
 
-- **Bundled**: Includes .NET runtime — works standalone
-- **Unbundled**: Smaller download, requires .NET 9.0 installed
+Includes .NET runtime — no separate install needed.
 
 See individual tool CHANGELOGs for complete details.


### PR DESCRIPTION
## Summary
- Trimmed release notes for radoub-v0.9.43
- Updated tool versions to current NBGV values
- Removed unbundled download reference (workflow only builds self-contained)

## Test plan
- [ ] Release notes read correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)