### PR TITLE
[Radoub] fix: Memory leaks top-3 — TextureService LRU, AppearancePanel unwire, GameDataService full-clear (#2034)

### DIFF
--- a/.claude/commands/documentation.md
+++ b/.claude/commands/documentation.md
@@ -91,7 +91,20 @@ cd d:\LOM\workspace\Radoub.wiki
 grep -l "Page freshness:" *.md | xargs grep "Page freshness:"
 ```
 
-**30-day rule**: Pages older than 30 days with related code changes are STALE.
+**Staleness thresholds** (pages older than this with related code changes are STALE):
+
+| Tool | Threshold |
+|------|-----------|
+| Parley | 60 days |
+| Manifest | 60 days |
+| Quartermaster | 30 days |
+| Fence | 30 days |
+| Relique | 30 days |
+| Trebuchet | 30 days |
+| Radoub.Formats | 30 days |
+| Radoub.UI | 30 days |
+
+Parley and Manifest use the longer window because their codebases are winding down and most changes affecting them are Radoub-wide refactors rather than tool-specific feature work.
 
 ### Step 4: Developer Docs Updates
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.84-alpha] - 2026-04-22
-**Branch**: `radoub/issue-2034` | **PR**: #TBD
+**Branch**: `radoub/issue-2034` | **PR**: #2129
 
 ### Fix: Memory leaks — top 3 (#2034)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.84-alpha] - 2026-04-22
+**Branch**: `radoub/issue-2034` | **PR**: #TBD
+
+### Fix: Memory leaks — top 3 (#2034)
+
+- Bounded `TextureService` palette and rendered-texture caches with LRU eviction (previously unbounded, grew to 500 MB+ in long sessions).
+- `AppearancePanel` now unsubscribes its 27+ event handlers on `Unloaded`, letting prior `CurrentCreature` graphs be garbage-collected between creature switches.
+- `GameDataService.ClearCache()` now clears the SSF and palette caches in addition to the 2DA cache, matching `ConfigureModuleHaks` behavior (affects all tools via Radoub.Formats).
+
+---
+
 ## [0.2.83-alpha] - 2026-04-22
 **Branch**: `quartermaster/issue-2124` | **PR**: #2125
 

--- a/Quartermaster/Quartermaster/Services/TextureService.cs
+++ b/Quartermaster/Quartermaster/Services/TextureService.cs
@@ -17,9 +17,16 @@ namespace Quartermaster.Services;
 /// </summary>
 public class TextureService
 {
+    // Capacities chosen to bound worst-case memory (#2034):
+    //   palette  ~250 KB each × 128 = ~32 MB
+    //   rendered ~2-4 MB each ×  64 = ~128-256 MB
+    // Typical sessions stay well below these caps; LRU eviction protects long runs.
+    private const int PaletteCacheCapacity = 128;
+    private const int RenderedTextureCacheCapacity = 64;
+
     private readonly IGameDataService _gameDataService;
-    private readonly Dictionary<string, PaletteData?> _paletteCache = new();
-    private readonly Dictionary<string, byte[]?> _renderedTextureCache = new();
+    private readonly LruCache<string, PaletteData?> _paletteCache = new(PaletteCacheCapacity);
+    private readonly LruCache<string, byte[]?> _renderedTextureCache = new(RenderedTextureCacheCapacity);
 
     public TextureService(IGameDataService gameDataService)
     {
@@ -555,7 +562,7 @@ public class TextureService
         var tgaData = _gameDataService.FindResource(paletteResRef, ResourceTypes.Tga);
         if (tgaData == null || tgaData.Length == 0)
         {
-            _paletteCache[paletteResRef] = null;
+            _paletteCache.Set(paletteResRef, null);
             return null;
         }
 
@@ -563,13 +570,13 @@ public class TextureService
         {
             var tgaImage = TgaReader.Read(tgaData);
             var palette = new PaletteData(tgaImage.Width, tgaImage.Height, tgaImage.Pixels);
-            _paletteCache[paletteResRef] = palette;
+            _paletteCache.Set(paletteResRef, palette);
             return palette;
         }
         catch (Exception ex)
         {
             UnifiedLogger.LogApplication(LogLevel.DEBUG, $"Failed to load palette '{paletteResRef}': {ex.Message}");
-            _paletteCache[paletteResRef] = null;
+            _paletteCache.Set(paletteResRef, null);
             return null;
         }
     }

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
@@ -94,15 +94,15 @@ public partial class AppearancePanel
         if (_zoomOutButton != null)
             _zoomOutButton.Click += OnZoomOutClicked;
         if (_viewFrontButton != null)
-            _viewFrontButton.Click += (_, _) => _modelPreviewGL?.SetViewPreset(ViewPreset.Front);
+            _viewFrontButton.Click += OnViewFrontClicked;
         if (_viewBackButton != null)
-            _viewBackButton.Click += (_, _) => _modelPreviewGL?.SetViewPreset(ViewPreset.Back);
+            _viewBackButton.Click += OnViewBackClicked;
         if (_viewSideButton != null)
-            _viewSideButton.Click += (_, _) => _modelPreviewGL?.SetViewPreset(ViewPreset.Side);
+            _viewSideButton.Click += OnViewSideClicked;
         if (_viewSideRightButton != null)
-            _viewSideRightButton.Click += (_, _) => _modelPreviewGL?.SetViewPreset(ViewPreset.SideRight);
+            _viewSideRightButton.Click += OnViewSideRightClicked;
         if (_viewTopButton != null)
-            _viewTopButton.Click += (_, _) => _modelPreviewGL?.SetViewPreset(ViewPreset.Top);
+            _viewTopButton.Click += OnViewTopClicked;
 
         // Animation dropdown / play / scrub (#2124)
         if (_animationComboBox != null)
@@ -343,6 +343,131 @@ public partial class AppearancePanel
         if (_rShinComboBox != null) _rShinComboBox.SelectionChanged += OnBodyPartSelectionChanged;
         if (_rFootComboBox != null) _rFootComboBox.SelectionChanged += OnBodyPartSelectionChanged;
     }
+
+    // Unsubscribe mirror of WireEvents(). Called on Unloaded to release handler
+    // references so the panel + its _currentCreature graph can be GC'd (#2034).
+    // Keep in exact symmetry with WireEvents — every += has a matching -=.
+    private void UnwireEvents()
+    {
+        if (_appearanceListBox != null)
+        {
+            _appearanceListBox.SelectionChanged -= OnAppearanceSelectionChanged;
+            _appearanceListBox.ContextMenu = null;
+        }
+
+        if (_appearanceSearchBox != null)
+            _appearanceSearchBox.TextChanged -= OnAppearanceSearchChanged;
+
+        if (_showBifCheckBox != null)
+            _showBifCheckBox.IsCheckedChanged -= OnSourceFilterChanged;
+        if (_showHakCheckBox != null)
+            _showHakCheckBox.IsCheckedChanged -= OnSourceFilterChanged;
+        if (_showOverrideCheckBox != null)
+            _showOverrideCheckBox.IsCheckedChanged -= OnSourceFilterChanged;
+
+        if (_excludePatternBox != null)
+            _excludePatternBox.LostFocus -= OnExcludePatternLostFocus;
+
+        if (_genderComboBox != null)
+            _genderComboBox.SelectionChanged -= OnGenderSelectionChanged;
+
+        if (_phenotypeComboBox != null)
+            _phenotypeComboBox.SelectionChanged -= OnPhenotypeSelectionChanged;
+
+        UnwireBodyPartComboEvents();
+
+        if (_skinColorSwatch != null)
+            _skinColorSwatch.PointerPressed -= OnSkinColorSwatchClicked;
+        if (_hairColorSwatch != null)
+            _hairColorSwatch.PointerPressed -= OnHairColorSwatchClicked;
+        if (_tattoo1ColorSwatch != null)
+            _tattoo1ColorSwatch.PointerPressed -= OnTattoo1ColorSwatchClicked;
+        if (_tattoo2ColorSwatch != null)
+            _tattoo2ColorSwatch.PointerPressed -= OnTattoo2ColorSwatchClicked;
+
+        if (_modelPreviewGL != null)
+        {
+            _modelPreviewGL.PreviewStateChanged -= OnPreviewStateChanged;
+            _modelPreviewGL.MeshInfoChanged -= OnMeshInfoChanged;
+        }
+
+        if (_rotateLeftButton != null)
+            _rotateLeftButton.Click -= OnRotateLeftClicked;
+        if (_rotateRightButton != null)
+            _rotateRightButton.Click -= OnRotateRightClicked;
+        if (_resetViewButton != null)
+            _resetViewButton.Click -= OnResetViewClicked;
+        if (_zoomInButton != null)
+            _zoomInButton.Click -= OnZoomInClicked;
+        if (_zoomOutButton != null)
+            _zoomOutButton.Click -= OnZoomOutClicked;
+        if (_viewFrontButton != null)
+            _viewFrontButton.Click -= OnViewFrontClicked;
+        if (_viewBackButton != null)
+            _viewBackButton.Click -= OnViewBackClicked;
+        if (_viewSideButton != null)
+            _viewSideButton.Click -= OnViewSideClicked;
+        if (_viewSideRightButton != null)
+            _viewSideRightButton.Click -= OnViewSideRightClicked;
+        if (_viewTopButton != null)
+            _viewTopButton.Click -= OnViewTopClicked;
+
+        if (_animationComboBox != null)
+            _animationComboBox.SelectionChanged -= OnAnimationSelectionChanged;
+        if (_animPlayButton != null)
+            _animPlayButton.Click -= OnAnimPlayClicked;
+        if (_animTimeSlider != null)
+            _animTimeSlider.PropertyChanged -= OnAnimSliderChanged;
+        if (_animSpeedSlider != null)
+            _animSpeedSlider.PropertyChanged -= OnAnimSpeedChanged;
+
+        if (_modelPreviewInputSurface != null)
+        {
+            _modelPreviewInputSurface.PointerPressed -= OnModelPreviewPointerPressed;
+            _modelPreviewInputSurface.PointerMoved -= OnModelPreviewPointerMoved;
+            _modelPreviewInputSurface.PointerReleased -= OnModelPreviewPointerReleased;
+            _modelPreviewInputSurface.PointerWheelChanged -= OnModelPreviewWheel;
+            _modelPreviewInputSurface.KeyDown -= OnModelPreviewKeyDown;
+        }
+    }
+
+    private void UnwireBodyPartComboEvents()
+    {
+        if (_headComboBox != null) _headComboBox.SelectionChanged -= OnHeadSelectionChanged;
+        if (_neckComboBox != null) _neckComboBox.SelectionChanged -= OnBodyPartSelectionChanged;
+        if (_torsoComboBox != null) _torsoComboBox.SelectionChanged -= OnBodyPartSelectionChanged;
+        if (_pelvisComboBox != null) _pelvisComboBox.SelectionChanged -= OnBodyPartSelectionChanged;
+        if (_beltComboBox != null) _beltComboBox.SelectionChanged -= OnBodyPartSelectionChanged;
+        if (_tailComboBox != null) _tailComboBox.SelectionChanged -= OnTailSelectionChanged;
+        if (_wingsComboBox != null) _wingsComboBox.SelectionChanged -= OnWingsSelectionChanged;
+
+        if (_lShoulComboBox != null) _lShoulComboBox.SelectionChanged -= OnBodyPartSelectionChanged;
+        if (_lBicepComboBox != null) _lBicepComboBox.SelectionChanged -= OnBodyPartSelectionChanged;
+        if (_lFArmComboBox != null) _lFArmComboBox.SelectionChanged -= OnBodyPartSelectionChanged;
+        if (_lHandComboBox != null) _lHandComboBox.SelectionChanged -= OnBodyPartSelectionChanged;
+        if (_lThighComboBox != null) _lThighComboBox.SelectionChanged -= OnBodyPartSelectionChanged;
+        if (_lShinComboBox != null) _lShinComboBox.SelectionChanged -= OnBodyPartSelectionChanged;
+        if (_lFootComboBox != null) _lFootComboBox.SelectionChanged -= OnBodyPartSelectionChanged;
+
+        if (_rShoulComboBox != null) _rShoulComboBox.SelectionChanged -= OnBodyPartSelectionChanged;
+        if (_rBicepComboBox != null) _rBicepComboBox.SelectionChanged -= OnBodyPartSelectionChanged;
+        if (_rFArmComboBox != null) _rFArmComboBox.SelectionChanged -= OnBodyPartSelectionChanged;
+        if (_rHandComboBox != null) _rHandComboBox.SelectionChanged -= OnBodyPartSelectionChanged;
+        if (_rThighComboBox != null) _rThighComboBox.SelectionChanged -= OnBodyPartSelectionChanged;
+        if (_rShinComboBox != null) _rShinComboBox.SelectionChanged -= OnBodyPartSelectionChanged;
+        if (_rFootComboBox != null) _rFootComboBox.SelectionChanged -= OnBodyPartSelectionChanged;
+    }
+
+    private void OnViewFrontClicked(object? sender, RoutedEventArgs e)
+        => _modelPreviewGL?.SetViewPreset(ViewPreset.Front);
+    private void OnViewBackClicked(object? sender, RoutedEventArgs e)
+        => _modelPreviewGL?.SetViewPreset(ViewPreset.Back);
+    private void OnViewSideClicked(object? sender, RoutedEventArgs e)
+        => _modelPreviewGL?.SetViewPreset(ViewPreset.Side);
+    private void OnViewSideRightClicked(object? sender, RoutedEventArgs e)
+        => _modelPreviewGL?.SetViewPreset(ViewPreset.SideRight);
+    private void OnViewTopClicked(object? sender, RoutedEventArgs e)
+        => _modelPreviewGL?.SetViewPreset(ViewPreset.Top);
 
     private void OnHeadSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
@@ -109,6 +109,15 @@ public partial class AppearancePanel : UserControl
         AvaloniaXamlLoader.Load(this);
         FindControls();
         WireEvents();
+        // Release ~40 event-handler subscriptions when the panel leaves the visual
+        // tree so the prior CurrentCreature graph can be GC'd (#2034).
+        Unloaded += OnPanelUnloaded;
+    }
+
+    private void OnPanelUnloaded(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        Unloaded -= OnPanelUnloaded;
+        UnwireEvents();
     }
 
     private void FindControls()

--- a/Radoub.Formats/Radoub.Formats.Tests/GameDataServiceTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/GameDataServiceTests.cs
@@ -219,6 +219,56 @@ public class GameDataServiceTests : IDisposable
         Assert.NotNull(second);
     }
 
+    [Fact]
+    public void ClearCache_AlsoClearsSsfAndPaletteCaches()
+    {
+        // #2034: ClearCache() only cleared _twoDACache, leaving _ssfCache and
+        // _paletteCache populated with stale data after module switches.
+        // It must now clear all three caches to match ConfigureModuleHaks behavior.
+        var config = new GameResourceConfig { OverridePath = _overrideDir };
+        using var service = new GameDataService(config);
+
+        // Seed all three caches via reflection (simulates populated caches from prior module).
+        // Null values are acceptable — each dictionary's value type is nullable or a collection.
+        SeedPrivateDictionaryCache(service, "_twoDACache", "some2da", value: null);
+        SeedPrivateDictionaryCache(service, "_ssfCache", "someresref", value: null);
+        SeedPrivateDictionaryCache(service, "_paletteCache", (ushort)2027, new List<PaletteCategory>());
+
+        Assert.Equal(1, GetPrivateDictionaryCount(service, "_twoDACache"));
+        Assert.Equal(1, GetPrivateDictionaryCount(service, "_ssfCache"));
+        Assert.Equal(1, GetPrivateDictionaryCount(service, "_paletteCache"));
+
+        service.ClearCache();
+
+        Assert.Equal(0, GetPrivateDictionaryCount(service, "_twoDACache"));
+        Assert.Equal(0, GetPrivateDictionaryCount(service, "_ssfCache"));
+        Assert.Equal(0, GetPrivateDictionaryCount(service, "_paletteCache"));
+    }
+
+    private static void SeedPrivateDictionaryCache(object target, string fieldName, object key, object? value)
+    {
+        var field = target.GetType().GetField(fieldName,
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        var dict = field!.GetValue(target);
+        Assert.NotNull(dict);
+        var indexer = dict!.GetType().GetProperty("Item");
+        Assert.NotNull(indexer);
+        indexer!.SetValue(dict, value, new[] { key });
+    }
+
+    private static int GetPrivateDictionaryCount(object target, string fieldName)
+    {
+        var field = target.GetType().GetField(fieldName,
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        var dict = field!.GetValue(target);
+        Assert.NotNull(dict);
+        var countProp = dict!.GetType().GetProperty("Count");
+        Assert.NotNull(countProp);
+        return (int)countProp!.GetValue(dict)!;
+    }
+
     #endregion
 
     #region TLK Tests

--- a/Radoub.Formats/Radoub.Formats.Tests/LruCacheTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/LruCacheTests.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Radoub.Formats.Common;
+using Xunit;
+
+namespace Radoub.Formats.Tests;
+
+public class LruCacheTests
+{
+    [Fact]
+    public void TryGetValue_ReturnsFalse_WhenKeyMissing()
+    {
+        var cache = new LruCache<string, int>(capacity: 4);
+
+        var found = cache.TryGetValue("missing", out var value);
+
+        Assert.False(found);
+        Assert.Equal(0, value);
+    }
+
+    [Fact]
+    public void Set_Then_TryGetValue_ReturnsStoredValue()
+    {
+        var cache = new LruCache<string, int>(capacity: 4);
+
+        cache.Set("a", 1);
+        var found = cache.TryGetValue("a", out var value);
+
+        Assert.True(found);
+        Assert.Equal(1, value);
+    }
+
+    [Fact]
+    public void Count_ReflectsNumberOfEntries()
+    {
+        var cache = new LruCache<string, int>(capacity: 4);
+        Assert.Equal(0, cache.Count);
+
+        cache.Set("a", 1);
+        cache.Set("b", 2);
+
+        Assert.Equal(2, cache.Count);
+    }
+
+    [Fact]
+    public void Capacity_IsExposed()
+    {
+        var cache = new LruCache<string, int>(capacity: 7);
+
+        Assert.Equal(7, cache.Capacity);
+    }
+
+    [Fact]
+    public void Set_EvictsLeastRecentlyUsed_WhenAtCapacity()
+    {
+        var cache = new LruCache<string, int>(capacity: 3);
+
+        cache.Set("a", 1);
+        cache.Set("b", 2);
+        cache.Set("c", 3);
+        cache.Set("d", 4); // Should evict "a"
+
+        Assert.Equal(3, cache.Count);
+        Assert.False(cache.TryGetValue("a", out _));
+        Assert.True(cache.TryGetValue("b", out _));
+        Assert.True(cache.TryGetValue("c", out _));
+        Assert.True(cache.TryGetValue("d", out _));
+    }
+
+    [Fact]
+    public void TryGetValue_PromotesKeyToMostRecentlyUsed()
+    {
+        var cache = new LruCache<string, int>(capacity: 3);
+
+        cache.Set("a", 1);
+        cache.Set("b", 2);
+        cache.Set("c", 3);
+
+        // Promote "a" to most-recently-used
+        cache.TryGetValue("a", out _);
+
+        // Adding "d" should now evict "b" (least recent), not "a"
+        cache.Set("d", 4);
+
+        Assert.True(cache.TryGetValue("a", out _));
+        Assert.False(cache.TryGetValue("b", out _));
+        Assert.True(cache.TryGetValue("c", out _));
+        Assert.True(cache.TryGetValue("d", out _));
+    }
+
+    [Fact]
+    public void Set_ExistingKey_UpdatesValueAndPromotesToMostRecentlyUsed()
+    {
+        var cache = new LruCache<string, int>(capacity: 3);
+
+        cache.Set("a", 1);
+        cache.Set("b", 2);
+        cache.Set("c", 3);
+
+        // Overwrite "a" with a new value; should both update and promote.
+        cache.Set("a", 99);
+
+        // "b" is now least recent; adding "d" should evict it, not "a".
+        cache.Set("d", 4);
+
+        Assert.True(cache.TryGetValue("a", out var aValue));
+        Assert.Equal(99, aValue);
+        Assert.False(cache.TryGetValue("b", out _));
+        Assert.True(cache.TryGetValue("c", out _));
+        Assert.True(cache.TryGetValue("d", out _));
+    }
+
+    [Fact]
+    public void Clear_RemovesAllEntries()
+    {
+        var cache = new LruCache<string, int>(capacity: 4);
+        cache.Set("a", 1);
+        cache.Set("b", 2);
+
+        cache.Clear();
+
+        Assert.Equal(0, cache.Count);
+        Assert.False(cache.TryGetValue("a", out _));
+        Assert.False(cache.TryGetValue("b", out _));
+    }
+
+    [Fact]
+    public void Set_CanStoreNullValues()
+    {
+        // TextureService stores null to remember "not found" lookups — this
+        // must be preserved by the cache without collapsing to "missing".
+        var cache = new LruCache<string, string?>(capacity: 4);
+
+        cache.Set("a", null);
+
+        var found = cache.TryGetValue("a", out var value);
+        Assert.True(found);
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void Constructor_ThrowsOnZeroOrNegativeCapacity()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new LruCache<string, int>(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new LruCache<string, int>(-1));
+    }
+
+    [Fact]
+    public async Task ConcurrentAccess_DoesNotCorruptCache()
+    {
+        var cache = new LruCache<int, int>(capacity: 64);
+        const int tasks = 16;
+        const int iterations = 1000;
+
+        await Task.WhenAll(Enumerable.Range(0, tasks).Select(taskId => Task.Run(() =>
+        {
+            for (int i = 0; i < iterations; i++)
+            {
+                int key = (taskId * iterations + i) % 128;
+                cache.Set(key, key * 10);
+                cache.TryGetValue(key, out _);
+            }
+        })));
+
+        // Capacity invariant must hold under concurrency.
+        Assert.InRange(cache.Count, 0, 64);
+    }
+}

--- a/Radoub.Formats/Radoub.Formats/Common/LruCache.cs
+++ b/Radoub.Formats/Radoub.Formats/Common/LruCache.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+
+namespace Radoub.Formats.Common;
+
+/// <summary>
+/// Thread-safe least-recently-used cache with a fixed capacity.
+/// Used by services (e.g. TextureService) that previously held unbounded Dictionaries
+/// and could grow indefinitely during long sessions (#2034).
+/// </summary>
+public sealed class LruCache<TKey, TValue> where TKey : notnull
+{
+    private readonly int _capacity;
+    private readonly Dictionary<TKey, LinkedListNode<Entry>> _map;
+    private readonly LinkedList<Entry> _order;
+    private readonly object _lock = new();
+
+    public LruCache(int capacity)
+    {
+        if (capacity <= 0)
+            throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be positive.");
+        _capacity = capacity;
+        _map = new Dictionary<TKey, LinkedListNode<Entry>>(capacity);
+        _order = new LinkedList<Entry>();
+    }
+
+    public int Capacity => _capacity;
+
+    public int Count
+    {
+        get { lock (_lock) return _map.Count; }
+    }
+
+    public bool TryGetValue(TKey key, out TValue? value)
+    {
+        lock (_lock)
+        {
+            if (_map.TryGetValue(key, out var node))
+            {
+                _order.Remove(node);
+                _order.AddFirst(node);
+                value = node.Value.Value;
+                return true;
+            }
+            value = default;
+            return false;
+        }
+    }
+
+    public void Set(TKey key, TValue? value)
+    {
+        lock (_lock)
+        {
+            if (_map.TryGetValue(key, out var existing))
+            {
+                _order.Remove(existing);
+                existing.Value = new Entry(key, value);
+                _order.AddFirst(existing);
+                return;
+            }
+
+            if (_map.Count >= _capacity)
+            {
+                var tail = _order.Last;
+                if (tail != null)
+                {
+                    _order.RemoveLast();
+                    _map.Remove(tail.Value.Key);
+                }
+            }
+
+            var node = new LinkedListNode<Entry>(new Entry(key, value));
+            _order.AddFirst(node);
+            _map[key] = node;
+        }
+    }
+
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _map.Clear();
+            _order.Clear();
+        }
+    }
+
+    private readonly struct Entry
+    {
+        public Entry(TKey key, TValue? value)
+        {
+            Key = key;
+            Value = value;
+        }
+        public TKey Key { get; }
+        public TValue? Value { get; }
+    }
+}

--- a/Radoub.Formats/Radoub.Formats/Services/GameDataService.cs
+++ b/Radoub.Formats/Radoub.Formats/Services/GameDataService.cs
@@ -93,9 +93,12 @@ public class GameDataService : IGameDataService
 
     public void ClearCache()
     {
+        // Must clear all three caches to match ConfigureModuleHaks (#2034).
         lock (_lock)
         {
             _twoDACache.Clear();
+            _ssfCache.Clear();
+            _paletteCache.Clear();
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes 3 of 9 leak points from #2034 (top by impact × blast radius):

- **TextureService** palette + rendered caches now LRU-bounded (previously unbounded, grew to 500 MB+ in long QM sessions).
- **AppearancePanel** unsubscribes all ~40 event handlers on `Unloaded`, letting prior `CurrentCreature` graphs be GC'd between creature switches. Five view-preset lambda handlers refactored to named methods for unsubscribability.
- **GameDataService.ClearCache()** now clears SSF + palette caches (previously only 2DA) — affects all tools via Radoub.Formats.

Pre-warm plan: `NonPublic/Plans/2026-04-20-2034-plan.md`. #2034 stays open for the remaining 6 items (lower-tier or architectural).

## Side-quests on this branch

- Extended documentation staleness threshold to 60 days for Parley/Manifest (winding down tools); other tools stay at 30 days.

## Pre-Merge Checklist

### Tests
| Check | Status |
|-------|--------|
| Privacy scan | ✅ Pass |
| Tech debt | ✅ No files >800 lines in this diff |
| Theme scan | ✅ 26 warnings, 0 in files touched by this PR |
| Radoub.Formats.Tests | ✅ 1161/1161 pass (11 new `LruCache`, 1 new `GameDataService`) |
| Radoub.UI.Tests | ✅ 481/481 pass |
| Radoub.Dictionary.Tests | ✅ 54/54 pass |
| Quartermaster.Tests | ✅ 1267/1267 pass |
| FlaUI Quartermaster (Smoke+Navigation) | ✅ 13/13 QM tests pass |

**FlaUI scope note**: one Parley test (`PropertiesTabs_NavigationWorks`) surfaced due to a test-filter scope issue (filter matched by name across all tool projects). Failure was caused by focus-steal during the run, not by this PR's diff (`git diff main...HEAD` touches no Parley file).

### Validation
| Check | Status |
|-------|--------|
| CHANGELOG entry with PR number + date | ✅ |
| `[Unreleased]` sections empty | ✅ all 6 tool CHANGELOGs clean |
| Wiki freshness | ✅ QM wiki 2026-04-22, Formats wiki 22 days old (under threshold) |
| Release notes draft updated | ✅ reset + appended post-v0.9.43 entries |

## Related Issues

- Addresses #2034 (parent stays open for remaining 6 items)
- Part of sprint #2115 (Cross-Tool Health)
- Filed during investigation: #2139 (non-humanoid animation coverage), #2140 (loop-all-animations diagnostic)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)