### PR TITLE
[Parley] Sprint: FlowView & Focus Bug Fixes (#2063)

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Parley. One-line highlights per version; full details in 
 ---
 
 ## [0.1.166-alpha] - 2026-04-18
-**Branch**: `parley/issue-2063` | **PR**: #TBD
+**Branch**: `parley/issue-2063` | **PR**: #2108
 
 ### Sprint: FlowView & Focus Bug Fixes (#2063)
 - Side-by-side view opens centered and self-heals corrupt window settings (#2049)

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Parley. One-line highlights per version; full details in 
 
 ---
 
+## [0.1.166-alpha] - 2026-04-18
+**Branch**: `parley/issue-2063` | **PR**: #TBD
+
+### Sprint: FlowView & Focus Bug Fixes (#2063)
+- Side-by-side view opens centered and self-heals corrupt window settings (#2049)
+- Token insertion keeps focus on text field; text-only edits no longer rebuild the tree (#2032)
+- FlowView supports drag-to-root parity with TreeView via shared drag-drop validator (#2060)
+
+---
+
 ## [0.1.165-alpha] - 2026-04-18 | PR #2097
 **Branch**: `fence/issue-2065`
 

--- a/Parley/Parley.Tests/DialogChangeKindTests.cs
+++ b/Parley/Parley.Tests/DialogChangeKindTests.cs
@@ -1,0 +1,86 @@
+using DialogEditor.Models;
+using DialogEditor.Services;
+using Xunit;
+
+namespace Parley.Tests
+{
+    /// <summary>
+    /// Tests for DialogChangeKind — the gate that lets text-only edits update
+    /// visible labels without forcing a full tree/flow rebuild (#2032).
+    /// </summary>
+    public class DialogChangeKindTests
+    {
+        [Fact]
+        public void DialogChangeEventArgs_DefaultsChangeKindToStructural()
+        {
+            // Arrange: construct an event args using the existing minimal ctor.
+            // Back-compat: callers that don't pass a kind must still get Structural
+            // behavior so existing rebuild paths keep working.
+            var args = new DialogChangeEventArgs(DialogChangeType.NodeModified);
+
+            // Assert
+            Assert.Equal(DialogChangeKind.Structural, args.ChangeKind);
+        }
+
+        [Fact]
+        public void DialogChangeEventArgs_AcceptsTextOnlyChangeKind()
+        {
+            // Arrange
+            var args = new DialogChangeEventArgs(
+                DialogChangeType.NodeModified,
+                changeKind: DialogChangeKind.TextOnly);
+
+            // Assert
+            Assert.Equal(DialogChangeKind.TextOnly, args.ChangeKind);
+        }
+
+        [Fact]
+        public void PublishNodeModified_WithoutKind_DefaultsToStructural()
+        {
+            // Arrange
+            var bus = DialogChangeEventBus.Instance;
+            DialogChangeEventArgs? received = null;
+            void Handler(object? s, DialogChangeEventArgs e) => received = e;
+            bus.DialogChanged += Handler;
+
+            try
+            {
+                // Act: existing call shape must keep working
+                bus.PublishNodeModified(new DialogNode(), "TextChanged");
+
+                // Assert
+                Assert.NotNull(received);
+                Assert.Equal(DialogChangeType.NodeModified, received!.ChangeType);
+                Assert.Equal(DialogChangeKind.Structural, received.ChangeKind);
+            }
+            finally
+            {
+                bus.DialogChanged -= Handler;
+            }
+        }
+
+        [Fact]
+        public void PublishNodeModified_WithTextOnlyKind_PropagatesKind()
+        {
+            // Arrange
+            var bus = DialogChangeEventBus.Instance;
+            DialogChangeEventArgs? received = null;
+            void Handler(object? s, DialogChangeEventArgs e) => received = e;
+            bus.DialogChanged += Handler;
+
+            try
+            {
+                // Act
+                bus.PublishNodeModified(new DialogNode(), "TextChanged", DialogChangeKind.TextOnly);
+
+                // Assert
+                Assert.NotNull(received);
+                Assert.Equal(DialogChangeKind.TextOnly, received!.ChangeKind);
+            }
+            finally
+            {
+                bus.DialogChanged -= Handler;
+            }
+        }
+    }
+}

--- a/Parley/Parley.Tests/DialogDragDropValidatorTests.cs
+++ b/Parley/Parley.Tests/DialogDragDropValidatorTests.cs
@@ -1,0 +1,175 @@
+using DialogEditor.Models;
+using DialogEditor.Services;
+using Xunit;
+
+namespace Parley.Tests
+{
+    /// <summary>
+    /// Tests the shared drag-drop validator that governs "drop as child of target"
+    /// (Into) and "drop to root" (target == null) decisions for both TreeView and
+    /// FlowView (#2060).
+    ///
+    /// Scoped to the Into + null-target case; Before/After sibling-reorder remains
+    /// in each view's own path for now (see follow-up #2109).
+    /// </summary>
+    public class DialogDragDropValidatorTests
+    {
+        // --- Helpers -----------------------------------------------------------
+
+        private static Dialog BuildDialog(out DialogNode entry, out DialogNode reply)
+        {
+            var dialog = new Dialog();
+
+            entry = dialog.CreateNode(DialogNodeType.Entry)!;
+            entry.Text.Add(0, "Entry");
+            dialog.AddNodeInternal(entry, entry.Type);
+
+            var start = dialog.CreatePtr()!;
+            start.Node = entry;
+            start.Type = DialogNodeType.Entry;
+            start.Index = 0;
+            start.IsStart = true;
+            dialog.Starts.Add(start);
+
+            reply = dialog.CreateNode(DialogNodeType.Reply)!;
+            reply.Text.Add(0, "Reply");
+            dialog.AddNodeInternal(reply, reply.Type);
+
+            var ptr = dialog.CreatePtr()!;
+            ptr.Node = reply;
+            ptr.Type = DialogNodeType.Reply;
+            ptr.Index = 0;
+            entry.Pointers.Add(ptr);
+
+            return dialog;
+        }
+
+        // --- Drop-to-root (target == null) ------------------------------------
+
+        [Fact]
+        public void DropEntryOnRoot_IsValid()
+        {
+            // Arrange
+            var dialog = BuildDialog(out var entry, out _);
+            var newEntry = dialog.CreateNode(DialogNodeType.Entry)!;
+            newEntry.Text.Add(0, "New Entry");
+            dialog.AddNodeInternal(newEntry, newEntry.Type);
+
+            // Act
+            var result = DialogDragDropValidator.ValidateReparent(newEntry, target: null, dialog);
+
+            // Assert
+            Assert.True(result.IsValid);
+            Assert.Equal(DropTargetKind.Root, result.TargetKind);
+            Assert.Null(result.RejectReason);
+        }
+
+        [Fact]
+        public void DropReplyOnRoot_IsInvalid_WithReason()
+        {
+            // Arrange
+            var dialog = BuildDialog(out _, out var reply);
+
+            // Act: Reply cannot be a root — only NPC Entries are valid starts
+            var result = DialogDragDropValidator.ValidateReparent(reply, target: null, dialog);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Equal(DropTargetKind.Root, result.TargetKind);
+            Assert.NotNull(result.RejectReason);
+        }
+
+        // --- Drop-on-self ------------------------------------------------------
+
+        [Fact]
+        public void DropOnSelf_IsInvalid()
+        {
+            // Arrange
+            var dialog = BuildDialog(out var entry, out _);
+
+            // Act
+            var result = DialogDragDropValidator.ValidateReparent(entry, target: entry, dialog);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.NotNull(result.RejectReason);
+        }
+
+        // --- Circular reference -----------------------------------------------
+
+        [Fact]
+        public void DropOnDescendant_IsInvalid_CircularReference()
+        {
+            // Arrange: entry → reply → childEntry (3-deep chain)
+            var dialog = BuildDialog(out var entry, out var reply);
+            var childEntry = dialog.CreateNode(DialogNodeType.Entry)!;
+            childEntry.Text.Add(0, "Child Entry");
+            dialog.AddNodeInternal(childEntry, childEntry.Type);
+            var ptr = dialog.CreatePtr()!;
+            ptr.Node = childEntry;
+            ptr.Type = DialogNodeType.Entry;
+            ptr.Index = 0;
+            reply.Pointers.Add(ptr);
+
+            // Act: dragging entry onto its own descendant childEntry would create a cycle
+            var result = DialogDragDropValidator.ValidateReparent(entry, target: childEntry, dialog);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.NotNull(result.RejectReason);
+        }
+
+        // --- NPC / PC placement rules -----------------------------------------
+
+        [Fact]
+        public void DropEntryOnEntry_IsInvalid()
+        {
+            // Arrange: two root-level Entry nodes
+            var dialog = BuildDialog(out var entry, out _);
+            var other = dialog.CreateNode(DialogNodeType.Entry)!;
+            other.Text.Add(0, "Other Entry");
+            dialog.AddNodeInternal(other, other.Type);
+
+            // Act: Entry cannot be a child of an Entry (parent/child types must alternate)
+            var result = DialogDragDropValidator.ValidateReparent(entry, target: other, dialog);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.NotNull(result.RejectReason);
+        }
+
+        [Fact]
+        public void DropReplyOnEntry_IsValid()
+        {
+            // Arrange: new Reply, existing Entry target
+            var dialog = BuildDialog(out var entry, out _);
+            var newReply = dialog.CreateNode(DialogNodeType.Reply)!;
+            newReply.Text.Add(0, "New Reply");
+            dialog.AddNodeInternal(newReply, newReply.Type);
+
+            // Act
+            var result = DialogDragDropValidator.ValidateReparent(newReply, target: entry, dialog);
+
+            // Assert
+            Assert.True(result.IsValid);
+            Assert.Equal(DropTargetKind.Node, result.TargetKind);
+        }
+
+        [Fact]
+        public void DropEntryOnReply_IsValid()
+        {
+            // Arrange
+            var dialog = BuildDialog(out _, out var reply);
+            var newEntry = dialog.CreateNode(DialogNodeType.Entry)!;
+            newEntry.Text.Add(0, "New Entry");
+            dialog.AddNodeInternal(newEntry, newEntry.Type);
+
+            // Act
+            var result = DialogDragDropValidator.ValidateReparent(newEntry, target: reply, dialog);
+
+            // Assert
+            Assert.True(result.IsValid);
+            Assert.Equal(DropTargetKind.Node, result.TargetKind);
+        }
+    }
+}

--- a/Parley/Parley.Tests/DragDropParityIntegrationTests.cs
+++ b/Parley/Parley.Tests/DragDropParityIntegrationTests.cs
@@ -1,0 +1,121 @@
+using DialogEditor.Models;
+using DialogEditor.Services;
+using Xunit;
+
+namespace Parley.Tests
+{
+    /// <summary>
+    /// Integration test for TreeView/FlowView drag-drop parity (#2060).
+    ///
+    /// Exercises the shared DialogDragDropValidator with scenarios both views hit
+    /// and asserts identical Accept/Reject decisions — no Avalonia UI, service-level
+    /// wiring only.
+    /// </summary>
+    public class DragDropParityIntegrationTests
+    {
+        private static Dialog BuildDialog(out DialogNode entry, out DialogNode reply)
+        {
+            var dialog = new Dialog();
+
+            entry = dialog.CreateNode(DialogNodeType.Entry)!;
+            entry.Text.Add(0, "Entry");
+            dialog.AddNodeInternal(entry, entry.Type);
+
+            var start = dialog.CreatePtr()!;
+            start.Node = entry;
+            start.Type = DialogNodeType.Entry;
+            start.Index = 0;
+            start.IsStart = true;
+            dialog.Starts.Add(start);
+
+            reply = dialog.CreateNode(DialogNodeType.Reply)!;
+            reply.Text.Add(0, "Reply");
+            dialog.AddNodeInternal(reply, reply.Type);
+
+            var ptr = dialog.CreatePtr()!;
+            ptr.Node = reply;
+            ptr.Type = DialogNodeType.Reply;
+            ptr.Index = 0;
+            entry.Pointers.Add(ptr);
+
+            return dialog;
+        }
+
+        [Fact]
+        public void DragToRoot_AcceptDecision_IsTheSameForBothViews()
+        {
+            // Arrange: a loose Entry that either view could drag to the background
+            var dialog = BuildDialog(out _, out _);
+            var orphan = dialog.CreateNode(DialogNodeType.Entry)!;
+            orphan.Text.Add(0, "Orphan Entry");
+            dialog.AddNodeInternal(orphan, orphan.Type);
+
+            // Act: both views ultimately route through the same validator for the Into/Root decision
+            var treeViewDecision = DialogDragDropValidator.ValidateReparent(orphan, target: null, dialog);
+            var flowViewDecision = DialogDragDropValidator.ValidateReparent(orphan, target: null, dialog);
+
+            // Assert: identical outcome
+            Assert.Equal(treeViewDecision.IsValid, flowViewDecision.IsValid);
+            Assert.Equal(treeViewDecision.TargetKind, flowViewDecision.TargetKind);
+            Assert.True(treeViewDecision.IsValid);
+        }
+
+        [Fact]
+        public void DragReplyToRoot_RejectDecision_IsTheSameForBothViews()
+        {
+            // Arrange
+            var dialog = BuildDialog(out _, out var reply);
+
+            // Act
+            var treeViewDecision = DialogDragDropValidator.ValidateReparent(reply, target: null, dialog);
+            var flowViewDecision = DialogDragDropValidator.ValidateReparent(reply, target: null, dialog);
+
+            // Assert: both reject, both give a reason
+            Assert.False(treeViewDecision.IsValid);
+            Assert.False(flowViewDecision.IsValid);
+            Assert.Equal(treeViewDecision.RejectReason, flowViewDecision.RejectReason);
+        }
+
+        [Fact]
+        public void DragCircular_RejectDecision_IsTheSameForBothViews()
+        {
+            // Arrange: entry → reply → childEntry; drag entry onto its own descendant
+            var dialog = BuildDialog(out var entry, out var reply);
+            var childEntry = dialog.CreateNode(DialogNodeType.Entry)!;
+            childEntry.Text.Add(0, "Child Entry");
+            dialog.AddNodeInternal(childEntry, childEntry.Type);
+            var ptr = dialog.CreatePtr()!;
+            ptr.Node = childEntry;
+            ptr.Type = DialogNodeType.Entry;
+            ptr.Index = 0;
+            reply.Pointers.Add(ptr);
+
+            // Act
+            var treeViewDecision = DialogDragDropValidator.ValidateReparent(entry, target: childEntry, dialog);
+            var flowViewDecision = DialogDragDropValidator.ValidateReparent(entry, target: childEntry, dialog);
+
+            // Assert: both views refuse the circular drop for the same reason
+            Assert.False(treeViewDecision.IsValid);
+            Assert.False(flowViewDecision.IsValid);
+            Assert.Equal(treeViewDecision.RejectReason, flowViewDecision.RejectReason);
+        }
+
+        [Fact]
+        public void DragValidReply_OntoEntry_BothViewsAccept()
+        {
+            // Arrange
+            var dialog = BuildDialog(out var entry, out _);
+            var newReply = dialog.CreateNode(DialogNodeType.Reply)!;
+            newReply.Text.Add(0, "New Reply");
+            dialog.AddNodeInternal(newReply, newReply.Type);
+
+            // Act
+            var treeViewDecision = DialogDragDropValidator.ValidateReparent(newReply, target: entry, dialog);
+            var flowViewDecision = DialogDragDropValidator.ValidateReparent(newReply, target: entry, dialog);
+
+            // Assert
+            Assert.True(treeViewDecision.IsValid);
+            Assert.True(flowViewDecision.IsValid);
+        }
+    }
+}

--- a/Parley/Parley.Tests/PanelWidthClamperTests.cs
+++ b/Parley/Parley.Tests/PanelWidthClamperTests.cs
@@ -1,0 +1,93 @@
+using DialogEditor.Services;
+using Xunit;
+
+namespace Parley.Tests
+{
+    /// <summary>
+    /// Tests for PanelWidthClamper — ensures the side-by-side flowchart panel
+    /// never restores to an off-screen or unusable width (#2049).
+    /// </summary>
+    public class PanelWidthClamperTests
+    {
+        // Contract (from sprint plan #2063 / #2049):
+        //   Reset-if-invalid: storedWidth < 100 OR storedWidth > 0.95 * windowWidth -> 0.50 * windowWidth
+        //   Belt-and-suspenders clamp: min(max(width, 200), windowWidth - 400)
+        //
+        //   Net effect per (storedWidth, windowWidth):
+        //     valid range  = [100, 0.95 * windowWidth] and [200, windowWidth - 400] after clamp
+        //     reset path   = chooses 0.50 * windowWidth, then clamps to same hard bounds
+
+        [Fact]
+        public void ReturnsStoredWidth_WhenInValidRange()
+        {
+            // Arrange: stored width sits squarely inside both reset-valid and hard-clamp ranges
+            double storedWidth = 500;
+            double windowWidth = 1600;
+
+            // Act
+            var result = PanelWidthClamper.Clamp(storedWidth, windowWidth);
+
+            // Assert
+            Assert.Equal(500, result);
+        }
+
+        [Fact]
+        public void ResetsToHalfWidth_WhenStoredBelowMinimum()
+        {
+            // Arrange: stored width is corrupt-low (< 100)
+            double storedWidth = 10;
+            double windowWidth = 1600;
+
+            // Act
+            var result = PanelWidthClamper.Clamp(storedWidth, windowWidth);
+
+            // Assert: resets to 50% of window (800), which is also inside hard-clamp bounds
+            Assert.Equal(800, result);
+        }
+
+        [Fact]
+        public void ResetsToHalfWidth_WhenStoredExceeds95Percent()
+        {
+            // Arrange: stored width is corrupt-high (> 95% of window)
+            double storedWidth = 1580; // 98.75% of 1600
+            double windowWidth = 1600;
+
+            // Act
+            var result = PanelWidthClamper.Clamp(storedWidth, windowWidth);
+
+            // Assert: resets to 50% of window
+            Assert.Equal(800, result);
+        }
+
+        [Fact]
+        public void ClampsToMin200_WhenWindowTooSmall()
+        {
+            // Arrange: tiny window where 50% reset would still be below hard min 200
+            // Window = 300, reset would be 150, hard min is 200
+            double storedWidth = 50; // triggers reset path
+            double windowWidth = 300;
+
+            // Act
+            var result = PanelWidthClamper.Clamp(storedWidth, windowWidth);
+
+            // Assert: clamped up to hard min 200
+            Assert.Equal(200, result);
+        }
+
+        [Fact]
+        public void ClampsToMaxLeavingLeftPanel_WhenWindowShrinks()
+        {
+            // Arrange: valid stored width, but window shrinks so stored > windowWidth - 400
+            // storedWidth 900, windowWidth 1000 -> hard max is 1000 - 400 = 600
+            // 900 is inside reset-valid range (< 95% of 1000 = 950), so we reach the clamp
+            double storedWidth = 900;
+            double windowWidth = 1000;
+
+            // Act
+            var result = PanelWidthClamper.Clamp(storedWidth, windowWidth);
+
+            // Assert: clamped down to windowWidth - 400
+            Assert.Equal(600, result);
+        }
+    }
+}

--- a/Parley/Parley.Tests/TreeViewSafeNodeBindingTests.cs
+++ b/Parley/Parley.Tests/TreeViewSafeNodeBindingTests.cs
@@ -1,0 +1,40 @@
+using DialogEditor.Models;
+using Xunit;
+
+namespace Parley.Tests
+{
+    /// <summary>
+    /// Tests that TreeViewSafeNode can refresh its DisplayText binding without
+    /// a full tree rebuild — the per-node signal used when a text-only change
+    /// updates the underlying DialogNode (#2032).
+    /// </summary>
+    public class TreeViewSafeNodeBindingTests
+    {
+        [Fact]
+        public void NotifyTextChanged_RaisesPropertyChangedForDisplayText()
+        {
+            // Arrange: construct a node and a safe wrapper
+            var originalNode = new DialogNode
+            {
+                Type = DialogNodeType.Entry,
+                Speaker = "Guard"
+            };
+            originalNode.Text.Add(0, "original");
+            var safe = new TreeViewSafeNode(originalNode);
+
+            var propertyChanges = new List<string>();
+            safe.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName != null) propertyChanges.Add(e.PropertyName);
+            };
+
+            // Act: simulate an external TextOnly update — the underlying node text changes
+            // and we ask the safe wrapper to notify its bindings without rebuilding the tree.
+            originalNode.Text.Add(0, "edited");
+            safe.NotifyTextChanged();
+
+            // Assert: binding target gets woken up
+            Assert.Contains(nameof(TreeViewSafeNode.DisplayText), propertyChanges);
+        }
+    }
+}

--- a/Parley/Parley/Models/TreeViewSafeNode.cs
+++ b/Parley/Parley/Models/TreeViewSafeNode.cs
@@ -146,7 +146,19 @@ namespace DialogEditor.Models
         {
             _globalExpandedNodes.Clear();
         }
-        
+
+        /// <summary>
+        /// Signals that the underlying DialogNode's text / speaker changed.
+        /// Raises PropertyChanged for the computed display properties so bindings
+        /// repaint the label without a full tree rebuild (#2032).
+        /// </summary>
+        public void NotifyTextChanged()
+        {
+            OnPropertyChanged(nameof(DisplayText));
+            OnPropertyChanged(nameof(Speaker));
+            OnPropertyChanged(nameof(TypeDisplay));
+        }
+
         protected virtual void OnPropertyChanged(string propertyName)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));

--- a/Parley/Parley/Services/DialogChangeEventBus.cs
+++ b/Parley/Parley/Services/DialogChangeEventBus.cs
@@ -47,6 +47,21 @@ namespace DialogEditor.Services
     }
 
     /// <summary>
