### PR TITLE
[Fence] Sprint: Search & Copy-to-Module (#2065)

### DIFF
--- a/Fence/CHANGELOG.md
+++ b/Fence/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.1.26-alpha] - 2026-04-18
+**Branch**: `fence/issue-2065` | **PR**: #TBD
+
+### Sprint: Search & Copy-to-Module (#2065)
+
+- Fix search bar inventory item name resolution (resolver race with async service init)
+- Copy-to-Module rename dialog (ResRef/Tag/Name edit before write)
+- Browser refresh after copy when Module checkbox is active
+- Promote Copy-to-Module to shared `FileBrowserPanelBase` (closes #1479 — QM, Relique, Parley now inherit it)
+
+---
+
 ## [0.1.25-alpha] - 2026-03-27
 **Branch**: `fence/issue-1980` | **PR**: #2013
 

--- a/Fence/CHANGELOG.md
+++ b/Fence/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.1.26-alpha] - 2026-04-18
-**Branch**: `fence/issue-2065` | **PR**: #TBD
+**Branch**: `fence/issue-2065` | **PR**: #2097
 
 ### Sprint: Search & Copy-to-Module (#2065)
 

--- a/Fence/Fence/Views/MainWindow.axaml.cs
+++ b/Fence/Fence/Views/MainWindow.axaml.cs
@@ -139,26 +139,8 @@ public partial class MainWindow : Window, INotifyPropertyChanged
         // Show module context in status bar (#1003)
         UpdateModuleIndicator();
 
-        // Initialize search bar with UTM search provider
-        // Item name resolver uses ItemResolutionService (initialized later in Opened event)
-        // The closure captures _itemResolutionService which is set during InitializeServicesAsync
-        var searchBar = this.FindControl<SearchBar>("FileSearchBar");
-        searchBar?.Initialize(
-            new FileSearchService(new UtmSearchProvider(resRef =>
-                _itemResolutionService?.ResolveItem(resRef)?.DisplayName)),
-            new (string, SearchFieldCategory)[]
-            {
-                ("Text", SearchFieldCategory.Content),
-                ("Tags", SearchFieldCategory.Identity),
-                ("Scripts", SearchFieldCategory.Script),
-                ("Metadata", SearchFieldCategory.Metadata),
-                ("Variables", SearchFieldCategory.Variable),
-            });
-        if (searchBar != null)
-        {
-            searchBar.FileModified += OnSearchFileModified;
-            searchBar.NavigateToMatch += OnSearchNavigateToMatch;
-        }
+        // Search bar initialization is deferred to InitializeAndLoadAsync (#2015)
+        // so the item-name resolver captures a non-null _itemResolutionService.
 
         UnifiedLogger.LogApplication(LogLevel.INFO, "Fence MainWindow initialized");
     }
@@ -188,12 +170,31 @@ public partial class MainWindow : Window, INotifyPropertyChanged
             await InitializeServicesAsync();
 
             // Wire up GameDataService to StoreBrowserPanel for BIF scanning (#1687)
+            // and initialize the search bar now that _itemResolutionService is set (#2015).
             await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
             {
                 var storeBrowserPanel = this.FindControl<StoreBrowserPanel>("StoreBrowserPanel");
                 if (storeBrowserPanel != null && _gameDataService != null)
                 {
                     storeBrowserPanel.GameDataService = _gameDataService;
+                }
+
+                var searchBar = this.FindControl<SearchBar>("FileSearchBar");
+                searchBar?.Initialize(
+                    new FileSearchService(new UtmSearchProvider(resRef =>
+                        _itemResolutionService?.ResolveItem(resRef)?.DisplayName)),
+                    new (string, SearchFieldCategory)[]
+                    {
+                        ("Text", SearchFieldCategory.Content),
+                        ("Tags", SearchFieldCategory.Identity),
+                        ("Scripts", SearchFieldCategory.Script),
+                        ("Metadata", SearchFieldCategory.Metadata),
+                        ("Variables", SearchFieldCategory.Variable),
+                    });
+                if (searchBar != null)
+                {
+                    searchBar.FileModified += OnSearchFileModified;
+                    searchBar.NavigateToMatch += OnSearchNavigateToMatch;
                 }
             });
 

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Parley. One-line highlights per version; full details in 
 
 ---
 
+## [0.1.165-alpha] - 2026-04-18 | PR #2097
+**Branch**: `fence/issue-2065`
+
+### Copy-to-Module for Dialogs (#1479)
+- Right-click any HAK dialog in the browser → Copy to Module with rename prompt (ResRef only)
+- DLG files have no Tag/LocName — dialog only prompts for the new filename
+
+---
+
 ## [0.1.164-alpha] - 2026-04-12 | PR #2082
 **Branch**: `parley/issue-2062`
 

--- a/Parley/Parley/Views/Helpers/DialogBrowserController.cs
+++ b/Parley/Parley/Views/Helpers/DialogBrowserController.cs
@@ -93,6 +93,12 @@ namespace Parley.Views.Helpers
             // Subscribe to collapse/expand events (#1143)
             dialogBrowserPanel.CollapsedChanged += OnCollapsedChanged;
 
+            // Copy-to-Module status feedback (#1479)
+            dialogBrowserPanel.FileCopiedToModule += (_, destPath) =>
+            {
+                _viewModel.StatusMessage = $"Copied to module: {Path.GetFileName(destPath)}";
+            };
+
             // Update menu item checkmark
             UpdateMenuState();
         }

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.80-alpha] - 2026-04-18
+**Branch**: `fence/issue-2065` | **PR**: #2097
+
+### Copy-to-Module for Creatures (#1479)
+
+- Right-click any BIF/HAK creature in the browser → Copy to Module with rename dialog
+- Edit TemplateResRef, Tag, and FirstName (LastName preserved) before writing to module
+- Inherits shared implementation from FileBrowserPanelBase
+
+---
+
 ## [0.2.79-alpha] - 2026-04-18
 **Branch**: `quartermaster/issue-1978` | **PR**: #2095
 

--- a/Quartermaster/Quartermaster/Views/MainWindow.CreatureBrowser.cs
+++ b/Quartermaster/Quartermaster/Views/MainWindow.CreatureBrowser.cs
@@ -65,6 +65,12 @@ public partial class MainWindow
         // Subscribe to collapse/expand events
         creatureBrowserPanel.CollapsedChanged += OnCreatureBrowserCollapsedChanged;
 
+        // Copy-to-Module status feedback (#1479)
+        creatureBrowserPanel.FileCopiedToModule += (_, destPath) =>
+        {
+            UpdateStatus($"Copied to module: {System.IO.Path.GetFileName(destPath)}");
+        };
+
         // Restore panel state from settings
         RestoreCreatureBrowserPanelState();
 

