### PR TITLE
[Quartermaster] Sprint: Wizard & List Polish (#1978)

### DIFF
--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.79-alpha] - 2026-04-18
-**Branch**: `quartermaster/issue-1978` | **PR**: #TBD
+**Branch**: `quartermaster/issue-1978` | **PR**: #2095
 
 ### Sprint: Wizard & List Polish (#1978)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.79-alpha] - 2026-04-18
+**Branch**: `quartermaster/issue-1978` | **PR**: #TBD
+
+### Sprint: Wizard & List Polish (#1978)
+
+- NCW feat selection should show previously chosen feats (#1883)
+- Simplify validation rules from LG/TN/CE to LG/CE (#1882)
+- NCW/LUW skill list should sort unavailable skills to bottom (#1881)
+- Rename 'Assigned' to 'Chosen' for feats terminology (#1865)
+- Consolidate GAINMULTIPLE subtypes (Weapon Focus, etc.) in feat list (#1734)
+
+---
+
 ## [0.2.78-alpha] - 2026-04-12
 **Branch**: `quartermaster/issue-2074` | **PR**: #2076
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -13,7 +13,6 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 - NCW feat selection should show previously chosen feats (#1883)
 - Simplify validation rules from LG/TN/CE to LG/CE (#1882)
 - NCW/LUW skill list should sort unavailable skills to bottom (#1881)
-- Rename 'Assigned' to 'Chosen' for feats terminology (#1865)
 - Consolidate GAINMULTIPLE subtypes (Weapon Focus, etc.) in feat list (#1734)
 
 ---

--- a/Quartermaster/Quartermaster.Tests/FeatServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/FeatServiceTests.cs
@@ -765,4 +765,128 @@ public class FeatServiceTests
     }
 
     #endregion
+
+    #region MASTERFEAT Subtype Grouping (#1734)
+
+    [Fact]
+    public void GetMasterFeatId_FeatWithMasterFeat_ReturnsParentId()
+    {
+        // Feat 100: Weapon Focus Club — child of master feat 1051
+        _mockGameData.Set2DAValue("feat", 100, "LABEL", "WeapFocus_Club");
+        _mockGameData.Set2DAValue("feat", 100, "FEAT", "500");
+        _mockGameData.Set2DAValue("feat", 100, "MASTERFEAT", "1051");
+
+        Assert.Equal(1051, _featService.GetMasterFeatId(100));
+    }
+
+    [Fact]
+    public void GetMasterFeatId_FeatWithoutMasterFeat_ReturnsNull()
+    {
+        Assert.Null(_featService.GetMasterFeatId(0)); // Alertness has no MASTERFEAT
+    }
+
+    [Fact]
+    public void GetMasterFeatId_FeatWithInvalidMasterFeat_ReturnsNull()
+    {
+        _mockGameData.Set2DAValue("feat", 101, "LABEL", "Foo");
+        _mockGameData.Set2DAValue("feat", 101, "FEAT", "500");
+        _mockGameData.Set2DAValue("feat", 101, "MASTERFEAT", "****");
+
+        Assert.Null(_featService.GetMasterFeatId(101));
+    }
+
+    [Fact]
+    public void GetSubtypeFeatIds_MasterFeat_ReturnsAllChildren()
+    {
+        // Set up a master feat (1051) with 3 subtypes
+        _mockGameData.Set2DAValue("feat", 1051, "LABEL", "WeapFocus");
+        _mockGameData.Set2DAValue("feat", 1051, "FEAT", "600");
+
+        _mockGameData.Set2DAValue("feat", 200, "LABEL", "WeapFocus_Club");
+        _mockGameData.Set2DAValue("feat", 200, "FEAT", "601");
+        _mockGameData.Set2DAValue("feat", 200, "MASTERFEAT", "1051");
+
+        _mockGameData.Set2DAValue("feat", 201, "LABEL", "WeapFocus_Dagger");
+        _mockGameData.Set2DAValue("feat", 201, "FEAT", "602");
+        _mockGameData.Set2DAValue("feat", 201, "MASTERFEAT", "1051");
+
+        _mockGameData.Set2DAValue("feat", 202, "LABEL", "WeapFocus_Bastard");
+        _mockGameData.Set2DAValue("feat", 202, "FEAT", "603");
+        _mockGameData.Set2DAValue("feat", 202, "MASTERFEAT", "1051");
+
+        var children = _featService.GetSubtypeFeatIds(1051);
+
+        Assert.Equal(3, children.Count);
+        Assert.Contains(200, children);
+        Assert.Contains(201, children);
+        Assert.Contains(202, children);
+    }
+
+    [Fact]
+    public void GetSubtypeFeatIds_FeatWithNoChildren_ReturnsEmpty()
+    {
+        Assert.Empty(_featService.GetSubtypeFeatIds(0));
+    }
+
+    [Fact]
+    public void GroupFeatsByMaster_SingletonFeats_KeptAsIs()
+    {
+        // Feats 0, 5, 10 have no MASTERFEAT — should appear as singleton groups
+        var groups = _featService.GroupFeatsByMaster(new[] { 0, 5, 10 });
+
+        Assert.Equal(3, groups.Count);
+        Assert.All(groups, g => Assert.False(g.IsMasterFeat));
+    }
+
+    [Fact]
+    public void GroupFeatsByMaster_SubtypeFeats_CollapsedToMaster()
+    {
+        // Set up master + children
+        _mockGameData.Set2DAValue("feat", 1051, "LABEL", "WeapFocus");
+        _mockGameData.Set2DAValue("feat", 1051, "FEAT", "600");
+
+        _mockGameData.Set2DAValue("feat", 200, "LABEL", "WeapFocus_Club");
+        _mockGameData.Set2DAValue("feat", 200, "FEAT", "601");
+        _mockGameData.Set2DAValue("feat", 200, "MASTERFEAT", "1051");
+
+        _mockGameData.Set2DAValue("feat", 201, "LABEL", "WeapFocus_Dagger");
+        _mockGameData.Set2DAValue("feat", 201, "FEAT", "602");
+        _mockGameData.Set2DAValue("feat", 201, "MASTERFEAT", "1051");
+
+        // Input contains two children of the same master, plus a singleton (feat 0)
+        var groups = _featService.GroupFeatsByMaster(new[] { 200, 201, 0 });
+
+        // Expect 2 groups: master (1051) + singleton (0)
+        Assert.Equal(2, groups.Count);
+        var master = groups.Single(g => g.IsMasterFeat);
+        Assert.Equal(1051, master.FeatId);
+        Assert.Equal(2, master.SubtypeIds.Count);
+        Assert.Contains(200, master.SubtypeIds);
+        Assert.Contains(201, master.SubtypeIds);
+    }
+
+    [Fact]
+    public void GroupFeatsByMaster_MixedMastersAndOrphans_GroupsIndependently()
+    {
+        _mockGameData.Set2DAValue("feat", 1051, "LABEL", "WeapFocus");
+        _mockGameData.Set2DAValue("feat", 1051, "FEAT", "600");
+        _mockGameData.Set2DAValue("feat", 1052, "LABEL", "WeapSpec");
+        _mockGameData.Set2DAValue("feat", 1052, "FEAT", "601");
+
+        _mockGameData.Set2DAValue("feat", 200, "LABEL", "WFC");
+        _mockGameData.Set2DAValue("feat", 200, "FEAT", "700");
+        _mockGameData.Set2DAValue("feat", 200, "MASTERFEAT", "1051");
+
+        _mockGameData.Set2DAValue("feat", 300, "LABEL", "WSpec_Club");
+        _mockGameData.Set2DAValue("feat", 300, "FEAT", "800");
+        _mockGameData.Set2DAValue("feat", 300, "MASTERFEAT", "1052");
+
+        var groups = _featService.GroupFeatsByMaster(new[] { 200, 300, 0 });
+
+        // Expect 3 groups: master 1051, master 1052, singleton 0
+        Assert.Equal(3, groups.Count);
+        Assert.Equal(2, groups.Count(g => g.IsMasterFeat));
+    }
+
+    #endregion
 }

--- a/Quartermaster/Quartermaster.Tests/FeatServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/FeatServiceTests.cs
@@ -866,6 +866,33 @@ public class FeatServiceTests
     }
 
     [Fact]
+    public void GetMasterFeatName_ReadsFromMasterfeats2da_NotFeat2da()
+    {
+        // masterfeats.2da row 5 has STRREF 900 -> "Weapon Focus" in TLK
+        _mockGameData.Set2DAValue("masterfeats", 5, "LABEL", "WeapFocus");
+        _mockGameData.Set2DAValue("masterfeats", 5, "STRREF", "900");
+        _mockGameData.WithString(900, "Weapon Focus");
+
+        // feat.2da row 5 would resolve to something else — confirm we DON'T use that
+        _mockGameData.Set2DAValue("feat", 5, "LABEL", "Blind_Fight"); // already set in fixture
+        _mockGameData.WithString(401, "Blind-Fight");
+
+        var name = _featService.GetMasterFeatName(5);
+        Assert.Equal("Weapon Focus", name);
+    }
+
+    [Fact]
+    public void GetMasterFeatName_MissingRow_ReturnsFallbackLabel()
+    {
+        // When STRREF lookup fails, fall back to LABEL
+        _mockGameData.Set2DAValue("masterfeats", 7, "LABEL", "ImprCrit");
+        _mockGameData.Set2DAValue("masterfeats", 7, "STRREF", "****");
+
+        var name = _featService.GetMasterFeatName(7);
+        Assert.Equal("ImprCrit", name);
+    }
+
+    [Fact]
     public void GroupFeatsByMaster_MixedMastersAndOrphans_GroupsIndependently()
     {
         _mockGameData.Set2DAValue("feat", 1051, "LABEL", "WeapFocus");

--- a/Quartermaster/Quartermaster.Tests/LevelUpSkillDisplayTests.cs
+++ b/Quartermaster/Quartermaster.Tests/LevelUpSkillDisplayTests.cs
@@ -254,6 +254,54 @@ public class LevelUpSkillDisplayTests
 
     #endregion
 
+    #region Feat Sort (#1883)
+
+    [Fact]
+    public void SortSelectedFeats_ChosenFirst_ThenGranted()
+    {
+        var feats = new List<(int id, string name, bool granted)>
+        {
+            (1, "Alertness", true),
+            (2, "Weapon Focus", false),
+            (3, "Toughness", true),
+            (4, "Power Attack", false),
+        };
+
+        var result = Services.SkillDisplayHelper.SortSelectedFeats(
+            feats, f => f.granted, f => f.name);
+
+        Assert.Equal("Power Attack", result[0].name);
+        Assert.Equal("Weapon Focus", result[1].name);
+        Assert.Equal("Alertness", result[2].name);
+        Assert.Equal("Toughness", result[3].name);
+    }
+
+    [Fact]
+    public void SortSelectedFeats_EmptyInput_ReturnsEmpty()
+    {
+        var result = Services.SkillDisplayHelper.SortSelectedFeats(
+            new List<(int, string, bool)>(),
+            f => f.Item3,
+            f => f.Item2);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void SortSelectedFeats_AllChosen_OrdersAlpha()
+    {
+        var feats = new List<(int id, string name, bool granted)>
+        {
+            (1, "Zombie Mastery", false),
+            (2, "Alertness", false),
+        };
+        var result = Services.SkillDisplayHelper.SortSelectedFeats(
+            feats, f => f.granted, f => f.name);
+        Assert.Equal("Alertness", result[0].name);
+        Assert.Equal("Zombie Mastery", result[1].name);
+    }
+
+    #endregion
+
     #region Helpers
 
     private static List<Services.SkillDisplayHelper.SkillFilterItem> CreateSampleSkills()

--- a/Quartermaster/Quartermaster.Tests/LevelUpSkillDisplayTests.cs
+++ b/Quartermaster/Quartermaster.Tests/LevelUpSkillDisplayTests.cs
@@ -191,6 +191,69 @@ public class LevelUpSkillDisplayTests
 
     #endregion
 
+    #region Skill Sort (#1881)
+
+    [Fact]
+    public void SortForDisplay_ClassSkillsFirst_ThenCrossClass_ThenUnavailable()
+    {
+        var skills = new List<Services.SkillDisplayHelper.SkillFilterItem>
+        {
+            new() { Name = "Use Magic Device", IsClassSkill = false, IsUnavailable = true },
+            new() { Name = "Hide", IsClassSkill = false, IsUnavailable = false },
+            new() { Name = "Concentration", IsClassSkill = true, IsUnavailable = false },
+        };
+
+        var result = Services.SkillDisplayHelper.SortForDisplay(skills);
+
+        Assert.Equal("Concentration", result[0].Name);
+        Assert.Equal("Hide", result[1].Name);
+        Assert.Equal("Use Magic Device", result[2].Name);
+    }
+
+    [Fact]
+    public void SortForDisplay_WithinBucket_OrdersAlphabetically()
+    {
+        var skills = new List<Services.SkillDisplayHelper.SkillFilterItem>
+        {
+            new() { Name = "Spellcraft", IsClassSkill = true, IsUnavailable = false },
+            new() { Name = "Concentration", IsClassSkill = true, IsUnavailable = false },
+            new() { Name = "Search", IsClassSkill = false, IsUnavailable = false },
+            new() { Name = "Hide", IsClassSkill = false, IsUnavailable = false },
+        };
+
+        var result = Services.SkillDisplayHelper.SortForDisplay(skills);
+
+        Assert.Equal("Concentration", result[0].Name);
+        Assert.Equal("Spellcraft", result[1].Name);
+        Assert.Equal("Hide", result[2].Name);
+        Assert.Equal("Search", result[3].Name);
+    }
+
+    [Fact]
+    public void SortForDisplay_UnavailableClassSkill_SortsToBottom()
+    {
+        // A class skill that is also unavailable should be in the unavailable bucket, not class
+        var skills = new List<Services.SkillDisplayHelper.SkillFilterItem>
+        {
+            new() { Name = "Hide", IsClassSkill = false, IsUnavailable = false },
+            new() { Name = "Tumble", IsClassSkill = true, IsUnavailable = true },
+        };
+
+        var result = Services.SkillDisplayHelper.SortForDisplay(skills);
+
+        Assert.Equal("Hide", result[0].Name);
+        Assert.Equal("Tumble", result[1].Name);
+    }
+
+    [Fact]
+    public void SortForDisplay_EmptyList_ReturnsEmpty()
+    {
+        var result = Services.SkillDisplayHelper.SortForDisplay(new List<Services.SkillDisplayHelper.SkillFilterItem>());
+        Assert.Empty(result);
+    }
+
+    #endregion
+
     #region Helpers
 
     private static List<Services.SkillDisplayHelper.SkillFilterItem> CreateSampleSkills()

--- a/Quartermaster/Quartermaster.Tests/SettingsServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/SettingsServiceTests.cs
@@ -158,4 +158,66 @@ public class SettingsServiceTests : IDisposable
 
         Assert.Equal(1000, reloaded.WindowWidth);
     }
+
+    [Fact]
+    public void ValidationLevel_LegacyWarningValue_MigratesToNone()
+    {
+        // #1882: The old Warning=1 tier was removed. Persisted settings with
+        // Warning (1) must migrate to None since TN allowed everything CE allows.
+        var settingsFile = Path.Combine(_testSettingsDir, "QuartermasterSettings.json");
+        File.WriteAllText(settingsFile,
+            "{ \"ValidationLevel\": 1, \"WindowWidth\": 1024, \"WindowHeight\": 768 }");
+
+        SingletonTestHelper.ResetSingleton<SettingsService>();
+        var service = SettingsService.Instance;
+
+        Assert.Equal(ValidationLevel.None, service.ValidationLevel);
+    }
+
+    [Fact]
+    public void ValidationLevel_DefaultValue_IsNone()
+    {
+        // #1882: Default is now None (CE) — permissive, matches prior TN default intent
+        SingletonTestHelper.ResetSingleton<SettingsService>();
+        var service = SettingsService.Instance;
+
+        Assert.Equal(ValidationLevel.None, service.ValidationLevel);
+    }
+
+    [Fact]
+    public void ValidationLevel_StrictValue_PreservedAcrossReload()
+    {
+        var service = SettingsService.Instance;
+        service.ValidationLevel = ValidationLevel.Strict;
+
+        SingletonTestHelper.ResetSingleton<SettingsService>();
+        var reloaded = SettingsService.Instance;
+
+        Assert.Equal(ValidationLevel.Strict, reloaded.ValidationLevel);
+    }
+
+    [Fact]
+    public void ValidationLevelComboBoxMap_ToIndex_NoneMapsTo0()
+    {
+        Assert.Equal(0, ValidationLevelComboBoxMap.ToComboBoxIndex(ValidationLevel.None));
+    }
+
+    [Fact]
+    public void ValidationLevelComboBoxMap_ToIndex_StrictMapsTo1()
+    {
+        // Strict is enum value 2, but occupies index 1 in the two-item ComboBox
+        Assert.Equal(1, ValidationLevelComboBoxMap.ToComboBoxIndex(ValidationLevel.Strict));
+    }
+
+    [Fact]
+    public void ValidationLevelComboBoxMap_FromIndex_0MapsToNone()
+    {
+        Assert.Equal(ValidationLevel.None, ValidationLevelComboBoxMap.FromComboBoxIndex(0));
+    }
+
+    [Fact]
+    public void ValidationLevelComboBoxMap_FromIndex_1MapsToStrict()
+    {
+        Assert.Equal(ValidationLevel.Strict, ValidationLevelComboBoxMap.FromComboBoxIndex(1));
+    }
 }

--- a/Quartermaster/Quartermaster/Models/WizardDisplayItems.cs
+++ b/Quartermaster/Quartermaster/Models/WizardDisplayItems.cs
@@ -13,7 +13,7 @@ namespace Quartermaster.Models;
 /// LUW-specific properties (CurrentRanks, AddedRanks, NameBrush, computed properties)
 /// default to safe values when unused by NCW.
 /// </summary>
-public class SkillDisplayItem : SkillDisplayHelper.INamedItem
+public class SkillDisplayItem : SkillDisplayHelper.ISortableSkill
 {
     public int SkillId { get; set; }
     public string Name { get; set; } = "";

--- a/Quartermaster/Quartermaster/Services/FeatService.Subtypes.cs
+++ b/Quartermaster/Quartermaster/Services/FeatService.Subtypes.cs
@@ -33,6 +33,7 @@ public partial class FeatService
 
     /// <summary>
     /// Reads the MASTERFEAT column for a feat. Returns null if unset, "****", or unparseable.
+    /// The returned value is an index into <c>masterfeats.2da</c> (NOT <c>feat.2da</c>).
     /// </summary>
     public int? GetMasterFeatId(int featId)
     {
@@ -40,6 +41,25 @@ public partial class FeatService
         if (string.IsNullOrEmpty(raw) || raw == "****")
             return null;
         return int.TryParse(raw, out var parsed) ? parsed : null;
+    }
+
+    /// <summary>
+    /// Resolves the display name of a master feat by looking up <c>masterfeats.2da</c>
+    /// STRREF in the TLK. Falls back to the LABEL column when the string lookup fails.
+    /// The <paramref name="masterFeatId"/> is the value stored in feat.2da's MASTERFEAT column.
+    /// </summary>
+    public string GetMasterFeatName(int masterFeatId)
+    {
+        var strRef = _gameDataService.Get2DAValue("masterfeats", masterFeatId, "STRREF");
+        if (!string.IsNullOrEmpty(strRef) && strRef != "****")
+        {
+            var tlkName = _gameDataService.GetString(strRef);
+            if (!string.IsNullOrEmpty(tlkName))
+                return tlkName;
+        }
+
+        var label = _gameDataService.Get2DAValue("masterfeats", masterFeatId, "LABEL");
+        return !string.IsNullOrEmpty(label) && label != "****" ? label : $"Master feat #{masterFeatId}";
     }
 
     /// <summary>

--- a/Quartermaster/Quartermaster/Services/FeatService.Subtypes.cs
+++ b/Quartermaster/Quartermaster/Services/FeatService.Subtypes.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Quartermaster.Services;
+
+/// <summary>
+/// MASTERFEAT subtype grouping for feat list consolidation (#1734).
+///
+/// In feat.2da, variants like "Weapon Focus (Club)", "Weapon Focus (Dagger)" each have
+/// their own row but share a MASTERFEAT value pointing to a parent "Weapon Focus" row.
+/// This grouping collapses the variants so the UI can show a single entry per master feat
+/// and present subtypes via a sub-picker dialog.
+/// </summary>
+public partial class FeatService
+{
+    /// <summary>
+    /// A group of feats that share the same MASTERFEAT parent, or a singleton
+    /// representing a feat with no master.
+    /// </summary>
+    public sealed class FeatGroup
+    {
+        /// <summary>
+        /// For singletons: the feat's own ID. For master-feat groups: the MASTERFEAT parent's ID.
+        /// </summary>
+        public int FeatId { get; init; }
+
+        /// <summary>True when this group represents multiple child subtypes.</summary>
+        public bool IsMasterFeat { get; init; }
+
+        /// <summary>Child feat IDs that belong to this master. Empty for singletons.</summary>
+        public IReadOnlyList<int> SubtypeIds { get; init; } = System.Array.Empty<int>();
+    }
+
+    /// <summary>
+    /// Reads the MASTERFEAT column for a feat. Returns null if unset, "****", or unparseable.
+    /// </summary>
+    public int? GetMasterFeatId(int featId)
+    {
+        var raw = _gameDataService.Get2DAValue("feat", featId, "MASTERFEAT");
+        if (string.IsNullOrEmpty(raw) || raw == "****")
+            return null;
+        return int.TryParse(raw, out var parsed) ? parsed : null;
+    }
+
+    /// <summary>
+    /// Finds all feats whose MASTERFEAT column points at <paramref name="masterFeatId"/>.
+    /// </summary>
+    public List<int> GetSubtypeFeatIds(int masterFeatId)
+    {
+        var result = new List<int>();
+        int rowCount = _gameDataService.Get2DA("feat")?.RowCount ?? 0;
+        for (int i = 0; i < rowCount; i++)
+        {
+            if (GetMasterFeatId(i) == masterFeatId)
+                result.Add(i);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Groups a list of feats by their MASTERFEAT. Feats without a master become singletons;
+    /// feats sharing a master are collapsed into a single <see cref="FeatGroup"/>.
+    /// Preserves first-occurrence order from the input.
+    /// </summary>
+    public List<FeatGroup> GroupFeatsByMaster(IEnumerable<int> featIds)
+    {
+        var groups = new List<FeatGroup>();
+        var masterIndex = new Dictionary<int, int>(); // masterId -> index in `groups`
+
+        foreach (var featId in featIds)
+        {
+            var masterId = GetMasterFeatId(featId);
+            if (masterId is null)
+            {
+                groups.Add(new FeatGroup { FeatId = featId, IsMasterFeat = false });
+                continue;
+            }
+
+            if (masterIndex.TryGetValue(masterId.Value, out var existingIdx))
+            {
+                var existing = groups[existingIdx];
+                var merged = new List<int>(existing.SubtypeIds) { featId };
+                groups[existingIdx] = new FeatGroup
+                {
+                    FeatId = existing.FeatId,
+                    IsMasterFeat = true,
+                    SubtypeIds = merged
+                };
+            }
+            else
+            {
+                masterIndex[masterId.Value] = groups.Count;
+                groups.Add(new FeatGroup
+                {
+                    FeatId = masterId.Value,
+                    IsMasterFeat = true,
+                    SubtypeIds = new List<int> { featId }
+                });
+            }
+        }
+
+        return groups;
+    }
+}

--- a/Quartermaster/Quartermaster/Services/SettingsService.cs
+++ b/Quartermaster/Quartermaster/Services/SettingsService.cs
@@ -47,7 +47,7 @@ public class SettingsService : BaseToolSettingsService<SettingsService.SettingsD
     private bool _recordLevelHistory = true;
 
     // Validation level for wizards (NCW/LUW)
-    private ValidationLevel _validationLevel = ValidationLevel.Warning;
+    private ValidationLevel _validationLevel = ValidationLevel.None;
 
     // Appearance filter exclude patterns (#1520)
     private string _appearanceExcludeFilter = "Invisible;object";
@@ -104,7 +104,7 @@ public class SettingsService : BaseToolSettingsService<SettingsService.SettingsD
 
     /// <summary>
     /// Validation strictness for NCW and LUW character creation rules.
-    /// Default: Warning (True Neutral) — shows warnings but allows rule violations.
+    /// Default: None (Chaotic Evil) — permissive; Strict (Lawful Good) enforces ELC (#1882).
     /// </summary>
     public ValidationLevel ValidationLevel
     {
@@ -132,7 +132,8 @@ public class SettingsService : BaseToolSettingsService<SettingsService.SettingsD
         _creatureBrowserPanelVisible = settings.CreatureBrowserPanelVisible;
         _levelHistoryEncoding = settings.LevelHistoryEncoding;
         _recordLevelHistory = settings.RecordLevelHistory;
-        _validationLevel = settings.ValidationLevel;
+        // #1882: Legacy Warning=1 tier was removed; migrate persisted value to None.
+        _validationLevel = MigrateValidationLevel(settings.ValidationLevel);
         _appearanceExcludeFilter = settings.AppearanceExcludeFilter ?? "Invisible;object";
     }
 
@@ -149,6 +150,13 @@ public class SettingsService : BaseToolSettingsService<SettingsService.SettingsD
         settings.AppearanceExcludeFilter = AppearanceExcludeFilter;
     }
 
+    // #1882: Removed Warning tier (int 1). Persisted None (0) and Strict (2) map directly;
+    // the legacy Warning value collapses to None since it allowed everything None allows.
+    private static ValidationLevel MigrateValidationLevel(ValidationLevel persisted) =>
+        persisted == ValidationLevel.None || persisted == ValidationLevel.Strict
+            ? persisted
+            : ValidationLevel.None;
+
     public class SettingsData : BaseSettingsData
     {
         public double LeftPanelWidth { get; set; } = 350;
@@ -161,7 +169,7 @@ public class SettingsService : BaseToolSettingsService<SettingsService.SettingsD
 
         public LevelHistoryEncoding LevelHistoryEncoding { get; set; } = LevelHistoryEncoding.Readable;
         public bool RecordLevelHistory { get; set; } = true;
-        public ValidationLevel ValidationLevel { get; set; } = ValidationLevel.Warning;
+        public ValidationLevel ValidationLevel { get; set; } = ValidationLevel.None;
         public string AppearanceExcludeFilter { get; set; } = "Invisible;object";
     }
 }

--- a/Quartermaster/Quartermaster/Services/SkillDisplayHelper.cs
+++ b/Quartermaster/Quartermaster/Services/SkillDisplayHelper.cs
@@ -19,9 +19,18 @@ public static class SkillDisplayHelper
     }
 
     /// <summary>
-    /// Minimal interface for skill filter operations — avoids coupling to UI display items.
+    /// Interface for items that can be sorted by skill availability (#1881).
     /// </summary>
-    public class SkillFilterItem : INamedItem
+    public interface ISortableSkill : INamedItem
+    {
+        bool IsClassSkill { get; }
+        bool IsUnavailable { get; }
+    }
+
+    /// <summary>
+    /// Minimal class for skill filter/sort operations — avoids coupling to UI display items.
+    /// </summary>
+    public class SkillFilterItem : ISortableSkill
     {
         public string Name { get; set; } = "";
         public bool IsClassSkill { get; set; }
@@ -59,5 +68,17 @@ public static class SkillDisplayHelper
     public static bool ShouldUseClassSkillColor(bool isClassSkill, bool isUnavailable)
     {
         return isClassSkill && !isUnavailable;
+    }
+
+    /// <summary>
+    /// Sorts skills for wizard display: available class skills first, then available cross-class,
+    /// then unavailable skills. Alphabetical within each bucket (#1881).
+    /// </summary>
+    public static List<T> SortForDisplay<T>(List<T> skills) where T : ISortableSkill
+    {
+        return skills
+            .OrderBy(s => s.IsUnavailable ? 2 : (s.IsClassSkill ? 0 : 1))
+            .ThenBy(s => s.Name)
+            .ToList();
     }
 }

--- a/Quartermaster/Quartermaster/Services/SkillDisplayHelper.cs
+++ b/Quartermaster/Quartermaster/Services/SkillDisplayHelper.cs
@@ -81,4 +81,19 @@ public static class SkillDisplayHelper
             .ThenBy(s => s.Name)
             .ToList();
     }
+
+    /// <summary>
+    /// Sorts selected feats for NCW display: chosen feats first, granted feats last (#1883).
+    /// Alphabetical within each group.
+    /// </summary>
+    public static List<T> SortSelectedFeats<T>(
+        IEnumerable<T> feats,
+        Func<T, bool> isGranted,
+        Func<T, string> nameSelector)
+    {
+        return feats
+            .OrderBy(f => isGranted(f) ? 1 : 0)
+            .ThenBy(nameSelector)
+            .ToList();
+    }
 }

--- a/Quartermaster/Quartermaster/Services/ValidationLevel.cs
+++ b/Quartermaster/Quartermaster/Services/ValidationLevel.cs
@@ -3,6 +3,8 @@ namespace Quartermaster.Services;
 /// <summary>
 /// Controls how strictly character creation and level-up rules are enforced.
 /// Named after NWN alignment flavors for thematic fun.
+/// Simplified to two tiers in #1882 — the previous TN/Warning tier allowed
+/// everything CE allows, so it was merged into None.
 /// </summary>
 public enum ValidationLevel
 {
@@ -13,15 +15,24 @@ public enum ValidationLevel
     None = 0,
 
     /// <summary>
-    /// True Neutral: Warn about rule violations but allow them. Show visual indicators
-    /// (yellow highlights, warning icons) when selections break rules, but don't block progression.
-    /// This is the default.
-    /// </summary>
-    Warning = 1,
-
-    /// <summary>
     /// Lawful Good: Enforce ELC (Enforceable Legal Character) rules. Block invalid selections,
     /// enforce prerequisites, match NWN server ELC checks.
+    /// Value intentionally 2 to preserve compatibility with settings written before #1882
+    /// when the removed Warning tier occupied value 1.
     /// </summary>
     Strict = 2
+}
+
+/// <summary>
+/// Maps between ValidationLevel enum values and the two-item wizard ComboBox index
+/// (ComboBox: index 0 = None, index 1 = Strict). Needed because Strict = 2 skips 1
+/// to preserve settings compatibility with the removed Warning tier (#1882).
+/// </summary>
+public static class ValidationLevelComboBoxMap
+{
+    public static int ToComboBoxIndex(ValidationLevel level) =>
+        level == ValidationLevel.Strict ? 1 : 0;
+
+    public static ValidationLevel FromComboBoxIndex(int index) =>
+        index == 1 ? ValidationLevel.Strict : ValidationLevel.None;
 }

--- a/Quartermaster/Quartermaster/Views/Dialogs/FeatSubtypePickerWindow.axaml
+++ b/Quartermaster/Quartermaster/Views/Dialogs/FeatSubtypePickerWindow.axaml
@@ -1,0 +1,71 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="Quartermaster.Views.Dialogs.FeatSubtypePickerWindow"
+        Title="Select Feat Subtype"
+        AutomationProperties.AutomationId="FeatSubtypePickerWindow"
+        Width="420" Height="500"
+        MinWidth="320" MinHeight="300"
+        WindowStartupLocation="CenterOwner">
+
+    <Window.Styles>
+        <Style Selector="ListBoxItem:selected /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource ThemeAccent}"/>
+            <Setter Property="Foreground" Value="{DynamicResource ThemeTitleBarForeground}"/>
+        </Style>
+        <Style Selector="ListBoxItem:selected:focus /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource ThemeAccent}"/>
+            <Setter Property="Foreground" Value="{DynamicResource ThemeTitleBarForeground}"/>
+        </Style>
+    </Window.Styles>
+
+    <Grid Margin="15">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" x:Name="HeaderLabel"
+                   Text="Select a subtype"
+                   FontWeight="SemiBold" Margin="0,0,0,10"/>
+
+        <TextBox Grid.Row="1" x:Name="SearchBox"
+                 AutomationProperties.AutomationId="FeatSubtypeSearchBox"
+                 Watermark="Filter subtypes..."
+                 Margin="0,0,0,8"/>
+
+        <Border Grid.Row="2" BorderBrush="{DynamicResource ThemeBorder}" BorderThickness="1" Padding="5">
+            <ListBox x:Name="SubtypesListBox"
+                     AutomationProperties.AutomationId="FeatSubtypesListBox"
+                     SelectionChanged="OnSubtypeSelected"
+                     DoubleTapped="OnSubtypeDoubleTapped">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <Grid Margin="2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="{Binding Name}" VerticalAlignment="Center"/>
+                            <TextBlock Grid.Column="1" Text="{Binding Badge}"
+                                       FontSize="{DynamicResource FontSizeSmall}"
+                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                       VerticalAlignment="Center" Margin="8,0,0,0"/>
+                        </Grid>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </Border>
+
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right"
+                    Spacing="10" Margin="0,15,0,0">
+            <Button x:Name="OkButton" Content="OK" Width="80"
+                    IsEnabled="False" Click="OnOkClick"
+                    AutomationProperties.AutomationId="OkButton"/>
+            <Button x:Name="CancelButton" Content="Cancel" Width="80"
+                    Click="OnCancelClick"
+                    AutomationProperties.AutomationId="CancelButton"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Quartermaster/Quartermaster/Views/Dialogs/FeatSubtypePickerWindow.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/FeatSubtypePickerWindow.axaml.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+
+namespace Quartermaster.Views.Dialogs;
+
+/// <summary>
+/// Picker for MASTERFEAT subtypes (e.g. choose "Weapon Focus (Club)" from
+/// the Weapon Focus master). Consolidates the wall-of-text feat list (#1734).
+/// </summary>
+public partial class FeatSubtypePickerWindow : Window
+{
+    public sealed class SubtypeItem
+    {
+        public int FeatId { get; init; }
+        public string Name { get; init; } = "";
+        public bool MeetsPrereqs { get; init; } = true;
+        public bool AlreadyOwned { get; init; }
+        public string Badge => AlreadyOwned ? "(owned)" : (MeetsPrereqs ? "" : "(prereqs)");
+    }
+
+    private readonly TextBlock _headerLabel;
+    private readonly TextBox _searchBox;
+    private readonly ListBox _subtypesListBox;
+    private readonly Button _okButton;
+    private readonly List<SubtypeItem> _allSubtypes;
+
+    public bool Confirmed { get; private set; }
+    public int? SelectedFeatId { get; private set; }
+
+    public FeatSubtypePickerWindow() : this("Select subtype", new List<SubtypeItem>())
+    {
+    }
+
+    public FeatSubtypePickerWindow(string masterFeatName, List<SubtypeItem> subtypes)
+    {
+        InitializeComponent();
+
+        _headerLabel = this.FindControl<TextBlock>("HeaderLabel")!;
+        _searchBox = this.FindControl<TextBox>("SearchBox")!;
+        _subtypesListBox = this.FindControl<ListBox>("SubtypesListBox")!;
+        _okButton = this.FindControl<Button>("OkButton")!;
+
+        _headerLabel.Text = $"Select a subtype for {masterFeatName}";
+        _allSubtypes = subtypes;
+
+        _searchBox.TextChanged += OnSearchChanged;
+        ApplyFilter();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private void OnSearchChanged(object? sender, TextChangedEventArgs e) => ApplyFilter();
+
+    private void ApplyFilter()
+    {
+        var text = _searchBox.Text?.Trim() ?? "";
+        IEnumerable<SubtypeItem> filtered = _allSubtypes;
+        if (!string.IsNullOrEmpty(text))
+            filtered = filtered.Where(s => s.Name.Contains(text, StringComparison.OrdinalIgnoreCase));
+
+        _subtypesListBox.ItemsSource = filtered
+            .OrderByDescending(s => s.MeetsPrereqs && !s.AlreadyOwned)
+            .ThenBy(s => s.Name)
+            .ToList();
+
+        _subtypesListBox.SelectedItem = null;
+        _okButton.IsEnabled = false;
+    }
+
+    private void OnSubtypeSelected(object? sender, SelectionChangedEventArgs e)
+    {
+        _okButton.IsEnabled = _subtypesListBox.SelectedItem is SubtypeItem s && !s.AlreadyOwned;
+    }
+
+    private void OnSubtypeDoubleTapped(object? sender, Avalonia.Input.TappedEventArgs e)
+    {
+        if (_subtypesListBox.SelectedItem is SubtypeItem s && !s.AlreadyOwned)
+        {
+            SelectedFeatId = s.FeatId;
+            Confirmed = true;
+            Close();
+        }
+    }
+
+    private void OnOkClick(object? sender, RoutedEventArgs e)
+    {
+        if (_subtypesListBox.SelectedItem is SubtypeItem s && !s.AlreadyOwned)
+        {
+            SelectedFeatId = s.FeatId;
+            Confirmed = true;
+            Close();
+        }
+    }
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e)
+    {
+        Confirmed = false;
+        Close();
+    }
+}

--- a/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.FeatSelection.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.FeatSelection.cs
@@ -159,11 +159,12 @@ public partial class LevelUpWizardWindow
         {
             if (group.IsMasterFeat)
             {
-                // Master row: aggregate selectability from children. A master is "selectable"
-                // if at least one subtype is selectable under the current validation level.
-                var masterName = _displayService.GetFeatName(group.FeatId);
+                // group.FeatId is a masterfeats.2da row — look up name there, NOT in feat.2da
+                var masterName = _displayService.Feats.GetMasterFeatName(group.FeatId);
                 if (string.IsNullOrEmpty(masterName)) continue;
 
+                // Master row: aggregate selectability from children. A master is "selectable"
+                // if at least one subtype is selectable under the current validation level.
                 bool anySelectable = false;
                 FeatCategory masterCategory = FeatCategory.Other;
                 bool sampleIsClassFeat = false;
@@ -190,7 +191,7 @@ public partial class LevelUpWizardWindow
                 {
                     FeatId = group.FeatId,
                     Name = $"{masterName} (choose type)",
-                    Description = _displayService.GetFeatDescription(group.FeatId) ?? "",
+                    Description = "", // master feat has no per-row description; subtypes carry their own
                     Category = masterCategory,
                     MeetsPrereqs = anySelectable,
                     PrereqResult = null,
@@ -452,7 +453,7 @@ public partial class LevelUpWizardWindow
             })
             .ToList();
 
-        var masterName = _displayService.GetFeatName(master.FeatId);
+        var masterName = _displayService.Feats.GetMasterFeatName(master.FeatId);
         var picker = new FeatSubtypePickerWindow(masterName, subtypes);
         await picker.ShowDialog(this);
         return picker.Confirmed ? picker.SelectedFeatId : null;

--- a/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.FeatSelection.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.FeatSelection.cs
@@ -130,9 +130,9 @@ public partial class LevelUpWizardWindow
         foreach (var sf in _selectedFeats)
             currentFeats.Add((ushort)sf);
 
-        // Get all feat IDs
+        // Build raw candidate list first — applies MaxLevel / universal / class-feat filters
         var allFeatIds = _displayService.Feats.GetAllFeatIds();
-
+        var candidates = new List<int>();
         foreach (var featId in allFeatIds)
         {
             // Skip feats the creature already has — unless GAINMULTIPLE=1 in feat.2da
@@ -145,27 +145,73 @@ public partial class LevelUpWizardWindow
                 int.TryParse(maxLevelStr, out int featMaxLevel) && featMaxLevel == 1)
                 continue;
 
-            // Check if feat is available to select (universal or in class table)
             bool isUniversal = _displayService.Feats.IsFeatUniversal(featId);
             bool isClassFeat = classFeatIds.Contains(featId);
-
             if (!isUniversal && !isClassFeat)
                 continue;
 
-            // Get feat info
-            var featInfo = _displayService.Feats.GetFeatInfo(featId);
+            candidates.Add(featId);
+        }
 
-            // Check prerequisites with projected state (#1744)
+        // Group candidates by MASTERFEAT so variants like Weapon Focus (Club/Dagger/...)
+        // collapse into a single selectable row (#1734).
+        foreach (var group in _displayService.Feats.GroupFeatsByMaster(candidates))
+        {
+            if (group.IsMasterFeat)
+            {
+                // Master row: aggregate selectability from children. A master is "selectable"
+                // if at least one subtype is selectable under the current validation level.
+                var masterName = _displayService.GetFeatName(group.FeatId);
+                if (string.IsNullOrEmpty(masterName)) continue;
+
+                bool anySelectable = false;
+                FeatCategory masterCategory = FeatCategory.Other;
+                bool sampleIsClassFeat = false;
+                foreach (var childId in group.SubtypeIds)
+                {
+                    var childPrereq = _displayService.Feats.CheckFeatPrerequisites(
+                        _creature, childId, currentFeats,
+                        c => _projectedBab,
+                        cid => _displayService.GetClassName(cid),
+                        _prereqOverrides);
+                    bool childCanSelect = _validationLevel != ValidationLevel.Strict || childPrereq.AllMet;
+                    if (childCanSelect) anySelectable = true;
+
+                    // Take category/class-feat flag from first child (all subtypes of a master share these)
+                    if (masterCategory == FeatCategory.Other)
+                    {
+                        masterCategory = _displayService.Feats.GetFeatCategory(childId);
+                        bool childIsUniversal = _displayService.Feats.IsFeatUniversal(childId);
+                        sampleIsClassFeat = classFeatIds.Contains(childId) && !childIsUniversal;
+                    }
+                }
+
+                _allAvailableFeats.Add(new FeatDisplayItem
+                {
+                    FeatId = group.FeatId,
+                    Name = $"{masterName} (choose type)",
+                    Description = _displayService.GetFeatDescription(group.FeatId) ?? "",
+                    Category = masterCategory,
+                    MeetsPrereqs = anySelectable,
+                    PrereqResult = null,
+                    IsClassFeat = sampleIsClassFeat,
+                    CanSelect = anySelectable,
+                    IsMasterFeat = true,
+                    SubtypeIds = group.SubtypeIds.ToList()
+                });
+                continue;
+            }
+
+            // Singleton: original per-feat logic
+            var featId = group.FeatId;
+            var featInfo = _displayService.Feats.GetFeatInfo(featId);
             var prereqResult = _displayService.Feats.CheckFeatPrerequisites(
-                _creature,
-                featId,
-                currentFeats,
+                _creature, featId, currentFeats,
                 c => _projectedBab,
                 cid => _displayService.GetClassName(cid),
                 _prereqOverrides);
-
-            // Strict: must meet prereqs. Warning/None: can select regardless
             bool canSelect = _validationLevel != ValidationLevel.Strict || prereqResult.AllMet;
+            bool isUniversalFeat = _displayService.Feats.IsFeatUniversal(featId);
 
             _allAvailableFeats.Add(new FeatDisplayItem
             {
@@ -175,7 +221,7 @@ public partial class LevelUpWizardWindow
                 Category = featInfo.Category,
                 MeetsPrereqs = prereqResult.AllMet,
                 PrereqResult = prereqResult,
-                IsClassFeat = isClassFeat && !isUniversal,
+                IsClassFeat = classFeatIds.Contains(featId) && !isUniversalFeat,
                 CanSelect = canSelect
             });
         }
@@ -337,7 +383,7 @@ public partial class LevelUpWizardWindow
         RemoveSelectedFeat();
     }
 
-    private void AddSelectedFeat()
+    private async void AddSelectedFeat()
     {
         if (_availableFeatsListBox.SelectedItem is not FeatDisplayItem item)
             return;
@@ -351,17 +397,65 @@ public partial class LevelUpWizardWindow
         if (!isCeMode && _selectedFeats.Count >= _featsToSelect)
             return;
 
-        // Enforce bonus feat pool restriction (non-CE only)
-        if (!isCeMode && IsSelectingBonusFeat() && _bonusFeatPool != null && !_bonusFeatPool.Contains(item.FeatId))
+        int featIdToAdd;
+        if (item.IsMasterFeat)
+        {
+            // #1734: route master-feat selection through the subtype picker
+            var chosen = await PromptForFeatSubtypeAsync(item);
+            if (chosen is null) return;
+            featIdToAdd = chosen.Value;
+        }
+        else
+        {
+            featIdToAdd = item.FeatId;
+        }
+
+        // Enforce bonus feat pool restriction (non-CE only) — check the resolved feat id
+        if (!isCeMode && IsSelectingBonusFeat() && _bonusFeatPool != null && !_bonusFeatPool.Contains(featIdToAdd))
             return;
 
-        _selectedFeats.Add(item.FeatId);
+        _selectedFeats.Add(featIdToAdd);
 
-        // Re-evaluate prerequisites since selected feat may unlock others
-        RefreshFeatPrerequisites();
+        // Rebuild the available list so the master regroups (or the singleton is removed)
+        // and prerequisites re-evaluate with the new selection.
+        LoadAvailableFeats();
         ApplyFeatFilter();
         RefreshSelectedFeatsList();
         UpdateFeatSelectionUI();
+    }
+
+    private async System.Threading.Tasks.Task<int?> PromptForFeatSubtypeAsync(FeatDisplayItem master)
+    {
+        var existingFeats = new HashSet<int>(_creature.FeatList.Select(f => (int)f));
+        foreach (var sf in _selectedFeats) existingFeats.Add(sf);
+
+        var currentFeats = new HashSet<ushort>(_creature.FeatList);
+        foreach (var sf in _selectedFeats) currentFeats.Add((ushort)sf);
+
+        bool isStrict = _validationLevel == ValidationLevel.Strict;
+
+        var subtypes = master.SubtypeIds
+            .Select(id =>
+            {
+                var prereq = _displayService.Feats.CheckFeatPrerequisites(
+                    _creature, id, currentFeats,
+                    c => _projectedBab,
+                    cid => _displayService.GetClassName(cid),
+                    _prereqOverrides);
+                return new FeatSubtypePickerWindow.SubtypeItem
+                {
+                    FeatId = id,
+                    Name = _displayService.GetFeatName(id),
+                    MeetsPrereqs = !isStrict || prereq.AllMet,
+                    AlreadyOwned = existingFeats.Contains(id)
+                };
+            })
+            .ToList();
+
+        var masterName = _displayService.GetFeatName(master.FeatId);
+        var picker = new FeatSubtypePickerWindow(masterName, subtypes);
+        await picker.ShowDialog(this);
+        return picker.Confirmed ? picker.SelectedFeatId : null;
     }
 
     private void RemoveSelectedFeat()
@@ -372,8 +466,9 @@ public partial class LevelUpWizardWindow
 
         _selectedFeats.RemoveAt(index);
 
-        // Re-evaluate prerequisites since removed feat may lock others
-        RefreshFeatPrerequisites();
+        // Rebuild the available list so removed subtypes regroup under their master (#1734)
+        // and prerequisites re-evaluate.
+        LoadAvailableFeats();
         ApplyFeatFilter();
         RefreshSelectedFeatsList();
         UpdateFeatSelectionUI();

--- a/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.SkillAllocation.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.SkillAllocation.cs
@@ -96,8 +96,8 @@ public partial class LevelUpWizardWindow
             });
         }
 
-        // Sort: class skills first, then by name
-        return skills.OrderByDescending(s => s.IsClassSkill).ThenBy(s => s.Name).ToList();
+        // Sort: class skills → cross-class → unavailable, alpha within bucket (#1881)
+        return SkillDisplayHelper.SortForDisplay(skills);
     }
 
     private void ApplySkillFilter()