+    /// Distinguishes changes that require a full tree/flow rebuild (Structural)
+    /// from changes that only need to repaint a single node's label (TextOnly).
+    /// Used to prevent focus loss during in-place text edits (#2032).
+    /// </summary>
+    public enum DialogChangeKind
+    {
+        /// <summary>Topology changed; subscribers must rebuild their view.</summary>
+        Structural,
+
+        /// <summary>Only a node's displayed text/property changed; subscribers
+        /// should repaint the affected node in place without rebuilding.</summary>
+        TextOnly
+    }
+
+    /// <summary>
     /// Event arguments containing details about a dialog change.
     /// </summary>
     public class DialogChangeEventArgs : EventArgs
@@ -69,13 +84,20 @@ namespace DialogEditor.Services
         /// <summary>Optional additional context about the change.</summary>
         public string? Context { get; }
 
+        /// <summary>
+        /// Whether this change requires a full rebuild or just an in-place repaint.
+        /// Defaults to Structural so existing call sites keep their current behavior (#2032).
+        /// </summary>
+        public DialogChangeKind ChangeKind { get; }
+
         public DialogChangeEventArgs(
             DialogChangeType changeType,
             DialogNode? affectedNode = null,
             DialogNode? newParent = null,
             DialogNode? oldParent = null,
             DialogNode? previousSelection = null,
-            string? context = null)
+            string? context = null,
+            DialogChangeKind changeKind = DialogChangeKind.Structural)
         {
             ChangeType = changeType;
             AffectedNode = affectedNode;
@@ -83,6 +105,7 @@ namespace DialogEditor.Services
             OldParent = oldParent;
             PreviousSelection = previousSelection;
             Context = context;
+            ChangeKind = changeKind;
         }
     }
 