--- a/Radoub.UI/Radoub.UI.Tests/CopyToModuleValidatorTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/CopyToModuleValidatorTests.cs
@@ -1,0 +1,238 @@
+using System.IO;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Tests for CopyToModuleValidator — validation logic used by the
+/// Copy-to-Module dialog to guard ResRef and Tag inputs before
+/// writing a copied archive resource into the module directory.
+/// </summary>
+public class CopyToModuleValidatorTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public CopyToModuleValidatorTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "CopyToModuleTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void Validate_EmptyResRef_ReturnsEmptyResRefState()
+    {
+        var result = CopyToModuleValidator.Validate(
+            resRef: "",
+            tag: null,
+            originalResRef: "nw_store_01",
+            moduleDirectory: _tempDir,
+            extension: ".utm",
+            showTagAndName: true);
+
+        Assert.Equal(CopyToModuleValidationState.EmptyResRef, result.State);
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void Validate_WhitespaceResRef_ReturnsEmptyResRefState()
+    {
+        var result = CopyToModuleValidator.Validate(
+            resRef: "   ",
+            tag: null,
+            originalResRef: "nw_store_01",
+            moduleDirectory: _tempDir,
+            extension: ".utm",
+            showTagAndName: true);
+
+        Assert.Equal(CopyToModuleValidationState.EmptyResRef, result.State);
+    }
+
+    [Fact]
+    public void Validate_ResRefTooLong_ReturnsInvalidResRefState()
+    {
+        var result = CopyToModuleValidator.Validate(
+            resRef: "this_is_way_too_long_for_aurora",
+            tag: null,
+            originalResRef: "nw_store_01",
+            moduleDirectory: _tempDir,
+            extension: ".utm",
+            showTagAndName: true);
+
+        Assert.Equal(CopyToModuleValidationState.InvalidResRef, result.State);
+    }
+
+    [Fact]
+    public void Validate_ResRefInvalidChars_ReturnsInvalidResRefState()
+    {
+        var result = CopyToModuleValidator.Validate(
+            resRef: "bad-name",
+            tag: null,
+            originalResRef: "nw_store_01",
+            moduleDirectory: _tempDir,
+            extension: ".utm",
+            showTagAndName: true);
+
+        Assert.Equal(CopyToModuleValidationState.InvalidResRef, result.State);
+    }
+
+    [Fact]
+    public void Validate_DuplicateFileInModuleDir_ReturnsDuplicateFileState()
+    {
+        var existingResRef = "existing_store";
+        File.WriteAllBytes(Path.Combine(_tempDir, existingResRef + ".utm"), new byte[] { 0 });
+
+        var result = CopyToModuleValidator.Validate(
+            resRef: existingResRef,
+            tag: null,
+            originalResRef: "nw_store_01",
+            moduleDirectory: _tempDir,
+            extension: ".utm",
+            showTagAndName: true);
+
+        Assert.Equal(CopyToModuleValidationState.DuplicateFile, result.State);
+    }
+
+    [Fact]
+    public void Validate_TagTooLong_ReturnsTagTooLongState()
+    {
+        var longTag = new string('x', CopyToModuleValidator.MaxTagLength + 1);
+
+        var result = CopyToModuleValidator.Validate(
+            resRef: "good_name",
+            tag: longTag,
+            originalResRef: "nw_store_01",
+            moduleDirectory: _tempDir,
+            extension: ".utm",
+            showTagAndName: true);
+
+        Assert.Equal(CopyToModuleValidationState.TagTooLong, result.State);
+    }
+
+    [Fact]
+    public void Validate_TagTooLongIgnoredWhenShowTagAndNameFalse()
+    {
+        var longTag = new string('x', CopyToModuleValidator.MaxTagLength + 1);
+
+        var result = CopyToModuleValidator.Validate(
+            resRef: "good_name",
+            tag: longTag,
+            originalResRef: "nw_store_01",
+            moduleDirectory: _tempDir,
+            extension: ".dlg",
+            showTagAndName: false);
+
+        Assert.Equal(CopyToModuleValidationState.Valid, result.State);
+    }
+
+    [Fact]
+    public void Validate_TagAtMaxLength_IsValid()
+    {
+        var tagAtLimit = new string('x', CopyToModuleValidator.MaxTagLength);
+
+        var result = CopyToModuleValidator.Validate(
+            resRef: "good_name",
+            tag: tagAtLimit,
+            originalResRef: "nw_store_01",
+            moduleDirectory: _tempDir,
+            extension: ".utm",
+            showTagAndName: true);
+
+        Assert.Equal(CopyToModuleValidationState.Valid, result.State);
+    }
+
+    [Fact]
+    public void Validate_UnchangedResRef_ReturnsUnchangedState()
+    {
+        var result = CopyToModuleValidator.Validate(
+            resRef: "nw_store_01",
+            tag: "TestTag",
+            originalResRef: "nw_store_01",
+            moduleDirectory: _tempDir,
+            extension: ".utm",
+            showTagAndName: true);
+
+        Assert.Equal(CopyToModuleValidationState.Unchanged, result.State);
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void Validate_UnchangedResRef_CaseInsensitive()
+    {
+        var result = CopyToModuleValidator.Validate(
+            resRef: "NW_STORE_01",  // uppercase form should still fail Aurora validation first
+            tag: "TestTag",
+            originalResRef: "nw_store_01",
+            moduleDirectory: _tempDir,
+            extension: ".utm",
+            showTagAndName: true);
+
+        // Uppercase fails filename validation before the unchanged check.
+        Assert.Equal(CopyToModuleValidationState.InvalidResRef, result.State);
+    }
+
+    [Fact]
+    public void Validate_ValidInput_ReturnsValid()
+    {
+        var result = CopyToModuleValidator.Validate(
+            resRef: "my_new_store",
+            tag: "MyStore",
+            originalResRef: "nw_store_01",
+            moduleDirectory: _tempDir,
+            extension: ".utm",
+            showTagAndName: true);
+
+        Assert.Equal(CopyToModuleValidationState.Valid, result.State);
+        Assert.True(result.IsValid);
+        Assert.Null(result.Message);
+    }
+
+    [Fact]
+    public void Validate_EmptyModuleDirectory_SkipsDuplicateCheck()
+    {
+        // Tests that pass an empty module dir (for pure field validation)
+        // should not error out on missing directory.
+        var result = CopyToModuleValidator.Validate(
+            resRef: "my_new_store",
+            tag: null,
+            originalResRef: "nw_store_01",
+            moduleDirectory: "",
+            extension: ".utm",
+            showTagAndName: true);
+
+        Assert.Equal(CopyToModuleValidationState.Valid, result.State);
+    }
+
+    [Fact]
+    public void Validate_NullTag_IsValidWhenShowTagAndNameTrue()
+    {
+        // Null tag is how the dialog represents "not entered yet" — shouldn't fail validation.
+        var result = CopyToModuleValidator.Validate(
+            resRef: "my_new_store",
+            tag: null,
+            originalResRef: "nw_store_01",
+            moduleDirectory: _tempDir,
+            extension: ".utm",
+            showTagAndName: true);
+
+        Assert.Equal(CopyToModuleValidationState.Valid, result.State);
+    }
+
+    [Fact]
+    public void CopyToModuleResult_AcceptsNullTagAndName()
+    {
+        // Parley-style result: ResRef only.
+        var result = new CopyToModuleResult("my_dialog", NewTag: null, NewName: null);
+
+        Assert.Equal("my_dialog", result.NewResRef);
+        Assert.Null(result.NewTag);
+        Assert.Null(result.NewName);
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/CreatureBrowserPanelCopyTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/CreatureBrowserPanelCopyTests.cs
@@ -1,0 +1,80 @@
+using Radoub.Formats.Utc;
+using Radoub.UI.Controls;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Tests for CreatureBrowserPanel.ApplyUtcCopyCustomizations —
+/// UTC-specific byte mutation for Copy-to-Module (#1479).
+/// The dialog "Name" field maps to FirstName; LastName is preserved.
+/// </summary>
+public class CreatureBrowserPanelCopyTests
+{
+    private static byte[] BuildSourceCreature()
+    {
+        var source = new UtcFile
+        {
+            TemplateResRef = "nw_blinkdog",
+            Tag = "NW_BLINKDOG"
+        };
+        source.FirstName.SetString(0, "Blink");
+        source.LastName.SetString(0, "Dog");
+        return UtcWriter.Write(source);
+    }
+
+    [Fact]
+    public void ApplyUtcCopyCustomizations_RewritesTemplateResRefTagFirstName()
+    {
+        var sourceBytes = BuildSourceCreature();
+        var result = new CopyToModuleResult(
+            NewResRef: "my_blink_dog",
+            NewTag: "MyBlinkTag",
+            NewName: "Bruno");
+
+        var modified = CreatureBrowserPanel.ApplyUtcCopyCustomizations(sourceBytes, result);
+        var parsed = UtcReader.Read(modified);
+
+        Assert.Equal("my_blink_dog", parsed.TemplateResRef);
+        Assert.Equal("MyBlinkTag", parsed.Tag);
+        Assert.Equal("Bruno", parsed.FirstName.GetDefault());
+    }
+
+    [Fact]
+    public void ApplyUtcCopyCustomizations_LastNameNotOverwrittenByDialogName()
+    {
+        var sourceBytes = BuildSourceCreature();
+        var result = new CopyToModuleResult("my_dog", "MyTag", "Bruno");
+
+        var modified = CreatureBrowserPanel.ApplyUtcCopyCustomizations(sourceBytes, result);
+        var parsed = UtcReader.Read(modified);
+
+        // Dialog "Name" only maps to FirstName — LastName is preserved.
+        Assert.Equal("Dog", parsed.LastName.GetDefault());
+    }
+
+    [Fact]
+    public void ApplyUtcCopyCustomizations_NullTagLeavesTagUnchanged()
+    {
+        var sourceBytes = BuildSourceCreature();
+        var result = new CopyToModuleResult("my_dog", NewTag: null, NewName: "Bruno");
+
+        var modified = CreatureBrowserPanel.ApplyUtcCopyCustomizations(sourceBytes, result);
+        var parsed = UtcReader.Read(modified);
+
+        Assert.Equal("NW_BLINKDOG", parsed.Tag);
+    }
+
+    [Fact]
+    public void ApplyUtcCopyCustomizations_NullNameLeavesFirstNameUnchanged()
+    {
+        var sourceBytes = BuildSourceCreature();
+        var result = new CopyToModuleResult("my_dog", NewTag: "MyTag", NewName: null);
+
+        var modified = CreatureBrowserPanel.ApplyUtcCopyCustomizations(sourceBytes, result);
+        var parsed = UtcReader.Read(modified);
+
+        Assert.Equal("Blink", parsed.FirstName.GetDefault());
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/ItemBrowserPanelCopyTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/ItemBrowserPanelCopyTests.cs
@@ -1,0 +1,65 @@
+using Radoub.Formats.Uti;
+using Radoub.UI.Controls;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Tests for ItemBrowserPanel.ApplyUtiCopyCustomizations —
+/// UTI-specific byte mutation for Copy-to-Module (#1479).
+/// </summary>
+public class ItemBrowserPanelCopyTests
+{
+    private static byte[] BuildSourceItem()
+    {
+        var source = new UtiFile
+        {
+            TemplateResRef = "nw_wblcl001",
+            Tag = "NW_WBLCL001"
+        };
+        source.LocalizedName.SetString(0, "Club");
+        return UtiWriter.Write(source);
+    }
+
+    [Fact]
+    public void ApplyUtiCopyCustomizations_RewritesAllThreeFields()
+    {
+        var sourceBytes = BuildSourceItem();
+        var result = new CopyToModuleResult(
+            NewResRef: "my_club",
+            NewTag: "MyClubTag",
+            NewName: "Cudgel of Ages");
+
+        var modified = ItemBrowserPanel.ApplyUtiCopyCustomizations(sourceBytes, result);
+        var parsed = UtiReader.Read(modified);
+
+        Assert.Equal("my_club", parsed.TemplateResRef);
+        Assert.Equal("MyClubTag", parsed.Tag);
+        Assert.Equal("Cudgel of Ages", parsed.LocalizedName.GetDefault());
+    }
+
+    [Fact]
+    public void ApplyUtiCopyCustomizations_NullTagLeavesTagUnchanged()
+    {
+        var sourceBytes = BuildSourceItem();
+        var result = new CopyToModuleResult("my_club", NewTag: null, NewName: "Stick");
+
+        var modified = ItemBrowserPanel.ApplyUtiCopyCustomizations(sourceBytes, result);
+        var parsed = UtiReader.Read(modified);
+
+        Assert.Equal("NW_WBLCL001", parsed.Tag);
+    }
+
+    [Fact]
+    public void ApplyUtiCopyCustomizations_NullNameLeavesLocalizedNameUnchanged()
+    {
+        var sourceBytes = BuildSourceItem();
+        var result = new CopyToModuleResult("my_club", NewTag: "MyTag", NewName: null);
+
+        var modified = ItemBrowserPanel.ApplyUtiCopyCustomizations(sourceBytes, result);
+        var parsed = UtiReader.Read(modified);
+
+        Assert.Equal("Club", parsed.LocalizedName.GetDefault());
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/StoreBrowserPanelCopyTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/StoreBrowserPanelCopyTests.cs
@@ -1,0 +1,99 @@
+using Radoub.Formats.Utm;
+using Radoub.UI.Controls;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Tests for StoreBrowserPanel.ApplyUtmCopyCustomizations —
+/// UTM-specific byte mutation applied when a user copies a store
+/// from BIF/HAK into the module directory (#2017).
+/// </summary>
+public class StoreBrowserPanelCopyTests
+{
+    private static byte[] BuildSourceStore()
+    {
+        var source = new UtmFile
+        {
+            ResRef = "nw_stk_01",
+            Tag = "NW_STK_STANDARD",
+            MarkUp = 35,
+            MarkDown = 50
+        };
+        source.LocName.SetString(0, "Standard Shop");
+        return UtmWriter.Write(source);
+    }
+
+    [Fact]
+    public void ApplyUtmCopyCustomizations_RewritesAllThreeFields()
+    {
+        var sourceBytes = BuildSourceStore();
+        var result = new CopyToModuleResult(
+            NewResRef: "my_test_store",
+            NewTag: "MyTestTag",
+            NewName: "Bob's Emporium");
+
+        var modified = StoreBrowserPanel.ApplyUtmCopyCustomizations(sourceBytes, result);
+        var parsed = UtmReader.Read(modified);
+
+        Assert.Equal("my_test_store", parsed.ResRef);
+        Assert.Equal("MyTestTag", parsed.Tag);
+        Assert.Equal("Bob's Emporium", parsed.LocName.GetDefault());
+    }
+
+    [Fact]
+    public void ApplyUtmCopyCustomizations_PreservesOtherFields()
+    {
+        var sourceBytes = BuildSourceStore();
+        var result = new CopyToModuleResult("my_test_store", "MyTestTag", "My Name");
+
+        var modified = StoreBrowserPanel.ApplyUtmCopyCustomizations(sourceBytes, result);
+        var parsed = UtmReader.Read(modified);
+
+        Assert.Equal(35, parsed.MarkUp);
+        Assert.Equal(50, parsed.MarkDown);
+    }
+
+    [Fact]
+    public void ApplyUtmCopyCustomizations_NullTagLeavesTagUnchanged()
+    {
+        var sourceBytes = BuildSourceStore();
+        var result = new CopyToModuleResult("my_test_store", NewTag: null, NewName: "New Name");
+
+        var modified = StoreBrowserPanel.ApplyUtmCopyCustomizations(sourceBytes, result);
+        var parsed = UtmReader.Read(modified);
+
+        Assert.Equal("my_test_store", parsed.ResRef);
+        Assert.Equal("NW_STK_STANDARD", parsed.Tag);  // unchanged
+        Assert.Equal("New Name", parsed.LocName.GetDefault());
+    }
+
+    [Fact]
+    public void ApplyUtmCopyCustomizations_NullNameLeavesLocNameUnchanged()
+    {
+        var sourceBytes = BuildSourceStore();
+        var result = new CopyToModuleResult("my_test_store", NewTag: "NewTag", NewName: null);
+
+        var modified = StoreBrowserPanel.ApplyUtmCopyCustomizations(sourceBytes, result);
+        var parsed = UtmReader.Read(modified);
+
+        Assert.Equal("my_test_store", parsed.ResRef);
+        Assert.Equal("NewTag", parsed.Tag);
+        Assert.Equal("Standard Shop", parsed.LocName.GetDefault());  // unchanged
+    }
+
+    [Fact]
+    public void ApplyUtmCopyCustomizations_ResRefAlwaysReplaced()
+    {
+        // ResRef is required in the dialog, so the result always carries a value —
+        // verify the mutation always writes it even when Tag/Name are null.
+        var sourceBytes = BuildSourceStore();
+        var result = new CopyToModuleResult("renamed_only", null, null);
+
+        var modified = StoreBrowserPanel.ApplyUtmCopyCustomizations(sourceBytes, result);
+        var parsed = UtmReader.Read(modified);
+
+        Assert.Equal("renamed_only", parsed.ResRef);
+    }
+}

--- a/Radoub.UI/Radoub.UI/Controls/CreatureBrowserPanel.cs
+++ b/Radoub.UI/Radoub.UI/Controls/CreatureBrowserPanel.cs
@@ -176,6 +176,61 @@ public class CreatureBrowserPanel : FileBrowserPanelBase
     /// </summary>
     public IGameDataService? GameDataService { get; set; }
 
+    protected override bool SupportsCopyToModule() => true;
+
+    protected override bool IsArchiveEntry(FileBrowserEntry entry)
+        => entry is CreatureBrowserEntry c && (c.IsFromHak || c.IsFromBif);
+
+    protected override Task<byte[]?> ExtractArchiveBytesAsync(FileBrowserEntry entry)
+    {
+        if (entry is not CreatureBrowserEntry ce) return Task.FromResult<byte[]?>(null);
+
+        if (ce.IsFromBif && GameDataService is { IsConfigured: true })
+        {
+            return Task.FromResult(GameDataService.FindResource(ce.Name, ResourceTypes.Utc));
+        }
+        if (ce.IsFromHak && !string.IsNullOrEmpty(ce.HakPath))
+        {
+            return Task.FromResult(ExtractFromHak(ce.HakPath, ce.Name, ResourceTypes.Utc));
+        }
+        return Task.FromResult<byte[]?>(null);
+    }
+
+    protected override Task<(string tag, string name)> ReadSourceMetadataAsync(byte[] bytes)
+    {
+        try
+        {
+            var utc = Radoub.Formats.Utc.UtcReader.Read(bytes);
+            var firstName = utc.FirstName.GetDefault() ?? string.Empty;
+            var lastName = utc.LastName.GetDefault() ?? string.Empty;
+            var fullName = string.IsNullOrEmpty(lastName) ? firstName : $"{firstName} {lastName}".Trim();
+            return Task.FromResult((utc.Tag ?? string.Empty, fullName));
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"CreatureBrowserPanel.ReadSourceMetadataAsync: {ex.Message}");
+            return Task.FromResult((string.Empty, string.Empty));
+        }
+    }
+
+    protected override Task<byte[]> ApplyCopyCustomizationsAsync(byte[] sourceBytes, CopyToModuleResult result)
+        => Task.FromResult(ApplyUtcCopyCustomizations(sourceBytes, result));
+
+    /// <summary>
+    /// Rewrite a UTC byte blob with the user's new TemplateResRef/Tag/FirstName.
+    /// The dialog's "Name" maps to FirstName; LastName is left unchanged because
+    /// the dialog does not expose a separate last-name field.
+    /// </summary>
+    internal static byte[] ApplyUtcCopyCustomizations(byte[] sourceBytes, CopyToModuleResult result)
+    {
+        var utc = Radoub.Formats.Utc.UtcReader.Read(sourceBytes);
+        utc.TemplateResRef = result.NewResRef;
+        if (result.NewTag != null) utc.Tag = result.NewTag;
+        if (result.NewName != null) utc.FirstName.SetString(0, result.NewName);
+        return Radoub.Formats.Utc.UtcWriter.Write(utc);
+    }
+
     private void OnFilterChanged(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
         OnFilterOptionsChanged();

--- a/Radoub.UI/Radoub.UI/Controls/DialogBrowserPanel.cs
+++ b/Radoub.UI/Radoub.UI/Controls/DialogBrowserPanel.cs
@@ -68,6 +68,22 @@ public class DialogBrowserPanel : FileBrowserPanelBase
         FilterOptionsContent = _showHakCheckBox;
     }
 
+    protected override bool SupportsCopyToModule() => true;
+
+    // DLG has no Tag or LocName equivalents — ResRef-only rename.
+    protected override bool SupportsTagNameRename() => false;
+
+    protected override Task<byte[]?> ExtractArchiveBytesAsync(FileBrowserEntry entry)
+    {
+        if (!entry.IsFromHak || string.IsNullOrEmpty(entry.HakPath))
+            return Task.FromResult<byte[]?>(null);
+
+        return Task.FromResult(ExtractFromHak(entry.HakPath, entry.Name, ResourceTypes.Dlg));
+    }
+
+    // Default ApplyCopyCustomizationsAsync returns bytes unchanged — exactly what we want
+    // for DLG since the filename is the only thing that changes.
+
     /// <summary>
     /// Gets or sets whether HAK dialogs are shown.
     /// </summary>

--- a/Radoub.UI/Radoub.UI/Controls/FileBrowserPanelBase.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Controls/FileBrowserPanelBase.axaml.cs
@@ -1,13 +1,16 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Media;
+using Radoub.Formats.Erf;
 using Radoub.Formats.Logging;
 using Radoub.UI.Services;
+using Radoub.UI.Views;
 
 namespace Radoub.UI.Controls;
 
@@ -38,6 +41,12 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
     /// Raised when the panel's collapsed state changes.
     /// </summary>
     public event EventHandler<bool>? CollapsedChanged;
+
+    /// <summary>
+    /// Raised when an archive resource is successfully copied to the module folder.
+    /// The string is the destination file path. Consumers typically update a status bar.
+    /// </summary>
+    public event EventHandler<string>? FileCopiedToModule;
 
     /// <summary>
     /// The header text displayed at the top of the panel.
@@ -84,6 +93,10 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
 
         // Update Delete menu item state when context menu opens
         FileListContextMenu.Opening += OnContextMenuOpening;
+
+        // Lazily add Copy-to-Module menu item once the visual tree is ready so
+        // subclass constructors have finished setting FileExtension/SupportsCopyToModule.
+        Loaded += (_, _) => TryAddCopyToModuleMenuItem();
     }
 
     #region IFileBrowserPanel Implementation
@@ -453,6 +466,174 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
             {
                 target.Add(entry);
             }
+        }
+    }
+
+    #endregion
+
+    #region Copy-to-Module (shared across all derived panels)
+
+    /// <summary>
+    /// Whether this panel exposes a "Copy to Module" context menu item for
+    /// archive-sourced entries. Override to return true in panels that wrap
+    /// a GFF file format (UTM/UTC/UTI/DLG).
+    /// </summary>
+    protected virtual bool SupportsCopyToModule() => false;
+
+    /// <summary>
+    /// Whether the Copy-to-Module dialog should show editable Tag/Name fields.
+    /// UTM/UTC/UTI: true. DLG (Parley): false — ResRef only.
+    /// </summary>
+    protected virtual bool SupportsTagNameRename() => true;
+
+    /// <summary>
+    /// Extract the raw bytes of an archive-sourced entry (BIF or HAK).
+    /// Returning null aborts the copy. Default implementation returns null.
+    /// </summary>
+    protected virtual Task<byte[]?> ExtractArchiveBytesAsync(FileBrowserEntry entry)
+        => Task.FromResult<byte[]?>(null);
+
+    /// <summary>
+    /// Read the source resource's Tag and default-language Name so the dialog
+    /// can pre-fill those fields. Default returns empty strings.
+    /// Only called when <see cref="SupportsTagNameRename"/> returns true.
+    /// </summary>
+    protected virtual Task<(string tag, string name)> ReadSourceMetadataAsync(byte[] bytes)
+        => Task.FromResult((string.Empty, string.Empty));
+
+    /// <summary>
+    /// Apply the user's Tag/Name/ResRef choices to the raw source bytes, returning
+    /// the bytes that should be written to the module file. Default implementation
+    /// returns input bytes unchanged (Parley path — ResRef-only rename).
+    /// </summary>
+    protected virtual Task<byte[]> ApplyCopyCustomizationsAsync(byte[] sourceBytes, CopyToModuleResult result)
+        => Task.FromResult(sourceBytes);
+
+    /// <summary>
+    /// Shared HAK extraction helper — looks up a resource in a HAK/ERF by ResRef +
+    /// resource type, returns the decompressed bytes, or null on any failure.
+    /// </summary>
+    protected static byte[]? ExtractFromHak(string hakPath, string resRef, ushort resourceType)
+    {
+        try
+        {
+            var erf = ErfReader.ReadMetadataOnly(hakPath);
+            var entry = erf.Resources.FirstOrDefault(r =>
+                r.ResRef.Equals(resRef, StringComparison.OrdinalIgnoreCase)
+                && r.ResourceType == resourceType);
+
+            return entry == null ? null : ErfReader.ExtractResource(hakPath, entry);
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"Failed to extract {resRef} from {Path.GetFileName(hakPath)}: {ex.Message}");
+            return null;
+        }
+    }
+
+    private MenuItem? _copyToModuleMenuItem;
+
+    private void TryAddCopyToModuleMenuItem()
+    {
+        if (_copyToModuleMenuItem != null) return;
+        if (!SupportsCopyToModule()) return;
+
+        _copyToModuleMenuItem = new MenuItem { Header = "Copy to Module" };
+        _copyToModuleMenuItem.Click += async (_, _) =>
+        {
+            if (FileListBox.SelectedItem is FileBrowserEntry entry)
+                await CopyArchiveEntryToModuleAsync(entry);
+        };
+
+        // Insert before Delete so it appears at the top of the menu.
+        FileListContextMenu.Items.Insert(0, _copyToModuleMenuItem);
+        FileListContextMenu.Items.Insert(1, new Separator());
+
+        FileListContextMenu.Opening += OnCopyToModuleContextMenuOpening;
+    }
+
+    private void OnCopyToModuleContextMenuOpening(object? sender, System.ComponentModel.CancelEventArgs e)
+    {
+        if (_copyToModuleMenuItem == null) return;
+
+        var entry = FileListBox.SelectedItem as FileBrowserEntry;
+        var isArchive = entry != null && IsArchiveEntry(entry);
+        _copyToModuleMenuItem.IsVisible = isArchive && !string.IsNullOrEmpty(ModulePath);
+    }
+
+    /// <summary>
+    /// Check whether an entry came from an archive (HAK or BIF) — i.e. it's
+    /// a candidate for Copy-to-Module. Derived panels with their own "IsFromBif"
+    /// flag override this to also accept BIF entries.
+    /// </summary>
+    protected virtual bool IsArchiveEntry(FileBrowserEntry entry) => entry.IsFromHak;
+
+    private async Task CopyArchiveEntryToModuleAsync(FileBrowserEntry entry)
+    {
+        if (string.IsNullOrEmpty(ModulePath)) return;
+        if (!SupportsCopyToModule())
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                "CopyArchiveEntryToModuleAsync called on a panel that does not support copy-to-module");
+            return;
+        }
+
+        try
+        {
+            var bytes = await ExtractArchiveBytesAsync(entry);
+            if (bytes == null)
+            {
+                UnifiedLogger.LogApplication(LogLevel.WARN,
+                    $"Could not extract {entry.Name} from archive");
+                return;
+            }
+
+            var (tag, name) = SupportsTagNameRename()
+                ? await ReadSourceMetadataAsync(bytes)
+                : (string.Empty, string.Empty);
+
+            var owner = TopLevel.GetTopLevel(this) as Window;
+            if (owner == null)
+            {
+                UnifiedLogger.LogApplication(LogLevel.WARN,
+                    "Cannot show CopyToModuleDialog — no owner window");
+                return;
+            }
+
+            var dialogResult = await CopyToModuleDialog.ShowAsync(
+                owner,
+                currentResRef: entry.Name,
+                currentTag: tag,
+                currentName: name,
+                moduleDirectory: ModulePath,
+                extension: FileExtension,
+                showTagAndName: SupportsTagNameRename());
+
+            if (dialogResult == null) return; // user cancelled
+
+            var modifiedBytes = await ApplyCopyCustomizationsAsync(bytes, dialogResult);
+
+            var destPath = Path.Combine(ModulePath, dialogResult.NewResRef + FileExtension);
+            if (File.Exists(destPath))
+            {
+                // Dialog already validated this, but re-check defensively.
+                UnifiedLogger.LogApplication(LogLevel.WARN,
+                    $"Destination already exists: {Path.GetFileName(destPath)}");
+                return;
+            }
+
+            await File.WriteAllBytesAsync(destPath, modifiedBytes);
+            UnifiedLogger.LogApplication(LogLevel.INFO,
+                $"Copied archive resource to module: {UnifiedLogger.SanitizePath(destPath)}");
+
+            FileCopiedToModule?.Invoke(this, destPath);
+            await RefreshAsync();
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.ERROR,
+                $"Failed to copy {entry.Name} to module: {ex.Message}");
         }
     }
 

