### PR TITLE
[Radoub] Sprint: Upgrade to Avalonia 12

### DIFF
--- a/Fence/CHANGELOG.md
+++ b/Fence/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.2.0-alpha] - 2026-04-13
-**Branch**: `radoub/issue-2092` | **PR**: #TBD
+**Branch**: `radoub/issue-2092` | **PR**: #2094
 
 ### Sprint: Upgrade to Avalonia 12 (#2092)
 - Avalonia 12.0.x package upgrade

--- a/Fence/CHANGELOG.md
+++ b/Fence/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.2.0-alpha] - 2026-04-13
+**Branch**: `radoub/issue-2092` | **PR**: #TBD
+
+### Sprint: Upgrade to Avalonia 12 (#2092)
+- Avalonia 12.0.x package upgrade
+
+---
+
 ## [0.1.25-alpha] - 2026-03-27
 **Branch**: `fence/issue-1980` | **PR**: #2013
 

--- a/Manifest/CHANGELOG.md
+++ b/Manifest/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.16.0-alpha] - 2026-04-13
+**Branch**: `radoub/issue-2092` | **PR**: #TBD
+
+### Sprint: Upgrade to Avalonia 12 (#2092)
+- Avalonia 12.0.x package upgrade
+
+---
+
 ## [0.15.6-alpha] - 2026-03-24
 **Branch**: `quartermaster/issue-1900` | **PR**: #1969
 

--- a/Manifest/CHANGELOG.md
+++ b/Manifest/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.16.0-alpha] - 2026-04-13
-**Branch**: `radoub/issue-2092` | **PR**: #TBD
+**Branch**: `radoub/issue-2092` | **PR**: #2094
 
 ### Sprint: Upgrade to Avalonia 12 (#2092)
 - Avalonia 12.0.x package upgrade

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Parley. One-line highlights per version; full details in 
 ---
 
 ## [0.2.0-alpha] - 2026-04-13
-**Branch**: `radoub/issue-2092` | **PR**: #TBD
+**Branch**: `radoub/issue-2092` | **PR**: #2094
 
 ### Sprint: Upgrade to Avalonia 12 (#2092)
 - Migrate tree view drag-and-drop from `IDataObject` to `IDataTransfer`

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Parley. One-line highlights per version; full details in 
 
 ---
 
+## [0.2.0-alpha] - 2026-04-13
+**Branch**: `radoub/issue-2092` | **PR**: #TBD
+
+### Sprint: Upgrade to Avalonia 12 (#2092)
+- Migrate tree view drag-and-drop from `IDataObject` to `IDataTransfer`
+
+---
+
 ## [0.1.164-alpha] - 2026-04-12 | PR #2082
 **Branch**: `parley/issue-2062`
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.3.0-alpha] - 2026-04-13
+**Branch**: `radoub/issue-2092` | **PR**: #TBD
+
+### Sprint: Upgrade to Avalonia 12 (#2092)
+- Migrate inventory drag-and-drop from `IDataObject` to `IDataTransfer`
+
+---
+
 ## [0.2.78-alpha] - 2026-04-12
 **Branch**: `quartermaster/issue-2074` | **PR**: #2076
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.3.0-alpha] - 2026-04-13
-**Branch**: `radoub/issue-2092` | **PR**: #TBD
+**Branch**: `radoub/issue-2092` | **PR**: #2094
 
 ### Sprint: Upgrade to Avalonia 12 (#2092)
 - Migrate inventory drag-and-drop from `IDataObject` to `IDataTransfer`

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.11.0-alpha] - 2026-04-13
-**Branch**: `radoub/issue-2092` | **PR**: #TBD
+**Branch**: `radoub/issue-2092` | **PR**: #2094
 
 ### Sprint: Upgrade to Avalonia 12 (#2092)
 - Avalonia 12.0.x package upgrade

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.11.0-alpha] - 2026-04-13
+**Branch**: `radoub/issue-2092` | **PR**: #TBD
+
+### Sprint: Upgrade to Avalonia 12 (#2092)
+- Avalonia 12.0.x package upgrade
+
+---
+
 ## [0.10.8-alpha] - 2026-04-09
 **Branch**: `relique/issue-1983` | **PR**: #2044
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [1.31.0-alpha] - 2026-04-13
-**Branch**: `radoub/issue-2092` | **PR**: #TBD
+**Branch**: `radoub/issue-2092` | **PR**: #2094
 
 ### Sprint: Upgrade to Avalonia 12 (#2092)
 - Avalonia 12.0.x package upgrade across all tools

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.31.0-alpha] - 2026-04-13
+**Branch**: `radoub/issue-2092` | **PR**: #TBD
+
+### Sprint: Upgrade to Avalonia 12 (#2092)
+- Avalonia 12.0.x package upgrade across all tools
+- `IDataTransfer` compatibility helper in Radoub.UI
+
+---
+
 ## [1.30.0-alpha] - 2026-04-11
 **Branch**: `trebuchet/issue-2067` | **PR**: #2071
 


### PR DESCRIPTION
## Summary

Upgrade the entire Radoub toolset from Avalonia 11.3.x to 12.0.x. Major version with breaking changes across all six tools and Radoub.UI.

## Scope

- `IDataObject` → `IDataTransfer` migration (3 drag sources, 2 event-args classes, ~17 consumer call sites in QM and Parley)
- Avalonia.Diagnostics package removal/replacement (6 projects)
- Third-party package compatibility check (`Svg.Controls.Skia.Avalonia`, `AvaloniaGraphControl`)
- Avalonia 12.0.x bump in `Directory.Packages.props`
- Manual drag-drop spot-checks (QM inventory, Parley tree view)

## Related Issues

- Closes #2092
- Related research: #2093 (.NET 10 upgrade feasibility)
- Supersedes dependabot PRs: #2086, #2087, #2088, #2089, #2090 (close after merge)

## Checklist

- [ ] Third-party package compatibility verified
- [ ] `IDataTransfer` compatibility helper added to Radoub.UI
- [ ] Drag sources migrated (ItemListView, EquipmentSlotsPanel, Parley TreeViewUIController)
- [ ] Consumers migrated (QM MainWindow.Inventory, Parley TreeViewUIController, InventoryPanel)
- [ ] Avalonia packages bumped to 12.0.x
- [ ] All unit tests pass
- [ ] Manual drag-drop spot-checks completed
- [ ] CHANGELOG entries dated and PR-numbered across all six tools

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)