@@ -204,13 +227,15 @@ namespace DialogEditor.Services
 
         /// <summary>
         /// Publish a node modified event (text, speaker, or other property changed).
+        /// Defaults to Structural for back-compat with existing callers (#2032).
         /// </summary>
-        public void PublishNodeModified(DialogNode modifiedNode, string? context = null)
+        public void PublishNodeModified(DialogNode modifiedNode, string? context = null, DialogChangeKind kind = DialogChangeKind.Structural)
         {
             Publish(new DialogChangeEventArgs(
                 DialogChangeType.NodeModified,
                 affectedNode: modifiedNode,
-                context: context));
+                context: context,
+                changeKind: kind));
         }
 
         /// <summary>

--- a/Parley/Parley/Services/DialogDragDropValidator.cs
+++ b/Parley/Parley/Services/DialogDragDropValidator.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using DialogEditor.Models;
+
+namespace DialogEditor.Services
+{
+    /// <summary>
+    /// Classification of a drag-drop target.
+    /// </summary>
+    public enum DropTargetKind
+    {
+        /// <summary>Dropped onto another node — source becomes a child of target.</summary>
+        Node,
+
+        /// <summary>Dropped onto the empty background — source becomes a new root/start point.</summary>
+        Root,
+
+        /// <summary>Invalid target (e.g., dropped on self).</summary>
+        Invalid
+    }
+
+    /// <summary>
+    /// Result of validating a drag-drop reparent operation.
+    /// </summary>
+    public class DropValidationResult
+    {
+        public bool IsValid { get; init; }
+        public DropTargetKind TargetKind { get; init; }
+        public string? RejectReason { get; init; }
+    }
+
+    /// <summary>
+    /// Shared drag-drop validator for "drop as child of target" (Into) and
+    /// "drop to root" (target == null) scenarios.
+    ///
+    /// Both TreeView and FlowView delegate their parent-assignment validation
+    /// here so the two views can never disagree about which drops are legal (#2060).
+    /// Sibling-reorder (Before / After) remains in each view's own path pending
+    /// full unification (#2109).
+    /// </summary>
+    public static class DialogDragDropValidator
+    {
+        /// <summary>
+        /// Validates a reparent operation.
+        /// </summary>
+        /// <param name="source">The node being dragged.</param>
+        /// <param name="target">The node being dropped onto, or null for drop-to-root.</param>
+        /// <param name="dialog">The dialog that owns both nodes.</param>
+        public static DropValidationResult ValidateReparent(DialogNode source, DialogNode? target, Dialog dialog)
+        {
+            // Drop onto empty background → root placement
+            if (target == null)
+            {
+                if (source.Type != DialogNodeType.Entry)
+                {
+                    return new DropValidationResult
+                    {
+                        IsValid = false,
+                        TargetKind = DropTargetKind.Root,
+                        RejectReason = "Only NPC Entry nodes can be at root level"
+                    };
+                }
+                return new DropValidationResult
+                {
+                    IsValid = true,
+                    TargetKind = DropTargetKind.Root
+                };
+            }
+
+            // Drop on self
+            if (source == target)
+            {
+                return new DropValidationResult
+                {
+                    IsValid = false,
+                    TargetKind = DropTargetKind.Invalid,
+                    RejectReason = "Cannot drop node on itself"
+                };
+            }
+
+            // Circular reference: target must not be reachable from source
+            if (IsDescendant(source, target))
+            {
+                return new DropValidationResult
+                {
+                    IsValid = false,
+                    TargetKind = DropTargetKind.Node,
+                    RejectReason = "Cannot drop node on its own descendant"
+                };
+            }
+
+            // NPC/PC alternation — Entry parent may only have Reply children and vice versa
+            if (target.Type == DialogNodeType.Entry && source.Type != DialogNodeType.Reply)
+            {
+                return new DropValidationResult
+                {
+                    IsValid = false,
+                    TargetKind = DropTargetKind.Node,
+                    RejectReason = "NPC Entry nodes can only have PC Reply children"
+                };
+            }
+            if (target.Type == DialogNodeType.Reply && source.Type != DialogNodeType.Entry)
+            {
+                return new DropValidationResult
+                {
+                    IsValid = false,
+                    TargetKind = DropTargetKind.Node,
+                    RejectReason = "PC Reply nodes can only have NPC Entry children"
+                };
+            }
+
+            return new DropValidationResult
+            {
+                IsValid = true,
+                TargetKind = DropTargetKind.Node
+            };
+        }
+
+        /// <summary>
+        /// True if <paramref name="possibleDescendant"/> is reachable from
+        /// <paramref name="source"/> via its pointer graph.
+        /// </summary>
+        private static bool IsDescendant(DialogNode source, DialogNode possibleDescendant)
+        {
+            var visited = new HashSet<DialogNode>();
+            return IsReachable(source, possibleDescendant, visited);
+        }
+
+        private static bool IsReachable(DialogNode current, DialogNode target, HashSet<DialogNode> visited)
+        {
+            if (current == target) return true;
+            if (!visited.Add(current)) return false;
+
+            foreach (var ptr in current.Pointers)
+            {
+                if (ptr.Node != null && IsReachable(ptr.Node, target, visited))
+                    return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Parley/Parley/Services/PanelWidthClamper.cs
+++ b/Parley/Parley/Services/PanelWidthClamper.cs
@@ -1,0 +1,36 @@
+namespace DialogEditor.Services
+{
+    /// <summary>
+    /// Clamps the side-by-side flowchart panel width to a usable, on-screen range.
+    /// Self-heals corrupted settings that would otherwise leave the panel off-screen (#2049).
+    /// </summary>
+    public static class PanelWidthClamper
+    {
+        private const double HardMinWidth = 200;
+        private const double MinLeftPanelReserve = 400;
+        private const double ResetLowerThreshold = 100;
+        private const double ResetUpperFraction = 0.95;
+        private const double ResetDefaultFraction = 0.50;
+
+        /// <summary>
+        /// Returns a safe panel width for the given window width.
+        /// Reset path: if storedWidth is outside [ResetLowerThreshold, 0.95 * windowWidth],
+        /// replace with 0.50 * windowWidth. Then clamp to [HardMinWidth, windowWidth - MinLeftPanelReserve].
+        /// </summary>
+        public static double Clamp(double storedWidth, double windowWidth)
+        {
+            var width = storedWidth;
+
+            if (width < ResetLowerThreshold || width > windowWidth * ResetUpperFraction)
+            {
+                width = windowWidth * ResetDefaultFraction;
+            }
+
+            var hardMax = windowWidth - MinLeftPanelReserve;
+            if (width > hardMax) width = hardMax;
+            if (width < HardMinWidth) width = HardMinWidth;
+
+            return width;
+        }
+    }
+}

--- a/Parley/Parley/Services/PropertyAutoSaveService.cs
+++ b/Parley/Parley/Services/PropertyAutoSaveService.cs
@@ -94,10 +94,12 @@ namespace DialogEditor.Services
             if (control != null && !control.IsReadOnly)
             {
                 node.OriginalNode.Speaker = control.Text ?? "";
-                _treeRefreshCoordinator.RefreshPreservingSelection(); // Update tree to show new speaker name
 
-                // Notify FlowView of speaker change (#1223)
-                DialogChangeEventBus.Instance.PublishNodeModified(node.OriginalNode, "SpeakerChanged");
+                // #2032: Publish TextOnly — views repaint the affected node in place
+                // instead of rebuilding, so focus stays on the edited field.
+                node.NotifyTextChanged();
+                DialogChangeEventBus.Instance.PublishNodeModified(
+                    node.OriginalNode, "SpeakerChanged", DialogChangeKind.TextOnly);
             }
         }
 
@@ -109,11 +111,12 @@ namespace DialogEditor.Services
                 var newText = control.Text ?? "";
                 UnifiedLogger.LogApplication(LogLevel.DEBUG, $"💾 SaveText: Updating text to '{newText.Substring(0, Math.Min(50, newText.Length))}...'");
                 node.OriginalNode.Text.Strings[0] = newText;
-                UnifiedLogger.LogApplication(LogLevel.DEBUG, "💾 SaveText: Calling _treeRefreshCoordinator.RefreshPreservingSelection()");
-                _treeRefreshCoordinator.RefreshPreservingSelection(); // Update tree display
 
-                // Notify FlowView and other subscribers of the text change
-                DialogChangeEventBus.Instance.PublishNodeModified(node.OriginalNode, "TextChanged");
+                // #2032: Publish TextOnly — TreeView node raises PropertyChanged to
+                // repaint its label; FlowView updates the node in place. No rebuild.
+                node.NotifyTextChanged();
+                DialogChangeEventBus.Instance.PublishNodeModified(
+                    node.OriginalNode, "TextChanged", DialogChangeKind.TextOnly);
             }
         }
 
@@ -204,8 +207,9 @@ namespace DialogEditor.Services
             {
                 node.OriginalNode.Quest = control.Text ?? "";
 
-                // Notify FlowView so quest tag indicator (📋) updates immediately
-                DialogChangeEventBus.Instance.PublishNodeModified(node.OriginalNode, "QuestChanged");
+                // #2032: Quest tag is pointer metadata — repaint in place, no rebuild.
+                DialogChangeEventBus.Instance.PublishNodeModified(
+                    node.OriginalNode, "QuestChanged", DialogChangeKind.TextOnly);
             }
         }
 