--- a/Radoub.UI/Radoub.UI/Controls/ItemBrowserPanel.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ItemBrowserPanel.cs
@@ -8,6 +8,7 @@ using Radoub.Formats.Common;
 using Radoub.Formats.Erf;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Settings;
+using Radoub.UI.Services;
 
 namespace Radoub.UI.Controls;
 
@@ -59,6 +60,46 @@ public class ItemBrowserPanel : FileBrowserPanelBase
         _showHakCheckBox.IsCheckedChanged += OnShowHakChanged;
 
         FilterOptionsContent = _showHakCheckBox;
+    }
+
+    protected override bool SupportsCopyToModule() => true;
+
+    protected override Task<byte[]?> ExtractArchiveBytesAsync(FileBrowserEntry entry)
+    {
+        if (!entry.IsFromHak || string.IsNullOrEmpty(entry.HakPath))
+            return Task.FromResult<byte[]?>(null);
+
+        return Task.FromResult(ExtractFromHak(entry.HakPath, entry.Name, ResourceTypes.Uti));
+    }
+
+    protected override Task<(string tag, string name)> ReadSourceMetadataAsync(byte[] bytes)
+    {
+        try
+        {
+            var uti = Radoub.Formats.Uti.UtiReader.Read(bytes);
+            return Task.FromResult((uti.Tag ?? string.Empty, uti.LocalizedName.GetDefault() ?? string.Empty));
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"ItemBrowserPanel.ReadSourceMetadataAsync: {ex.Message}");
+            return Task.FromResult((string.Empty, string.Empty));
+        }
+    }
+
+    protected override Task<byte[]> ApplyCopyCustomizationsAsync(byte[] sourceBytes, CopyToModuleResult result)
+        => Task.FromResult(ApplyUtiCopyCustomizations(sourceBytes, result));
+
+    /// <summary>
+    /// Rewrite a UTI byte blob with the user's new TemplateResRef/Tag/LocalizedName.
+    /// </summary>
+    internal static byte[] ApplyUtiCopyCustomizations(byte[] sourceBytes, CopyToModuleResult result)
+    {
+        var uti = Radoub.Formats.Uti.UtiReader.Read(sourceBytes);
+        uti.TemplateResRef = result.NewResRef;
+        if (result.NewTag != null) uti.Tag = result.NewTag;
+        if (result.NewName != null) uti.LocalizedName.SetString(0, result.NewName);
+        return Radoub.Formats.Uti.UtiWriter.Write(uti);
     }
 
     /// <summary>