--- a/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.SummaryAndApply.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.SummaryAndApply.cs
@@ -352,9 +352,13 @@ public partial class LevelUpWizardWindow
         public bool IsClassFeat { get; set; }
         public bool CanSelect { get; set; }
 
+        // MASTERFEAT grouping (#1734): master-feat rows open the subtype picker on add.
+        public bool IsMasterFeat { get; set; }
+        public System.Collections.Generic.List<int> SubtypeIds { get; set; } = new();
+
         public string DisplayName => Name;
         public string PrereqTooltip => PrereqResult?.GetTooltip() ?? "No prerequisites";
-        public string Badge => !MeetsPrereqs ? "(prereqs)" : IsClassFeat ? "(class)" : "";
+        public string Badge => IsMasterFeat ? "(choose)" : !MeetsPrereqs ? "(prereqs)" : IsClassFeat ? "(class)" : "";
     }
 
     // SpellDisplayItem moved to Quartermaster.Models.WizardDisplayItems (#1798)

--- a/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.axaml
+++ b/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.axaml
@@ -133,15 +133,14 @@
                     </StackPanel>
                 </Border>
 
-                <!-- Validation Level Toggle (#1503) -->
+                <!-- Validation Level Toggle (#1503, simplified #1882) -->
                 <Separator Margin="0,15,0,10"/>
                 <TextBlock Text="Validation Level" FontWeight="SemiBold" Margin="0,0,0,5"/>
                 <ComboBox x:Name="ValidationLevelComboBox"
                           AutomationProperties.AutomationId="ValidationLevelComboBox"
                           HorizontalAlignment="Stretch"
-                          SelectedIndex="1">
+                          SelectedIndex="0">
                     <ComboBoxItem Content="😈 Chaotic Evil" ToolTip.Tip="No validation. Anything goes — for power users and custom content."/>
-                    <ComboBoxItem Content="⚖️ True Neutral" ToolTip.Tip="Warn about rule violations but allow them. Default."/>
                     <ComboBoxItem Content="⚔️ Lawful Good" ToolTip.Tip="Enforce ELC rules. Block invalid selections."/>
                 </ComboBox>
             </StackPanel>

--- a/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.axaml.cs
@@ -457,7 +457,30 @@ public partial class LevelUpWizardWindow : Window
     {
         var level = ValidationLevelComboBoxMap.FromComboBoxIndex(_validationLevelComboBox.SelectedIndex);
         SettingsService.Instance.ValidationLevel = level;
+
+        // Refresh step-specific UI so filters/button states reflect the new level,
+        // without clobbering the user's in-progress selections. (#1978 follow-up)
+        RefreshCurrentStepForValidationChange();
         ValidateCurrentStep();
+    }
+
+    private void RefreshCurrentStepForValidationChange()
+    {
+        switch (_currentStep)
+        {
+            case 3:
+                // Feats: rebuild available list (prereq filtering depends on level) and refresh UI
+                LoadAvailableFeats();
+                ApplyFeatFilter();
+                UpdateFeatSelectionUI();
+                break;
+            case 4:
+                // Skills: rebuild rows so [+]/[-] enablement reflects current caps
+                _allSkills = BuildSkillList();
+                ApplySkillFilter();
+                UpdateSkillPointsDisplay();
+                break;
+        }
     }
 
     private void ValidateCurrentStep()

--- a/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.axaml.cs
@@ -150,7 +150,7 @@ public partial class LevelUpWizardWindow : Window
 
     // Validation level (#1503)
     private readonly ComboBox _validationLevelComboBox;
-    private ValidationLevel _validationLevel => (ValidationLevel)_validationLevelComboBox.SelectedIndex;
+    private ValidationLevel _validationLevel => ValidationLevelComboBoxMap.FromComboBoxIndex(_validationLevelComboBox.SelectedIndex);
 
     // Step 6 controls
     private readonly TextBlock _summaryClassLabel;
@@ -320,7 +320,7 @@ public partial class LevelUpWizardWindow : Window
 
         // Validation level toggle (#1503)
         _validationLevelComboBox = this.FindControl<ComboBox>("ValidationLevelComboBox")!;
-        _validationLevelComboBox.SelectedIndex = (int)SettingsService.Instance.ValidationLevel;
+        _validationLevelComboBox.SelectedIndex = ValidationLevelComboBoxMap.ToComboBoxIndex(SettingsService.Instance.ValidationLevel);
         _validationLevelComboBox.SelectionChanged += OnValidationLevelChanged;
 
         // Consolidated level-up presets (#1645)
@@ -455,7 +455,7 @@ public partial class LevelUpWizardWindow : Window
 
     private void OnValidationLevelChanged(object? sender, SelectionChangedEventArgs e)
     {
-        var level = (ValidationLevel)_validationLevelComboBox.SelectedIndex;
+        var level = ValidationLevelComboBoxMap.FromComboBoxIndex(_validationLevelComboBox.SelectedIndex);
         SettingsService.Instance.ValidationLevel = level;
         ValidateCurrentStep();
     }
@@ -489,33 +489,13 @@ public partial class LevelUpWizardWindow : Window
                 2 => true, // Allow skipping ability selection in CE mode
                 _ => true
             },
-            ValidationLevel.Warning => _currentStep switch
-            {
-                1 => _selectedClassId >= 0, // Must select something, but warn if unqualified
-                2 => true,
-                _ => true
-            },
             _ => strictValid
         };
 
         _nextButton.IsEnabled = canProceed;
         _finishButton.IsEnabled = canProceed;
 