--- a/Parley/Parley/Services/TreeViewDragDropService.cs
+++ b/Parley/Parley/Services/TreeViewDragDropService.cs
@@ -81,6 +81,17 @@ namespace DialogEditor.Services
         }
 
         /// <summary>
+        /// Fires the DropCompleted event so subscribers can execute the move.
+        /// Call this after a valid drop has been validated.
+        /// </summary>
+        public void NotifyDropCompleted(TreeViewSafeNode draggedNode, DialogNode? newParent, DropPosition position, int insertIndex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.INFO,
+                $"TreeViewDragDrop: Dropping '{draggedNode.DisplayText}' {position} parent='{newParent?.DisplayText ?? "ROOT"}', index={insertIndex}");
+            DropCompleted?.Invoke(draggedNode, newParent, position, insertIndex);
+        }
+
+        /// <summary>
         /// The node currently being dragged, if any.
         /// </summary>
         public TreeViewSafeNode? DraggedNode => _draggedNode;

--- a/Parley/Parley/Services/TreeViewDragDropService.cs
+++ b/Parley/Parley/Services/TreeViewDragDropService.cs
@@ -279,16 +279,21 @@ namespace DialogEditor.Services
                     break;
             }
 
-            // Validate NPC/PC alternation rules
+            // #2060: Delegate NPC/PC alternation + root-drop rules to the shared validator
+            // so FlowView and TreeView stay in lock-step on parent-assignment decisions.
             UnifiedLogger.LogApplication(LogLevel.DEBUG,
                 $"TreeViewDragDrop: Validating source='{sourceNode.DisplayText}' (Type={sourceNode.Type}) " +
                 $"under parent='{newParent?.DisplayText ?? "ROOT"}' (Type={newParent?.Type})");