--- a/Radoub.UI/Radoub.UI/Controls/StoreBrowserPanel.cs
+++ b/Radoub.UI/Radoub.UI/Controls/StoreBrowserPanel.cs
@@ -107,107 +107,56 @@ public class StoreBrowserPanel : FileBrowserPanelBase
         filterPanel.Children.Add(_showHakCheckBox);
         filterPanel.Children.Add(_showBifCheckBox);
         FilterOptionsContent = filterPanel;
-
-        // Add "Copy to Module" context menu item for archive entries
-        Loaded += (_, _) => AddCopyToModuleMenuItem();
     }
+
+    protected override bool SupportsCopyToModule() => true;
+
+    protected override bool IsArchiveEntry(FileBrowserEntry entry)
+        => entry is StoreBrowserEntry s && (s.IsFromHak || s.IsFromBif);
+
+    protected override Task<byte[]?> ExtractArchiveBytesAsync(FileBrowserEntry entry)
+    {
+        if (entry is not StoreBrowserEntry storeEntry) return Task.FromResult<byte[]?>(null);
+
+        if (storeEntry.IsFromBif && GameDataService is { IsConfigured: true })
+        {
+            return Task.FromResult(GameDataService.FindResource(storeEntry.Name, ResourceTypes.Utm));
+        }
+        if (storeEntry.IsFromHak && !string.IsNullOrEmpty(storeEntry.HakPath))
+        {
+            return Task.FromResult(ExtractFromHak(storeEntry.HakPath, storeEntry.Name, ResourceTypes.Utm));
+        }
+        return Task.FromResult<byte[]?>(null);
+    }
+
+    protected override Task<(string tag, string name)> ReadSourceMetadataAsync(byte[] bytes)
+    {
+        try
+        {
+            var utm = Radoub.Formats.Utm.UtmReader.Read(bytes);
+            return Task.FromResult((utm.Tag ?? string.Empty, utm.LocName.GetDefault() ?? string.Empty));
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"StoreBrowserPanel.ReadSourceMetadataAsync: {ex.Message}");
+            return Task.FromResult((string.Empty, string.Empty));
+        }
+    }
+
+    protected override Task<byte[]> ApplyCopyCustomizationsAsync(byte[] sourceBytes, CopyToModuleResult result)
+        => Task.FromResult(ApplyUtmCopyCustomizations(sourceBytes, result));
 
     /// <summary>