-        // Status messages
-        if (_validationLevel == ValidationLevel.Warning && !strictValid)
-        {
-            _statusLabel.Foreground = BrushManager.GetWarningBrush(this);
-            _statusLabel.Text = _currentStep switch
-            {
-                1 when !classIsQualified => "⚠ Selected class does not meet prerequisites.",
-                2 => "⚠ No ability score selected.",
-                3 => $"⚠ {_featsToSelect - _selectedFeats.Count} feat(s) not selected.",
-                4 => $"⚠ {GetRemainingSkillPoints()} skill point(s) unspent.",
-                5 when !_isDivineCaster => "⚠ Spell selection incomplete.",
-                _ => ""
-            };
-        }
-        else if (!canProceed)
+        if (!canProceed)
         {
             _statusLabel.ClearValue(Avalonia.Controls.TextBlock.ForegroundProperty);
             _statusLabel.Text = _currentStep switch

--- a/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.BuildCreature.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.BuildCreature.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Quartermaster.Views.Dialogs;
 
 /// <summary>
@@ -48,6 +50,11 @@ public partial class NewCharacterWizardWindow
         public bool IsGranted { get; set; }
         public bool MeetsPrereqs { get; set; } = true;
         public string SourceLabel { get; set; } = "";
+
+        // MASTERFEAT grouping (#1734): when true, FeatId is the master feat and SubtypeIds
+        // lists all children. Selecting this item opens the subtype picker.
+        public bool IsMasterFeat { get; set; }
+        public List<int> SubtypeIds { get; set; } = new();
     }
 
     private class EquipmentDisplayItem