-            var validationError = ValidateNodePlacement(sourceNode, newParent);
-            if (validationError != null)
+            var dialog = sourceNode.Parent;
+            if (dialog != null)
             {
-                result.ErrorMessage = validationError;
-                UnifiedLogger.LogApplication(LogLevel.DEBUG, $"TreeViewDragDrop.ValidateDrop: REJECTED - {result.ErrorMessage}");
-                return result;
+                var sharedResult = DialogDragDropValidator.ValidateReparent(sourceNode, newParent, dialog);
+                if (!sharedResult.IsValid)
+                {
+                    result.ErrorMessage = sharedResult.RejectReason;
+                    UnifiedLogger.LogApplication(LogLevel.DEBUG, $"TreeViewDragDrop.ValidateDrop: REJECTED - {result.ErrorMessage}");
+                    return result;
+                }
             }
 
             // Find the TreeViewSafeNode for the new parent
@@ -303,42 +308,6 @@ namespace DialogEditor.Services
                 $"NewParentDialogNode={result.NewParentDialogNode?.DisplayText ?? "ROOT"}, InsertIndex={insertIndex}");
 
             return result;
-        }
-
-        /// <summary>
-        /// Validates NPC/PC alternation rules for node placement.
-        /// </summary>
-        private string? ValidateNodePlacement(DialogNode source, DialogNode? newParent)
-        {
-            if (newParent == null)
-            {
-                // Dropping at root level - only NPC Entries allowed
-                if (source.Type != DialogNodeType.Entry)
-                {
-                    return "Only NPC Entry nodes can be at root level";
-                }
-                return null;
-            }
-
-            // Check parent-child type compatibility
-            if (newParent.Type == DialogNodeType.Entry)
-            {
-                // NPC Entry parent can only have PC Reply children
-                if (source.Type != DialogNodeType.Reply)
-                {
-                    return "NPC Entry nodes can only have PC Reply children";
-                }
-            }
-            else // Reply
-            {
-                // PC Reply parent can only have NPC Entry children
-                if (source.Type != DialogNodeType.Entry)
-                {
-                    return "PC Reply nodes can only have NPC Entry children";
-                }
-            }
-
-            return null;
         }
 
         /// <summary>

--- a/Parley/Parley/Views/FlowchartPanel.axaml.cs
+++ b/Parley/Parley/Views/FlowchartPanel.axaml.cs
@@ -763,11 +763,7 @@ namespace DialogEditor.Views
                 // #2060: The ROOT visual node represents the dialog's start-pointer container,
                 // not an actual DialogNode. Dropping onto it means "make this a start" — same
                 // semantics as dropping on empty background. Normalize to null here.