-    /// Raised when an archive store is copied to the module folder.
-    /// The string is the destination file path.
+    /// Rewrite a UTM byte blob with the user's new ResRef/Tag/Name. Pure, testable.
     /// </summary>
-    public event EventHandler<string>? FileCopiedToModule;
-
-    private void AddCopyToModuleMenuItem()
+    internal static byte[] ApplyUtmCopyCustomizations(byte[] sourceBytes, CopyToModuleResult result)
     {
-        var contextMenu = this.FindControl<Avalonia.Controls.ContextMenu>("FileListContextMenu");
-        var fileListBox = this.FindControl<ListBox>("FileListBox");
-        if (contextMenu == null || fileListBox == null) return;
-
-        var copyItem = new MenuItem { Header = "Copy to Module" };
-        copyItem.Click += async (_, _) =>
-        {
-            if (fileListBox.SelectedItem is not StoreBrowserEntry entry) return;
-            if (!entry.IsFromHak && !entry.IsFromBif) return;
-            if (string.IsNullOrEmpty(ModulePath)) return;
-
-            await CopyArchiveStoreToModuleAsync(entry);
-        };
-
-        // Insert before Delete
-        contextMenu.Items.Insert(0, copyItem);
-        contextMenu.Items.Insert(1, new Avalonia.Controls.Separator());
-
-        // Update menu item visibility when context menu opens
-        contextMenu.Opening += (_, _) =>
-        {
-            var selected = fileListBox.SelectedItem as StoreBrowserEntry;
-            var isArchive = selected != null && (selected.IsFromHak || selected.IsFromBif);
-            copyItem.IsVisible = isArchive && !string.IsNullOrEmpty(ModulePath);
-        };
-    }
-
-    private async Task CopyArchiveStoreToModuleAsync(StoreBrowserEntry entry)
-    {
-        if (string.IsNullOrEmpty(ModulePath)) return;
-
-        try
-        {
-            byte[]? data = null;
-
-            if (entry.IsFromBif && GameDataService != null && GameDataService.IsConfigured)
-            {
-                data = GameDataService.FindResource(entry.Name, ResourceTypes.Utm);
-            }
-            else if (entry.IsFromHak && !string.IsNullOrEmpty(entry.HakPath))
-            {
-                data = ExtractFromHakStatic(entry.HakPath, entry.Name, ResourceTypes.Utm);
-            }
-
-            if (data == null)
-            {
-                UnifiedLogger.LogApplication(LogLevel.WARN, $"Could not extract {entry.Name} from archive");
-                return;
-            }
-
-            var destPath = Path.Combine(ModulePath, $"{entry.Name}.utm");
-            if (File.Exists(destPath))
-            {
-                UnifiedLogger.LogApplication(LogLevel.WARN, $"Store already exists in module: {entry.Name}.utm");
-                return;
-            }
-
-            await File.WriteAllBytesAsync(destPath, data);
-            UnifiedLogger.LogApplication(LogLevel.INFO, $"Copied archive store to module: {destPath}");
-
-            FileCopiedToModule?.Invoke(this, destPath);
-            await RefreshAsync();
-        }
-        catch (Exception ex)
-        {
-            UnifiedLogger.LogApplication(LogLevel.ERROR, $"Failed to copy {entry.Name} to module: {ex.Message}");
-        }
-    }
-
-    private static byte[]? ExtractFromHakStatic(string hakPath, string resRef, ushort resourceType)
-    {
-        try
-        {
-            var erf = ErfReader.ReadMetadataOnly(hakPath);
-            var resourceEntry = erf.Resources
-                .FirstOrDefault(r => r.ResRef.Equals(resRef, StringComparison.OrdinalIgnoreCase)
-                                  && r.ResourceType == resourceType);
-
-            if (resourceEntry == null)
-                return null;
-
-            return ErfReader.ExtractResource(hakPath, resourceEntry);
-        }
-        catch (Exception ex)
-        {
-            UnifiedLogger.LogApplication(LogLevel.WARN, $"Failed to extract {resRef} from {Path.GetFileName(hakPath)}: {ex.Message}");
-            return null;
-        }
+        var utm = Radoub.Formats.Utm.UtmReader.Read(sourceBytes);
+        utm.ResRef = result.NewResRef;
+        if (result.NewTag != null) utm.Tag = result.NewTag;
+        if (result.NewName != null) utm.LocName.SetString(0, result.NewName);
+        return Radoub.Formats.Utm.UtmWriter.Write(utm);
     }
 
     /// <summary>