--- a/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Feats.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Feats.cs
@@ -60,10 +60,22 @@ public partial class NewCharacterWizardWindow
         _availableFeats = new List<FeatDisplayItem>();
         foreach (var group in _displayService.Feats.GroupFeatsByMaster(candidateFeatIds))
         {
-            var name = _displayService.GetFeatName(group.FeatId);
+            string name;
+            FeatCategory category;
+            if (group.IsMasterFeat)
+            {
+                // group.FeatId is a masterfeats.2da row — look up via GetMasterFeatName
+                name = _displayService.Feats.GetMasterFeatName(group.FeatId);
+                // Category comes from a child feat (all subtypes share the same category)
+                category = _displayService.Feats.GetFeatCategory(group.SubtypeIds[0]);
+            }
+            else
+            {
+                name = _displayService.GetFeatName(group.FeatId);
+                category = _displayService.Feats.GetFeatCategory(group.FeatId);
+            }
             if (string.IsNullOrEmpty(name)) continue;
 
-            var category = _displayService.Feats.GetFeatCategory(group.FeatId);
             _availableFeats.Add(new FeatDisplayItem
             {
                 FeatId = group.FeatId,
@@ -266,7 +278,7 @@ public partial class NewCharacterWizardWindow
             })
             .ToList();
 
-        var masterName = _displayService.GetFeatName(master.FeatId);
+        var masterName = _displayService.Feats.GetMasterFeatName(master.FeatId);
         var picker = new FeatSubtypePickerWindow(masterName, subtypes);
         await picker.ShowDialog(this);
         return picker.Confirmed ? picker.SelectedFeatId : null;

--- a/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Feats.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Feats.cs
@@ -150,29 +150,13 @@ public partial class NewCharacterWizardWindow
     private void UpdateSelectedFeatsDisplay()
     {
         var grantedFeatIds = GetGrantedFeatIds();
-        var selectedItems = new List<FeatDisplayItem>();
+        var allItems = new List<FeatDisplayItem>();
 
-        // Add granted feats first (read-only)
-        foreach (var featId in grantedFeatIds.OrderBy(id => _displayService.GetFeatName(id)))
-        {
-            var name = _displayService.GetFeatName(featId);
-            if (string.IsNullOrEmpty(name)) continue;
-            selectedItems.Add(new FeatDisplayItem
-            {
-                FeatId = featId,
-                Name = name,
-                IsGranted = true,
-                SourceLabel = "(granted)",
-                MeetsPrereqs = true
-            });
-        }
-
-        // Add chosen feats
         foreach (var featId in _chosenFeatIds)
         {
             var name = _displayService.GetFeatName(featId);
             if (string.IsNullOrEmpty(name)) continue;
-            selectedItems.Add(new FeatDisplayItem
+            allItems.Add(new FeatDisplayItem
             {
                 FeatId = featId,
                 Name = name,
@@ -182,7 +166,24 @@ public partial class NewCharacterWizardWindow
             });
         }
 
-        _selectedFeatsListBox.ItemsSource = selectedItems;
+        foreach (var featId in grantedFeatIds)
+        {
+            var name = _displayService.GetFeatName(featId);
+            if (string.IsNullOrEmpty(name)) continue;
+            allItems.Add(new FeatDisplayItem
+            {
+                FeatId = featId,
+                Name = name,
+                IsGranted = true,
+                SourceLabel = "(granted)",
+                MeetsPrereqs = true
+            });
+        }
+
+        // Chosen feats first (player-selected), granted last (auto-granted) — #1883
+        var sorted = SkillDisplayHelper.SortSelectedFeats(allItems, f => f.IsGranted, f => f.Name);
+
+        _selectedFeatsListBox.ItemsSource = sorted;
         _selectedFeatCountLabel.Text = $"({_chosenFeatIds.Count} chosen + {grantedFeatIds.Count} granted)";
     }
 

--- a/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Feats.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Feats.cs
@@ -42,40 +42,38 @@ public partial class NewCharacterWizardWindow
         // Build ability scores for prereq checking
         var racialMods = _displayService.GetRacialModifiers(_selectedRaceId);
 
-        // Build available feats list (excluding granted and already chosen)
-        _availableFeats = new List<FeatDisplayItem>();
+        // Build raw list of candidate feat IDs (visible to player in this step)
+        var candidateFeatIds = new List<int>();
         foreach (var featId in allFeatIds)
         {
-            // Skip granted feats
             if (grantedFeatIds.Contains(featId)) continue;
-
-            // Skip already chosen feats
             if (_chosenFeatIds.Contains(featId)) continue;
+            if (!_displayService.Feats.IsFeatAvailable(_tempCreature, featId)) continue;
+            if (_validationLevel != ValidationLevel.None && !CheckFeatPrereqsForWizard(featId)) continue;
+            var featName = _displayService.GetFeatName(featId);
+            if (string.IsNullOrEmpty(featName)) continue;
+            candidateFeatIds.Add(featId);
+        }
 
-            // Check if feat is available to this class
-            if (!_displayService.Feats.IsFeatAvailable(_tempCreature, featId))
-                continue;
-
-            // Check prerequisites against current wizard state via FeatService (#1800)
-            // In None mode (Chaotic Evil), skip prereq filtering — show all feats
-            if (_validationLevel != ValidationLevel.None)
-            {
-                if (!CheckFeatPrereqsForWizard(featId)) continue;
-            }
-
-            var name = _displayService.GetFeatName(featId);
+        // Group by MASTERFEAT so variants like Weapon Focus (Club/Dagger/...) collapse
+        // into a single selectable row (#1734). Singletons remain as-is.
+        _availableFeats = new List<FeatDisplayItem>();
+        foreach (var group in _displayService.Feats.GroupFeatsByMaster(candidateFeatIds))
+        {
+            var name = _displayService.GetFeatName(group.FeatId);
             if (string.IsNullOrEmpty(name)) continue;
 
-            var category = _displayService.Feats.GetFeatCategory(featId);
-
+            var category = _displayService.Feats.GetFeatCategory(group.FeatId);
             _availableFeats.Add(new FeatDisplayItem
             {
-                FeatId = featId,
-                Name = name,
+                FeatId = group.FeatId,
+                Name = group.IsMasterFeat ? $"{name} (choose type)" : name,
                 CategoryAbbrev = GetFeatCategoryAbbrev(category),
                 IsGranted = false,
                 MeetsPrereqs = true,
-                SourceLabel = ""
+                SourceLabel = "",
+                IsMasterFeat = group.IsMasterFeat,
+                SubtypeIds = group.IsMasterFeat ? group.SubtypeIds.ToList() : new List<int>()
             });
         }
 
@@ -210,7 +208,7 @@ public partial class NewCharacterWizardWindow
         ApplyFeatFilter();
     }
 
-    private void OnAddFeatClick(object? sender, RoutedEventArgs e)
+    private async void OnAddFeatClick(object? sender, RoutedEventArgs e)
     {
         var selectedItems = _availableFeatsListBox.SelectedItems?
             .OfType<FeatDisplayItem>()
@@ -221,6 +219,23 @@ public partial class NewCharacterWizardWindow
         {
             // Only Strict (LG) enforces feat count cap
             if (_validationLevel == ValidationLevel.Strict && _chosenFeatIds.Count >= _featsToChoose) break;
+
+            if (item.IsMasterFeat)
+            {
+                // #1734: open sub-picker to resolve a subtype feat
+                var chosenSubtype = await PromptForFeatSubtypeAsync(item);
+                if (chosenSubtype is null) continue;
+
+                if (!_chosenFeatIds.Contains(chosenSubtype.Value))
+                {
+                    _chosenFeatIds.Add(chosenSubtype.Value);
+                    // Remove the entire master group from available (master collapse assumes
+                    // a single variant is enough — matches current GAINMULTIPLE UI behavior).
+                    _availableFeats.RemoveAll(f => f.FeatId == item.FeatId && f.IsMasterFeat);
+                }
+                continue;
+            }
+
             if (!_chosenFeatIds.Contains(item.FeatId))
             {
                 _chosenFeatIds.Add(item.FeatId);
@@ -234,6 +249,29 @@ public partial class NewCharacterWizardWindow
         ValidateCurrentStep();
     }
 
+    /// <summary>
+    /// Shows the subtype picker for a master feat (#1734). Returns the chosen
+    /// subtype's feat ID or null if the user cancelled.
+    /// </summary>
+    private async System.Threading.Tasks.Task<int?> PromptForFeatSubtypeAsync(FeatDisplayItem master)
+    {
+        var subtypes = master.SubtypeIds
+            .Select(id => new FeatSubtypePickerWindow.SubtypeItem
+            {
+                FeatId = id,
+                Name = _displayService.GetFeatName(id),
+                MeetsPrereqs = _validationLevel == ValidationLevel.None || CheckFeatPrereqsForWizard(id),
+                AlreadyOwned = _chosenFeatIds.Contains(id)
+                    || GetGrantedFeatIds().Contains(id)
+            })
+            .ToList();
+
+        var masterName = _displayService.GetFeatName(master.FeatId);
+        var picker = new FeatSubtypePickerWindow(masterName, subtypes);
+        await picker.ShowDialog(this);
+        return picker.Confirmed ? picker.SelectedFeatId : null;
+    }
+
     private void OnRemoveFeatClick(object? sender, RoutedEventArgs e)
     {
         var selectedItems = _selectedFeatsListBox.SelectedItems?
@@ -244,34 +282,10 @@ public partial class NewCharacterWizardWindow
         foreach (var item in selectedItems)
         {
             _chosenFeatIds.Remove(item.FeatId);
-
-            // Re-add to available list
-            var category = _displayService.Feats.GetFeatCategory(item.FeatId);
-            bool meetsPrereqs = true;
-            if (_validationLevel != ValidationLevel.None)
-            {
-                meetsPrereqs = CheckFeatPrereqsForWizard(item.FeatId);
-            }
-
-            _availableFeats.Add(new FeatDisplayItem
-            {
-                FeatId = item.FeatId,
-                Name = item.Name,
-                CategoryAbbrev = GetFeatCategoryAbbrev(category),
-                IsGranted = false,
-                MeetsPrereqs = meetsPrereqs,
-                SourceLabel = meetsPrereqs ? "" : "(prereqs)"
-            });
         }
 
-        _availableFeats = _availableFeats
-            .OrderByDescending(f => f.MeetsPrereqs)
-            .ThenBy(f => f.Name)
-            .ToList();
-
-        ApplyFeatFilter();
-        UpdateSelectedFeatsDisplay();
-        UpdateFeatSelectionCount();
+        // Rebuild available list so removed subtypes regroup under their master (#1734)
+        PrepareStep7();
         ValidateCurrentStep();
     }
 

--- a/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Navigation.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Navigation.cs
@@ -45,7 +45,7 @@ public partial class NewCharacterWizardWindow
 
     private void OnValidationLevelChanged(object? sender, SelectionChangedEventArgs e)
     {
-        var level = (ValidationLevel)_validationLevelComboBox.SelectedIndex;
+        var level = ValidationLevelComboBoxMap.FromComboBoxIndex(_validationLevelComboBox.SelectedIndex);
         SettingsService.Instance.ValidationLevel = level;
 
         // Refresh step-specific UI when validation level changes
@@ -91,13 +91,6 @@ public partial class NewCharacterWizardWindow
                 5 => _selectedClassId >= 0,
                 _ => true
             },
-            // True Neutral: warn but allow proceeding (except hard requirements)
-            ValidationLevel.Warning => _currentStep switch
-            {
-                2 => _selectedRaceId != 255,
-                5 => _selectedClassId >= 0 && !IsFamiliarNameRequired(),
-                _ => true
-            },
             // Lawful Good: enforce all rules
             _ => strictValid
         };
@@ -105,21 +98,7 @@ public partial class NewCharacterWizardWindow
         _nextButton.IsEnabled = canProceed;
         _finishButton.IsEnabled = canProceed;
 
-        // Status message: Warning mode shows yellow warnings, Strict mode shows blocking messages
-        if (_validationLevel == ValidationLevel.Warning && !strictValid)
-        {
-            _statusLabel.Foreground = BrushManager.GetWarningBrush(this);
-            _statusLabel.Text = _currentStep switch
-            {
-                3 when _isBicFile && !_voiceSetSelected => "⚠ No voice set selected. BIC files need a voice set for in-game dialog.",
-                5 when IsFamiliarNameRequired() => "⚠ Familiar name is empty.",
-                6 => $"⚠ {GetAbilityPointsRemaining()} ability point(s) unspent.",
-                7 => $"⚠ {_featsToChoose - _chosenFeatIds.Count} feat(s) not selected.",
-                9 => "⚠ Spell selection incomplete.",
-                _ => ""
-            };
-        }
-        else if (!canProceed)
+        if (!canProceed)
         {
             // Voice set uses warning brush (advisory, not an error); other blocks use default foreground
             if (_currentStep == 3 && _isBicFile && !_voiceSetSelected)

--- a/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Navigation.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Navigation.cs
@@ -48,19 +48,12 @@ public partial class NewCharacterWizardWindow
         var level = ValidationLevelComboBoxMap.FromComboBoxIndex(_validationLevelComboBox.SelectedIndex);
         SettingsService.Instance.ValidationLevel = level;
 
-        // Refresh step-specific UI when validation level changes
-        switch (_currentStep)
-        {
-            case 6 when _step5Loaded:
-                UpdateAbilityDisplay(); // Also calls ValidateCurrentStep
-                break;
-            case 8 when _step7Loaded:
-                RenderSkillRows(); // Rebuild buttons with new enabled state; also calls ValidateCurrentStep
-                break;
-            default:
-                ValidateCurrentStep();
-                break;
-        }
+        // Rebuild current step so lists/filters/button states reflect the new level.
+        // Prepare methods are idempotent (guarded by per-step _loaded flags), so user
+        // selections are preserved. Fixes stale feat/skill/spell filtering when toggling
+        // CE <-> LG without navigating (#1978 follow-up).
+        PrepareCurrentStep();
+        ValidateCurrentStep();
     }
 
     private void ValidateCurrentStep()

--- a/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Skills.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Skills.cs
@@ -73,11 +73,8 @@ public partial class NewCharacterWizardWindow
             });
         }
 
