### PR TITLE
[Radoub] chore: Dependabot safe dependency updates (#2083, #2084)

### DIFF
--- a/.github/workflows/radoub-release.yml
+++ b/.github/workflows/radoub-release.yml
@@ -430,7 +430,7 @@ jobs:
         find ./artifacts -type f
 
     - name: Create Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         files: |
           ./artifacts/**/*.zip

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -55,7 +55,7 @@ jobs:
             -OutputPath "${{ github.workspace }}"
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: "${{ steps.tag.outputs.plugin }} v${{ steps.tag.outputs.version }}"
           files: "*.zip"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,7 +48,7 @@
 
     <!-- Testing -->
     <PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.13" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
## Summary

- **softprops/action-gh-release** v2 → v3 (Node 20 → Node 24 runtime) — #2083
- **Microsoft.NET.Test.Sdk** 18.3.0 → 18.4.0 (minor: LoongArch64 support, .NET 10 trait fix) — #2084

Consolidates the two low-risk dependabot PRs.

## Avalonia 12 Assessment

PRs #2086-#2090 propose Avalonia 11.3.13 → 12.0.0. After investigation:

- ❌ `Avalonia.Diagnostics` package removed (no 12.0.0 exists)
- ❌ `IDataObject` removed — replacement `IDataTransfer` has different API (breaks drag-drop in Radoub.UI)
- ❌ SkiaSharp bumped to **preview** version (3.119.3-preview.1.1)
- ⚠️ Third-party packages (`Svg.Controls.Skia.Avalonia`, `AvaloniaGraphControl`) may lack Avalonia 12 builds
- ⚠️ Affects **all tools** (Parley, Manifest, QM, Fence, Relique, Trebuchet, Radoub.UI) — not just Parley

**Recommendation**: Close #2086-#2090 and create a dedicated Avalonia 12 migration epic.

## Test Results

- Build: ✅ 0 errors, 13 warnings (pre-existing)
- Unit tests: ✅ 4,296 passed, 0 failed

## Post-Merge Cleanup

Close superseded dependabot PRs:
- #2083 — `softprops/action-gh-release`
- #2084 — `Microsoft.NET.Test.Sdk`

Close with comment (not viable as dependabot bump):
- #2086, #2087, #2088, #2089, #2090 — Avalonia 12 + SkiaSharp

🤖 Generated with [Claude Code](https://claude.com/claude-code)