--- a/Radoub.UI/Radoub.UI/Services/CopyToModuleValidator.cs
+++ b/Radoub.UI/Radoub.UI/Services/CopyToModuleValidator.cs
@@ -1,0 +1,107 @@
+using System;
+using System.IO;
+
+namespace Radoub.UI.Services;
+
+/// <summary>
+/// Result of a Copy-to-Module dialog. Null values for Tag/Name
+/// indicate the dialog was configured to hide those fields (e.g., Parley).
+/// </summary>
+public sealed record CopyToModuleResult(string NewResRef, string? NewTag, string? NewName);
+
+/// <summary>
+/// Validation state for the Copy-to-Module dialog's editable fields.
+/// </summary>
+public enum CopyToModuleValidationState
+{
+    Valid,
+    EmptyResRef,
+    InvalidResRef,
+    DuplicateFile,
+    TagTooLong,
+    Unchanged
+}
+
+public sealed record CopyToModuleValidationResult(
+    CopyToModuleValidationState State,
+    string? Message)
+{
+    public bool IsValid => State == CopyToModuleValidationState.Valid;
+}
+
+/// <summary>
+/// Validates Copy-to-Module dialog inputs:
+/// ResRef (Aurora filename rules + duplicate-in-module check),
+/// Tag (NWN 32-char limit), Name (any non-empty string).
+/// </summary>
+public static class CopyToModuleValidator
+{
+    /// <summary>NWN Tag field maximum length.</summary>
+    public const int MaxTagLength = 32;
+
+    /// <summary>
+    /// Validate the dialog's current state against target module directory and extension.
+    /// </summary>
+    /// <param name="resRef">New ResRef (filename stem)</param>
+    /// <param name="tag">New Tag (ignored when showTagAndName is false)</param>
+    /// <param name="originalResRef">Original ResRef — used to detect "unchanged"</param>
+    /// <param name="moduleDirectory">Directory where the copy will be written</param>
+    /// <param name="extension">File extension including the dot (e.g. ".utm")</param>
+    /// <param name="showTagAndName">Whether Tag/Name are being edited (Parley: false)</param>
+    public static CopyToModuleValidationResult Validate(
+        string resRef,
+        string? tag,
+        string originalResRef,
+        string moduleDirectory,
+        string extension,
+        bool showTagAndName)
+    {
+        var trimmed = resRef?.Trim() ?? string.Empty;
+
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            return new CopyToModuleValidationResult(
+                CopyToModuleValidationState.EmptyResRef,
+                "ResRef is required.");
+        }
+
+        var filenameResult = AuroraFilenameValidator.Validate(trimmed);
+        if (!filenameResult.IsValid)
+        {
+            return new CopyToModuleValidationResult(
+                CopyToModuleValidationState.InvalidResRef,
+                filenameResult.GetErrorMessage());
+        }
+
+        if (showTagAndName && tag != null && tag.Length > MaxTagLength)
+        {
+            return new CopyToModuleValidationResult(
+                CopyToModuleValidationState.TagTooLong,
+                $"Tag is too long ({tag.Length} characters). Maximum is {MaxTagLength}.");
+        }
+
+        // Duplicate-file check only fires when we have a real directory to check.
+        // Tests that pass null/empty directory skip this branch.
+        if (!string.IsNullOrEmpty(moduleDirectory))
+        {
+            var destPath = Path.Combine(moduleDirectory, trimmed + extension);
+            if (File.Exists(destPath))
+            {
+                return new CopyToModuleValidationResult(
+                    CopyToModuleValidationState.DuplicateFile,
+                    $"A file named \"{trimmed}{extension}\" already exists in this directory.");
+            }
+        }
+
+        // Unchanged is only a soft state — the copy should still be allowed as long as
+        // a duplicate check didn't fire (same resref, different target dir is fine).
+        if (string.Equals(trimmed, originalResRef, StringComparison.OrdinalIgnoreCase))
+        {
+            return new CopyToModuleValidationResult(
+                CopyToModuleValidationState.Unchanged,
+                "ResRef is unchanged from the source.");
+        }
+
+        return new CopyToModuleValidationResult(CopyToModuleValidationState.Valid, null);
+    }
+}

