### PR TITLE
[Radoub] fix: FlaUI integration tests flaky under concurrent execution (#1526)

### DIFF
--- a/.github/workflows/relique-pr-build.yml
+++ b/.github/workflows/relique-pr-build.yml
@@ -1,0 +1,48 @@
+name: Relique PR Build Check
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'Relique/**'
+      - 'Radoub.Formats/**'
+      - 'Radoub.UI/**'
+      - '.github/workflows/relique-pr-build.yml'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0  # NBGV needs full history
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '9.0.x'
+
+    - name: Restore dependencies
+      run: dotnet restore Relique/Relique/Relique.csproj
+
+    - name: Build Relique
+      id: build
+      run: dotnet build Relique/Relique/Relique.csproj --configuration Release --no-restore
+      continue-on-error: true
+
+    - name: Report status
+      if: always()
+      shell: bash
+      run: |
+        if [ "${{ steps.build.outcome }}" = "success" ]; then
+          echo "✅ Relique build successful (${{ matrix.os }})"
+        else
+          echo "❌ Relique build failed (${{ matrix.os }})"
+          exit 1
+        fi

--- a/.github/workflows/relique-pr-tests.yml
+++ b/.github/workflows/relique-pr-tests.yml
@@ -1,0 +1,77 @@
+name: Relique PR Tests
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'Relique/**'
+      - 'Radoub.Formats/**'
+      - 'Radoub.UI/**'
+      - '.github/workflows/relique-pr-tests.yml'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0  # NBGV needs full history
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '9.0.x'
+
+    - name: Restore and build
+      run: dotnet build Relique/Relique.Tests/Relique.Tests.csproj --configuration Release
+
+    - name: Run Relique.Tests
+      id: relique-tests
+      shell: bash
+      run: |
+        dotnet test Relique/Relique.Tests/Relique.Tests.csproj \
+          --configuration Release \
+          --no-build \
+          --verbosity normal \
+          --logger "trx;LogFileName=relique-results.trx" \
+          --collect:"XPlat Code Coverage" \
+          --results-directory ./TestResults/Relique
+      continue-on-error: true
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: relique-test-results-${{ matrix.os }}
+        path: ./TestResults
+        retention-days: 30
+
+    - name: Test Report
+      uses: dorny/test-reporter@v3
+      if: always()
+      with:
+        name: Relique Test Results (${{ matrix.os }})
+        path: './TestResults/Relique/relique-results.trx'
+        reporter: dotnet-trx
+        fail-on-error: false
+
+    - name: Report test results
+      if: always()
+      shell: bash
+      run: |
+        if [ "${{ steps.relique-tests.outcome }}" = "success" ]; then
+          echo "✅ Relique tests passed (${{ matrix.os }})"
+        else
+          echo "❌ Relique tests failed (${{ matrix.os }})"
+          exit 1
+        fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -518,6 +518,7 @@ dotnet nbgv get-version --project [ToolDir]
 - Add delays before closing to let Avalonia's compositor finish pending renders
 - Wait for process to fully exit between tests to prevent resource conflicts
 - See `FlaUITestBase.StopApplication()` for reference implementation
+- **Sequential execution is enforced (#1526)**: `Radoub.IntegrationTests/AssemblyInfo.cs` carries `[assembly: CollectionBehavior(DisableTestParallelization = true)]` for within-assembly serialization. `FlaUITestBase` acquires a named system mutex (`Global\Radoub.FlaUI.SerialExecution`, 30 s timeout) for cross-process serialization — terminal + IDE Test Explorer collisions block on the mutex with a clear error rather than racing for desktop focus.
 
 **FlaUI Window Focus (CRITICAL)**:
 - **NEVER use direct `Keyboard.TypeSimultaneously()` calls** - keystrokes go to focused window, not necessarily test app

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -13,6 +13,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 - Assembly-level `[CollectionBehavior(DisableTestParallelization = true)]` on `Radoub.IntegrationTests` so every FlaUI test runs sequentially regardless of `[Collection]` assignment — fixes the canonical `SmokeTests.Quartermaster_LaunchAndCoreUI` flake when multiple test projects load via `dotnet test` directory walks or IDE Test Explorer
 - Named system mutex (`Global\Radoub.FlaUI.SerialExecution`) prevents two FlaUI test runs from racing across processes (e.g. terminal + IDE); 30 s timeout with a clear error
 - Defense-in-depth: `DisableParallelization = true` added to Fence and Trebuchet collection definitions
+- One-shot relaunch retry in `StartApplication` when `GetMainWindow` returns null (residual H3 mitigation for desktop-focus races); both null events log loudly so real launch regressions can't hide as transient
 - Affects test-runner behavior only — no runtime change in Quartermaster itself
 
 ---

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.85-alpha] - 2026-04-25
-**Branch**: `radoub/issue-1526` | **PR**: #TBD
+**Branch**: `radoub/issue-1526` | **PR**: #2141
 
 ### Fix: FlaUI integration tests flaky under concurrent execution (#1526)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.85-alpha] - 2026-04-25
+**Branch**: `radoub/issue-1526` | **PR**: #TBD
+
+### Fix: FlaUI integration tests flaky under concurrent execution (#1526)
+
+- Assembly-level `[CollectionBehavior(DisableTestParallelization = true)]` on `Radoub.IntegrationTests` so every FlaUI test runs sequentially regardless of `[Collection]` assignment — fixes the canonical `SmokeTests.Quartermaster_LaunchAndCoreUI` flake when multiple test projects load via `dotnet test` directory walks or IDE Test Explorer
+- Named system mutex (`Global\Radoub.FlaUI.SerialExecution`) prevents two FlaUI test runs from racing across processes (e.g. terminal + IDE); 30 s timeout with a clear error
+- Defense-in-depth: `DisableParallelization = true` added to Fence and Trebuchet collection definitions
+- Affects test-runner behavior only — no runtime change in Quartermaster itself
+
+---
+
 ## [0.2.84-alpha] - 2026-04-22
 **Branch**: `radoub/issue-2034` | **PR**: #2129
 

--- a/Radoub.Formats/Radoub.Formats.Tests/TestCollections.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/TestCollections.cs
@@ -1,0 +1,16 @@
+using Xunit;
+
+namespace Radoub.Formats.Tests;
+
+/// <summary>
+/// Collection that serializes RadoubSettings singleton tests so the static
+/// `_instance` and `_settingsDirectory` fields are not raced across parallel
+/// test classes (#1526 / #2051). Both `RadoubSettingsTests` and the nested
+/// `Settings/RadoubSettingsTests` carry [Collection("RadoubSettings")];
+/// declaring DisableParallelization here serializes them as a unit while
+/// pure-fast tests in this project keep running in parallel.
+/// </summary>
+[CollectionDefinition("RadoubSettings", DisableParallelization = true)]
+public class RadoubSettingsCollection
+{
+}

--- a/Radoub.IntegrationTests/AssemblyInfo.cs
+++ b/Radoub.IntegrationTests/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using Xunit;
+
+// Force every test in this assembly to run sequentially. FlaUI tests drive
+// real GUI processes via UI Automation — desktop focus, the foreground window,
+// and the UIA client are process-global resources, so concurrent execution of
+// FlaUI tests in the same assembly will sabotage one another (#1526).
+//
+// This is the assembly-wide guard. Per-collection DisableParallelization on
+// each tool's *TestCollections.cs is kept as defense in depth.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Radoub.IntegrationTests/Fence/FenceTestCollections.cs
+++ b/Radoub.IntegrationTests/Fence/FenceTestCollections.cs
@@ -9,7 +9,7 @@ namespace Radoub.IntegrationTests.Fence;
 /// 2. FlaUI can only control one application at a time
 /// 3. Running in parallel causes window focus conflicts
 /// </summary>
-[CollectionDefinition("FenceSequential")]
+[CollectionDefinition("FenceSequential", DisableParallelization = true)]
 public class FenceSequentialCollection : ICollectionFixture<FenceSequentialFixture>
 {
 }

--- a/Radoub.IntegrationTests/README.md
+++ b/Radoub.IntegrationTests/README.md
@@ -23,6 +23,17 @@ This project uses [FlaUI](https://github.com/FlaUI/FlaUI) for Windows UI automat
 - Native .NET library
 - Works with WPF, WinForms, UWP, and Avalonia apps
 
+### Serialization guarantee (#1526)
+
+FlaUI tests share desktop-global resources — the foreground window, keyboard focus, and the UIA client — so they must run sequentially.
+
+Two safeguards enforce this:
+
+1. **Within the assembly**: `[assembly: CollectionBehavior(DisableTestParallelization = true)]` (`AssemblyInfo.cs`) makes every test in `Radoub.IntegrationTests` run one at a time, regardless of `[Collection]` assignment.
+2. **Across processes**: `FlaUITestBase` acquires a named system mutex (`Global\Radoub.FlaUI.SerialExecution`) per test. A second `dotnet test` invocation, IDE Test Explorer run, or developer session attempting to run FlaUI tests at the same time will block on the mutex (30 s timeout, then a clear error naming the lock).
+
+The FlaUI mutex itself is unit-tested in `Shared/FlaUIGlobalMutexTests.cs` — those tests use unique `Local\…` mutex names so they don't interfere with real FlaUI runs.
+
 ---
 
 ## Prerequisites

--- a/Radoub.IntegrationTests/Shared/FlaUIGlobalMutex.cs
+++ b/Radoub.IntegrationTests/Shared/FlaUIGlobalMutex.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading;
+
+namespace Radoub.IntegrationTests.Shared;
+
+/// <summary>
+/// Cross-process serialization for FlaUI tests. Desktop input (focus,
+/// foreground window, the UIA client) is process-global, so two simultaneous
+/// FlaUI test runs on the same machine — even from different test
+/// assemblies, IDE Test Explorer + terminal, or two developer sessions —
+/// will sabotage each other.
+///
+/// <para>
+/// The default mutex name (<see cref="DefaultName"/>) is `Global\` so it
+/// covers user sessions on a shared runner. Tests should use
+/// <see cref="Acquire(string, TimeSpan)"/> with a per-test name to avoid
+/// colliding with a real FlaUI run on the same machine. (#1526)
+/// </para>
+/// </summary>
+public sealed class FlaUIGlobalMutex : IDisposable
+{
+    public const string DefaultName = "Global\\Radoub.FlaUI.SerialExecution";
+
+    /// <summary>Default acquisition timeout (#1526 decision: 30 seconds).</summary>
+    public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly Mutex _mutex;
+    private bool _released;
+
+    private FlaUIGlobalMutex(Mutex mutex)
+    {
+        _mutex = mutex;
+    }
+
+    /// <summary>
+    /// Acquire the named mutex or throw <see cref="TimeoutException"/> with a
+    /// clear message if another FlaUI run is holding it.
+    /// </summary>
+    public static FlaUIGlobalMutex Acquire(string name, TimeSpan timeout)
+    {
+        var mutex = new Mutex(initiallyOwned: false, name: name);
+        bool acquired;
+        try
+        {
+            acquired = mutex.WaitOne(timeout);
+        }
+        catch (AbandonedMutexException)
+        {
+            // Previous holder process crashed without releasing. We now own
+            // the mutex; treat as success and proceed.
+            acquired = true;
+        }
+
+        if (!acquired)
+        {
+            mutex.Dispose();
+            throw new TimeoutException(
+                $"Could not acquire FlaUI mutex '{name}' within {timeout}. " +
+                "Another FlaUI test run is holding the lock — wait for it to " +
+                "finish or kill the holder process.");
+        }
+
+        return new FlaUIGlobalMutex(mutex);
+    }
+
+    /// <summary>Acquire <see cref="DefaultName"/> with <see cref="DefaultTimeout"/>.</summary>
+    public static FlaUIGlobalMutex AcquireDefault() => Acquire(DefaultName, DefaultTimeout);
+
+    public void Dispose()
+    {
+        if (_released) return;
+        _released = true;
+
+        try { _mutex.ReleaseMutex(); } catch { /* released or never owned */ }
+        _mutex.Dispose();
+    }
+}

--- a/Radoub.IntegrationTests/Shared/FlaUIGlobalMutexTests.cs
+++ b/Radoub.IntegrationTests/Shared/FlaUIGlobalMutexTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Radoub.IntegrationTests.Shared;
+using Xunit;
+
+namespace Radoub.IntegrationTests.Shared;
+
+public class FlaUIGlobalMutexTests
+{
+    // Use a unique mutex name per test run so we don't collide with a real
+    // FlaUI run on the same machine (or with other test cases below).
+    private static string UniqueName() =>
+        $"Local\\Radoub.FlaUI.UnitTest.{Guid.NewGuid():N}";
+
+    [Fact]
+    public void Acquire_ReturnsHandleWhenUncontested()
+    {
+        using var mutex = FlaUIGlobalMutex.Acquire(UniqueName(), TimeSpan.FromSeconds(1));
+
+        Assert.NotNull(mutex);
+    }
+
+    [Fact]
+    public async Task Acquire_ThrowsTimeoutExceptionWithMutexNameInMessage_WhenAlreadyHeld()
+    {
+        var name = UniqueName();
+        using var first = FlaUIGlobalMutex.Acquire(name, TimeSpan.FromSeconds(1));
+
+        // Foreign thread so we don't recursively acquire on the same thread
+        // (Mutex is reentrant per-thread).
+        var ex = await Assert.ThrowsAsync<TimeoutException>(() =>
+            Task.Run(() => FlaUIGlobalMutex.Acquire(name, TimeSpan.FromMilliseconds(200))));
+
+        Assert.Contains(name, ex.Message);
+    }
+
+    [Fact]
+    public async Task Release_AllowsSubsequentAcquireFromAnotherThread()
+    {
+        var name = UniqueName();
+        var first = FlaUIGlobalMutex.Acquire(name, TimeSpan.FromSeconds(1));
+        first.Dispose();
+
+        var second = await Task.Run(() =>
+            FlaUIGlobalMutex.Acquire(name, TimeSpan.FromSeconds(1)));
+        second.Dispose();
+    }
+
+    [Fact]
+    public async Task Acquire_ZeroTimeout_ThrowsImmediatelyWhenContended()
+    {
+        var name = UniqueName();
+        using var first = FlaUIGlobalMutex.Acquire(name, TimeSpan.FromSeconds(1));
+
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            Task.Run(() => FlaUIGlobalMutex.Acquire(name, TimeSpan.Zero)));
+    }
+}

--- a/Radoub.IntegrationTests/Shared/FlaUITestBase.cs
+++ b/Radoub.IntegrationTests/Shared/FlaUITestBase.cs
@@ -149,10 +149,36 @@ public abstract class FlaUITestBase : IDisposable
         processInfo.Environment["FENCE_SETTINGS_DIR"] = fenceSettingsDir;
         processInfo.Environment["TREBUCHET_SETTINGS_DIR"] = trebuchetSettingsDir;
 
-        App = Application.Launch(processInfo);
+        // GetMainWindow can return null when the desktop is racing with the
+        // launching app — the window appears in time but UIA doesn't enumerate
+        // it before DefaultTimeout. This is one of the documented residual
+        // sources of #1526 flake (see CLAUDE.md "FlaUI Window Focus"). One
+        // narrowly-scoped retry: on null, kill the launched app, sleep briefly,
+        // and relaunch once. Logging is loud so a real launch regression isn't
+        // hidden as transient.
+        App = LaunchWithRetry(processInfo);
 
         // Wait for main window to appear
         MainWindow = App.GetMainWindow(Automation, DefaultTimeout);
+
+        if (MainWindow == null)
+        {
+            Console.Error.WriteLine(
+                $"[FlaUITestBase] WARNING: GetMainWindow returned null on first attempt " +
+                $"for PID {App.ProcessId}; killing and retrying once (#1526).");
+            try { App.Kill(); } catch { }
+            try { App.WaitWhileMainHandleIsMissing(TimeSpan.FromSeconds(2)); } catch { }
+            Thread.Sleep(500); // let UIA + window manager settle
+
+            App = LaunchWithRetry(processInfo);
+            MainWindow = App.GetMainWindow(Automation, DefaultTimeout);
+
+            if (MainWindow == null)
+            {
+                Console.Error.WriteLine(
+                    "[FlaUITestBase] ERROR: GetMainWindow null on retry too — real launch issue.");
+            }
+        }
 
         // Explicitly focus the main window to prevent keyboard input going to other apps
         // This fixes issues where VSCode or other apps steal focus during test startup
@@ -170,6 +196,15 @@ public abstract class FlaUITestBase : IDisposable
             MainWindow.Focus();
             Thread.Sleep(100);
         }
