### PR TITLE
[Quartermaster] Sprint: Performance & UX Polish (#2064)

### DIFF
--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.81-alpha] - 2026-04-19
-**Branch**: `quartermaster/issue-2064` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2064` | **PR**: #2112
 
 ### Sprint: Performance & UX Polish (#2064)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.81-alpha] - 2026-04-19
+**Branch**: `quartermaster/issue-2064` | **PR**: #TBD
+
+### Sprint: Performance & UX Polish (#2064)
+
+- Address general UI lag and performance (#2058)
+- Color picker swatches not displaying until picker dialog opened (#2004)
+
+---
+
 ## [0.2.80-alpha] - 2026-04-18
 **Branch**: `fence/issue-2065` | **PR**: #2097
 

--- a/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
+++ b/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
@@ -46,6 +46,10 @@ public class ModelPreviewGLControl : OpenGlControlBase
     private uint _ebo;
     private int _indexCount;
     private readonly Dictionary<string, uint> _textureCache = new();
+    // Names of textures in _textureCache that came from PLT sources and depend on
+    // the current color indices. Color-index changes invalidate only these — not
+    // flat TGA/DDS textures whose pixels are color-independent (#2058).
+    private readonly HashSet<string> _pltTextureNames = new();
     // Maps unresolvable bitmap names to valid fallback texture names
     private readonly Dictionary<string, string> _textureRemapping = new();
 
@@ -208,11 +212,28 @@ public class ModelPreviewGLControl : OpenGlControlBase
         if (!ColorsEqual(_colorIndices, colorIndices))
         {
             _colorIndices = colorIndices;
-            // Clear cached textures so they reload with new color indices
-            ClearTextureCache();
+            // Only PLT textures depend on color indices. Flat TGA/DDS textures
+            // are color-independent and can survive the change (#2058).
+            InvalidatePltTextures();
             _needsTextureUpdate = true;
             RequestNextFrameRendering();
         }
+    }
+
+    private void InvalidatePltTextures()
+    {
+        if (_pltTextureNames.Count == 0) return;
+
+        foreach (var name in _pltTextureNames)
+        {
+            if (_textureCache.TryGetValue(name, out var texId))
+            {
+                if (_gl != null && texId != 0)
+                    _gl.DeleteTexture(texId);
+                _textureCache.Remove(name);
+            }
+        }
+        _pltTextureNames.Clear();
     }
 
     /// <summary>
@@ -247,6 +268,7 @@ public class ModelPreviewGLControl : OpenGlControlBase
                 _gl.DeleteTexture(texId);
         }
         _textureCache.Clear();
+        _pltTextureNames.Clear();
     }
 
     private static bool ColorsEqual(PltColorIndices a, PltColorIndices b)
@@ -322,6 +344,7 @@ public class ModelPreviewGLControl : OpenGlControlBase
                     _gl.DeleteTexture(texId);
                 }
                 _textureCache.Clear();
+                _pltTextureNames.Clear();
 
                 // Clean up buffers and program
                 _gl.DeleteBuffer(_vbo);
@@ -898,7 +921,10 @@ public class ModelPreviewGLControl : OpenGlControlBase
             }
         }
         foreach (var key in toRemove)
+        {
             _textureCache.Remove(key);
+            _pltTextureNames.Remove(key);
+        }
 
         // Load new textures
         UnifiedLogger.LogApplication(LogLevel.DEBUG,
@@ -914,8 +940,8 @@ public class ModelPreviewGLControl : OpenGlControlBase
             try
             {
                 var textureData = _preferBifTextures
-                    ? _textureService.LoadTexturePreferBIF(texName, _colorIndices)
-                    : _textureService.LoadTexture(texName, _colorIndices);
+                    ? _textureService.LoadTexturePreferBIFWithKind(texName, _colorIndices)
+                    : _textureService.LoadTextureWithKind(texName, _colorIndices);
                 if (textureData == null)
                 {
                     UnifiedLogger.LogApplication(LogLevel.DEBUG, $"  Texture '{texName}' returned null");
@@ -923,12 +949,13 @@ public class ModelPreviewGLControl : OpenGlControlBase
                     continue;
                 }
 
-                var (width, height, pixels) = textureData.Value;
+                var (width, height, pixels, isPlt) = textureData.Value;
                 var texId = UploadTexture(width, height, pixels);
                 if (texId != 0)
                 {
                     _textureCache[texName] = texId;
-                    UnifiedLogger.LogApplication(LogLevel.DEBUG, $"  Loaded texture '{texName}' ({width}x{height}) -> texId={texId}");
+                    if (isPlt) _pltTextureNames.Add(texName);
+                    UnifiedLogger.LogApplication(LogLevel.DEBUG, $"  Loaded texture '{texName}' ({width}x{height}) -> texId={texId}, isPlt={isPlt}");
                 }
             }
             catch (Exception ex)
@@ -947,17 +974,18 @@ public class ModelPreviewGLControl : OpenGlControlBase
             if (!string.IsNullOrEmpty(modelTexture) && !_textureCache.ContainsKey(modelTexture))
             {
                 var fallbackData = _preferBifTextures
-                    ? _textureService.LoadTexturePreferBIF(modelTexture, _colorIndices)
-                    : _textureService.LoadTexture(modelTexture, _colorIndices);
+                    ? _textureService.LoadTexturePreferBIFWithKind(modelTexture, _colorIndices)
+                    : _textureService.LoadTextureWithKind(modelTexture, _colorIndices);
                 if (fallbackData != null)
                 {
-                    var (w, h, px) = fallbackData.Value;
+                    var (w, h, px, isPlt) = fallbackData.Value;
                     var fallbackId = UploadTexture(w, h, px);
                     if (fallbackId != 0)
                     {
                         _textureCache[modelTexture] = fallbackId;
+                        if (isPlt) _pltTextureNames.Add(modelTexture);
                         UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                            $"  Loaded model fallback texture '{modelTexture}' ({w}x{h}) -> texId={fallbackId}");
+                            $"  Loaded model fallback texture '{modelTexture}' ({w}x{h}) -> texId={fallbackId}, isPlt={isPlt}");
                     }
                 }
             }

--- a/Quartermaster/Quartermaster/Services/TextureService.cs
+++ b/Quartermaster/Quartermaster/Services/TextureService.cs
@@ -318,6 +318,19 @@ public class TextureService
         string resRef,
         PltColorIndices? colorIndices = null)
     {
+        var result = LoadTexturePreferBIFWithKind(resRef, colorIndices);
+        return result.HasValue ? (result.Value.width, result.Value.height, result.Value.pixels) : null;
+    }
+
+    /// <summary>
+    /// Same as <see cref="LoadTexturePreferBIF"/> but also reports whether the texture
+    /// came from a PLT (color-index-dependent) source. Callers can use this to cache
+    /// non-PLT textures across color changes.
+    /// </summary>
+    public (int width, int height, byte[] pixels, bool isPlt)? LoadTexturePreferBIFWithKind(
+        string resRef,
+        PltColorIndices? colorIndices = null)
+    {
         if (string.IsNullOrEmpty(resRef))
             return null;
 
@@ -325,20 +338,20 @@ public class TextureService
         resRef = resRef.ToLowerInvariant();
 
         // Try BIF first (Override → BIF, skip HAK)
-        var bifResult = LoadTextureFromBase(resRef, colorIndices);
+        var bifResult = LoadTextureFromBaseWithKind(resRef, colorIndices);
         if (bifResult.HasValue)
         {
             UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                $"TextureService.LoadTexturePreferBIF: '{resRef}' from BIF");
+                $"TextureService.LoadTexturePreferBIF: '{resRef}' from BIF (isPlt={bifResult.Value.isPlt})");
             return bifResult;
         }
 
         // Not in BIF — fall back to full resolution (CEP-only texture)
-        var fullResult = LoadTexture(resRef, colorIndices);
+        var fullResult = LoadTextureWithKind(resRef, colorIndices);
         if (fullResult.HasValue)
         {
             UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                $"TextureService.LoadTexturePreferBIF: '{resRef}' from HAK (CEP-only)");
+                $"TextureService.LoadTexturePreferBIF: '{resRef}' from HAK (CEP-only, isPlt={fullResult.Value.isPlt})");
         }
         return fullResult;
     }
@@ -348,6 +361,14 @@ public class TextureService
     /// Tries PLT, TGA, DDS in order using FindBaseResource.
     /// </summary>
     private (int width, int height, byte[] pixels)? LoadTextureFromBase(
+        string resRef,
+        PltColorIndices colorIndices)
+    {
+        var result = LoadTextureFromBaseWithKind(resRef, colorIndices);
+        return result.HasValue ? (result.Value.width, result.Value.height, result.Value.pixels) : null;
+    }
+
+    private (int width, int height, byte[] pixels, bool isPlt)? LoadTextureFromBaseWithKind(
         string resRef,
         PltColorIndices colorIndices)
     {
@@ -368,7 +389,7 @@ public class TextureService
                 var layerColors = BuildLayerColors(colorIndices);
                 var pixels = PltReader.Render(pltFile, palettes, layerColors);
                 FlipVertically(pixels, pltFile.Width, pltFile.Height);
-                return (pltFile.Width, pltFile.Height, pixels);
+                return (pltFile.Width, pltFile.Height, pixels, true);
             }
             catch (Exception ex)
             {
@@ -385,7 +406,7 @@ public class TextureService
             {
                 var tgaImage = TgaReader.Read(tgaData);
                 FlipVertically(tgaImage.Pixels, tgaImage.Width, tgaImage.Height);
-                return (tgaImage.Width, tgaImage.Height, tgaImage.Pixels);
+                return (tgaImage.Width, tgaImage.Height, tgaImage.Pixels, false);
             }
             catch (Exception ex)
             {
@@ -410,7 +431,7 @@ public class TextureService
                     byte[] rgbaPixels = ConvertPfimToRgba(image);
                     if (isBiowareDds)
                         SwapRedBlue(rgbaPixels);
-                    return (image.Width, image.Height, rgbaPixels);
+                    return (image.Width, image.Height, rgbaPixels, false);
                 }
                 catch (Exception ex)
                 {
@@ -450,6 +471,19 @@ public class TextureService
         string resRef,
         PltColorIndices? colorIndices = null)
     {
+        var result = LoadTextureWithKind(resRef, colorIndices);
+        return result.HasValue ? (result.Value.width, result.Value.height, result.Value.pixels) : null;
+    }
+
+    /// <summary>
+    /// Same as <see cref="LoadTexture"/> but also reports whether the texture came from
+    /// a PLT (color-index-dependent) source. Callers can use this to cache non-PLT
+    /// textures across color changes.
+    /// </summary>
+    public (int width, int height, byte[] pixels, bool isPlt)? LoadTextureWithKind(
+        string resRef,
+        PltColorIndices? colorIndices = null)
+    {
         if (string.IsNullOrEmpty(resRef))
             return null;
 
@@ -458,15 +492,15 @@ public class TextureService
         // Try PLT first, then TGA, then DDS (matches Aurora Engine resolution order)
         var pltResult = RenderPltTexture(resRef, colorIndices);
         if (pltResult.HasValue)
-            return pltResult;
+            return (pltResult.Value.width, pltResult.Value.height, pltResult.Value.pixels, true);
 
         var tgaResult = LoadTgaTexture(resRef);
         if (tgaResult.HasValue)
-            return tgaResult;
+            return (tgaResult.Value.width, tgaResult.Value.height, tgaResult.Value.pixels, false);
 
         var ddsResult = LoadDdsTexture(resRef);
         if (ddsResult.HasValue)
-            return ddsResult;
+            return (ddsResult.Value.width, ddsResult.Value.height, ddsResult.Value.pixels, false);
 
         // If race-specific texture not found, try human fallback
         // e.g., pme0_head001 -> pmh0_head001
@@ -479,15 +513,15 @@ public class TextureService
             {
                 pltResult = RenderPltTexture(humanResRef, colorIndices);
                 if (pltResult.HasValue)
-                    return pltResult;
+                    return (pltResult.Value.width, pltResult.Value.height, pltResult.Value.pixels, true);
 
                 tgaResult = LoadTgaTexture(humanResRef);
                 if (tgaResult.HasValue)
-                    return tgaResult;
+                    return (tgaResult.Value.width, tgaResult.Value.height, tgaResult.Value.pixels, false);
 
                 ddsResult = LoadDdsTexture(humanResRef);
                 if (ddsResult.HasValue)
-                    return ddsResult;
+                    return (ddsResult.Value.width, ddsResult.Value.height, ddsResult.Value.pixels, false);
             }
         }
 

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.DataLoading.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.DataLoading.cs
@@ -78,7 +78,8 @@ public partial class AppearancePanel
                 Content = displayText,
                 Tag = app.AppearanceId
             };
-            item.ContextMenu = CreateAppearanceCopyMenu(app.AppearanceId, baseName, modelRef);
+            // Context menu is attached once to the parent ListBox (see WireEvents),
+            // not per-item — #2058.
             Avalonia.Controls.ToolTip.SetTip(item, $"ID: {app.AppearanceId} | Model: {modelRef} | Type: {(app.IsPartBased ? "Part-Based" : "Static")} | Label: {app.Label}");
             _appearanceListBox.Items.Add(item);
         }
@@ -344,13 +345,13 @@ public partial class AppearancePanel
             }
         }
 
-        // Still not found, add it with consistent format
+        // Still not found, add it with consistent format. Shared ContextMenu
+        // on the parent ListBox handles the copy actions for all rows (#2058).
         var fallbackItem = new ListBoxItem
         {
             Content = $"[{appearanceId}] Appearance {appearanceId}",
             Tag = appearanceId
         };
-        fallbackItem.ContextMenu = CreateAppearanceCopyMenu(appearanceId, $"Appearance {appearanceId}", "");
         _appearanceListBox.Items.Add(fallbackItem);
         _appearanceListBox.SelectedIndex = _appearanceListBox.Items.Count - 1;
     }

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
@@ -111,7 +111,9 @@ public partial class AppearancePanel
                 if (_currentCreature != null)
                 {
                     _currentCreature.AppearanceType = appearanceId;
-                    UpdateModelPreview();
+                    // Debounce so arrow-key navigation through the ListBox doesn't
+                    // fire a full mesh+texture rebuild per keystroke (#2058).
+                    ScheduleAppearancePreviewRebuild();
                 }
 
                 AppearanceChanged?.Invoke(this, EventArgs.Empty);
@@ -122,6 +124,30 @@ public partial class AppearancePanel
             UnifiedLogger.LogApplication(LogLevel.ERROR,
                 $"AppearancePanel: Appearance change failed: {ex.GetType().Name}: {ex.Message}");
         }
+    }
+
+    private void ScheduleAppearancePreviewRebuild()
+    {
+        if (_appearancePreviewDebounceTimer == null)
+        {
+            _appearancePreviewDebounceTimer = new Avalonia.Threading.DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(AppearancePreviewDebounceMs)
+            };
+            _appearancePreviewDebounceTimer.Tick += OnAppearancePreviewDebounceTick;
+        }
+
+        // Restart the countdown on each call — only the last selection in a
+        // rapid burst triggers the rebuild.
+        _appearancePreviewDebounceTimer.Stop();
+        _appearancePreviewDebounceTimer.Start();
+    }
+
+    private void OnAppearancePreviewDebounceTick(object? sender, EventArgs e)
+    {
+        _appearancePreviewDebounceTimer?.Stop();
+        if (_currentCreature == null) return;
+        UpdateModelPreview();
     }
 
     private void OnAppearanceSearchChanged(object? sender, TextChangedEventArgs e)

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
@@ -111,9 +111,7 @@ public partial class AppearancePanel
                 if (_currentCreature != null)
                 {
                     _currentCreature.AppearanceType = appearanceId;
-                    // Debounce so arrow-key navigation through the ListBox doesn't
-                    // fire a full mesh+texture rebuild per keystroke (#2058).
-                    ScheduleAppearancePreviewRebuild();
+                    UpdateModelPreview();
                 }
 
                 AppearanceChanged?.Invoke(this, EventArgs.Empty);
@@ -124,30 +122,6 @@ public partial class AppearancePanel
             UnifiedLogger.LogApplication(LogLevel.ERROR,
                 $"AppearancePanel: Appearance change failed: {ex.GetType().Name}: {ex.Message}");
         }
-    }
-
-    private void ScheduleAppearancePreviewRebuild()
-    {
-        if (_appearancePreviewDebounceTimer == null)
-        {
-            _appearancePreviewDebounceTimer = new Avalonia.Threading.DispatcherTimer
-            {
-                Interval = TimeSpan.FromMilliseconds(AppearancePreviewDebounceMs)
-            };
-            _appearancePreviewDebounceTimer.Tick += OnAppearancePreviewDebounceTick;
-        }
-
-        // Restart the countdown on each call — only the last selection in a
-        // rapid burst triggers the rebuild.
-        _appearancePreviewDebounceTimer.Stop();
-        _appearancePreviewDebounceTimer.Start();
-    }
-
-    private void OnAppearancePreviewDebounceTick(object? sender, EventArgs e)
-    {
-        _appearancePreviewDebounceTimer?.Stop();
-        if (_currentCreature == null) return;
-        UpdateModelPreview();
     }
 
     private void OnAppearanceSearchChanged(object? sender, TextChangedEventArgs e)

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
@@ -20,7 +20,13 @@ public partial class AppearancePanel
     private void WireEvents()
     {
         if (_appearanceListBox != null)
+        {
             _appearanceListBox.SelectionChanged += OnAppearanceSelectionChanged;
+            // Attach the Copy context menu once to the ListBox rather than per-item.
+            // Per-item ContextMenu allocation was a hot path during load and filter
+            // refresh with ~1000 rows (#2058).
+            _appearanceListBox.ContextMenu = BuildSharedAppearanceCopyMenu();
+        }
 
         if (_appearanceSearchBox != null)
             _appearanceSearchBox.TextChanged += OnAppearanceSearchChanged;
@@ -417,27 +423,79 @@ public partial class AppearancePanel
         }
     }
 
-    private ContextMenu CreateAppearanceCopyMenu(ushort id, string name, string resref)
+    /// <summary>
+    /// Build the shared "Copy ..." context menu attached once to the appearance ListBox.
+    /// Per-item allocation of 5+ objects × ~1000 rows was a measurable hot path on load
+    /// and on every filter/search refresh (#2058). Handlers resolve the current selection
+    /// at click time rather than capturing per-row data.
+    /// </summary>
+    private ContextMenu BuildSharedAppearanceCopyMenu()
     {
         var menu = new ContextMenu();
 
         var copyAll = new MenuItem { Header = "Copy Appearance Info" };
-        copyAll.Click += async (_, _) => await CopyToClipboard($"[{id}] {name} ({resref})");
+        copyAll.Click += async (_, _) =>
+        {
+            if (TryGetSelectedAppearanceCopyData(out var id, out var name, out var resref))
+                await CopyToClipboard($"[{id}] {name} ({resref})");
+        };
         menu.Items.Add(copyAll);
 
         var copyName = new MenuItem { Header = "Copy Name" };
-        copyName.Click += async (_, _) => await CopyToClipboard(name);
+        copyName.Click += async (_, _) =>
+        {
+            if (TryGetSelectedAppearanceCopyData(out _, out var name, out _))
+                await CopyToClipboard(name);
+        };
         menu.Items.Add(copyName);
 
         var copyResRef = new MenuItem { Header = "Copy ResRef" };
-        copyResRef.Click += async (_, _) => await CopyToClipboard(resref);
+        copyResRef.Click += async (_, _) =>
+        {
+            if (TryGetSelectedAppearanceCopyData(out _, out _, out var resref))
+                await CopyToClipboard(resref);
+        };
         menu.Items.Add(copyResRef);
 
         var copyId = new MenuItem { Header = "Copy ID" };
-        copyId.Click += async (_, _) => await CopyToClipboard(id.ToString());
+        copyId.Click += async (_, _) =>
+        {
+            if (TryGetSelectedAppearanceCopyData(out var id, out _, out _))
+                await CopyToClipboard(id.ToString());
+        };
         menu.Items.Add(copyId);
 
         return menu;
+    }
+
+    private bool TryGetSelectedAppearanceCopyData(out ushort id, out string name, out string resref)
+    {
+        id = 0;
+        name = string.Empty;
+        resref = string.Empty;
+
+        if (_appearanceListBox?.SelectedItem is not ListBoxItem selected) return false;
+        if (selected.Tag is not ushort selectedId) return false;
+
+        id = selectedId;
+
+        if (_appearances != null)
+        {
+            foreach (var app in _appearances)
+            {
+                if (app.AppearanceId != selectedId) continue;
+
+                name = app.IsPartBased && !app.Name.Contains("(Dynamic)")
+                    ? $"(Dynamic) {app.Name}"
+                    : app.Name;
+                resref = !string.IsNullOrEmpty(app.Race) ? app.Race : app.Label;
+                return true;
+            }
+        }
+
+        // Fallback: synthesize from ListBoxItem content (matches the "Appearance N" row format)
+        name = selected.Content?.ToString() ?? $"Appearance {selectedId}";
+        return true;
     }
 
     private async System.Threading.Tasks.Task CopyToClipboard(string text)

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
@@ -255,7 +255,7 @@
                                            VerticalAlignment="Center"/>
                                 <Border Grid.Row="0" Grid.Column="1" x:Name="SkinColorSwatch" Width="18" Height="18"
                                         CornerRadius="2" BorderBrush="{DynamicResource ThemeBorder}" BorderThickness="1"
-                                        Background="{DynamicResource ThemeBorder}" VerticalAlignment="Center"
+                                        VerticalAlignment="Center"
                                         ToolTip.Tip="Click to choose skin color"/>
 
                                 <TextBlock Grid.Row="0" Grid.Column="3" Text="Hair:" FontSize="{DynamicResource FontSizeSmall}"
@@ -263,7 +263,7 @@
                                            VerticalAlignment="Center"/>
                                 <Border Grid.Row="0" Grid.Column="4" x:Name="HairColorSwatch" Width="18" Height="18"
                                         CornerRadius="2" BorderBrush="{DynamicResource ThemeBorder}" BorderThickness="1"
-                                        Background="{DynamicResource ThemeBorder}" VerticalAlignment="Center"
+                                        VerticalAlignment="Center"
                                         ToolTip.Tip="Click to choose hair color"/>
 
                                 <!-- Tattoo 1 / Tattoo 2 -->
@@ -273,7 +273,7 @@
                                            ToolTip.Tip="Tattoo colors apply to pixels painted in body part textures. Most base game models have minimal tattoo areas."/>
                                 <Border Grid.Row="1" Grid.Column="1" x:Name="Tattoo1ColorSwatch" Width="18" Height="18"
                                         CornerRadius="2" BorderBrush="{DynamicResource ThemeBorder}" BorderThickness="1"
-                                        Background="{DynamicResource ThemeBorder}" VerticalAlignment="Center"
+                                        VerticalAlignment="Center"
                                         ToolTip.Tip="Click to choose tattoo 1 color"/>
 
                                 <TextBlock Grid.Row="1" Grid.Column="3" Text="Tat 2:" FontSize="{DynamicResource FontSizeSmall}"
@@ -282,7 +282,7 @@
                                            ToolTip.Tip="Tattoo colors apply to pixels painted in body part textures. Custom content may add more tattoo areas."/>
                                 <Border Grid.Row="1" Grid.Column="4" x:Name="Tattoo2ColorSwatch" Width="18" Height="18"
                                         CornerRadius="2" BorderBrush="{DynamicResource ThemeBorder}" BorderThickness="1"
-                                        Background="{DynamicResource ThemeBorder}" VerticalAlignment="Center"
+                                        VerticalAlignment="Center"
                                         ToolTip.Tip="Click to choose tattoo 2 color"/>
                             </Grid>
                         </StackPanel>

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
@@ -86,12 +86,6 @@ public partial class AppearancePanel : UserControl
     private List<PhenotypeInfo>? _phenotypes;
     private bool _isLoading;
 
-    // Debounces model preview rebuild when the user arrow-key-navigates the
-    // appearance list. Mesh + texture work happens on the GL thread and was
-    // firing per arrow press (#2058).
-    private Avalonia.Threading.DispatcherTimer? _appearancePreviewDebounceTimer;
-    private const int AppearancePreviewDebounceMs = 150;
-
     public event EventHandler? AppearanceChanged;
 
     public AppearancePanel()

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
@@ -86,6 +86,12 @@ public partial class AppearancePanel : UserControl
     private List<PhenotypeInfo>? _phenotypes;
     private bool _isLoading;
 
+    // Debounces model preview rebuild when the user arrow-key-navigates the
+    // appearance list. Mesh + texture work happens on the GL thread and was
+    // firing per arrow press (#2058).
+    private Avalonia.Threading.DispatcherTimer? _appearancePreviewDebounceTimer;
+    private const int AppearancePreviewDebounceMs = 150;
+
     public event EventHandler? AppearanceChanged;
 
     public AppearancePanel()


### PR DESCRIPTION
## Summary

Sprint bundling a color-swatch fix and two Quartermaster perf wins. Third perf hotspot (debounce) was reverted after a suspected regression — filter/list contents turned out to be unrelated per the spike's own evidence.

## Work Items

- [x] #2004 — Color picker swatches not displaying until picker dialog opened
- [x] #2058 — Address general UI lag and performance (2 of 3 hotspots landed)

## Commits on this branch

| Commit | Description |
|--------|-------------|
| b0b23cff | #2004 fix: remove `DynamicResource` Background on swatch Borders so code-assigned SolidColorBrush isn't overwritten on theme re-apply |
| 0e82b88c | #2058 hotspot 1: track PLT-vs-flat textures in `ModelPreviewGLControl`; `SetColorIndices` deletes only PLT entries |
| 04ab7abc | #2058 hotspot 2: single shared ContextMenu on appearance ListBox instead of ~5000 per-row allocations |
| 081be09e | Revert of #2058 hotspot 3 (debounce on appearance selection) — shelved after manual-test regressions; symptom couldn't be reproduced in fresh sessions |

## Related Issues

- Closes #2064, #2004
- Addresses #2058 (2 of 3 spike hotspots; 3rd reverted)
- Files follow-up #2113 (CEP HAK-shadow behavior surfaced during testing — pre-existing, not caused by this sprint)

## Checklist

- [x] Implementation complete
- [x] Tests added/updated (existing coverage sufficient — 1240 unit tests pass, 12 FlaUI tests pass)
- [x] CHANGELOG updated with date
- [x] Documentation updated (release notes)

## Pre-Merge Results

- **Privacy scan**: PASS
- **Tech debt**: `ModelPreviewGLControl.cs` at 941 lines (warning threshold 800, issue threshold 1000 — no issue required)
- **Theme scan**: pre-existing warnings only (no new hardcoded colors in sprint diff)
- **Unit tests**: 1240/1240 pass (Quartermaster.Tests)
- **FlaUI integration tests**: 12/21 pass, 0 failures (9 skipped by trait filter — expected)
- **Wiki**: current (dated 2026-04-18)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)