--- a/Radoub.UI/Radoub.UI/Views/CopyToModuleDialog.axaml
+++ b/Radoub.UI/Radoub.UI/Views/CopyToModuleDialog.axaml
@@ -1,0 +1,103 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="Radoub.UI.Views.CopyToModuleDialog"
+        Title="Copy to Module"
+        MinWidth="480" MinHeight="420"
+        MaxHeight="750"
+        SizeToContent="WidthAndHeight"
+        CanResize="False"
+        WindowStartupLocation="CenterOwner">
+
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+    <Grid Margin="20" MinWidth="440">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <TextBlock Grid.Row="0"
+                   x:Name="HeaderText"
+                   Text="Copy resource to module"
+                   FontWeight="SemiBold"
+                   Margin="0,0,0,15"/>
+
+        <!-- ResRef -->
+        <StackPanel Grid.Row="1" Margin="0,0,0,10">
+            <TextBlock Text="ResRef (filename):" FontWeight="SemiBold" Margin="0,0,0,5"/>
+            <TextBox x:Name="ResRefBox" FontFamily="Consolas, Courier New, monospace"
+                     TextChanged="OnFieldChanged"
+                     KeyDown="OnFieldKeyDown"
+                     Watermark="max 16 chars, a-z, 0-9, _"/>
+        </StackPanel>
+
+        <!-- ResRef char count -->
+        <TextBlock Grid.Row="2" x:Name="ResRefCharCountText"
+                   Text="0 / 16 characters"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                   Margin="0,0,0,10"/>
+
+        <!-- Tag -->
+        <StackPanel Grid.Row="3" x:Name="TagPanel" Margin="0,0,0,10">
+            <TextBlock Text="Tag:" FontWeight="SemiBold" Margin="0,0,0,5"/>
+            <TextBox x:Name="TagBox" FontFamily="Consolas, Courier New, monospace"
+                     TextChanged="OnFieldChanged"
+                     KeyDown="OnFieldKeyDown"
+                     Watermark="max 32 chars"/>
+        </StackPanel>
+
+        <!-- Tag char count -->
+        <TextBlock Grid.Row="4" x:Name="TagCharCountText"
+                   Text="0 / 32 characters"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                   Margin="0,0,0,10"/>
+
+        <!-- Name -->
+        <StackPanel Grid.Row="5" x:Name="NamePanel" Margin="0,0,0,10">
+            <TextBlock Text="Name:" FontWeight="SemiBold" Margin="0,0,0,5"/>
+            <TextBox x:Name="NameBox"
+                     KeyDown="OnFieldKeyDown"
+                     Watermark="display name shown in-game"/>
+        </StackPanel>
+
+        <!-- Validation messages -->
+        <Border Grid.Row="6" x:Name="ValidationBorder"
+                Background="{DynamicResource SystemControlErrorTextForegroundBrush}"
+                CornerRadius="4"
+                Padding="10"
+                Margin="0,0,0,10"
+                IsVisible="False">
+            <TextBlock x:Name="ValidationText"
+                       TextWrapping="Wrap"
+                       Foreground="White"/>
+        </Border>
+
+        <!-- Info block -->
+        <Border Grid.Row="7"
+                Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                CornerRadius="4"
+                Padding="10"
+                Margin="0,0,0,15">
+            <StackPanel>
+                <TextBlock Text="Copy-to-Module rules:" FontWeight="SemiBold" Margin="0,0,0,5"/>
+                <TextBlock Text="• ResRef must be unique in the module directory"/>
+                <TextBlock Text="• Aurora filenames: max 16 chars, lowercase, a-z, 0-9, _"/>
+                <TextBlock x:Name="InfoTagLine" Text="• Tag limit: 32 characters"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Buttons -->
+        <StackPanel Grid.Row="8" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
+            <Button x:Name="CopyButton" Content="Copy" MinWidth="90" Click="OnCopyClick" IsEnabled="False"/>
+            <Button Content="Cancel" MinWidth="90" Click="OnCancelClick"/>
+        </StackPanel>
+    </Grid>
+    </ScrollViewer>
+</Window>