+    }
+
+    /// <summary>
+    /// Helper to wrap <see cref="Application.Launch(ProcessStartInfo)"/> so the
+    /// retry path in <see cref="StartApplication"/> stays readable.
+    /// </summary>
+    private static Application LaunchWithRetry(ProcessStartInfo processInfo)
+    {
+        return Application.Launch(processInfo);
     }
 
     /// <summary>

--- a/Radoub.IntegrationTests/Shared/FlaUITestBase.cs
+++ b/Radoub.IntegrationTests/Shared/FlaUITestBase.cs
@@ -23,6 +23,20 @@ public abstract class FlaUITestBase : IDisposable
     private string? _isolatedSettingsDir;
 
     /// <summary>
+    /// Cross-process serialization for FlaUI runs (#1526). Acquired per-test
+    /// in the constructor; released on Dispose. Without this, two `dotnet
+    /// test` invocations on the same machine — terminal + IDE Test Explorer,
+    /// or two developers, or a CI runner colliding with a local run — race
+    /// for desktop focus and produce intermittent failures.
+    /// </summary>
+    private readonly FlaUIGlobalMutex _globalMutex;
+
+    protected FlaUITestBase()
+    {
+        _globalMutex = FlaUIGlobalMutex.AcquireDefault();
+    }
+
+    /// <summary>
     /// Path to the application executable. Override in derived classes.
     /// </summary>
     protected abstract string ApplicationPath { get; }