-                bool isRootSurrogate = targetNode != null && IsRootVisualNode(targetNode);
-                if (isRootSurrogate) targetNode = null;
-
-                UnifiedLogger.LogUI(LogLevel.DEBUG,
-                    $"FlowView drop: dragged='{_draggedNode.Id}' target='{targetNode?.Id ?? (isRootSurrogate ? "ROOT-SURROGATE" : "BACKGROUND")}'");
+                if (targetNode != null && IsRootVisualNode(targetNode)) targetNode = null;
 
                 if (targetNode != null && targetNode != _draggedNode)
                 {
@@ -779,31 +775,11 @@ namespace DialogEditor.Views
                     {
                         ExecuteReparent(_draggedNode, targetNode);
                     }
-                    else
-                    {
-                        UnifiedLogger.LogUI(LogLevel.DEBUG,
-                            $"FlowView drop: no action — not siblings, not valid reparent target");
-                    }
                 }
-                else if (targetNode == null)
+                else if (targetNode == null && IsValidRootDropTarget(_draggedNode))
                 {
                     // Drop on empty background or ROOT visual node → new root start point.
-                    if (IsValidRootDropTarget(_draggedNode))
-                    {
-                        UnifiedLogger.LogUI(LogLevel.DEBUG,
-                            $"FlowView drop-to-root: executing for '{_draggedNode.Id}'");
-                        ExecuteReparentToRoot(_draggedNode);
-                    }
-                    else
-                    {
-                        UnifiedLogger.LogUI(LogLevel.DEBUG,
-                            $"FlowView drop-to-root: rejected — not a valid root drop (source type={_draggedNode.OriginalNode?.Type})");
-                    }
-                }
-                else
-                {
-                    UnifiedLogger.LogUI(LogLevel.DEBUG,
-                        $"FlowView drop: dropped on self — no action");
+                    ExecuteReparentToRoot(_draggedNode);
                 }
 
                 HideInsertionIndicator();

--- a/Parley/Parley/Views/FlowchartPanel.axaml.cs
+++ b/Parley/Parley/Views/FlowchartPanel.axaml.cs
@@ -757,6 +757,9 @@ namespace DialogEditor.Views
                 var currentPos = e.GetPosition(FlowchartGraphPanel);
                 var targetNode = FindFlowchartNodeAtPoint(currentPos);
 
+                UnifiedLogger.LogUI(LogLevel.DEBUG,
+                    $"FlowView drop: dragged='{_draggedNode.Id}' target='{targetNode?.Id ?? "BACKGROUND"}'");
+
                 if (targetNode != null && targetNode != _draggedNode)
                 {
                     if (AreSiblings(targetNode, _draggedNode))
@@ -767,11 +770,31 @@ namespace DialogEditor.Views
                     {
                         ExecuteReparent(_draggedNode, targetNode);
                     }
+                    else
+                    {
+                        UnifiedLogger.LogUI(LogLevel.DEBUG,
+                            $"FlowView drop: no action — not siblings, not valid reparent target");
+                    }
                 }
-                else if (targetNode == null && IsValidRootDropTarget(_draggedNode))
+                else if (targetNode == null)
                 {
                     // #2060: Drop on empty background → new root start point.
-                    ExecuteReparentToRoot(_draggedNode);
+                    if (IsValidRootDropTarget(_draggedNode))
+                    {
+                        UnifiedLogger.LogUI(LogLevel.DEBUG,
+                            $"FlowView drop-to-root: executing for '{_draggedNode.Id}'");
+                        ExecuteReparentToRoot(_draggedNode);
+                    }
+                    else
+                    {
+                        UnifiedLogger.LogUI(LogLevel.DEBUG,
+                            $"FlowView drop-to-root: rejected — not a valid root drop (source type={_draggedNode.OriginalNode?.Type})");
+                    }
+                }
+                else
+                {
+                    UnifiedLogger.LogUI(LogLevel.DEBUG,
+                        $"FlowView drop: dropped on self — no action");
                 }
 
                 HideInsertionIndicator();

--- a/Parley/Parley/Views/FlowchartPanel.axaml.cs
+++ b/Parley/Parley/Views/FlowchartPanel.axaml.cs
@@ -716,11 +716,35 @@ namespace DialogEditor.Views
                     FlowchartGraphPanel.Cursor = new Avalonia.Input.Cursor(StandardCursorType.No);
                 }
             }
+            else if (targetNode == null)
+            {
+                // #2060: Dragging over empty background — drop-to-root if valid (Entry source).
+                HideInsertionIndicator();
+                FlowchartGraphPanel.Cursor = new Avalonia.Input.Cursor(
+                    IsValidRootDropTarget(_draggedNode)
+                        ? StandardCursorType.DragLink
+                        : StandardCursorType.No);
+            }
             else
             {
                 HideInsertionIndicator();
                 FlowchartGraphPanel.Cursor = new Avalonia.Input.Cursor(StandardCursorType.DragMove);
             }
+        }
+
+        /// <summary>
+        /// #2060: True if the dragged node may be dropped onto the empty background
+        /// to become a new root start point. Delegates to the shared validator.
+        /// </summary>
+        private bool IsValidRootDropTarget(FlowchartNode dragged)
+        {
+            if (dragged.OriginalNode == null) return false;
+            var dialog = _viewModel.CurrentDialog;
+            if (dialog == null) return false;
+
+            return DialogDragDropValidator
+                .ValidateReparent(dragged.OriginalNode, target: null, dialog)
+                .IsValid;
         }
 
         /// <summary>
@@ -743,6 +767,11 @@ namespace DialogEditor.Views
                     {
                         ExecuteReparent(_draggedNode, targetNode);
                     }
+                }
+                else if (targetNode == null && IsValidRootDropTarget(_draggedNode))
+                {
+                    // #2060: Drop on empty background → new root start point.
+                    ExecuteReparentToRoot(_draggedNode);
                 }
 
                 HideInsertionIndicator();
@@ -864,8 +893,9 @@ namespace DialogEditor.Views
         }
 
         /// <summary>
-        /// Checks if a target node is a valid reparent destination for the dragged node (#1965).
-        /// Enforces Entry↔Reply alternation and prevents circular references.
+        /// Checks if a target node is a valid reparent destination for the dragged node.
+        /// #2060: Delegates to DialogDragDropValidator so TreeView and FlowView share
+        /// one authoritative source for parent-assignment rules.
         /// </summary>
         private bool IsValidReparentTarget(FlowchartNode target, FlowchartNode dragged)
         {
@@ -874,44 +904,9 @@ namespace DialogEditor.Views
             var dialog = _viewModel.CurrentDialog;
             if (dialog == null) return false;
 
-            // Alternation rule: Entry nodes can only be children of Reply nodes (or root)
-            // Reply nodes can only be children of Entry nodes
-            var draggedType = dragged.OriginalNode.Type;
-            var targetType = target.OriginalNode.Type;
-
-            // Drop INTO target as new child — dragged becomes child of target
-            // Entry dragged → target must be Reply (or drop to root, handled separately)
-            // Reply dragged → target must be Entry
-            if (draggedType == DialogNodeType.Entry && targetType != DialogNodeType.Reply) return false;
-            if (draggedType == DialogNodeType.Reply && targetType != DialogNodeType.Entry) return false;
-
-            // Prevent circular reference: target cannot be a descendant of dragged
-            if (IsDescendantOf(target.OriginalNode, dragged.OriginalNode, dialog)) return false;
-
-            return true;
-        }
-
-        /// <summary>
-        /// Checks if possibleDescendant is reachable from possibleAncestor (#1965).
-        /// </summary>
-        private bool IsDescendantOf(DialogNode possibleDescendant, DialogNode possibleAncestor, Dialog dialog)
-        {
-            var visited = new HashSet<DialogNode>();
-            return IsReachableFrom(possibleAncestor, possibleDescendant, visited);
-        }
-
-        private bool IsReachableFrom(DialogNode current, DialogNode target, HashSet<DialogNode> visited)
-        {
-            if (current == target) return true;
-            if (visited.Contains(current)) return false;
-            visited.Add(current);
-
-            foreach (var ptr in current.Pointers)
-            {
-                if (ptr.Node != null && IsReachableFrom(ptr.Node, target, visited))
-                    return true;
-            }
-            return false;
+            return DialogDragDropValidator
+                .ValidateReparent(dragged.OriginalNode, target.OriginalNode, dialog)
+                .IsValid;
         }
 
         /// <summary>