--- a/Radoub.UI/Radoub.UI/Views/CopyToModuleDialog.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Views/CopyToModuleDialog.axaml.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Radoub.UI.Services;
+
+namespace Radoub.UI.Views;
+
+/// <summary>
+/// Dialog shown when copying an archive resource (BIF/HAK) into the module directory.
+/// Lets the user edit the new ResRef, Tag, and Name before the copy is written.
+/// Parley and other formats without Tag/Name pass showTagAndName: false to get a
+/// ResRef-only variant.
+/// </summary>
+public partial class CopyToModuleDialog : Window
+{
+    private string _originalResRef = "";
+    private string _moduleDirectory = "";
+    private string _extension = "";
+    private bool _showTagAndName = true;
+
+    /// <summary>
+    /// The user's choices if they confirmed the copy; null if they cancelled.
+    /// </summary>
+    public CopyToModuleResult? Result { get; private set; }
+
+    public CopyToModuleDialog()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>
+    /// Show the dialog and return the user's choices, or null if cancelled.
+    /// </summary>
+    /// <param name="owner">Parent window.</param>
+    /// <param name="currentResRef">ResRef of the source resource.</param>
+    /// <param name="currentTag">Tag of the source resource (ignored when showTagAndName is false).</param>
+    /// <param name="currentName">Display name of the source resource (ignored when showTagAndName is false).</param>
+    /// <param name="moduleDirectory">Directory the copy will be written to (used for duplicate detection).</param>
+    /// <param name="extension">File extension including the dot (e.g. ".utm", ".dlg").</param>
+    /// <param name="showTagAndName">True for formats with editable Tag/Name (UTM/UTC/UTI); false for ResRef-only (DLG).</param>
+    public static async Task<CopyToModuleResult?> ShowAsync(
+        Window owner,
+        string currentResRef,
+        string currentTag,
+        string currentName,
+        string moduleDirectory,
+        string extension,
+        bool showTagAndName = true)
+    {
+        var dialog = new CopyToModuleDialog();
+        dialog.Configure(currentResRef, currentTag, currentName, moduleDirectory, extension, showTagAndName);
+        await dialog.ShowDialog(owner);
+        return dialog.Result;
+    }
+
+    private void Configure(string currentResRef, string currentTag, string currentName,
+        string moduleDirectory, string extension, bool showTagAndName)
+    {
+        _originalResRef = currentResRef ?? "";
+        _moduleDirectory = moduleDirectory ?? "";
+        _extension = extension ?? "";
+        _showTagAndName = showTagAndName;
+
+        var extLabel = _extension.TrimStart('.').ToUpperInvariant();
+        Title = showTagAndName
+            ? $"Copy {extLabel} to Module"
+            : $"Copy {extLabel} to Module (ResRef only)";
+
+        HeaderText.Text = $"Copy \"{currentResRef}{_extension}\" to module";
+
+        ResRefBox.Text = currentResRef;
+        ResRefBox.SelectAll();
+        TagBox.Text = currentTag ?? "";
+        NameBox.Text = currentName ?? "";
+
+        TagPanel.IsVisible = showTagAndName;
+        TagCharCountText.IsVisible = showTagAndName;
+        NamePanel.IsVisible = showTagAndName;
+        InfoTagLine.IsVisible = showTagAndName;
+
+        UpdateValidation();
+    }
+
+    private void OnFieldChanged(object? sender, TextChangedEventArgs e) => UpdateValidation();
+
+    private void OnFieldKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter && CopyButton.IsEnabled)
+        {
+            OnCopyClick(sender, e);
+        }
+        else if (e.Key == Key.Escape)
+        {
+            OnCancelClick(sender, e);
+        }
+    }
+
+    private void UpdateValidation()
+    {
+        var resRef = ResRefBox.Text?.Trim() ?? "";
+        var tag = _showTagAndName ? TagBox.Text ?? "" : null;
+
+        // ResRef char count
+        ResRefCharCountText.Text = $"{resRef.Length} / {AuroraFilenameValidator.MaxFilenameLength} characters";
+        ResRefCharCountText.Foreground = resRef.Length > AuroraFilenameValidator.MaxFilenameLength
+            ? BrushManager.GetErrorBrush()
+            : (this.FindResource("SystemControlForegroundBaseMediumBrush") as IBrush ?? BrushManager.GetDisabledBrush());
+
+        // Tag char count (only meaningful when shown)
+        if (_showTagAndName)
+        {
+            var tagLen = tag?.Length ?? 0;
+            TagCharCountText.Text = $"{tagLen} / {CopyToModuleValidator.MaxTagLength} characters";
+            TagCharCountText.Foreground = tagLen > CopyToModuleValidator.MaxTagLength
+                ? BrushManager.GetErrorBrush()
+                : (this.FindResource("SystemControlForegroundBaseMediumBrush") as IBrush ?? BrushManager.GetDisabledBrush());
+        }
+
+        var result = CopyToModuleValidator.Validate(
+            resRef, tag, _originalResRef, _moduleDirectory, _extension, _showTagAndName);
+
+        if (result.State == CopyToModuleValidationState.Valid)
+        {
+            HideValidation();
+            CopyButton.IsEnabled = true;
+            return;
+        }
+
+        if (result.State == CopyToModuleValidationState.Unchanged)
+        {
+            // Soft state — the user may legitimately want to copy with the same resref
+            // if they're copying into a different context, but duplicate check already
+            // forbids writing over an existing file in this directory. So allow if no dup.
+            ShowValidation(result.Message ?? "", isError: false);
+            CopyButton.IsEnabled = true;
+            return;
+        }
+
+        ShowValidation(result.Message ?? "Invalid input.", isError: true);
+        CopyButton.IsEnabled = false;
+    }
+
+    private void ShowValidation(string message, bool isError)
+    {
+        ValidationText.Text = message;
+        ValidationBorder.IsVisible = true;
+        ValidationBorder.Background = isError
+            ? BrushManager.GetErrorBrush()
+            : (this.FindResource("SystemControlBackgroundBaseLowBrush") as IBrush ?? BrushManager.GetDisabledBrush());
+    }
+
+    private void HideValidation() => ValidationBorder.IsVisible = false;
+
+    private void OnCopyClick(object? sender, RoutedEventArgs e)
+    {
+        var newResRef = ResRefBox.Text?.Trim() ?? "";
+        Result = new CopyToModuleResult(
+            NewResRef: newResRef,
+            NewTag: _showTagAndName ? (TagBox.Text ?? "") : null,
+            NewName: _showTagAndName ? (NameBox.Text ?? "") : null);
+        Close();
+    }
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e)
+    {
+        Result = null;
+        Close();
+    }
+}

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.10.9-alpha] - 2026-04-18
+**Branch**: `fence/issue-2065` | **PR**: #2097
+
+### Copy-to-Module for Items (#1479)
+
+- Right-click any HAK item in the browser → Copy to Module with rename dialog
+- Edit TemplateResRef, Tag, and LocalizedName before writing to module
+- Inherits shared implementation from FileBrowserPanelBase
+
+---
+
 ## [0.10.8-alpha] - 2026-04-09
 **Branch**: `relique/issue-1983` | **PR**: #2044
 

--- a/Relique/Relique/Views/MainWindow.Lifecycle.cs
+++ b/Relique/Relique/Views/MainWindow.Lifecycle.cs
@@ -177,6 +177,12 @@ public partial class MainWindow
         ItemBrowserPanel.FileDeleteRequested += OnItemBrowserFileDeleteRequested;
         ItemBrowserPanel.CollapsedChanged += (_, isCollapsed) => SetItemBrowserPanelVisible(!isCollapsed);
 
+        // Copy-to-Module status feedback (#1479)
+        ItemBrowserPanel.FileCopiedToModule += (_, destPath) =>
+        {
+            UpdateStatus($"Copied to module: {Path.GetFileName(destPath)}");
+        };
+
         UpdateItemBrowserMenuState();
         UnifiedLogger.LogUI(LogLevel.INFO, "ItemBrowserPanel initialized");
     }


### PR DESCRIPTION
## Summary

Sprint #2065 — two Fence items plus cross-tool Copy-to-Module promotion (closes #1479):

- **#2015** — Fix Fence search bar inventory item name resolver race: deferred `searchBar.Initialize()` until after `InitializeServicesAsync()` completes. "club" now finds `nw_wblcl001`.
- **#2017** — New shared `CopyToModuleDialog` in Radoub.UI with editable ResRef/Tag/Name, Aurora filename validation, duplicate detection.
- **#1479** — Promoted Copy-to-Module from `StoreBrowserPanel` into `FileBrowserPanelBase` via virtual hooks (`SupportsCopyToModule`, `SupportsTagNameRename`, `ExtractArchiveBytesAsync`, `ReadSourceMetadataAsync`, `ApplyCopyCustomizationsAsync`, `IsArchiveEntry`). QM creatures, Relique items, and Parley dialogs all inherit it. Parley uses the ResRef-only variant.

Plan: `NonPublic/Plans/2026-04-18-2065-plan.md`.

## Related Issues

- Closes #2065
- Closes #2015
- Closes #2017
- Closes #1479

Follow-up filed: #2106 — Relique needs BIF support in ItemBrowserPanel (gap surfaced during manual testing).

## Test Results

- **Unit tests**: 4346/4346 pass
- **Privacy scan**: clean
- **Tech debt**: 1 warning — `Fence/Views/MainWindow.axaml.cs` 920 lines (under 1000 threshold, no issue required)
- **Theme compat**: 56 pre-existing hardcoded values (none in files touched by this sprint)
- **FlaUI**: not run (user preference — recommended for next session if UI regressions suspected)

## Manual Spot-Checks (done before merge)

- [x] Fence #2015: search "club" in a store with `nw_wblcl001` → hit
- [x] Fence #2017: rename BIF store ResRef/Tag/Name on copy → file appears
- [x] Fence #2017 refresh: Module checkbox checked, new file appears without manual refresh
- [x] QM Copy-to-Module: BIF creature with new tag/name → opens correctly
- [x] Relique Copy-to-Module: HAK item with new tag/name → opens correctly (BIF support tracked in #2106)
- [x] Parley Copy-to-Module: HAK dialog → ResRef-only dialog → file appears
- [x] Cancel behavior: no file written on cancel in any tool

## CHANGELOG

- Fence 0.1.26-alpha
- Quartermaster 0.2.80-alpha
- Relique 0.10.9-alpha
- Parley 0.1.165-alpha

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)