### PR TITLE
[Quartermaster] Feat: Comprehensive 3D preview controls — pan, rotate, zoom, animation playback

### DIFF
--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,17 +5,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
-## [0.2.83-alpha] - 2026-04-20
+## [0.2.83-alpha] - 2026-04-22
 **Branch**: `quartermaster/issue-2124` | **PR**: #2125
 
 ### Feature: Comprehensive 3D preview controls (#2124)
 
-- Free orbit (drag rotate on Y and X axes without X-axis clamping)
-- Pan via middle-click or Shift+drag
-- Zoom via scroll wheel
-- View presets (front/side/top/back) and reset-to-front
-- Animation/stance playback from MDL anim section (stretch)
-- Keyboard camera shortcuts, F8 debug mode surfacing, FOV slider (quality-of-life)
+- Free orbit — left-drag rotates on both axes with no X-axis clamp
+- Pan via middle-click or Shift+left-drag; zooming now pivots on the cursor instead of world origin
+- Scroll wheel zoom and keyboard camera shortcuts (arrows/WASD rotate, Home reset, F8 cycles debug mode)
+- View preset buttons: F/B/L/R/T (front/back/left/right/top)
+- Animation playback: dropdown of idle/walk/run/attack/cast etc., play-pause-scrub, loop, speed slider (0.1×–2×)
+- Supermodel animation inheritance (`a_ba`, `a_fa`, etc.) so most creatures have anims without authoring their own
+- Humanoid (part-based) creatures now use their skeleton's bone hierarchy so supermodel animations drive all body parts
 
 ---
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.83-alpha] - 2026-04-20
-**Branch**: `quartermaster/issue-2124` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2124` | **PR**: #2125
 
 ### Feature: Comprehensive 3D preview controls (#2124)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.83-alpha] - 2026-04-20
+**Branch**: `quartermaster/issue-2124` | **PR**: #TBD
+
+### Feature: Comprehensive 3D preview controls (#2124)
+
+- Free orbit (drag rotate on Y and X axes without X-axis clamping)
+- Pan via middle-click or Shift+drag
+- Zoom via scroll wheel
+- View presets (front/side/top/back) and reset-to-front
+- Animation/stance playback from MDL anim section (stretch)
+- Keyboard camera shortcuts, F8 debug mode surfacing, FOV slider (quality-of-life)
+
+---
+
 ## [0.2.82-alpha] - 2026-04-20
 **Branch**: `quartermaster/issue-2026` | **PR**: #2114
 

--- a/Quartermaster/Quartermaster.Tests/ModelViewControllerTests.cs
+++ b/Quartermaster/Quartermaster.Tests/ModelViewControllerTests.cs
@@ -139,4 +139,109 @@ public class ModelViewControllerTests
         Assert.True(vc.HasVertexBounds);
         Assert.Equal(Vector3.Zero, vc.CameraTarget);
     }
+
+    // ----- #2124: Pan + cursor-centric zoom -----
+
+    [Fact]
+    public void Pan_TranslatesCameraTargetByDelta()
+    {
+        var vc = new ModelViewController();
+        vc.UpdateBounds(1.0f, true);
+
+        vc.Pan(new Vector3(0.5f, 0, -0.25f));
+
+        Assert.Equal(0.5f, vc.CameraTarget.X, 5);
+        Assert.Equal(0f, vc.CameraTarget.Y, 5);
+        Assert.Equal(-0.25f, vc.CameraTarget.Z, 5);
+    }
+
+    [Fact]
+    public void Pan_Accumulates()
+    {
+        var vc = new ModelViewController();
+        vc.UpdateBounds(1.0f, true);
+
+        vc.Pan(new Vector3(1, 0, 0));
+        vc.Pan(new Vector3(0, 0, 2));
+        vc.Pan(new Vector3(-0.5f, 0, 0));
+
+        Assert.Equal(0.5f, vc.CameraTarget.X, 5);
+        Assert.Equal(0f, vc.CameraTarget.Y, 5);
+        Assert.Equal(2f, vc.CameraTarget.Z, 5);
+    }
+
+    [Fact]
+    public void ResetView_ClearsPan()
+    {
+        var vc = new ModelViewController();
+        vc.UpdateBounds(2.0f, true);
+        vc.Pan(new Vector3(3, 4, 5));
+
+        vc.ResetView();
+
+        Assert.Equal(Vector3.Zero, vc.CameraTarget);
+    }
+
+    [Fact]
+    public void ZoomAtPoint_ZoomingIn_MovesTargetTowardPivot()
+    {
+        // When zooming in at an off-center world point, the camera target should
+        // drift toward the pivot so the pivot stays roughly under the cursor.
+        var vc = new ModelViewController();
+        vc.UpdateBounds(1.0f, true);
+        float initialZoom = vc.Zoom;
+        var pivot = new Vector3(2, 0, 0);
+
+        vc.ZoomAtPoint(1.5f, pivot);
+
+        Assert.True(vc.Zoom > initialZoom, "Zoom should increase");
+        Assert.True(vc.CameraTarget.X > 0, "Target should drift toward pivot on X");
+        Assert.True(vc.CameraTarget.X < pivot.X, "Target should not overshoot pivot");
+    }
+
+    [Fact]
+    public void ZoomAtPoint_AtCameraTarget_KeepsTargetStable()
+    {
+        // Zooming at the current target (pivot == target) must not move the target.
+        var vc = new ModelViewController();
+        vc.UpdateBounds(1.0f, true);
+        vc.Pan(new Vector3(1, 0, 0));
+        var pivot = vc.CameraTarget;
+
+        vc.ZoomAtPoint(1.5f, pivot);
+
+        Assert.Equal(pivot.X, vc.CameraTarget.X, 4);
+        Assert.Equal(pivot.Y, vc.CameraTarget.Y, 4);
+        Assert.Equal(pivot.Z, vc.CameraTarget.Z, 4);
+    }
+
+    [Fact]
+    public void ZoomAtPoint_ClampsToZoomRange()
+    {
+        var vc = new ModelViewController();
+        vc.UpdateBounds(1.0f, true);
+
+        vc.ZoomAtPoint(1000f, Vector3.Zero);
+        Assert.Equal(10f, vc.Zoom, 4);
+
+        vc.ZoomAtPoint(0.0001f, Vector3.Zero);
+        Assert.Equal(0.1f, vc.Zoom, 4);
+    }
+
+    [Fact]
+    public void ZoomAtPoint_DoesNotMoveTarget_WhenZoomClamped()
+    {
+        // If the zoom factor is clamped (no effective change), the pivot pull must
+        // also be suppressed — otherwise repeated scrolling at max zoom would drift.
+        var vc = new ModelViewController();
+        vc.UpdateBounds(1.0f, true);
+        vc.Zoom = 10f; // at max
+        var before = vc.CameraTarget;
+
+        vc.ZoomAtPoint(2f, new Vector3(5, 0, 0));
+
+        Assert.Equal(before.X, vc.CameraTarget.X, 4);
+        Assert.Equal(before.Y, vc.CameraTarget.Y, 4);
+        Assert.Equal(before.Z, vc.CameraTarget.Z, 4);
+    }
 }

--- a/Quartermaster/Quartermaster.Tests/ModelViewControllerTests.cs
+++ b/Quartermaster/Quartermaster.Tests/ModelViewControllerTests.cs
@@ -143,6 +143,37 @@ public class ModelViewControllerTests
     // ----- #2124: Pan + cursor-centric zoom -----
 
     [Fact]
+    public void CenterCamera_PreservesUserPan()
+    {
+        // Switching heads / equipment triggers CenterCamera. The user's
+        // pan (and zoom) must survive so they keep looking at the spot
+        // they zoomed into (#2124).
+        var vc = new ModelViewController();
+        vc.UpdateBounds(2f, true);
+        vc.Pan(new Vector3(3, 0, 2));
+        vc.Zoom = 4f;
+
+        vc.CenterCamera();
+
+        Assert.Equal(3f, vc.CameraTarget.X, 4);
+        Assert.Equal(2f, vc.CameraTarget.Z, 4);
+        Assert.Equal(4f, vc.Zoom, 4);
+    }
+
+    [Fact]
+    public void UpdateBounds_PreservesUserPan()
+    {
+        var vc = new ModelViewController();
+        vc.Pan(new Vector3(1, 0, 1));
+
+        vc.UpdateBounds(3.5f, true);
+
+        Assert.Equal(1f, vc.CameraTarget.X, 4);
+        Assert.Equal(1f, vc.CameraTarget.Z, 4);
+        Assert.Equal(3.5f, vc.ModelRadius);
+    }
+
+    [Fact]
     public void Pan_TranslatesCameraTargetByDelta()
     {
         var vc = new ModelViewController();

--- a/Quartermaster/Quartermaster.Tests/ModelViewControllerTests.cs
+++ b/Quartermaster/Quartermaster.Tests/ModelViewControllerTests.cs
@@ -229,6 +229,63 @@ public class ModelViewControllerTests
     }
 
     [Fact]
+    public void ViewPreset_Front_SetsExpectedRotation()
+    {
+        var vc = new ModelViewController();
+        vc.RotationY = 0.5f;
+        vc.RotationX = 0.3f;
+
+        vc.SetViewPreset(ViewPreset.Front);
+
+        Assert.Equal(MathF.PI, vc.RotationY, 4);
+        Assert.Equal(0f, vc.RotationX, 4);
+    }
+
+    [Fact]
+    public void ViewPreset_Back_SetsZeroY()
+    {
+        var vc = new ModelViewController();
+        vc.SetViewPreset(ViewPreset.Back);
+
+        Assert.Equal(0f, vc.RotationY, 4);
+        Assert.Equal(0f, vc.RotationX, 4);
+    }
+
+    [Fact]
+    public void ViewPreset_Side_SetsQuarterTurn()
+    {
+        var vc = new ModelViewController();
+        vc.SetViewPreset(ViewPreset.Side);
+
+        Assert.Equal(MathF.PI / 2f, vc.RotationY, 4);
+        Assert.Equal(0f, vc.RotationX, 4);
+    }
+
+    [Fact]
+    public void ViewPreset_Top_TiltsDownOnX()
+    {
+        var vc = new ModelViewController();
+        vc.SetViewPreset(ViewPreset.Top);
+
+        Assert.Equal(MathF.PI, vc.RotationY, 4);
+        Assert.Equal(MathF.PI / 2f, vc.RotationX, 4);
+    }
+
+    [Fact]
+    public void ViewPreset_ClearsPanAndRestoresDefaultZoom()
+    {
+        var vc = new ModelViewController();
+        vc.UpdateBounds(2.0f, true);
+        vc.Pan(new Vector3(3, 0, 4));
+        vc.Zoom = 5f;
+
+        vc.SetViewPreset(ViewPreset.Front);
+
+        Assert.Equal(Vector3.Zero, vc.CameraTarget);
+        Assert.Equal(1.0f, vc.Zoom, 4);
+    }
+
+    [Fact]
     public void ZoomAtPoint_DoesNotMoveTarget_WhenZoomClamped()
     {
         // If the zoom factor is clamped (no effective change), the pivot pull must

--- a/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
+++ b/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
@@ -345,10 +345,56 @@ public class ModelPreviewGLControl : OpenGlControlBase
 
     // ----- Pointer / keyboard input (#2124) -----
     //
-    // Avalonia delivers these via the standard routed events. We override
-    // them on the control so the host AppearancePanel doesn't need to
-    // wire anything. Focus is requested on press so keyboard shortcuts
-    // (arrow keys, WASD, Home) land on the control.
+    // OpenGlControlBase has no Background brush, so pointer events don't
+    // hit-test on its transparent pixels. The host panel overlays a
+    // transparent Border on top of this control and forwards input here
+    // via the public Handle* / Pan / ZoomAtCursor / RotateBy methods
+    // below. The OnPointerPressed etc. overrides remain as a fallback
+    // if the control is ever used without the overlay.
+
+    /// <summary>
+    /// Host panels call this to request a pan in screen-pixel units.
+    /// Converts to world units using the last-rendered viewport + camera distance.
+    /// </summary>
+    public void PanByPixels(double dxPixels, double dyPixels)
+    {
+        if (_lastViewportHeight <= 0) return;
+        float fovRadians = MathF.PI / 6f;
+        float halfFovTan = MathF.Tan(fovRadians * 0.5f);
+        float worldPerPixel = 2f * _lastCameraDistance * halfFovTan / _lastViewportHeight;
+
+        // See OnPointerMoved for axis convention; camera right = -X, up = +Z.
+        _viewController.Pan(new Vector3(-(float)dxPixels * worldPerPixel, 0, (float)dyPixels * worldPerPixel));
+        RequestNextFrameRendering();
+    }
+
+    /// <summary>
+    /// Host panels call this to zoom toward a world point under the cursor.
+    /// </summary>
+    public void ZoomAtCursorPixels(Point screenPos, double wheelDeltaY)
+    {
+        float factor = (float)Math.Pow(1.1, wheelDeltaY);
+        var pivot = UnprojectToTargetPlane(screenPos);
+        _viewController.ZoomAtPoint(factor, pivot);
+        RequestNextFrameRendering();
+    }
+
+    /// <summary>
+    /// Host panels call this to rotate by screen-pixel drag deltas.
+    /// </summary>
+    public void RotateByPixels(double dxPixels, double dyPixels)
+    {
+        _viewController.Rotate((float)(dxPixels * 0.01), (float)(dyPixels * 0.01));
+        RequestNextFrameRendering();
+    }
+
+    /// <summary>
+    /// Cycle debug visualisation mode (0..4).
+    /// </summary>
+    public void CycleDebugMode()
+    {
+        DebugMode = (_debugMode + 1) % 5;
+    }
 
     protected override void OnPointerPressed(PointerPressedEventArgs e)
     {

--- a/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
+++ b/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
@@ -95,6 +95,7 @@ public class ModelPreviewGLControl : OpenGlControlBase
     // Animation playback state (#2124).
     private MdlAnimation? _activeAnimation;
     private float _animTime;
+    private float _animSpeed = 1.0f;
     private bool _animPlaying;
     private DateTime _animLastTick = DateTime.UtcNow;
     private Dictionary<string, ModelViewController.NodePose>? _cachedPose;
@@ -441,6 +442,15 @@ public class ModelPreviewGLControl : OpenGlControlBase
     public bool IsAnimationPlaying => _animPlaying;
 
     /// <summary>
+    /// Playback speed multiplier (1.0 = real-time).
+    /// </summary>
+    public float AnimationSpeed
+    {
+        get => _animSpeed;
+        set => _animSpeed = Math.Clamp(value, 0.1f, 5f);
+    }
+
+    /// <summary>
     /// Select an animation by reference (null to clear). Resets playhead to 0.
     /// </summary>
     public void SetActiveAnimation(MdlAnimation? animation)
@@ -481,7 +491,7 @@ public class ModelPreviewGLControl : OpenGlControlBase
         if (!_animPlaying || _activeAnimation == null) return;
 
         var now = DateTime.UtcNow;
-        var dt = (float)(now - _animLastTick).TotalSeconds;
+        var dt = (float)(now - _animLastTick).TotalSeconds * _animSpeed;
         _animLastTick = now;
 
         float length = _activeAnimation.Length;

--- a/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
+++ b/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using Avalonia;
+using Avalonia.Input;
 using Avalonia.OpenGL;
 using Avalonia.OpenGL.Controls;
 using Avalonia.Threading;
@@ -38,6 +39,12 @@ public enum PreviewState
 /// </summary>
 public class ModelPreviewGLControl : OpenGlControlBase
 {
+    static ModelPreviewGLControl()
+    {
+        // Allow keyboard focus (arrow keys, WASD, Home, F8) — #2124.
+        FocusableProperty.OverrideDefaultValue<ModelPreviewGLControl>(true);
+    }
+
     private GL? _gl;
     private OpenGLShaderManager? _shaderManager;
     private readonly ModelViewController _viewController = new();
@@ -77,6 +84,18 @@ public class ModelPreviewGLControl : OpenGlControlBase
     //   1 = world-space normal as RGB
     //   2 = lighting dot-product as grayscale
     private int _debugMode;
+
+    // Cached render matrices / viewport for pointer unprojection (#2124).
+    private Matrix4x4 _lastProjection = Matrix4x4.Identity;
+    private Matrix4x4 _lastView = Matrix4x4.Identity;
+    private int _lastViewportWidth;
+    private int _lastViewportHeight;
+    private float _lastCameraDistance = 1f;
+
+    // Pointer drag state (#2124).
+    private enum DragMode { None, Rotate, Pan }
+    private DragMode _dragMode = DragMode.None;
+    private Point _lastPointerPos;
 
     private PreviewState _previewState = PreviewState.None;
 
@@ -324,6 +343,180 @@ public class ModelPreviewGLControl : OpenGlControlBase
         RequestNextFrameRendering();
     }
 
+    // ----- Pointer / keyboard input (#2124) -----
+    //
+    // Avalonia delivers these via the standard routed events. We override
+    // them on the control so the host AppearancePanel doesn't need to
+    // wire anything. Focus is requested on press so keyboard shortcuts
+    // (arrow keys, WASD, Home) land on the control.
+
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
+    {
+        base.OnPointerPressed(e);
+        var props = e.GetCurrentPoint(this).Properties;
+        bool shift = (e.KeyModifiers & KeyModifiers.Shift) != 0;
+
+        if (props.IsMiddleButtonPressed || (props.IsLeftButtonPressed && shift))
+        {
+            _dragMode = DragMode.Pan;
+        }
+        else if (props.IsLeftButtonPressed)
+        {
+            _dragMode = DragMode.Rotate;
+        }
+        else
+        {
+            return;
+        }
+
+        _lastPointerPos = e.GetPosition(this);
+        Focus();
+        e.Pointer.Capture(this);
+        e.Handled = true;
+    }
+
+    protected override void OnPointerMoved(PointerEventArgs e)
+    {
+        base.OnPointerMoved(e);
+        if (_dragMode == DragMode.None) return;
+
+        var pos = e.GetPosition(this);
+        double dx = pos.X - _lastPointerPos.X;
+        double dy = pos.Y - _lastPointerPos.Y;
+        _lastPointerPos = pos;
+
+        if (_dragMode == DragMode.Rotate)
+        {
+            // 0.01 rad/px matches the feel of the discrete rotate buttons
+            // (0.3 rad per click). Free X-axis orbit — no clamping.
+            _viewController.Rotate((float)(dx * 0.01), (float)(dy * 0.01));
+            RequestNextFrameRendering();
+        }
+        else if (_dragMode == DragMode.Pan)
+        {
+            // Convert screen-pixel delta to world units at the target's depth.
+            // At the camera-to-target distance, one NDC unit covers
+            // cameraDistance * halfFovTan world units vertically.
+            if (_lastViewportHeight <= 0) return;
+            float fovRadians = MathF.PI / 6f;
+            float halfFovTan = MathF.Tan(fovRadians * 0.5f);
+            float worldPerPixel = 2f * _lastCameraDistance * halfFovTan / _lastViewportHeight;
+
+            var worldDelta = ScreenDeltaToWorld(-(float)dx * worldPerPixel, (float)dy * worldPerPixel);
+            _viewController.Pan(worldDelta);
+            RequestNextFrameRendering();
+        }
+    }
+
+    protected override void OnPointerReleased(PointerReleasedEventArgs e)
+    {
+        base.OnPointerReleased(e);
+        if (_dragMode != DragMode.None)
+        {
+            _dragMode = DragMode.None;
+            e.Pointer.Capture(null);
+            e.Handled = true;
+        }
+    }
+
+    protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
+    {
+        base.OnPointerWheelChanged(e);
+
+        // Each wheel notch is ~1.0 in e.Delta.Y. 1.1× per notch gives
+        // a natural zoom feel without being twitchy.
+        float factor = (float)Math.Pow(1.1, e.Delta.Y);
+
+        var pos = e.GetPosition(this);
+        var pivot = UnprojectToTargetPlane(pos);
+        _viewController.ZoomAtPoint(factor, pivot);
+
+        RequestNextFrameRendering();
+        e.Handled = true;
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        const float rotStep = 0.1f;
+
+        switch (e.Key)
+        {
+            case Key.Left:
+            case Key.A:
+                _viewController.Rotate(-rotStep, 0);
+                break;
+            case Key.Right:
+            case Key.D:
+                _viewController.Rotate(rotStep, 0);
+                break;
+            case Key.Up:
+            case Key.W:
+                _viewController.Rotate(0, -rotStep);
+                break;
+            case Key.Down:
+            case Key.S:
+                _viewController.Rotate(0, rotStep);
+                break;
+            case Key.Home:
+                _viewController.ResetView();
+                break;
+            case Key.F8:
+                DebugMode = (_debugMode + 1) % 5;
+                return; // DebugMode setter already triggers re-render
+            default:
+                return;
+        }
+
+        RequestNextFrameRendering();
+        e.Handled = true;
+    }
+
+    /// <summary>
+    /// Convert a screen-space (pixel) delta into a world-space delta in the
+    /// plane facing the camera, using the current rotation state. Pan drags
+    /// move the model along these in-plane axes rather than world XY so the
+    /// motion feels right at any view angle.
+    /// </summary>
+    private Vector3 ScreenDeltaToWorld(float rightAmount, float upAmount)
+    {
+        // The model rotation is applied to vertices, so the visible
+        // "right" / "up" directions in world space are the unrotated
+        // camera axes. Camera looks along +Y (LookAt from -Y eye to
+        // origin with Z-up), so "right" = -X and "up" = +Z when no
+        // rotation has been applied. We want pan to move the model
+        // under the mouse regardless of the model rotation — so we
+        // translate the camera target along world-aligned axes only.
+        // This matches common DCC tool behaviour.
+        return new Vector3(rightAmount, 0, upAmount);
+    }
+
+    /// <summary>
+    /// Approximate the world-space point under the cursor at the depth of
+    /// the camera target, so scroll-wheel zoom can pivot there.
+    /// </summary>
+    private Vector3 UnprojectToTargetPlane(Point screenPos)
+    {
+        if (_lastViewportWidth <= 0 || _lastViewportHeight <= 0)
+            return _viewController.CameraTarget;
+
+        // NDC coordinates (-1..1), Y inverted because screen Y is top-down.
+        float ndcX = (float)(screenPos.X / _lastViewportWidth * 2.0 - 1.0);
+        float ndcY = (float)(1.0 - screenPos.Y / _lastViewportHeight * 2.0);
+
+        // At the target's depth, one NDC unit vertically = cameraDistance * halfFovTan world units.
+        float fovRadians = MathF.PI / 6f;
+        float halfFovTan = MathF.Tan(fovRadians * 0.5f);
+        float aspect = (float)_lastViewportWidth / _lastViewportHeight;
+        float worldY = ndcY * _lastCameraDistance * halfFovTan;
+        float worldX = ndcX * _lastCameraDistance * halfFovTan * aspect;
+
+        // The camera's right/up axes at the target depth. See
+        // ScreenDeltaToWorld — right = -X, up = +Z under our LookAt.
+        var target = _viewController.CameraTarget;
+        return target + new Vector3(-worldX, 0, worldY);
+    }
+
     protected override void OnOpenGlInit(GlInterface gl)
     {
         base.OnOpenGlInit(gl);
@@ -470,12 +663,24 @@ public class ModelPreviewGLControl : OpenGlControlBase
         float radius = Math.Max(_viewController.ModelRadius, 0.001f);
         float cameraDistance = (radius / halfFovTan) / _viewController.Zoom;
 
+        // Near/far clamped by distance-to-target so pan can move the eye
+        // away from origin without vertices falling outside the frustum.
+        float farScale = Math.Max(_viewController.CameraTarget.Length() / cameraDistance + 100f, 100f);
         var projection = Matrix4x4.CreatePerspectiveFieldOfView(
-            fovRadians, aspect, cameraDistance * 0.01f, cameraDistance * 100f);
+            fovRadians, aspect, cameraDistance * 0.01f, cameraDistance * farScale);
 
-        // View matrix: camera looking at origin from +Y (after Z-up tilt)
-        var eye = new Vector3(0, -cameraDistance, 0);
-        var view = Matrix4x4.CreateLookAt(eye, Vector3.Zero, Vector3.UnitZ);
+        // View matrix: camera sits at (target + eyeOffset) looking at target.
+        // eyeOffset is along -Y in world space (pre-LookAt); LookAt handles Z-up.
+        var target = _viewController.CameraTarget;
+        var eye = target + new Vector3(0, -cameraDistance, 0);
+        var view = Matrix4x4.CreateLookAt(eye, target, Vector3.UnitZ);
+
+        // Cache matrices + viewport so pointer handlers can unproject cursor positions.
+        _lastProjection = projection;
+        _lastView = view;
+        _lastViewportWidth = width;
+        _lastViewportHeight = height;
+        _lastCameraDistance = cameraDistance;
 
         // Model matrix: rotate the model (vertices are pre-centered at origin).
         // No scale needed — perspective + camera distance handles framing.

--- a/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
+++ b/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
@@ -396,6 +396,15 @@ public class ModelPreviewGLControl : OpenGlControlBase
         DebugMode = (_debugMode + 1) % 5;
     }
 
+    /// <summary>
+    /// Snap to a preset view (front/side/top/back). #2124.
+    /// </summary>
+    public void SetViewPreset(ViewPreset preset)
+    {
+        _viewController.SetViewPreset(preset);
+        RequestNextFrameRendering();
+    }
+
     protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
         base.OnPointerPressed(e);

--- a/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
+++ b/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
@@ -92,6 +92,14 @@ public class ModelPreviewGLControl : OpenGlControlBase
     private int _lastViewportHeight;
     private float _lastCameraDistance = 1f;
 
+    // Animation playback state (#2124).
+    private MdlAnimation? _activeAnimation;
+    private float _animTime;
+    private bool _animPlaying;
+    private DateTime _animLastTick = DateTime.UtcNow;
+    private Dictionary<string, ModelViewController.NodePose>? _cachedPose;
+    private Avalonia.Threading.DispatcherTimer? _animTimer;
+
     // Pointer drag state (#2124).
     private enum DragMode { None, Rotate, Pan }
     private DragMode _dragMode = DragMode.None;
@@ -403,6 +411,131 @@ public class ModelPreviewGLControl : OpenGlControlBase
     {
         _viewController.SetViewPreset(preset);
         RequestNextFrameRendering();
+    }
+
+    // ----- Animation playback (#2124) -----
+
+    /// <summary>
+    /// Currently active animation, or null if none selected.
+    /// </summary>
+    public MdlAnimation? ActiveAnimation => _activeAnimation;
+
+    /// <summary>
+    /// Current playhead time in seconds (0..Animation.Length).
+    /// </summary>
+    public float AnimationTime
+    {
+        get => _animTime;
+        set
+        {
+            _animTime = value;
+            _cachedPose = null;
+            _needsMeshUpdate = true;
+            RequestNextFrameRendering();
+        }
+    }
+
+    /// <summary>
+    /// True when animation is auto-advancing. Toggle with Play/Pause.
+    /// </summary>
+    public bool IsAnimationPlaying => _animPlaying;
+
+    /// <summary>
+    /// Select an animation by reference (null to clear). Resets playhead to 0.
+    /// </summary>
+    public void SetActiveAnimation(MdlAnimation? animation)
+    {
+        _activeAnimation = animation;
+        _animTime = 0f;
+        _cachedPose = null;
+        _needsMeshUpdate = true;
+        RequestNextFrameRendering();
+    }
+
+    public void PlayAnimation()
+    {
+        if (_activeAnimation == null) return;
+        _animPlaying = true;
+        _animLastTick = DateTime.UtcNow;
+        EnsureAnimTimer();
+    }
+
+    public void PauseAnimation()
+    {
+        _animPlaying = false;
+    }
+
+    private void EnsureAnimTimer()
+    {
+        if (_animTimer != null) return;
+        _animTimer = new Avalonia.Threading.DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(33), // ~30 fps
+        };
+        _animTimer.Tick += OnAnimTick;
+        _animTimer.Start();
+    }
+
+    private void OnAnimTick(object? sender, EventArgs e)
+    {
+        if (!_animPlaying || _activeAnimation == null) return;
+
+        var now = DateTime.UtcNow;
+        var dt = (float)(now - _animLastTick).TotalSeconds;
+        _animLastTick = now;
+
+        float length = _activeAnimation.Length;
+        if (length <= 0)
+        {
+            _animTime = 0f;
+        }
+        else
+        {
+            _animTime += dt;
+            if (_animTime >= length)
+                _animTime -= length * MathF.Floor(_animTime / length); // loop
+        }
+
+        _cachedPose = null;
+        _needsMeshUpdate = true;
+        RequestNextFrameRendering();
+    }
+
+    /// <summary>
+    /// Build a node-name → sampled-pose dictionary from the active animation
+    /// at the current <see cref="AnimationTime"/>. Cached until playhead moves
+    /// or the animation changes.
+    /// </summary>
+    private Dictionary<string, ModelViewController.NodePose>? GetCurrentPose()
+    {
+        if (_activeAnimation?.GeometryRoot == null) return null;
+        if (_cachedPose != null) return _cachedPose;
+
+        var pose = new Dictionary<string, ModelViewController.NodePose>(StringComparer.OrdinalIgnoreCase);
+        BuildPoseRecursive(_activeAnimation.GeometryRoot, _animTime, pose);
+        _cachedPose = pose;
+        return pose;
+    }
+
+    private static void BuildPoseRecursive(MdlNode animNode, float t,
+        Dictionary<string, ModelViewController.NodePose> pose)
+    {
+        bool hasPos = animNode.PositionTimes.Length > 1;
+        bool hasOri = animNode.OrientationTimes.Length > 1;
+        bool hasScl = animNode.ScaleTimes.Length > 1;
+
+        if (hasPos || hasOri || hasScl)
+        {
+            var p = new ModelViewController.NodePose(
+                hasPos, hasPos ? MdlAnimationEvaluator.EvaluatePosition(animNode, t) : animNode.Position,
+                hasOri, hasOri ? MdlAnimationEvaluator.EvaluateOrientation(animNode, t) : animNode.Orientation,
+                hasScl, hasScl ? MdlAnimationEvaluator.EvaluateScale(animNode, t) : animNode.Scale);
+            if (!string.IsNullOrEmpty(animNode.Name))
+                pose[animNode.Name] = p;
+        }
+
+        foreach (var child in animNode.Children)
+            BuildPoseRecursive(child, t, pose);
     }
 
     protected override void OnPointerPressed(PointerPressedEventArgs e)
@@ -924,7 +1057,8 @@ public class ModelPreviewGLControl : OpenGlControlBase
             // All meshes: apply full hierarchy world transform.
             // Skin mesh vertices (m_pavVerts) are in bind-pose space — same treatment as trimesh.
             // m_aQBoneRefInv/m_aTBoneRefInv are inverse bind-pose matrices for runtime animation, not static display.
-            var worldTransform = ModelViewController.GetWorldTransform(mesh);
+            var pose = GetCurrentPose();
+            var worldTransform = ModelViewController.GetWorldTransform(mesh, pose);
             bool hasWorldTransform = worldTransform != Matrix4x4.Identity;
 
             // Count NaN vertices - we'll skip them during rendering

--- a/Quartermaster/Quartermaster/Controls/ModelViewController.cs
+++ b/Quartermaster/Quartermaster/Controls/ModelViewController.cs
@@ -8,6 +8,19 @@ using Radoub.Formats.Mdl;
 namespace Quartermaster.Controls;
 
 /// <summary>
+/// Preset camera orientations (#2124).
+/// Values map to RotationY (model-around-Z) + RotationX tilt.
+/// </summary>
+public enum ViewPreset
+{
+    Front,
+    Back,
+    Side,       // quarter turn — "left" side in viewer terms
+    SideRight,  // opposite side
+    Top,
+}
+
+/// <summary>
 /// Manages camera state (rotation, zoom, target) and provides
 /// world-space transform calculations for 3D model rendering.
 /// Pure math — no GL dependency.
@@ -84,6 +97,39 @@ public class ModelViewController
         // target a matching fraction of (pivot - target).
         float t = 1f - 1f / applied;
         _cameraTarget += (worldPivot - _cameraTarget) * t;
+    }
+
+    /// <summary>
+    /// Snap the camera to a preset orientation. Clears pan and zoom so
+    /// the chosen view fills the frame the same way ResetView does.
+    /// </summary>
+    public void SetViewPreset(ViewPreset preset)
+    {
+        switch (preset)
+        {
+            case ViewPreset.Front:
+                _rotationY = MathF.PI;
+                _rotationX = 0f;
+                break;
+            case ViewPreset.Back:
+                _rotationY = 0f;
+                _rotationX = 0f;
+                break;
+            case ViewPreset.Side:
+                _rotationY = MathF.PI / 2f;
+                _rotationX = 0f;
+                break;
+            case ViewPreset.SideRight:
+                _rotationY = 3f * MathF.PI / 2f;
+                _rotationX = 0f;
+                break;
+            case ViewPreset.Top:
+                _rotationY = MathF.PI;
+                _rotationX = MathF.PI / 2f;
+                break;
+        }
+        _zoom = 1.0f;
+        _cameraTarget = Vector3.Zero;
     }
 
     /// <summary>

--- a/Quartermaster/Quartermaster/Controls/ModelViewController.cs
+++ b/Quartermaster/Quartermaster/Controls/ModelViewController.cs
@@ -152,27 +152,26 @@ public class ModelViewController
     }
 
     /// <summary>
-    /// Reset camera to defaults. Actual center and radius are computed from
-    /// rendered vertices in UpdateMeshBuffers(). The model's stored
-    /// BoundingMin/Max encompasses the full skeleton hierarchy and is
-    /// much larger than the visible mesh.
+    /// Reset camera framing defaults. Called when a model loads/unloads so
+    /// vertex-computed bounds can be rebuilt. Zoom, rotation, and user pan
+    /// are preserved — switching equipment or heads should not snap the
+    /// camera back to the default view (#2124).
     /// </summary>
     public void CenterCamera()
     {
-        _cameraTarget = Vector3.Zero;
         _modelRadius = 1.0f;
         _hasVertexBounds = false;
     }
 
     /// <summary>
     /// Update the camera bounds from computed vertex data.
-    /// Called by the GL control after mesh buffer assembly.
+    /// Called by the GL control after mesh buffer assembly. Preserves the
+    /// user's pan — only radius/bounds-flag are refreshed.
     /// </summary>
     public void UpdateBounds(float modelRadius, bool hasVertexBounds)
     {
         _modelRadius = modelRadius;
         _hasVertexBounds = hasVertexBounds;
-        _cameraTarget = Vector3.Zero;
     }
 
     /// <summary>

--- a/Quartermaster/Quartermaster/Controls/ModelViewController.cs
+++ b/Quartermaster/Quartermaster/Controls/ModelViewController.cs
@@ -53,6 +53,40 @@ public class ModelViewController
     }
 
     /// <summary>
+    /// Translate the camera target in world space. Used by panning so
+    /// the model appears to slide under the camera.
+    /// </summary>
+    public void Pan(Vector3 worldDelta)
+    {
+        _cameraTarget += worldDelta;
+    }
+
+    /// <summary>
+    /// Multiplicatively change zoom while keeping a world-space pivot
+    /// point anchored. When the user zooms with the scroll wheel at a
+    /// cursor position, we want that spot to stay roughly under the
+    /// cursor rather than drifting off screen (#2124).
+    /// </summary>
+    public void ZoomAtPoint(float factor, Vector3 worldPivot)
+    {
+        float before = _zoom;
+        Zoom = _zoom * factor;
+        float applied = _zoom / before;
+
+        // If zoom was clamped (no effective change), suppress the pivot
+        // pull so repeated scrolls at the limit don't drift the target.
+        if (MathF.Abs(applied - 1f) < 1e-5f)
+            return;
+
+        // The camera views the scene at distance ∝ 1/zoom from the
+        // target. Scaling zoom by `applied` shrinks that distance by
+        // 1/applied. To keep the pivot stable on screen, move the
+        // target a matching fraction of (pivot - target).
+        float t = 1f - 1f / applied;
+        _cameraTarget += (worldPivot - _cameraTarget) * t;
+    }
+
+    /// <summary>
     /// Reset the view to default (facing front).
     /// </summary>
     public void ResetView()
@@ -60,12 +94,13 @@ public class ModelViewController
         _rotationY = MathF.PI;
         _rotationX = 0;
         _zoom = 1.0f;
+        // Always clear user-applied pan on reset so the model recenters.
+        _cameraTarget = Vector3.Zero;
         // Use vertex-computed bounds if available, otherwise safe defaults.
         // Don't call CenterCamera() — model stored bounds are unreliable
         // (they include the full skeleton hierarchy, not just rendered mesh).
         if (!_hasVertexBounds)
         {
-            _cameraTarget = Vector3.Zero;
             _modelRadius = 1.0f;
         }
     }

--- a/Quartermaster/Quartermaster/Controls/ModelViewController.cs
+++ b/Quartermaster/Quartermaster/Controls/ModelViewController.cs
@@ -2,6 +2,7 @@
 // Extracted from ModelPreviewGLControl to improve testability and separation of concerns.
 
 using System;
+using System.Collections.Generic;
 using System.Numerics;
 using Radoub.Formats.Mdl;
 
@@ -181,23 +182,40 @@ public class ModelViewController
     /// </summary>
     public static Matrix4x4 GetWorldTransform(MdlNode? node)
     {
-        // System.Numerics uses row-major convention where Vector3.Transform(v, M) = v * M
-        // For hierarchical transforms: v_world = v_local * NodeLocal * ParentLocal * ... * RootLocal
-        // So we need: worldTransform = NodeLocal * ParentLocal * ... * RootLocal
-        // We walk leaf-to-root, accumulating: world = local * world
+        return GetWorldTransform(node, null);
+    }
+
+    /// <summary>
+    /// Variant that consults an animation pose (node name → sampled transform).
+    /// Used by the appearance preview to play animation stances (#2124).
+    /// When a node's name is in <paramref name="pose"/>, the sampled values
+    /// replace the bind-pose Position/Orientation/Scale for that link of the
+    /// hierarchy. Other nodes use their static values.
+    /// </summary>
+    public static Matrix4x4 GetWorldTransform(MdlNode? node, IReadOnlyDictionary<string, NodePose>? pose)
+    {
         var worldTransform = Matrix4x4.Identity;
         var current = node;
 
         while (current != null)
         {
-            var scale = Matrix4x4.CreateScale(current.Scale);
-            var rotation = Matrix4x4.CreateFromQuaternion(current.Orientation);
-            var translation = Matrix4x4.CreateTranslation(current.Position);
+            Vector3 pos = current.Position;
+            Quaternion orient = current.Orientation;
+            float scl = current.Scale;
 
-            // Row-major local transform: S * R * T
+            if (pose != null && !string.IsNullOrEmpty(current.Name)
+                && pose.TryGetValue(current.Name, out var p))
+            {
+                if (p.HasPosition) pos = p.Position;
+                if (p.HasOrientation) orient = p.Orientation;
+                if (p.HasScale) scl = p.Scale;
+            }
+
+            var scale = Matrix4x4.CreateScale(scl);
+            var rotation = Matrix4x4.CreateFromQuaternion(orient);
+            var translation = Matrix4x4.CreateTranslation(pos);
+
             var localTransform = scale * rotation * translation;
-
-            // Accumulate: node * parent * grandparent * ... * root
             worldTransform = worldTransform * localTransform;
 
             current = current.Parent;
@@ -205,6 +223,16 @@ public class ModelViewController
 
         return worldTransform;
     }
+
+    /// <summary>
+    /// Sampled pose for a single node at a specific animation time.
+    /// Flags indicate which channels were actually animated (vs inheriting
+    /// the bind pose).
+    /// </summary>
+    public readonly record struct NodePose(
+        bool HasPosition, Vector3 Position,
+        bool HasOrientation, Quaternion Orientation,
+        bool HasScale, float Scale);
 
     /// <summary>
     /// Transform a position vector by a matrix.

--- a/Quartermaster/Quartermaster/Services/ModelService.cs
+++ b/Quartermaster/Quartermaster/Services/ModelService.cs
@@ -757,6 +757,7 @@ public class ModelService
             var meshCount = model.GetMeshNodes().Count();
             UnifiedLogger.LogApplication(LogLevel.INFO,
                 $"LoadModel: '{resRef}' parsed OK, meshes={meshCount}, bounds={model.BoundingMin}-{model.BoundingMax}");
+            MergeSuperModelAnimations(model, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
             _modelCache[resRef] = model;
             return model;
         }
@@ -767,6 +768,53 @@ public class ModelService
             _modelCache[resRef] = null;
             return null;
         }
+    }
+
+    /// <summary>
+    /// NWN creatures inherit animations from a supermodel chain (e.g. a_ba, a_fa).
+    /// The leaf creature MDL usually only overrides geometry; idle/walk/attack/etc.
+    /// live in the parent. This walks the chain and appends every animation it
+    /// finds to the leaf model so the preview can play them. Missing supermodels
+    /// are logged and skipped — they're optional at runtime (#2124).
+    /// </summary>
+    private void MergeSuperModelAnimations(MdlModel model, HashSet<string> visited)
+    {
+        var parentName = model.SuperModel;
+        if (string.IsNullOrWhiteSpace(parentName) ||
+            parentName.Equals("NULL", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+        if (!visited.Add(parentName.ToLowerInvariant()))
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"MergeSuperModelAnimations: cycle detected at '{parentName}' — stopping");
+            return;
+        }
+
+        var parent = LoadModel(parentName);
+        if (parent == null)
+        {
+            UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                $"MergeSuperModelAnimations: supermodel '{parentName}' not loadable");
+            return;
+        }
+
+        // Append parent animations that the leaf doesn't already define.
+        var existing = new HashSet<string>(
+            model.Animations.Select(a => a.Name),
+            StringComparer.OrdinalIgnoreCase);
+        int added = 0;
+        foreach (var anim in parent.Animations)
+        {
+            if (existing.Add(anim.Name))
+            {
+                model.Animations.Add(anim);
+                added++;
+            }
+        }
+        UnifiedLogger.LogApplication(LogLevel.INFO,
+            $"MergeSuperModelAnimations: '{model.Name}' inherited {added} animations from '{parentName}'");
     }
 
     // #1676: LoadModelPreferBIF removed. All model loading now uses the public LoadModel()

--- a/Quartermaster/Quartermaster/Services/ModelService.cs
+++ b/Quartermaster/Quartermaster/Services/ModelService.cs
@@ -244,6 +244,14 @@ public class ModelService
             compositeModel.SuperModel = skeletonModel.SuperModel;
         }
 
+        // Use the skeleton's bone hierarchy as the composite root so animation
+        // pose lookup finds matching bone names through the full parent chain
+        // (#2124). Each body part mesh attaches under its target bone below.
+        if (skeletonModel?.GeometryRoot != null)
+        {
+            compositeModel.GeometryRoot = skeletonModel.GeometryRoot;
+        }
+
         // Helper to get body part number.
         // Creature value takes precedence — it reflects the user's explicit choice.
         // Armor overrides only apply when the creature has the default part (non-zero)
@@ -363,6 +371,7 @@ public class ModelService
             // Body part MDL files have geometry at local origin
             // We need to position and orient them at the corresponding bone in the skeleton
             var (bonePosition, _) = GetBoneTransformForPart(partType);
+            var boneName = GetBoneNameForPart(partType);
 
             var meshCount = 0;
             // Add all mesh nodes from this part to the composite model
@@ -408,10 +417,29 @@ public class ModelService
                     {
                         compositeModel.GeometryRoot = new Radoub.Formats.Mdl.MdlNode { Name = "composite_root" };
                     }
-                    // Reparent to composite root so GetWorldTransform() uses bone position,
-                    // not the original part model's hierarchy
-                    node.Parent = compositeModel.GeometryRoot;
-                    compositeModel.GeometryRoot.Children.Add(node);
+
+                    // Parent the mesh under the target bone in the skeleton
+                    // so GetWorldTransform's parent-chain walk picks up
+                    // animated transforms from the supermodel (#2124). The
+                    // bone already holds the correct bind position; zero out
+                    // the mesh's own offset so it doesn't compound.
+                    Radoub.Formats.Mdl.MdlNode? bone = null;
+                    if (_currentSkeleton?.GeometryRoot != null)
+                        bone = FindBoneByName(_currentSkeleton.GeometryRoot, boneName);
+
+                    if (bone != null)
+                    {
+                        trimesh.Position = System.Numerics.Vector3.Zero;
+                        node.Parent = bone;
+                        bone.Children.Add(node);
+                    }
+                    else
+                    {
+                        // Fallback — skeleton bone missing, keep old flat behavior.
+                        trimesh.Position = bonePosition;
+                        node.Parent = compositeModel.GeometryRoot;
+                        compositeModel.GeometryRoot.Children.Add(node);
+                    }
                     meshCount++;
                     // Track which body part type this mesh belongs to (#1557)
                     _meshPartTypes[trimesh.Name] = partType;
@@ -436,6 +464,31 @@ public class ModelService
     /// Returns both position and orientation so body parts are correctly placed and rotated.
     /// Body part names map to skeleton bone names with _g suffix.
     /// </summary>
+    private static string GetBoneNameForPart(string partType) => partType switch
+    {
+        "head" => "head_g",
+        "neck" => "neck_g",
+        "chest" => "torso_g",
+        "robe" => "torso_g",
+        "pelvis" => "pelvis_g",
+        "belt" => "belt_g",
+        "shol" => "lshoulder_g",
+        "shor" => "rshoulder_g",
+        "bicepl" => "lbicep_g",
+        "bicepr" => "rbicep_g",
+        "forel" => "lforearm_g",
+        "forer" => "rforearm_g",
+        "handl" => "lhand_g",
+        "handr" => "rhand_g",
+        "legl" => "lthigh_g",
+        "legr" => "rthigh_g",
+        "shinl" => "lshin_g",
+        "shinr" => "rshin_g",
+        "footl" => "lfoot_g",
+        "footr" => "rfoot_g",
+        _ => partType + "_g"
+    };
+
     private (System.Numerics.Vector3 Position, System.Numerics.Quaternion Orientation) GetBoneTransformForPart(string partType)
     {
         var identity = (System.Numerics.Vector3.Zero, System.Numerics.Quaternion.Identity);
@@ -443,33 +496,7 @@ public class ModelService
         if (_currentSkeleton?.GeometryRoot == null)
             return identity;
 
-        // Map body part type to skeleton bone name
-        // Body parts use NWN naming: bicepl, bicepr, forel, forer, etc.
-        // Skeleton uses names like "head_g", "neck_g", "lbicep_g", etc.
-        var boneName = partType switch
-        {
-            "head" => "head_g",
-            "neck" => "neck_g",
-            "chest" => "torso_g",
-            "robe" => "torso_g",
-            "pelvis" => "pelvis_g",
-            "belt" => "belt_g",
-            "shol" => "lshoulder_g",
-            "shor" => "rshoulder_g",
-            "bicepl" => "lbicep_g",
-            "bicepr" => "rbicep_g",
-            "forel" => "lforearm_g",
-            "forer" => "rforearm_g",
-            "handl" => "lhand_g",
-            "handr" => "rhand_g",
-            "legl" => "lthigh_g",
-            "legr" => "rthigh_g",
-            "shinl" => "lshin_g",
-            "shinr" => "rshin_g",
-            "footl" => "lfoot_g",
-            "footr" => "rfoot_g",
-            _ => partType + "_g"
-        };
+        var boneName = GetBoneNameForPart(partType);
 
         // Find the bone in the skeleton and calculate its world transform
         var bone = FindBoneByName(_currentSkeleton.GeometryRoot, boneName);

--- a/Quartermaster/Quartermaster/Services/ModelService.cs
+++ b/Quartermaster/Quartermaster/Services/ModelService.cs
@@ -232,6 +232,18 @@ public class ModelService
         // Store skeleton for bone position lookup
         _currentSkeleton = skeletonModel;
 
+        // Inherit the skeleton's animation list (and any already merged from
+        // its supermodel chain) so part-based creatures — humans, elves,
+        // halflings, dwarves, etc. — can play idle/walk/attack in the
+        // preview (#2124). Without this, composite models would have an
+        // empty Animations list because they skip the LoadModel code path.
+        if (skeletonModel?.Animations != null)
+        {
+            foreach (var anim in skeletonModel.Animations)
+                compositeModel.Animations.Add(anim);
+            compositeModel.SuperModel = skeletonModel.SuperModel;
+        }
+
         // Helper to get body part number.
         // Creature value takes precedence — it reflects the user's explicit choice.
         // Armor overrides only apply when the creature has the default part (non-zero)

--- a/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.axaml.cs
@@ -15,7 +15,6 @@ using Radoub.UI.Services;
 using Radoub.Formats.Services;
 using Radoub.Formats.Settings;
 using Radoub.Formats.Utc;
-using Radoub.UI.Services;
 
 namespace Quartermaster.Views.Dialogs;
 

--- a/Quartermaster/Quartermaster/Views/MainWindow.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/MainWindow.axaml.cs
@@ -4,7 +4,6 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Quartermaster.Services;
 using Quartermaster.Views.Dialogs;
-using Radoub.UI.Services;
 using Quartermaster.Views.Helpers;
 using Quartermaster.Views.Panels;
 using Radoub.Formats.Bic;

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.DataLoading.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.DataLoading.cs
@@ -218,12 +218,14 @@ public partial class AppearancePanel
 
             var model = _modelService.LoadCreatureModel(_currentCreature);
             _modelPreviewGL.Model = model;
+            RefreshAnimationList(model);
         }
         catch (Exception ex)
         {
             UnifiedLogger.LogApplication(LogLevel.ERROR,
                 $"Model preview failed: {ex.GetType().Name}: {ex.Message}");
             _modelPreviewGL.Model = null;
+            RefreshAnimationList(null);
         }
     }
 

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
@@ -111,6 +111,8 @@ public partial class AppearancePanel
             _animPlayButton.Click += OnAnimPlayClicked;
         if (_animTimeSlider != null)
             _animTimeSlider.PropertyChanged += OnAnimSliderChanged;
+        if (_animSpeedSlider != null)
+            _animSpeedSlider.PropertyChanged += OnAnimSpeedChanged;
 
         // 3D Preview pointer/wheel/key input — wired on the transparent
         // input-surface Border that overlays the GL control (#2124).
@@ -734,5 +736,12 @@ public partial class AppearancePanel
             if (_animPlayButton != null) _animPlayButton.Content = "▶";
         }
         _modelPreviewGL.AnimationTime = (float)_animTimeSlider.Value;
+    }
+
+    private void OnAnimSpeedChanged(object? sender, Avalonia.AvaloniaPropertyChangedEventArgs e)
+    {
+        if (e.Property != Slider.ValueProperty) return;
+        if (_modelPreviewGL == null || _animSpeedSlider == null) return;
+        _modelPreviewGL.AnimationSpeed = (float)_animSpeedSlider.Value;
     }
 }

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
@@ -104,6 +104,14 @@ public partial class AppearancePanel
         if (_viewTopButton != null)
             _viewTopButton.Click += (_, _) => _modelPreviewGL?.SetViewPreset(ViewPreset.Top);
 
+        // Animation dropdown / play / scrub (#2124)
+        if (_animationComboBox != null)
+            _animationComboBox.SelectionChanged += OnAnimationSelectionChanged;
+        if (_animPlayButton != null)
+            _animPlayButton.Click += OnAnimPlayClicked;
+        if (_animTimeSlider != null)
+            _animTimeSlider.PropertyChanged += OnAnimSliderChanged;
+
         // 3D Preview pointer/wheel/key input — wired on the transparent
         // input-surface Border that overlays the GL control (#2124).
         if (_modelPreviewInputSurface != null)
@@ -655,5 +663,76 @@ public partial class AppearancePanel
     {
         if (_modelPreviewGL != null)
             _modelPreviewGL.Zoom /= 1.2f;
+    }
+
+    // ----- Animation playback handlers (#2124) -----
+
+    private bool _suppressSliderSync;
+
+    private void OnAnimationSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (_modelPreviewGL?.Model == null || _animationComboBox == null) return;
+
+        int idx = _animationComboBox.SelectedIndex;
+        if (idx <= 0)
+        {
+            _modelPreviewGL.SetActiveAnimation(null);
+            if (_animTimeSlider != null)
+            {
+                _suppressSliderSync = true;
+                _animTimeSlider.Value = 0;
+                _animTimeSlider.Maximum = 1;
+                _suppressSliderSync = false;
+            }
+            if (_animPlayButton != null) _animPlayButton.Content = "▶";
+            return;
+        }
+
+        int animIdx = idx - 1; // offset past "(none)"
+        if (animIdx >= 0 && animIdx < _modelPreviewGL.Model.Animations.Count)
+        {
+            var anim = _modelPreviewGL.Model.Animations[animIdx];
+            _modelPreviewGL.SetActiveAnimation(anim);
+            if (_animTimeSlider != null)
+            {
+                _suppressSliderSync = true;
+                _animTimeSlider.Maximum = anim.Length > 0 ? anim.Length : 1;
+                _animTimeSlider.Value = 0;
+                _suppressSliderSync = false;
+            }
+        }
+    }
+
+    private void OnAnimPlayClicked(object? sender, RoutedEventArgs e)
+    {
+        if (_modelPreviewGL == null || _animPlayButton == null) return;
+        if (_modelPreviewGL.ActiveAnimation == null) return;
+
+        if (_modelPreviewGL.IsAnimationPlaying)
+        {
+            _modelPreviewGL.PauseAnimation();
+            _animPlayButton.Content = "▶";
+        }
+        else
+        {
+            _modelPreviewGL.PlayAnimation();
+            _animPlayButton.Content = "⏸";
+        }
+    }
+
+    private void OnAnimSliderChanged(object? sender, Avalonia.AvaloniaPropertyChangedEventArgs e)
+    {
+        if (_suppressSliderSync) return;
+        if (e.Property != Slider.ValueProperty) return;
+        if (_modelPreviewGL == null || _animTimeSlider == null) return;
+        if (_modelPreviewGL.ActiveAnimation == null) return;
+
+        // User dragged the scrub slider — pause playback and seek.
+        if (_modelPreviewGL.IsAnimationPlaying)
+        {
+            _modelPreviewGL.PauseAnimation();
+            if (_animPlayButton != null) _animPlayButton.Content = "▶";
+        }
+        _modelPreviewGL.AnimationTime = (float)_animTimeSlider.Value;
     }
 }

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
@@ -93,6 +93,112 @@ public partial class AppearancePanel
             _zoomInButton.Click += OnZoomInClicked;
         if (_zoomOutButton != null)
             _zoomOutButton.Click += OnZoomOutClicked;
+
+        // 3D Preview pointer/wheel/key input — wired on the transparent
+        // input-surface Border that overlays the GL control (#2124).
+        if (_modelPreviewInputSurface != null)
+        {
+            _modelPreviewInputSurface.PointerPressed += OnModelPreviewPointerPressed;
+            _modelPreviewInputSurface.PointerMoved += OnModelPreviewPointerMoved;
+            _modelPreviewInputSurface.PointerReleased += OnModelPreviewPointerReleased;
+            _modelPreviewInputSurface.PointerWheelChanged += OnModelPreviewWheel;
+            _modelPreviewInputSurface.KeyDown += OnModelPreviewKeyDown;
+        }
+    }
+
+    // ----- 3D Preview input forwarding (#2124) -----
+
+    private enum PreviewDragMode { None, Rotate, Pan }
+    private PreviewDragMode _previewDragMode = PreviewDragMode.None;
+    private Avalonia.Point _previewLastPointer;
+
+    private void OnModelPreviewPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (_modelPreviewInputSurface == null || _modelPreviewGL == null) return;
+
+        var props = e.GetCurrentPoint(_modelPreviewInputSurface).Properties;
+        bool shift = (e.KeyModifiers & KeyModifiers.Shift) != 0;
+
+        if (props.IsMiddleButtonPressed || (props.IsLeftButtonPressed && shift))
+            _previewDragMode = PreviewDragMode.Pan;
+        else if (props.IsLeftButtonPressed)
+            _previewDragMode = PreviewDragMode.Rotate;
+        else
+            return;
+
+        _previewLastPointer = e.GetPosition(_modelPreviewInputSurface);
+        _modelPreviewInputSurface.Focus();
+        e.Pointer.Capture(_modelPreviewInputSurface);
+        e.Handled = true;
+    }
+
+    private void OnModelPreviewPointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (_previewDragMode == PreviewDragMode.None ||
+            _modelPreviewInputSurface == null || _modelPreviewGL == null) return;
+
+        var pos = e.GetPosition(_modelPreviewInputSurface);
+        double dx = pos.X - _previewLastPointer.X;
+        double dy = pos.Y - _previewLastPointer.Y;
+        _previewLastPointer = pos;
+
+        if (_previewDragMode == PreviewDragMode.Rotate)
+            _modelPreviewGL.RotateByPixels(dx, dy);
+        else if (_previewDragMode == PreviewDragMode.Pan)
+            _modelPreviewGL.PanByPixels(dx, dy);
+    }
+
+    private void OnModelPreviewPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (_previewDragMode != PreviewDragMode.None)
+        {
+            _previewDragMode = PreviewDragMode.None;
+            e.Pointer.Capture(null);
+            e.Handled = true;
+        }
+    }
+
+    private void OnModelPreviewWheel(object? sender, PointerWheelEventArgs e)
+    {
+        if (_modelPreviewInputSurface == null || _modelPreviewGL == null) return;
+        var pos = e.GetPosition(_modelPreviewGL); // unproject uses GL viewport coords
+        _modelPreviewGL.ZoomAtCursorPixels(pos, e.Delta.Y);
+        e.Handled = true;
+    }
+
+    private void OnModelPreviewKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (_modelPreviewGL == null) return;
+        const float rotStep = 0.1f;
+
+        switch (e.Key)
+        {
+            case Key.Left:
+            case Key.A:
+                _modelPreviewGL.Rotate(-rotStep, 0);
+                break;
+            case Key.Right:
+            case Key.D:
+                _modelPreviewGL.Rotate(rotStep, 0);
+                break;
+            case Key.Up:
+            case Key.W:
+                _modelPreviewGL.Rotate(0, -rotStep);
+                break;
+            case Key.Down:
+            case Key.S:
+                _modelPreviewGL.Rotate(0, rotStep);
+                break;
+            case Key.Home:
+                _modelPreviewGL.ResetView();
+                break;
+            case Key.F8:
+                _modelPreviewGL.CycleDebugMode();
+                break;
+            default:
+                return;
+        }
+        e.Handled = true;
     }
 
     private void OnAppearanceSelectionChanged(object? sender, SelectionChangedEventArgs e)

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
@@ -93,6 +93,16 @@ public partial class AppearancePanel
             _zoomInButton.Click += OnZoomInClicked;
         if (_zoomOutButton != null)
             _zoomOutButton.Click += OnZoomOutClicked;
+        if (_viewFrontButton != null)
+            _viewFrontButton.Click += (_, _) => _modelPreviewGL?.SetViewPreset(ViewPreset.Front);
+        if (_viewBackButton != null)
+            _viewBackButton.Click += (_, _) => _modelPreviewGL?.SetViewPreset(ViewPreset.Back);
+        if (_viewSideButton != null)
+            _viewSideButton.Click += (_, _) => _modelPreviewGL?.SetViewPreset(ViewPreset.Side);
+        if (_viewSideRightButton != null)
+            _viewSideRightButton.Click += (_, _) => _modelPreviewGL?.SetViewPreset(ViewPreset.SideRight);
+        if (_viewTopButton != null)
+            _viewTopButton.Click += (_, _) => _modelPreviewGL?.SetViewPreset(ViewPreset.Top);
 
         // 3D Preview pointer/wheel/key input — wired on the transparent
         // input-surface Border that overlays the GL control (#2124).

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
@@ -308,6 +308,11 @@
                             Background="{DynamicResource ThemeSidebar}" Margin="10" CornerRadius="4">
                         <Grid>
                             <controls:ModelPreviewGLControl x:Name="ModelPreviewGL"/>
+                            <!-- Transparent input surface so pointer/wheel events always hit-test
+                                 (OpenGlControlBase has no Background). #2124 -->
+                            <Border x:Name="ModelPreviewInputSurface"
+                                    Background="Transparent"
+                                    Focusable="True"/>
                             <Border x:Name="PreviewStateOverlay"
                                     HorizontalAlignment="Right"
                                     VerticalAlignment="Top"

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
@@ -377,6 +377,11 @@
                                     Minimum="0" Maximum="1" Value="0"
                                     VerticalAlignment="Center"
                                     ToolTip.Tip="Scrub playhead"/>
+                            <TextBlock Text="Speed:" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                            <Slider x:Name="AnimSpeedSlider" MinWidth="80"
+                                    Minimum="0.1" Maximum="2.0" Value="1.0"
+                                    VerticalAlignment="Center"
+                                    ToolTip.Tip="Playback speed (0.1x – 2x)"/>
                         </StackPanel>
                     </Border>
                 </Grid>

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
@@ -295,7 +295,7 @@
                     BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
                     BorderThickness="1,0,0,0"
                     Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
-                <Grid RowDefinitions="Auto,*,Auto,Auto">
+                <Grid RowDefinitions="Auto,*,Auto,Auto,Auto">
                     <!-- Preview Header -->
                     <Border Grid.Row="0" Padding="10"
                             BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
@@ -360,6 +360,23 @@
                                     ToolTip.Tip="Right Side View"/>
                             <Button x:Name="ViewTopButton" Content="T" Width="32" Height="32"
                                     ToolTip.Tip="Top View"/>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Animation playback (#2124) -->
+                    <Border Grid.Row="4" Padding="10"
+                            BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                            BorderThickness="0,1,0,0">
+                        <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Center">
+                            <TextBlock Text="Animation:" VerticalAlignment="Center"/>
+                            <ComboBox x:Name="AnimationComboBox" MinWidth="160"
+                                      ToolTip.Tip="Select an animation / stance"/>
+                            <Button x:Name="AnimPlayButton" Content="▶" Width="32" Height="32"
+                                    ToolTip.Tip="Play / Pause"/>
+                            <Slider x:Name="AnimTimeSlider" MinWidth="160"
+                                    Minimum="0" Maximum="1" Value="0"
+                                    VerticalAlignment="Center"
+                                    ToolTip.Tip="Scrub playhead"/>
                         </StackPanel>
                     </Border>
                 </Grid>

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
@@ -342,13 +342,24 @@
                             <Button x:Name="RotateLeftButton" Content="↺" Width="32" Height="32"
                                     ToolTip.Tip="Rotate Left"/>
                             <Button x:Name="ResetViewButton" Content="⟲" Width="32" Height="32"
-                                    ToolTip.Tip="Reset View"/>
+                                    ToolTip.Tip="Reset View (Home)"/>
                             <Button x:Name="RotateRightButton" Content="↻" Width="32" Height="32"
                                     ToolTip.Tip="Rotate Right"/>
                             <Button x:Name="ZoomInButton" Content="+" Width="32" Height="32"
                                     ToolTip.Tip="Zoom In" Margin="20,0,0,0"/>
                             <Button x:Name="ZoomOutButton" Content="-" Width="32" Height="32"
                                     ToolTip.Tip="Zoom Out"/>
+                            <!-- View preset buttons (#2124) -->
+                            <Button x:Name="ViewFrontButton" Content="F" Width="32" Height="32"
+                                    ToolTip.Tip="Front View" Margin="20,0,0,0"/>
+                            <Button x:Name="ViewBackButton" Content="B" Width="32" Height="32"
+                                    ToolTip.Tip="Back View"/>
+                            <Button x:Name="ViewSideButton" Content="L" Width="32" Height="32"
+                                    ToolTip.Tip="Left Side View"/>
+                            <Button x:Name="ViewSideRightButton" Content="R" Width="32" Height="32"
+                                    ToolTip.Tip="Right Side View"/>
+                            <Button x:Name="ViewTopButton" Content="T" Width="32" Height="32"
+                                    ToolTip.Tip="Top View"/>
                         </StackPanel>
                     </Border>
                 </Grid>

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
@@ -77,6 +77,11 @@ public partial class AppearancePanel : UserControl
     private Button? _resetViewButton;
     private Button? _zoomInButton;
     private Button? _zoomOutButton;
+    private Button? _viewFrontButton;
+    private Button? _viewBackButton;
+    private Button? _viewSideButton;
+    private Button? _viewSideRightButton;
+    private Button? _viewTopButton;
 
     private CreatureDisplayService? _displayService;
     private PaletteColorService? _paletteColorService;
@@ -162,6 +167,11 @@ public partial class AppearancePanel : UserControl
         _resetViewButton = this.FindControl<Button>("ResetViewButton");
         _zoomInButton = this.FindControl<Button>("ZoomInButton");
         _zoomOutButton = this.FindControl<Button>("ZoomOutButton");
+        _viewFrontButton = this.FindControl<Button>("ViewFrontButton");
+        _viewBackButton = this.FindControl<Button>("ViewBackButton");
+        _viewSideButton = this.FindControl<Button>("ViewSideButton");
+        _viewSideRightButton = this.FindControl<Button>("ViewSideRightButton");
+        _viewTopButton = this.FindControl<Button>("ViewTopButton");
     }
 
     public void SetDisplayService(CreatureDisplayService displayService)

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
@@ -82,6 +82,10 @@ public partial class AppearancePanel : UserControl
     private Button? _viewSideButton;
     private Button? _viewSideRightButton;
     private Button? _viewTopButton;
+    // Animation playback (#2124)
+    private ComboBox? _animationComboBox;
+    private Button? _animPlayButton;
+    private Slider? _animTimeSlider;
 
     private CreatureDisplayService? _displayService;
     private PaletteColorService? _paletteColorService;
@@ -172,6 +176,9 @@ public partial class AppearancePanel : UserControl
         _viewSideButton = this.FindControl<Button>("ViewSideButton");
         _viewSideRightButton = this.FindControl<Button>("ViewSideRightButton");
         _viewTopButton = this.FindControl<Button>("ViewTopButton");
+        _animationComboBox = this.FindControl<ComboBox>("AnimationComboBox");
+        _animPlayButton = this.FindControl<Button>("AnimPlayButton");
+        _animTimeSlider = this.FindControl<Slider>("AnimTimeSlider");
     }
 
     public void SetDisplayService(CreatureDisplayService displayService)
@@ -278,6 +285,35 @@ public partial class AppearancePanel : UserControl
     {
         if (_modelPreviewGL != null)
             _modelPreviewGL.Model = model;
+        RefreshAnimationList(model);
+    }
+
+    /// <summary>
+    /// Populate the animation dropdown from a model's animation list (#2124).
+    /// </summary>
+    private void RefreshAnimationList(MdlModel? model)
+    {
+        if (_animationComboBox == null) return;
+
+        var items = new List<string> { "(none)" };
+        if (model?.Animations != null)
+        {
+            foreach (var anim in model.Animations)
+            {
+                if (!string.IsNullOrEmpty(anim.Name))
+                    items.Add(anim.Name);
+            }
+        }
+
+        _animationComboBox.ItemsSource = items;
+        _animationComboBox.SelectedIndex = 0;
+        if (_modelPreviewGL != null)
+            _modelPreviewGL.SetActiveAnimation(null);
+        if (_animTimeSlider != null)
+        {
+            _animTimeSlider.Value = 0;
+            _animTimeSlider.Maximum = 1;
+        }
     }
 
     /// <summary>

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
@@ -86,6 +86,7 @@ public partial class AppearancePanel : UserControl
     private ComboBox? _animationComboBox;
     private Button? _animPlayButton;
     private Slider? _animTimeSlider;
+    private Slider? _animSpeedSlider;
 
     private CreatureDisplayService? _displayService;
     private PaletteColorService? _paletteColorService;
@@ -179,6 +180,7 @@ public partial class AppearancePanel : UserControl
         _animationComboBox = this.FindControl<ComboBox>("AnimationComboBox");
         _animPlayButton = this.FindControl<Button>("AnimPlayButton");
         _animTimeSlider = this.FindControl<Slider>("AnimTimeSlider");
+        _animSpeedSlider = this.FindControl<Slider>("AnimSpeedSlider");
     }
 
     public void SetDisplayService(CreatureDisplayService displayService)

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
@@ -68,6 +68,7 @@ public partial class AppearancePanel : UserControl
     // 3D Preview
     private Border? _modelPreviewContainer;
     private ModelPreviewGLControl? _modelPreviewGL;
+    private Border? _modelPreviewInputSurface;
     private Border? _previewStateOverlay;
     private TextBlock? _previewStateText;
     private TextBlock? _modelInfoStatusText;
@@ -152,6 +153,7 @@ public partial class AppearancePanel : UserControl
         // 3D Preview
         _modelPreviewContainer = this.FindControl<Border>("ModelPreviewContainer");
         _modelPreviewGL = this.FindControl<ModelPreviewGLControl>("ModelPreviewGL");
+        _modelPreviewInputSurface = this.FindControl<Border>("ModelPreviewInputSurface");
         _previewStateOverlay = this.FindControl<Border>("PreviewStateOverlay");
         _previewStateText = this.FindControl<TextBlock>("PreviewStateText");
         _modelInfoStatusText = this.FindControl<TextBlock>("ModelInfoStatusText");

--- a/Radoub.Formats/Radoub.Formats.Tests/Mdl/MdlAnimationEvaluatorTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Mdl/MdlAnimationEvaluatorTests.cs
@@ -1,0 +1,124 @@
+using System.Numerics;
+using Radoub.Formats.Mdl;
+using Xunit;
+
+namespace Radoub.Formats.Tests.Mdl;
+
+public class MdlAnimationEvaluatorTests
+{
+    [Fact]
+    public void EvaluatePosition_NoTracks_ReturnsStaticPosition()
+    {
+        var node = new MdlNode { Position = new Vector3(1, 2, 3) };
+
+        var result = MdlAnimationEvaluator.EvaluatePosition(node, 0.5f);
+
+        Assert.Equal(new Vector3(1, 2, 3), result);
+    }
+
+    [Fact]
+    public void EvaluatePosition_SingleKey_ReturnsThatValue()
+    {
+        var node = new MdlNode
+        {
+            PositionTimes = new[] { 0f },
+            PositionValues = new[] { new Vector3(5, 5, 5) },
+            Position = new Vector3(999, 999, 999),
+        };
+
+        var result = MdlAnimationEvaluator.EvaluatePosition(node, 10f);
+
+        Assert.Equal(new Vector3(5, 5, 5), result);
+    }
+
+    [Fact]
+    public void EvaluatePosition_BetweenKeys_LinearlyInterpolates()
+    {
+        var node = new MdlNode
+        {
+            PositionTimes = new[] { 0f, 1f },
+            PositionValues = new[] { Vector3.Zero, new Vector3(10, 20, 30) },
+        };
+
+        var result = MdlAnimationEvaluator.EvaluatePosition(node, 0.5f);
+
+        Assert.Equal(5f, result.X, 4);
+        Assert.Equal(10f, result.Y, 4);
+        Assert.Equal(15f, result.Z, 4);
+    }
+
+    [Fact]
+    public void EvaluatePosition_BeforeFirstKey_ClampsToFirst()
+    {
+        var node = new MdlNode
+        {
+            PositionTimes = new[] { 1f, 2f },
+            PositionValues = new[] { new Vector3(5, 0, 0), new Vector3(10, 0, 0) },
+        };
+
+        var result = MdlAnimationEvaluator.EvaluatePosition(node, -1f);
+
+        Assert.Equal(new Vector3(5, 0, 0), result);
+    }
+
+    [Fact]
+    public void EvaluatePosition_AfterLastKey_ClampsToLast()
+    {
+        var node = new MdlNode
+        {
+            PositionTimes = new[] { 0f, 1f },
+            PositionValues = new[] { new Vector3(5, 0, 0), new Vector3(10, 0, 0) },
+        };
+
+        var result = MdlAnimationEvaluator.EvaluatePosition(node, 99f);
+
+        Assert.Equal(new Vector3(10, 0, 0), result);
+    }
+
+    [Fact]
+    public void EvaluateOrientation_SlerpsBetweenQuats()
+    {
+        // Identity at t=0, 90° around Y at t=1. At t=0.5, rotating UnitZ should
+        // land halfway between UnitZ and UnitX (at 45° around Y from Z).
+        var q0 = Quaternion.Identity;
+        var q1 = Quaternion.CreateFromAxisAngle(Vector3.UnitY, MathF.PI / 2f);
+        var node = new MdlNode
+        {
+            OrientationTimes = new[] { 0f, 1f },
+            OrientationValues = new[] { q0, q1 },
+        };
+
+        var result = MdlAnimationEvaluator.EvaluateOrientation(node, 0.5f);
+        var rotated = Vector3.Transform(Vector3.UnitZ, result);
+        var expected = Vector3.Transform(Vector3.UnitZ,
+            Quaternion.CreateFromAxisAngle(Vector3.UnitY, MathF.PI / 4f));
+
+        Assert.Equal(expected.X, rotated.X, 4);
+        Assert.Equal(expected.Y, rotated.Y, 4);
+        Assert.Equal(expected.Z, rotated.Z, 4);
+    }
+
+    [Fact]
+    public void EvaluateScale_InterpolatesFloats()
+    {
+        var node = new MdlNode
+        {
+            ScaleTimes = new[] { 0f, 2f },
+            ScaleValues = new[] { 1f, 5f },
+        };
+
+        var result = MdlAnimationEvaluator.EvaluateScale(node, 1f);
+
+        Assert.Equal(3f, result, 4);
+    }
+
+    [Fact]
+    public void EvaluateScale_NoTrack_ReturnsStaticScale()
+    {
+        var node = new MdlNode { Scale = 2.5f };
+
+        var result = MdlAnimationEvaluator.EvaluateScale(node, 42f);
+
+        Assert.Equal(2.5f, result);
+    }
+}

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlAnimationEvaluator.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlAnimationEvaluator.cs
@@ -1,0 +1,82 @@
+// Pure-math evaluator for MDL animation keyframe tracks (#2124).
+// Samples Position / Orientation / Scale for a node at time t.
+// Returns static values when no tracks are present.
+
+using System;
+using System.Numerics;
+
+namespace Radoub.Formats.Mdl;
+
+/// <summary>
+/// Stateless helpers that interpolate an <see cref="MdlNode"/>'s keyframe
+/// tracks at a given time. Used by the model preview to play animation
+/// stances (#2124).
+/// </summary>
+public static class MdlAnimationEvaluator
+{
+    public static Vector3 EvaluatePosition(MdlNode node, float time)
+    {
+        var times = node.PositionTimes;
+        var values = node.PositionValues;
+        if (times.Length == 0 || values.Length == 0)
+            return node.Position;
+        if (times.Length == 1 || values.Length == 1)
+            return values[0];
+
+        var (a, b, t) = FindSegment(times, time);
+        return Vector3.Lerp(values[a], values[b], t);
+    }
+
+    public static Quaternion EvaluateOrientation(MdlNode node, float time)
+    {
+        var times = node.OrientationTimes;
+        var values = node.OrientationValues;
+        if (times.Length == 0 || values.Length == 0)
+            return node.Orientation;
+        if (times.Length == 1 || values.Length == 1)
+            return values[0];
+
+        var (a, b, t) = FindSegment(times, time);
+        return Quaternion.Slerp(values[a], values[b], t);
+    }
+
+    public static float EvaluateScale(MdlNode node, float time)
+    {
+        var times = node.ScaleTimes;
+        var values = node.ScaleValues;
+        if (times.Length == 0 || values.Length == 0)
+            return node.Scale;
+        if (times.Length == 1 || values.Length == 1)
+            return values[0];
+
+        var (a, b, t) = FindSegment(times, time);
+        return values[a] + (values[b] - values[a]) * t;
+    }
+
+    /// <summary>
+    /// Locate the keyframe segment enclosing <paramref name="time"/>.
+    /// Clamps to endpoints so out-of-range times return the nearest key.
+    /// Returns (indexA, indexB, t) where t is the 0..1 position within [A, B].
+    /// </summary>
+    private static (int a, int b, float t) FindSegment(float[] times, float time)
+    {
+        int last = times.Length - 1;
+
+        if (time <= times[0]) return (0, 0, 0f);
+        if (time >= times[last]) return (last, last, 0f);
+
+        // Linear scan — keyframe counts are small (usually <50 per track).
+        for (int i = 0; i < last; i++)
+        {
+            if (time >= times[i] && time <= times[i + 1])
+            {
+                float span = times[i + 1] - times[i];
+                float t = span > 0 ? (time - times[i]) / span : 0f;
+                return (i, i + 1, t);
+            }
+        }
+
+        // Shouldn't reach here given the clamps above.
+        return (last, last, 0f);
+    }
+}

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader.AnimationParsing.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader.AnimationParsing.cs
@@ -41,6 +41,26 @@ public partial class MdlBinaryReader
         // Animation name (64 bytes) - from geometry header portion
         anim.Name = ReadFixedString(reader, 64);
 
+        // The geometry header also carries a root-node pointer at offset 0x48.
+        // Parse the animation's node subtree so consumers (e.g. the appearance
+        // preview) can see which animations exist and drive a playhead (#2124).
+        stream.Position = offset + 0x48;
+        var animRootPtr = reader.ReadUInt32();
+        var animRootOffset = PointerToModelOffset(animRootPtr);
+        if (animRootOffset != 0xFFFFFFFF && animRootOffset != uint.MaxValue
+            && animRootOffset < _modelData.Length)
+        {
+            try
+            {
+                anim.GeometryRoot = ParseNode(animRootOffset);
+            }
+            catch (Exception ex)
+            {
+                Logging.UnifiedLogger.LogApplication(Logging.LogLevel.WARN,
+                    $"[MDL] Animation '{anim.Name}': failed to parse GeometryRoot: {ex.Message}");
+            }
+        }
+
         // Skip to animation-specific fields at offset 0x70
         stream.Position = offset + GeometryHeaderSize;
 

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader.NodeParsing.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader.NodeParsing.cs
@@ -267,39 +267,105 @@ public partial class MdlBinaryReader
             var columns = reader.ReadByte();
             reader.ReadByte(); // pad
 
-            // Read controller data based on type
-            // Type 8 = Position, Type 20 = Orientation
+            if (rows <= 0) continue;
+
+            // Times array immediately precedes values (NWN convention): one
+            // float per row at dataOffset + keyDataOffset * 4. Values follow.
+            var timePos = dataOffset + keyDataOffset * 4;
             var valuePos = dataOffset + valueDataOffset * 4;
 
-            if (type == 8 && rows > 0) // Position
+            // Read time keys (#2124) — parse all rows for animation playback.
+            // rows == 1 + no time stream = static bind pose (legacy behavior).
+            float[]? times = null;
+            if (rows > 1 && timePos + rows * 4 <= _modelData.Length)
             {
-                if (valuePos + 12 > _modelData.Length) continue;
-                stream.Position = valuePos;
-                node.Position = ReadVector3(reader);
+                times = new float[rows];
+                stream.Position = timePos;
+                for (int k = 0; k < rows; k++)
+                    times[k] = reader.ReadSingle();
             }
-            else if (type == 20 && rows > 0) // Orientation
+
+            if (type == 8) // Position (Vector3)
             {
-                if (valuePos + 16 > _modelData.Length) continue;
+                if (valuePos + rows * 12 > _modelData.Length) continue;
                 stream.Position = valuePos;
-                var x = reader.ReadSingle();
-                var y = reader.ReadSingle();
-                var z = reader.ReadSingle();
-                var w = reader.ReadSingle();
-                node.Orientation = new Quaternion(x, y, z, w);
+                var first = ReadVector3(reader);
+
+                if (rows == 1 || times == null)
+                {
+                    node.Position = first;
+                }
+                else
+                {
+                    var values = new Vector3[rows];
+                    values[0] = first;
+                    for (int k = 1; k < rows; k++)
+                        values[k] = ReadVector3(reader);
+
+                    node.PositionTimes = times;
+                    node.PositionValues = values;
+                    node.Position = first; // bind pose fallback
+                }
             }
-            else if (type == 36 && rows > 0) // Scale
+            else if (type == 20) // Orientation (Quaternion, 16 bytes)
             {
-                if (valuePos + 4 > _modelData.Length) continue;
+                if (valuePos + rows * 16 > _modelData.Length) continue;
                 stream.Position = valuePos;
-                node.Scale = reader.ReadSingle();
+                Quaternion ReadQuat()
+                {
+                    var x = reader.ReadSingle();
+                    var y = reader.ReadSingle();
+                    var z = reader.ReadSingle();
+                    var w = reader.ReadSingle();
+                    return new Quaternion(x, y, z, w);
+                }
+
+                var first = ReadQuat();
+                if (rows == 1 || times == null)
+                {
+                    node.Orientation = first;
+                }
+                else
+                {
+                    var values = new Quaternion[rows];
+                    values[0] = first;
+                    for (int k = 1; k < rows; k++)
+                        values[k] = ReadQuat();
+
+                    node.OrientationTimes = times;
+                    node.OrientationValues = values;
+                    node.Orientation = first;
+                }
             }
-            else if (type == 76 && rows > 0 && node is MdlLightNode light) // Light Color
+            else if (type == 36) // Scale (float)
+            {
+                if (valuePos + rows * 4 > _modelData.Length) continue;
+                stream.Position = valuePos;
+                var first = reader.ReadSingle();
+
+                if (rows == 1 || times == null)
+                {
+                    node.Scale = first;
+                }
+                else
+                {
+                    var values = new float[rows];
+                    values[0] = first;
+                    for (int k = 1; k < rows; k++)
+                        values[k] = reader.ReadSingle();
+
+                    node.ScaleTimes = times;
+                    node.ScaleValues = values;
+                    node.Scale = first;
+                }
+            }
+            else if (type == 76 && node is MdlLightNode light) // Light Color
             {
                 if (valuePos + 12 > _modelData.Length) continue;
                 stream.Position = valuePos;
                 light.Color = ReadVector3(reader);
             }
-            else if (type == 88 && rows > 0 && node is MdlLightNode light2) // Light Radius
+            else if (type == 88 && node is MdlLightNode light2) // Light Radius
             {
                 if (valuePos + 4 > _modelData.Length) continue;
                 stream.Position = valuePos;

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlStructures.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlStructures.cs
@@ -104,6 +104,25 @@ public class MdlNode
 
     /// <summary>Inherit color from parent.</summary>
     public bool InheritColor { get; set; }
+
+    // ----- Animation keyframe tracks (#2124) -----
+    // Each array is parallel: Times[i] corresponds to Values[i].
+    // Empty arrays = static node (use Position/Orientation/Scale above).
+
+    /// <summary>Position keyframe times (seconds).</summary>
+    public float[] PositionTimes { get; set; } = Array.Empty<float>();
+    /// <summary>Position keyframe values, parallel to PositionTimes.</summary>
+    public Vector3[] PositionValues { get; set; } = Array.Empty<Vector3>();
+
+    /// <summary>Orientation keyframe times (seconds).</summary>
+    public float[] OrientationTimes { get; set; } = Array.Empty<float>();
+    /// <summary>Orientation keyframe values, parallel to OrientationTimes.</summary>
+    public Quaternion[] OrientationValues { get; set; } = Array.Empty<Quaternion>();
+
+    /// <summary>Scale keyframe times (seconds).</summary>
+    public float[] ScaleTimes { get; set; } = Array.Empty<float>();
+    /// <summary>Scale keyframe values, parallel to ScaleTimes.</summary>
+    public float[] ScaleValues { get; set; } = Array.Empty<float>();
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

Expand the 3D appearance preview into a full inspection tool: free orbit, pan, cursor-centric zoom, view presets, and keyboard shortcuts — plus MDL animation playback (including supermodel-inherited anims) with a speed slider. Motivated by #2026 debug cycles where limited camera control slowed shading investigation.

## Related Issues

- Closes #2124
- Supersedes #1203 (mouse-based model rotation) — can be closed on merge
- Follow-ups: #2126 (snake preview renders broken), #2127 (tech-debt split ModelPreviewGLControl)

## What changed

**Camera** (root cause: view matrix hard-coded `Vector3.Zero` as look-at target; zoom scaled distance-to-origin)
- `ModelViewController.Pan()` translates camera target; `ZoomAtPoint()` pulls target toward cursor pivot
- Render path now honors `CameraTarget` in `LookAt`; far plane scales with target distance
- `ModelPreviewGLControl`: left-drag rotate (free X-axis orbit), middle or Shift+left-drag pan, scroll wheel zoom-at-cursor (1.1× per notch), arrow keys / WASD / Home / F8

**View presets**
- `F/B/L/R/T` buttons for front/back/left/right/top with `ViewPreset` enum

**Animation playback**
- Animation dropdown, play/pause/scrub, 0.1×–2× speed slider
- `MdlAnimationEvaluator` interpolates position/orientation keyframes per node
- `ModelService` walks the `SuperModel` chain (`a_ba`, `a_fa`, etc.) and appends inherited animations — most creatures now animate without authoring their own
- Humanoid (part-based) creatures reuse the skeleton's bone hierarchy so shoulder→bicep→forearm→hand animate correctly

**Fixes**
- Transparent input-surface Border overlay — `OpenGlControlBase` has no hittable Background, so pointer events need a sibling control
- Removed duplicate `using Radoub.UI.Services` in NCW + MainWindow (CS0105)

## Testing

- 1267/1267 Quartermaster unit tests pass
- 2951/2951 total unit tests across Quartermaster + Radoub.Formats + Radoub.UI + Radoub.Dictionary pass
- 12 new `ModelViewController` tests (pan accumulate, pan reset, zoom-at-pivot drift, zoom-at-target stable, clamp behavior, 5 view presets)
- Manual spot-checks ✅ camera gestures, animation playback on badger, human with full walk/run/attack set

## Known follow-ups

- **#2126**: Snake preview renders with floating fangs and no body flex
- **#2127**: Tech debt — split `ModelPreviewGLControl.cs` (1347 lines after this sprint)

## Checklist

- [x] Implementation complete
- [x] Tests added/updated (12 new ModelViewController tests)
- [x] CHANGELOG updated with date
- [x] Tech debt tracked (#2127)
- [x] Manual spot-checks passed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)