-        // Sort: class skills first, then alphabetical
-        _allSkills = _allSkills
-            .OrderByDescending(s => s.IsClassSkill)
-            .ThenBy(s => s.Name)
-            .ToList();
+        // Sort: class skills → cross-class → unavailable, alpha within bucket (#1881)
+        _allSkills = SkillDisplayHelper.SortForDisplay(_allSkills);
 
         ApplySkillFilter();
     }

--- a/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.axaml
+++ b/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.axaml
@@ -155,15 +155,14 @@
                     </StackPanel>
                 </Border>
 
-                <!-- Validation Level Toggle (#1503) -->
+                <!-- Validation Level Toggle (#1503, simplified #1882) -->
                 <Separator Margin="0,15,0,10"/>
-                <TextBlock Text="Rules" FontWeight="SemiBold" Margin="0,0,0,5"/>
+                <TextBlock Text="Validation Level" FontWeight="SemiBold" Margin="0,0,0,5"/>
                 <ComboBox x:Name="ValidationLevelComboBox"
                           AutomationProperties.AutomationId="ValidationLevelComboBox"
                           HorizontalAlignment="Stretch"
-                          SelectedIndex="1">
+                          SelectedIndex="0">
                     <ComboBoxItem Content="😈 Chaotic Evil" ToolTip.Tip="No validation. Anything goes — for power users and custom content."/>
-                    <ComboBoxItem Content="⚖️ True Neutral" ToolTip.Tip="Warn about rule violations but allow them. Default."/>
                     <ComboBoxItem Content="⚔️ Lawful Good" ToolTip.Tip="Enforce ELC rules. Block invalid selections."/>
                 </ComboBox>
             </StackPanel>

--- a/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.axaml.cs
@@ -141,7 +141,7 @@ public partial class NewCharacterWizardWindow : Window
 
     // Validation level (#1503)
     private readonly ComboBox _validationLevelComboBox;
-    private ValidationLevel _validationLevel => (ValidationLevel)_validationLevelComboBox.SelectedIndex;
+    private ValidationLevel _validationLevel => ValidationLevelComboBoxMap.FromComboBoxIndex(_validationLevelComboBox.SelectedIndex);
 
     // Controls - navigation
     private readonly TextBlock _sidebarTitle;
@@ -596,7 +596,7 @@ public partial class NewCharacterWizardWindow : Window
 
         // Validation level toggle (#1503)
         _validationLevelComboBox = this.FindControl<ComboBox>("ValidationLevelComboBox")!;
-        _validationLevelComboBox.SelectedIndex = (int)SettingsService.Instance.ValidationLevel;
+        _validationLevelComboBox.SelectedIndex = ValidationLevelComboBoxMap.ToComboBoxIndex(SettingsService.Instance.ValidationLevel);
         _validationLevelComboBox.SelectionChanged += OnValidationLevelChanged;
 
         UpdateStepDisplay();


### PR DESCRIPTION
## Summary

Sprint polishing NCW/LUW wizard UX and feat list display.

## Work Items

- [x] #1883 — NCW: sort chosen feats above granted feats
- [x] #1882 — Simplify validation LG/TN/CE → LG/CE (unified "Validation Level" label)
- [x] #1881 — NCW/LUW: sort unavailable skills to bottom
- [x] #1734 — Consolidate GAINMULTIPLE subtypes via sub-picker (Weapon Focus / Spell Focus / Skill Focus) — applies to both NCW and LUW

## Notable Fixes During Sprint

- Validation toggle now refreshes the current step immediately (previously required nav)
- Master feat names resolve from `masterfeats.2da` STRREF via TLK instead of misreading `feat.2da` (was showing "Ambidexterity" for unrelated masters)

## Related Issues

- Closes #1978
- Closes #1883
- Closes #1882
- Closes #1881
- Closes #1734
- Followup #2096 — master feat subtype picker shows class-inappropriate subtypes (Skill Focus for Fighter, etc.)

## Checklist

- [x] Implementation complete
- [x] Tests added/updated (1240 unit tests pass; 16 new tests across sort helpers, settings migration, MASTERFEAT grouping/name resolution)
- [x] CHANGELOG updated with date and PR number
- [x] No hardcoded game data — all feat/skill/validation data reads from 2DA/TLK
- [x] Theme warnings: 8 pre-existing in untouched files (AppearancePanel, AdvancedPanel, SpellsPanel)
- [x] Privacy scan clean
- [x] No large files (>800 lines)
- [x] Manual spot-checks confirmed by user

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)