@@ -932,6 +927,24 @@ namespace DialogEditor.Views
             int insertIndex = targetNode.OriginalNode.Pointers.Count;
 
             ReparentRequested?.Invoke(draggedNode.OriginalNode, sourcePointer, targetNode.OriginalNode, insertIndex);
+        }
+
+        /// <summary>
+        /// #2060: Executes a drop-to-root reparent — the dragged Entry becomes a new
+        /// start pointer. Uses the same ReparentRequested event with newParent=null
+        /// and insertIndex at the end of Dialog.Starts.
+        /// </summary>
+        private void ExecuteReparentToRoot(FlowchartNode draggedNode)
+        {
+            if (draggedNode.OriginalNode == null) return;
+
+            var dialog = _viewModel.CurrentDialog;
+            if (dialog == null) return;
+
+            DialogPtr? sourcePointer = draggedNode.OriginalPointer ?? FindSourcePointer(dialog, draggedNode.OriginalNode);
+            int insertIndex = dialog.Starts.Count;
+
+            ReparentRequested?.Invoke(draggedNode.OriginalNode, sourcePointer, null, insertIndex);
         }
 
         /// <summary>

--- a/Parley/Parley/Views/FlowchartPanel.axaml.cs
+++ b/Parley/Parley/Views/FlowchartPanel.axaml.cs
@@ -693,8 +693,11 @@ namespace DialogEditor.Views
 
             if (!_isDragging || _draggedNode == null) return;
 
-            // Find target node under cursor
+            // Find target node under cursor. Normalize ROOT visual node to null so
+            // hovering over ROOT shows the drop-to-root cursor (#2060).
             var targetNode = FindFlowchartNodeAtPoint(currentPos);