@@ -593,7 +607,10 @@ public abstract class FlaUITestBase : IDisposable
                     // Ignore close errors - may already be closing
                 }
 
-                // Wait for process to fully exit (prevents resource conflicts between tests)
+                // Wait for process to fully exit (prevents resource conflicts between tests).
+                // The wait short-circuits when the app exits cleanly; the 5s ceiling only
+                // matters when shutdown actually hangs — which is itself a signal worth
+                // surfacing rather than silently killing (#1526).
                 var timeout = TimeSpan.FromSeconds(5);
                 var startTime = DateTime.Now;
                 while (!App.HasExited && (DateTime.Now - startTime) < timeout)
@@ -601,9 +618,15 @@ public abstract class FlaUITestBase : IDisposable
                     Thread.Sleep(100);
                 }
 
-                // Force kill if still running
+                // Force kill if still running. A timeout-then-kill here means the app
+                // didn't honor WM_CLOSE within 5 seconds — log it so flakes attributed
+                // to shutdown hangs are visible in the test output.
                 if (!App.HasExited)
                 {
+                    Console.Error.WriteLine(
+                        $"[FlaUITestBase] WARNING: app PID {App.ProcessId} did not exit " +
+                        $"within {timeout.TotalSeconds}s of App.Close(); force-killing. " +
+                        "Investigate if this recurs.");
                     try { App.Kill(); } catch { }
                 }
             }
