### PR TITLE
[Relique] Sprint: Editor Preview & 2DA-Sourced Categories

### DIFF
--- a/.claude/commands/init-item.md
+++ b/.claude/commands/init-item.md
@@ -80,7 +80,21 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-Cac
 - Overlapping file paths mentioned in body
 - Issues that were closed but reopened as new issues
 
-**If similar issues found**, report to user:
+**If similar issues found**, verify their live state before presenting. The cache only contains OPEN issues, but search matches on body text — so an open sprint issue may reference already-closed child issues.
+
+**Verify state of the current issue AND any referenced issue numbers** (e.g. numbers the target issue's body calls out as work items, dependencies, or parents):
+
+```bash
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Test-IssueState.ps1" -Numbers "1902,1903,1905"
+```
+
+Returns a JSON array with live `state` (OPEN/CLOSED) and `closedAt` for each number. Use this to:
+
+- Flag stale references in the target issue (e.g. a sprint still lists closed children as open)
+- Fail fast if the target issue itself is already CLOSED
+- Tell the user when a match is actually a closed/completed issue
+
+Then report to user:
 
 ```markdown
 ### ⚠️ Potentially Related Issues Found
@@ -88,7 +102,7 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-Cac
 | # | Title | State |
 |---|-------|-------|
 | #123 | [Similar title] | OPEN |
-| #456 | [Related work] | CLOSED |
+| #456 | [Related work] | CLOSED (YYYY-MM-DD) |
 
 Continue anyway? [y/n]
 ```

--- a/.claude/scripts/Test-IssueState.ps1
+++ b/.claude/scripts/Test-IssueState.ps1
@@ -1,0 +1,48 @@
+<#
+.SYNOPSIS
+    Check live open/closed state of one or more GitHub issues.
+
+.DESCRIPTION
+    The github-data.json cache only contains OPEN issues. Search results from
+    Get-CacheData.ps1 may match OPEN issues that *reference* other issues in
+    their body — and those referenced issues may have since been closed.
+
+    This script bypasses the cache and queries gh directly so /init-item can
+    verify state of related issues before presenting them to the user.
+
+.PARAMETER Numbers
+    Comma-separated issue numbers to check (e.g. "1902,1903,1905").
+
+.EXAMPLE
+    .\Test-IssueState.ps1 -Numbers "1902,1903,1905"
+    # Outputs JSON array: [{number:1902, state:"CLOSED", title:"..."}, ...]
+#>
+
+param(
+    [Parameter(Mandatory)]
+    [string]$Numbers
+)
+
+$numberList = $Numbers -split ',' | ForEach-Object { [int]$_.Trim() } | Where-Object { $_ -gt 0 }
+
+$results = @()
+foreach ($n in $numberList) {
+    $json = gh issue view $n --json number,state,title,closedAt 2>$null
+    if ($LASTEXITCODE -eq 0 -and $json) {
+        $results += ($json | ConvertFrom-Json)
+    } else {
+        $results += [PSCustomObject]@{
+            number = $n
+            state = "UNKNOWN"
+            title = $null
+            closedAt = $null
+        }
+    }
+}
+
+if ($results.Count -eq 1) {
+    # Force single-element array in JSON output for consistent parsing
+    "[" + ($results[0] | ConvertTo-Json -Depth 3 -Compress) + "]"
+} else {
+    $results | ConvertTo-Json -Depth 3
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1060,6 +1060,14 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-Cac
 - Summary stats (stale issues, missing labels)
 - Auto-refreshes when >1 hour old
 
+**Verify Live State** (closed issues are not in cache, but their numbers may appear in other issues' bodies):
+
+```bash
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Test-IssueState.ps1" -Numbers "1902,1903,1905"
+```
+
+Returns JSON array with live `state` (OPEN/CLOSED) and `closedAt`. Use when `/init-item` or `/research` surfaces referenced issue numbers that may have been closed since the cache was last written.
+
 **Commands that use cache**: `/backlog`, `/init-item`, `/pre-merge`, `/research`
 
 **Commands that trigger post-mutation refresh**: `/init-item` (after PR create), `/pre-merge` (after tech debt issue create), `/post-merge` (after issue close/comment)

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.10.10-alpha] - 2026-04-18
+**Branch**: `relique/sprint/1905-categories` | **PR**: #TBD
+
+### Sprint: Editor Preview & 2DA-Sourced Categories (#1905)
+
+- Replace hardcoded item property categories with 2DA-sourced data (#1903)
+
+---
+
 ## [0.10.9-alpha] - 2026-04-18
 **Branch**: `fence/issue-2065` | **PR**: #2097
 

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.10.10-alpha] - 2026-04-18
-**Branch**: `relique/sprint/1905-categories` | **PR**: #TBD
+**Branch**: `relique/sprint/1905-categories` | **PR**: #2107
 
 ### Sprint: Editor Preview & 2DA-Sourced Categories (#1905)
 

--- a/Relique/Relique.Tests/Services/PropertyCategoryServiceTests.cs
+++ b/Relique/Relique.Tests/Services/PropertyCategoryServiceTests.cs
@@ -1,0 +1,153 @@
+using ItemEditor.Services;
+
+namespace ItemEditor.Tests.Services;
+
+public class PropertyCategoryServiceTests
+{
+    private static PropertyTypeInfo MakeProp(string label)
+        => new PropertyTypeInfo(0, label, label, null, null, null);
+
+    [Theory]
+    [InlineData("Enhancement", "Bonus/Enhancement")]
+    [InlineData("AttackBonus", "Bonus/Enhancement")]
+    [InlineData("Ability", "Bonus/Enhancement")]
+    [InlineData("Keen", "Bonus/Enhancement")]
+    [InlineData("Mighty", "Bonus/Enhancement")]
+    [InlineData("Damage", "Damage")]
+    [InlineData("Massive_Criticals", "Damage")]
+    [InlineData("Monster_damage", "Damage")]
+    [InlineData("DamageMelee", "Damage")]
+    [InlineData("Armor", "Defense/AC")]
+    [InlineData("ImprovedSavingThrows", "Defense/AC")]
+    [InlineData("ImprovedMagicResist", "Defense/AC")]
+    [InlineData("DamageResist", "Defense/AC")]
+    [InlineData("Immunity", "Defense/AC")]
+    [InlineData("OnHit", "On Hit")]
+    [InlineData("OnMonsterHit", "On Hit")]
+    [InlineData("OnHitCastSpell", "On Hit")]
+    [InlineData("CastSpell", "Cast Spell")]
+    [InlineData("BonusFeats", "Cast Spell")]
+    [InlineData("DecreaseAbilityScore", "Penalty/Decreased")]
+    [InlineData("AttackPenalty", "Penalty/Decreased")]
+    [InlineData("DamagePenalty", "Penalty/Decreased")]
+    [InlineData("Damage_Vulnerability", "Penalty/Decreased")]
+    [InlineData("Skill", "Skill/Ability")]
+    [InlineData("UseLimitationClass", "Use Limitation")]
+    [InlineData("UseLimitationRacial", "Use Limitation")]
+    [InlineData("Regeneration", "Miscellaneous")]
+    [InlineData("Haste", "Miscellaneous")]
+    [InlineData("HolyAvenger", "Miscellaneous")]
+    [InlineData("Trap", "Miscellaneous")]
+    public void IsInCategory_known_stock_label_returns_true_for_expected_category(string label, string expected)
+    {
+        var svc = new PropertyCategoryService();
+        Assert.True(svc.IsInCategory(MakeProp(label), expected));
+    }
+
+    [Fact]
+    public void IsInCategory_known_stock_label_returns_false_for_other_categories()
+    {
+        var svc = new PropertyCategoryService();
+        var prop = MakeProp("Damage");
+        Assert.False(svc.IsInCategory(prop, "Defense/AC"));
+        Assert.False(svc.IsInCategory(prop, "Miscellaneous"));
+        Assert.False(svc.IsInCategory(prop, PropertyCategoryService.OtherCategory));
+    }
+
+    [Fact]
+    public void IsInCategory_unmapped_label_returns_true_for_Other_only()
+    {
+        var svc = new PropertyCategoryService();
+        var prop = MakeProp("CEP_CUSTOM_PROPERTY_XYZ");
+
+        Assert.True(svc.IsInCategory(prop, PropertyCategoryService.OtherCategory));
+        Assert.False(svc.IsInCategory(prop, "Damage"));
+        Assert.False(svc.IsInCategory(prop, "Bonus/Enhancement"));
+    }
+
+    [Fact]
+    public void IsInCategory_empty_label_treated_as_Other()
+    {
+        var svc = new PropertyCategoryService();
+        var prop = MakeProp("");
+
+        Assert.True(svc.IsInCategory(prop, PropertyCategoryService.OtherCategory));
+        Assert.False(svc.IsInCategory(prop, "Damage"));
+    }
+
+    [Fact]
+    public void IsInCategory_is_case_insensitive()
+    {
+        var svc = new PropertyCategoryService();
+        Assert.True(svc.IsInCategory(MakeProp("enhancement"), "Bonus/Enhancement"));
+        Assert.True(svc.IsInCategory(MakeProp("ENHANCEMENT"), "Bonus/Enhancement"));
+        Assert.True(svc.IsInCategory(MakeProp("EnHaNcEmEnT"), "Bonus/Enhancement"));
+    }
+
+    [Fact]
+    public void GetCategoryNames_hides_empty_buckets()
+    {
+        var svc = new PropertyCategoryService();
+        var props = new[]
+        {
+            MakeProp("Damage"),
+            MakeProp("Regeneration"),
+        };
+
+        var result = svc.GetCategoryNames(props);
+
+        Assert.Equal(new[] { "Damage", "Miscellaneous" }, result);
+    }
+
+    [Fact]
+    public void GetCategoryNames_includes_Other_when_unmapped_present()
+    {
+        var svc = new PropertyCategoryService();
+        var props = new[]
+        {
+            MakeProp("Damage"),
+            MakeProp("CEP_CUSTOM_UNKNOWN"),
+        };
+
+        var result = svc.GetCategoryNames(props);
+
+        Assert.Contains(PropertyCategoryService.OtherCategory, result);
+        Assert.Contains("Damage", result);
+    }
+
+    [Fact]
+    public void GetCategoryNames_preserves_fixed_display_order()
+    {
+        var svc = new PropertyCategoryService();
+        // One property per canonical bucket, listed out of order
+        var props = new[]
+        {
+            MakeProp("CEP_CUSTOM_UNKNOWN"),      // Other
+            MakeProp("Regeneration"),            // Miscellaneous
+            MakeProp("UseLimitationClass"),      // Use Limitation
+            MakeProp("Skill"),                   // Skill/Ability
+            MakeProp("DecreaseAC"),              // Penalty/Decreased
+            MakeProp("CastSpell"),               // Cast Spell
+            MakeProp("OnHit"),                   // On Hit
+            MakeProp("Armor"),                   // Defense/AC
+            MakeProp("Damage"),                  // Damage
+            MakeProp("Enhancement"),             // Bonus/Enhancement
+        };
+
+        var result = svc.GetCategoryNames(props);
+
+        Assert.Equal(new[]
+        {
+            "Bonus/Enhancement",
+            "Damage",
+            "Defense/AC",
+            "On Hit",
+            "Cast Spell",
+            "Penalty/Decreased",
+            "Skill/Ability",
+            "Use Limitation",
+            "Miscellaneous",
+            PropertyCategoryService.OtherCategory,
+        }, result);
+    }
+}

--- a/Relique/Relique/Services/PropertyCategoryService.cs
+++ b/Relique/Relique/Services/PropertyCategoryService.cs
@@ -1,0 +1,174 @@
+using Radoub.Formats.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ItemEditor.Services;
+
+/// <summary>
+/// Maps itempropdef.2da Labels to curated display categories.
+/// Unmapped labels (custom content: CEP, PRC, etc.) fall into "Other".
+/// </summary>
+public sealed class PropertyCategoryService
+{
+    public const string OtherCategory = "Other";
+
+    private static readonly string[] DisplayOrder =
+    {
+        "Bonus/Enhancement",
+        "Damage",
+        "Defense/AC",
+        "On Hit",
+        "Cast Spell",
+        "Penalty/Decreased",
+        "Skill/Ability",
+        "Use Limitation",
+        "Miscellaneous",
+        OtherCategory,
+    };
+
+    private static readonly Dictionary<string, string> LabelToCategory = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Bonus/Enhancement
+        { "Enhancement", "Bonus/Enhancement" },
+        { "EnhancementAlignmentGroup", "Bonus/Enhancement" },
+        { "EnhancementRacialGroup", "Bonus/Enhancement" },
+        { "EnhancementSpecificAlignment", "Bonus/Enhancement" },
+        { "AttackBonus", "Bonus/Enhancement" },
+        { "AttackBonusAlignmentGroup", "Bonus/Enhancement" },
+        { "AttackBonusRacialGroup", "Bonus/Enhancement" },
+        { "AttackBonusSpecificAlignment", "Bonus/Enhancement" },
+        { "Ability", "Bonus/Enhancement" },
+        { "Keen", "Bonus/Enhancement" },
+        { "Mighty", "Bonus/Enhancement" },
+
+        // Damage
+        { "Damage", "Damage" },
+        { "DamageAlignmentGroup", "Damage" },
+        { "DamageRacialGroup", "Damage" },
+        { "DamageSpecificAlignment", "Damage" },
+        { "DamageMelee", "Damage" },
+        { "DamageRanged", "Damage" },
+        { "Massive_Criticals", "Damage" },
+        { "Monster_damage", "Damage" },
+        { "Wounding", "Damage" },
+        { "Vorpal", "Damage" },
+
+        // Defense/AC
+        { "Armor", "Defense/AC" },
+        { "ArmorAlignmentGroup", "Defense/AC" },
+        { "ArmorDamageType", "Defense/AC" },
+        { "ArmorRacialGroup", "Defense/AC" },
+        { "ArmorSpecificAlignment", "Defense/AC" },
+        { "ImprovedSavingThrows", "Defense/AC" },
+        { "ImprovedSavingThrowsSpecific", "Defense/AC" },
+        { "ImprovedMagicResist", "Defense/AC" },
+        { "DamageImmunity", "Defense/AC" },
+        { "Immunity", "Defense/AC" },
+        { "Immunity_To_Spell_By_Level", "Defense/AC" },
+        { "SpellImmunity_Specific", "Defense/AC" },
+        { "SpellSchool_Immunity", "Defense/AC" },
+        { "DamageReduced", "Defense/AC" },
+        { "DamageResist", "Defense/AC" },
+        { "MindBlank", "Defense/AC" },
+        { "Turn_Resistance", "Defense/AC" },
+        { "ImprovedEvasion", "Defense/AC" },
+
+        // On Hit
+        { "OnHit", "On Hit" },
+        { "OnMonsterHit", "On Hit" },
+        { "OnHitCastSpell", "On Hit" },
+
+        // Cast Spell
+        { "CastSpell", "Cast Spell" },
+        { "BonusFeats", "Cast Spell" },
+        { "SingleBonusSpellOfLevel", "Cast Spell" },
+
+        // Penalty/Decreased
+        { "DecreaseAbilityScore", "Penalty/Decreased" },
+        { "DecreaseAC", "Penalty/Decreased" },
+        { "AttackPenalty", "Penalty/Decreased" },
+        { "ToHitPenalty", "Penalty/Decreased" },
+        { "DamagePenalty", "Penalty/Decreased" },
+        { "DamageNone", "Penalty/Decreased" },
+        { "Damage_Vulnerability", "Penalty/Decreased" },
+        { "ReducedSavingThrows", "Penalty/Decreased" },
+        { "ReducedSpecificSavingThrow", "Penalty/Decreased" },
+        { "DecreasedSkill", "Penalty/Decreased" },
+        { "Value_Decrease", "Penalty/Decreased" },
+
+        // Skill/Ability
+        { "Skill", "Skill/Ability" },
+
+        // Use Limitation
+        { "UseLimitationAlignmentGroup", "Use Limitation" },
+        { "UseLimitationClass", "Use Limitation" },
+        { "UseLimitationGender", "Use Limitation" },
+        { "UseLimitationRacial", "Use Limitation" },
+        { "UseLimitationSpecificAlignment", "Use Limitation" },
+        { "UseLimitationTerrain", "Use Limitation" },
+
+        // Miscellaneous
+        { "Regeneration", "Miscellaneous" },
+        { "VampiricRegeneration", "Miscellaneous" },
+        { "Haste", "Miscellaneous" },
+        { "Darkvision", "Miscellaneous" },
+        { "Light", "Miscellaneous" },
+        { "True_Seeing", "Miscellaneous" },
+        { "Freedom_of_Movement", "Miscellaneous" },
+        { "Trap", "Miscellaneous" },
+        { "Poison", "Miscellaneous" },
+        { "VisualEffect", "Miscellaneous" },
+        { "Weight_Increase", "Miscellaneous" },
+        { "WeightReduction", "Miscellaneous" },
+        { "Material", "Miscellaneous" },
+        { "Quality", "Miscellaneous" },
+        { "Additional_Property", "Miscellaneous" },
+        { "UnlimitedAmmo", "Miscellaneous" },
+        { "Special_Walk", "Miscellaneous" },
+        { "Healers_Kit", "Miscellaneous" },
+        { "ThievesTools", "Miscellaneous" },
+        { "HolyAvenger", "Miscellaneous" },
+        { "ArcaneSpellFailure", "Miscellaneous" },
+        { "Boomerang", "Miscellaneous" },
+        { "Dancing_Scimitar", "Miscellaneous" },
+        { "DoubleStack", "Miscellaneous" },
+        { "EnhancedContainer_BonusSlot", "Miscellaneous" },
+        { "EnhancedContainer_Weight", "Miscellaneous" },
+        { "Value_Increase", "Miscellaneous" },
+    };
+
+    private readonly HashSet<string> _loggedUnmappedLabels = new(StringComparer.OrdinalIgnoreCase);
+
+    public IReadOnlyList<string> GetCategoryNames(IEnumerable<PropertyTypeInfo> availableProperties)
+    {
+        var presentCategories = new HashSet<string>();
+        foreach (var prop in availableProperties)
+        {
+            presentCategories.Add(Resolve(prop.Label));
+        }
+
+        return DisplayOrder.Where(presentCategories.Contains).ToList();
+    }
+
+    public bool IsInCategory(PropertyTypeInfo prop, string categoryName)
+    {
+        return string.Equals(Resolve(prop.Label), categoryName, StringComparison.Ordinal);
+    }
+
+    private string Resolve(string? label)
+    {
+        if (string.IsNullOrWhiteSpace(label))
+            return OtherCategory;
+
+        if (LabelToCategory.TryGetValue(label, out var category))
+            return category;
+
+        if (_loggedUnmappedLabels.Add(label))
+        {
+            UnifiedLogger.LogApplication(LogLevel.DEBUG, $"PropertyCategoryService: unmapped Label '{label}' -> Other");
+        }
+
+        return OtherCategory;
+    }
+}

--- a/Relique/Relique/Views/MainWindow.ItemProperties.cs
+++ b/Relique/Relique/Views/MainWindow.ItemProperties.cs
@@ -14,7 +14,6 @@ public partial class MainWindow
     // --- Item Properties UI ---
 
     private string? _selectedCategory;
-    private Dictionary<string, string[]> _categoryKeywords = new();
 
     private void InitializePropertySearchHandler()
     {
@@ -27,26 +26,15 @@ public partial class MainWindow
         CategoryFilterComboBox.Items.Clear();
         CategoryFilterComboBox.Items.Add(new ComboBoxItem { Content = "All Categories", Tag = (string?)null });
 
-        // Categories based on common item property groupings from nwscript.nss
-        var categories = new (string Label, string[] Keywords)[]
+        if (_itemPropertyService != null)
         {
-            ("Bonus/Enhancement", new[] { "Bonus", "Enhancement", "Mighty", "Keen" }),
-            ("Damage", new[] { "Damage", "Massive Critical" }),
-            ("Defense/AC", new[] { "AC", "Saving Throw", "Spell Resistance", "Immunity", "Damage Reduction", "Damage Resistance" }),
-            ("On Hit", new[] { "On Hit", "On Monster" }),
-            ("Cast Spell", new[] { "Cast Spell" }),
-            ("Penalty/Decreased", new[] { "Decreased", "Vulnerability", "No Damage" }),
-            ("Skill/Ability", new[] { "Skill", "Ability" }),
-            ("Use Limitation", new[] { "Use Limitation" }),
-            ("Miscellaneous", new[] { "Regeneration", "Haste", "Darkvision", "Light", "True Seeing", "Freedom", "Trap", "Poison", "Visual", "Weight", "Material", "Quality" }),
-        };
-
-        foreach (var (label, _) in categories)
-        {
-            CategoryFilterComboBox.Items.Add(new ComboBoxItem { Content = label, Tag = label });
+            var availableProps = _itemPropertyService.GetAvailablePropertyTypes();
+            foreach (var category in _categoryService.GetCategoryNames(availableProps))
+            {
+                CategoryFilterComboBox.Items.Add(new ComboBoxItem { Content = category, Tag = category });
+            }
         }
 
-        _categoryKeywords = categories.ToDictionary(c => c.Label, c => c.Keywords);
         CategoryFilterComboBox.SelectedIndex = 0;
         CategoryFilterComboBox.SelectionChanged += OnCategoryFilterChanged;
     }
@@ -65,11 +53,9 @@ public partial class MainWindow
             : _itemPropertyService.SearchProperties(searchFilter);
 
         // Apply category filter
-        if (_selectedCategory != null && _categoryKeywords.TryGetValue(_selectedCategory, out var keywords))
+        if (_selectedCategory != null)
         {
-            types = types.Where(t =>
-                keywords.Any(k => t.DisplayName.Contains(k, StringComparison.OrdinalIgnoreCase)))
-                .ToList();
+            types = types.Where(t => _categoryService.IsInCategory(t, _selectedCategory)).ToList();
         }
 
         // Filter by base item type: only show properties valid for the current base item (#1972)

--- a/Relique/Relique/Views/MainWindow.axaml.cs
+++ b/Relique/Relique/Views/MainWindow.axaml.cs
@@ -26,6 +26,7 @@ public partial class MainWindow : Window, INotifyPropertyChanged
     private List<BaseItemTypeInfo>? _baseItemTypes;
     private List<PaletteCategory> _paletteCategories = new();
     private ItemPropertyService? _itemPropertyService;
+    private readonly PropertyCategoryService _categoryService = new();
     private ItemStatisticsService? _itemStatisticsService;
     private PropertyTypeInfo? _selectedPropertyType;
     private int _editingPropertyIndex = -1; // -1 = add mode, >= 0 = editing that index


### PR DESCRIPTION
## Summary

Sprint #1905 — replace hardcoded item property category keywords with Label-keyed 2DA-sourced data for custom content compatibility (CEP, PRC). Adds a new `PropertyCategoryService` that maps each property's `itempropdef.2da` Label to a curated category; unmapped labels fall into a new "Other" bucket so custom content remains visible when filtered.

Also includes a tooling fix discovered during init: new `Test-IssueState.ps1` script verifies live open/closed state of related issues (the cache only contains OPEN issues, so closed sprint children were being surfaced as potential duplicates).

Note: Sprint companion issue #1902 (item appearance/icon preview) was already completed in #2044 (merged 2026-04-10), so this sprint PR covers only the remaining #1903 refactor.

## Related Issues

- Closes #1903
- Closes #1905

## Implementation

- New `PropertyCategoryService` in `Relique/Relique/Services/` — case-insensitive Label→Category map, 89 stock NWN labels seeded from live `itempropdef.2da` dump
- `MainWindow.ItemProperties.cs`: removed `_categoryKeywords` dictionary and keyword-matching lambda; `InitializeCategoryFilter` and the filter predicate both call into the service
- Canonical category order: Bonus/Enhancement, Damage, Defense/AC, On Hit, Cast Spell, Penalty/Decreased, Skill/Ability, Use Limitation, Miscellaneous, Other
- Categories with no matching properties are hidden from the dropdown (e.g. Other appears only when CEP/PRC content is loaded)

## Tests

- 30 new tests in `PropertyCategoryServiceTests.cs` (Theory-driven for stock labels, Facts for ordering, case-insensitivity, Other bucket, empty-bucket hiding)
- All 290 Relique unit tests pass
- Manual verification: category dropdown tested in running app against LNS_DLG (non-CEP module)

## Checklist

- [x] Implementation complete
- [x] Tests added/updated
- [x] CHANGELOG updated with date
- [x] Manual verification in running app
- [x] No pre-existing tests broken
- [x] PR marked ready for review (after /pre-merge)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)