+            if (targetNode != null && IsRootVisualNode(targetNode)) targetNode = null;
+
             if (targetNode != null && targetNode != _draggedNode)
             {
                 if (AreSiblings(targetNode, _draggedNode))
@@ -718,7 +721,7 @@ namespace DialogEditor.Views
             }
             else if (targetNode == null)
             {
-                // #2060: Dragging over empty background — drop-to-root if valid (Entry source).
+                // #2060: Dragging over empty background (or ROOT visual) — drop-to-root if valid.
                 HideInsertionIndicator();
                 FlowchartGraphPanel.Cursor = new Avalonia.Input.Cursor(
                     IsValidRootDropTarget(_draggedNode)
@@ -757,8 +760,14 @@ namespace DialogEditor.Views
                 var currentPos = e.GetPosition(FlowchartGraphPanel);
                 var targetNode = FindFlowchartNodeAtPoint(currentPos);
 
+                // #2060: The ROOT visual node represents the dialog's start-pointer container,
+                // not an actual DialogNode. Dropping onto it means "make this a start" — same
+                // semantics as dropping on empty background. Normalize to null here.
+                bool isRootSurrogate = targetNode != null && IsRootVisualNode(targetNode);
+                if (isRootSurrogate) targetNode = null;
+
                 UnifiedLogger.LogUI(LogLevel.DEBUG,
-                    $"FlowView drop: dragged='{_draggedNode.Id}' target='{targetNode?.Id ?? "BACKGROUND"}'");
+                    $"FlowView drop: dragged='{_draggedNode.Id}' target='{targetNode?.Id ?? (isRootSurrogate ? "ROOT-SURROGATE" : "BACKGROUND")}'");
 
                 if (targetNode != null && targetNode != _draggedNode)
                 {
@@ -778,7 +787,7 @@ namespace DialogEditor.Views
                 }
                 else if (targetNode == null)
                 {
-                    // #2060: Drop on empty background → new root start point.
+                    // Drop on empty background or ROOT visual node → new root start point.
                     if (IsValidRootDropTarget(_draggedNode))
                     {
                         UnifiedLogger.LogUI(LogLevel.DEBUG,
@@ -804,6 +813,13 @@ namespace DialogEditor.Views
 
             ResetDragState();
         }
+
+        /// <summary>
+        /// #2060: True if this FlowchartNode is the synthetic ROOT visual node
+        /// (not a real DialogNode). Used to normalize drops onto ROOT as drops-to-root.
+        /// </summary>
+        private static bool IsRootVisualNode(FlowchartNode node) =>
+            node.NodeType == FlowchartNodeType.Root || node.OriginalNode == null;
 
         private void ResetDragState()
         {

--- a/Parley/Parley/Views/Helpers/FlowchartManager.Layout.cs
+++ b/Parley/Parley/Views/Helpers/FlowchartManager.Layout.cs
@@ -123,8 +123,9 @@ namespace Parley.Views.Helpers
                     if (grid.ColumnDefinitions.Count < 5) return;
 
                     // Show columns (indices 3 and 4 are the splitter and panel columns)
-                    // Use saved width or default (#377)
-                    var savedWidth = _settings.FlowchartPanelWidth;
+                    // Use saved width clamped to on-screen range (#2049 — self-heals corrupt settings)
+                    var windowWidth = _window.Bounds.Width > 0 ? _window.Bounds.Width : _window.Width;
+                    var savedWidth = PanelWidthClamper.Clamp(_settings.FlowchartPanelWidth, windowWidth);
                     grid.ColumnDefinitions[3].Width = new GridLength(5);
                     grid.ColumnDefinitions[4].Width = new GridLength(savedWidth, GridUnitType.Pixel);
                     grid.ColumnDefinitions[4].MinWidth = 200;
@@ -277,7 +278,9 @@ namespace Parley.Views.Helpers
         {
             if (e.Property.Name == "Width" && sender is ColumnDefinition colDef && colDef.Width.IsAbsolute)
             {
-                _settings.FlowchartPanelWidth = colDef.Width.Value;
+                // #2049: Clamp on save so corrupt state can't survive a session
+                var windowWidth = _window.Bounds.Width > 0 ? _window.Bounds.Width : _window.Width;
+                _settings.FlowchartPanelWidth = PanelWidthClamper.Clamp(colDef.Width.Value, windowWidth);
             }
         }
     }

--- a/Parley/Parley/Views/Helpers/TreeViewUIController.cs
+++ b/Parley/Parley/Views/Helpers/TreeViewUIController.cs
@@ -252,9 +252,15 @@ namespace Parley.Views.Helpers
                     // Get the new parent - prefer TreeViewSafeNode.OriginalNode, fall back to NewParentDialogNode
                     var newParentDialogNode = validation.NewParent?.OriginalNode ?? validation.NewParentDialogNode;
 
-                    _dragDropService.Reset();
                     e.DragEffects = DragDropEffects.Move;
                     e.Handled = true;
+
+                    // Fire DropCompleted so MainWindow.OnDragDropCompleted actually moves the node.
+                    // Prior to this, the tuple return value was discarded by Avalonia's routed-event
+                    // dispatcher, so validated drops never executed — pre-existing bug from #463
+                    // refactor, surfaced during sprint #2063.
+                    _dragDropService.NotifyDropCompleted(draggedNode, newParentDialogNode, dropPosition, validation.InsertIndex);
+                    _dragDropService.Reset();
 
                     return (draggedNode, newParentDialogNode, dropPosition, validation.InsertIndex);
                 }

--- a/Parley/Parley/Views/MainWindow.ResourceBrowsing.cs
+++ b/Parley/Parley/Views/MainWindow.ResourceBrowsing.cs
@@ -22,12 +22,15 @@ namespace DialogEditor.Views
 
         private async void OnInsertTokenClick(object? sender, RoutedEventArgs e)
         {
-            // Set flag to suppress tree refresh during token insertion
+            // #2032: IsInsertingToken still suppresses OnFieldLostFocus auto-save
+            // (the token dialog steals focus, which would otherwise re-fire AutoSaveProperty
+            // on the same unchanged value). Tree rebuild is no longer the risk since
+            // PropertyAutoSaveService now uses DialogChangeKind.TextOnly, but the lost-focus
+            // guard still matters to avoid a redundant save pass.
             _uiState.IsInsertingToken = true;
-            var deferredClear = false;
             try
             {
-                // Capture cursor position BEFORE opening dialog (OnFieldLostFocus fires when button clicked)
+                // Capture cursor position BEFORE opening dialog (focus is lost when button clicked)
                 var textBox = this.FindControl<TextBox>("TextTextBox");
                 var savedSelStart = textBox?.SelectionStart ?? 0;
                 var savedSelEnd = textBox?.SelectionEnd ?? 0;
@@ -38,13 +41,9 @@ namespace DialogEditor.Views
 
                 if (result && !string.IsNullOrEmpty(tokenWindow.SelectedToken) && textBox != null)
                 {
-                    // Use saved values since focus was lost when dialog opened
                     var selStart = savedSelStart;
                     var selLength = savedSelEnd - savedSelStart;
                     var currentText = savedText;
-
-                    string newText;
-                    int newCursorPos;
 
                     // Determine if we need spaces around the token
                     var needsSpaceBefore = selStart > 0 &&
@@ -55,46 +54,42 @@ namespace DialogEditor.Views
                         tokenWindow.SelectedToken +
                         (needsSpaceAfter ? " " : "");
 
+                    string newText;
+                    int newCursorPos;
                     if (selLength > 0)
                     {
-                        // Replace selection
                         newText = currentText.Remove(selStart, selLength).Insert(selStart, tokenToInsert);
                         newCursorPos = selStart + tokenToInsert.Length;
                     }
                     else
                     {
-                        // Insert at cursor
                         newText = currentText.Insert(selStart, tokenToInsert);
                         newCursorPos = selStart + tokenToInsert.Length;
                     }
 
                     textBox.Text = newText;
 
-                    // Save directly to node without tree refresh (avoids focus jump)
+                    // #2032: Update node, notify bindings, publish TextOnly so FlowView
+                    // / TreeView repaint in place. No tree rebuild — focus stays put.
                     if (_selectedNode?.OriginalNode?.Text != null)
                     {
                         _selectedNode.OriginalNode.Text.Strings[0] = newText;
+                        _selectedNode.NotifyTextChanged();
                         _viewModel.HasUnsavedChanges = true;
                         _viewModel.StatusMessage = "Text updated with token";
+
+                        DialogEditor.Services.DialogChangeEventBus.Instance.PublishNodeModified(
+                            _selectedNode.OriginalNode,
+                            "TokenInserted",
+                            DialogEditor.Services.DialogChangeKind.TextOnly);
                     }
 
-                    // Restore cursor position and focus (deferred to let dialog close complete).
-                    // Keep IsInsertingToken true until focus is restored to prevent
-                    // debounced auto-save from triggering a tree refresh that jumps to root.
-                    // See #2050 for the proper architectural fix.
-                    deferredClear = true;
+                    // Restore cursor position after the token dialog finishes closing.
                     Avalonia.Threading.Dispatcher.UIThread.Post(() =>
                     {
-                        try
-                        {
-                            textBox.Focus();
-                            textBox.SelectionStart = newCursorPos;
-                            textBox.SelectionEnd = newCursorPos;
-                        }
-                        finally
-                        {
-                            _uiState.IsInsertingToken = false;
-                        }
+                        textBox.Focus();
+                        textBox.SelectionStart = newCursorPos;
+                        textBox.SelectionEnd = newCursorPos;
                     }, Avalonia.Threading.DispatcherPriority.Background);
                 }
             }
@@ -104,9 +99,7 @@ namespace DialogEditor.Views
             }
             finally
             {
-                // Only clear here if we didn't defer it to the focus restoration callback
-                if (!deferredClear)
-                    _uiState.IsInsertingToken = false;
+                _uiState.IsInsertingToken = false;
             }
         }
 


### PR DESCRIPTION
## Summary

Sprint fixing three user-facing Parley UX bugs, structured around a parity theme: TreeView and FlowView as presenters over the same source-of-truth behavior.

- **#2049** — Side-by-side panel self-heals corrupt window settings
- **#2032** — Token insertion keeps focus on text field; `DialogChangeKind` decouples text-only edits from tree/flow rebuild
- **#2060** — Shared `DialogDragDropValidator` restores FlowView drag-to-root and keeps TreeView/FlowView validation in lock-step

### Extra fix surfaced during testing

- **TreeView drop dispatch restored** — commit ff47e7e6 (#463 refactor, Dec 2025) extracted `OnTreeViewDrop` into a controller and changed its signature to return a tuple that Avalonia's event dispatcher silently discarded. Validated drops never executed. Wired the existing `DropCompleted` event back up via a new `NotifyDropCompleted` helper.
- **FlowView ROOT visual node** — drops onto the synthetic ROOT visual were routed through the regular "drop on target" path and rejected by alternation rules. Treat ROOT visual as drop-to-root.

### Follow-ups

- [#2109](https://github.com/LordOfMyatar/issues/2109) — Full unification of Before/After drag-drop paths
- [#2110](https://github.com/LordOfMyatar/issues/2110) — Log build/version info at session start across all tools

Plan: `NonPublic/Plans/2026-04-18-2063-plan.md`

## Related Issues

- Closes #2063
- Closes #2049
- Closes #2032
- Closes #2060

## Pre-Merge Results

- Privacy scan: PASS
- Tech debt: WARN — `FlowchartPanel.axaml.cs` 906 lines (warning threshold, no issue required; will shrink with #2109)
- Theme compat scan: 3 pre-existing warnings in unrelated files (ModuleSearchWindow, TokenSelectorWindow) — not sprint-introduced
- Unit tests: 838/838 PASS
- FlaUI (Parley): 27/27 PASS (one test flaked first run, passed clean in isolated retry — unrelated to sprint changes)

## Checklist

- [x] #2049 — Panel clamp + reset-if-invalid
- [x] #2032 — Decouple auto-save from tree/flow rebuild (node ViewModel `NotifyTextChanged`)
- [x] #2060 — Shared `DialogDragDropValidator`; TreeView + FlowView use same source
- [x] TreeView drop dispatch restored (pre-existing regression)
- [x] FlowView ROOT visual normalized to drop-to-root
- [x] Unit tests (5 + 5 + 11 new = 21 additions)
- [x] Integration parity test: `DragDropParityIntegrationTests`
- [x] CHANGELOG updated with date + PR number
- [x] Release notes updated
- [x] Manual spot-checks: user-confirmed TreeView drops + FlowView drop-to-root working

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)