@@ -634,6 +657,7 @@ public abstract class FlaUITestBase : IDisposable
     {
         StopApplication();
         CleanupIsolatedSettings();
+        _globalMutex.Dispose();
         GC.SuppressFinalize(this);
     }
 

--- a/Radoub.IntegrationTests/Trebuchet/TrebuchetTestCollections.cs
+++ b/Radoub.IntegrationTests/Trebuchet/TrebuchetTestCollections.cs
@@ -9,7 +9,7 @@ namespace Radoub.IntegrationTests.Trebuchet;
 /// 2. FlaUI can only control one application at a time
 /// 3. Running in parallel causes window focus conflicts
 /// </summary>
-[CollectionDefinition("TrebuchetSequential")]
+[CollectionDefinition("TrebuchetSequential", DisableParallelization = true)]
 public class TrebuchetSequentialCollection : ICollectionFixture<TrebuchetSequentialFixture>
 {
 }

--- a/Radoub.IntegrationTests/run-tests.ps1
+++ b/Radoub.IntegrationTests/run-tests.ps1
@@ -317,9 +317,11 @@ function Get-TestsToRun {
             $entry = $toolUiTests[$Tool].Clone()
             # Override filter if custom UIFilter provided
             # UIFilter values use FullyQualifiedName~ by default (Name~ doesn't work with xUnit VSTest adapter)
+            # Wrap both sides in parens — VSTest parses `|` higher than `&`, so a user
+            # filter like `Category=Smoke|Navigation` would otherwise leak across tools (#1526).
             if ($UIFilter) {
                 $filterExpr = if ($UIFilter -match '(FullyQualifiedName|DisplayName|Category)') { $UIFilter } else { "FullyQualifiedName~$UIFilter" }
-                $entry.Filter = "$($entry.Filter)&$filterExpr"
+                $entry.Filter = "($($entry.Filter))&($filterExpr)"
                 $entry.Name = "$($entry.Name) (filtered: $UIFilter)"
             }
             $uiTests += $entry


### PR DESCRIPTION
## Summary

Make FlaUI integration tests immune to concurrent execution — fixes the canonical `SmokeTests.Quartermaster_LaunchAndCoreUI` flake (and similar Parley/Manifest/Fence/Trebuchet smoke flakes) when multiple test projects load in the same `dotnet test` invocation, IDE Test Explorer run, or simultaneous terminal sessions.

Pre-warmed plan: \`NonPublic/Plans/2026-04-19-1526-plan.md\`. Decisions captured in \`NonPublic/Plans/2026-04-19-prewarm-decisions.md\` apply.

## Approach

- **Layer 1**: \`[assembly: CollectionBehavior(DisableTestParallelization = true)]\` on \`Radoub.IntegrationTests\` — every FlaUI test runs sequentially regardless of \`[Collection]\`
- **Layer 2**: Named system mutex \`Global\Radoub.FlaUI.SerialExecution\` on a 30 s timeout with a clear error message (cross-process serialization)
- **H3 retry**: One-shot relaunch in \`StartApplication\` when \`GetMainWindow\` returns null; loud Console.Error logging so real regressions can't hide
- **Defense in depth**: Fence + Trebuchet collection definitions get explicit \`DisableParallelization = true\`
- **Bundle**: \`[CollectionDefinition("RadoubSettings", DisableParallelization = true)]\` declared (complements #2051)
- **Q2 carry-out**: New Relique PR build + tests workflows added (Relique was the only tool without CI)
- **Side-fix**: \`run-tests.ps1\` UIFilter precedence — parens around tool-namespace filter prevent leaks across tools when user passes \`Category=A|B\`
- **No retry helper** at the test method level (project culture prefers strict signal)

## Pre-Merge Checklist

### Tests
| Check | Status |
|-------|--------|
| Privacy scan | ✅ Pass |
| Tech debt | ✅ No files >800 lines in this diff |
| Theme scan | ✅ 26 pre-existing warnings, 0 in files I touched |
| Radoub.Formats.Tests | ✅ 1161/1161 |
| Radoub.UI.Tests | ✅ 481/481 |
| Radoub.Dictionary.Tests | ✅ 54/54 |
| Quartermaster.Tests | ✅ 1267/1267 |
| FlaUIGlobalMutexTests (TDD) | ✅ 4/4 |
| FlaUI smoke (Quartermaster) | ✅ 3/3 sequential runs after H3 retry added (one prior run flaked, motivating the retry) |

### Validation
| Check | Status |
|-------|--------|
| CHANGELOG entry | ✅ \`Quartermaster/CHANGELOG.md\` 0.2.85-alpha with PR #2141 |
| \`[Unreleased]\` sections empty | ✅ all 6 tool CHANGELOGs clean |
| Wiki freshness | ✅ no stale + code-changed combos for this PR |
| Release notes draft updated | ✅ entry appended |

## Related Issues

- Closes #1526
- Part of sprint #2115 (Cross-Tool Health)
- Coordinates with #2051 (RadoubSettings singleton — complementary fix; collection definition is bundled here)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)