### PR TITLE
[Radoub] Fix: Memory leaks round 2 — SharedPaletteCacheService dispose, ItemIconService LRU, AdvancedPanel unwire (#2034)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"3f92083c-95a8-42c3-ae97-b7a51fe2c453","pid":25928,"acquiredAt":1777173709919}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"3f92083c-95a8-42c3-ae97-b7a51fe2c453","pid":25928,"acquiredAt":1777173709919}

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ __pycache__/
 venv/
 /.claude/settings.local.json
 /.claude/cache/
+/.claude/scheduled_tasks.lock
 NonPublic
 TestOutput
 /Radoub.IntegrationTests/TestOutput

--- a/Fence/Fence/Views/MainWindow.axaml.cs
+++ b/Fence/Fence/Views/MainWindow.axaml.cs
@@ -371,6 +371,9 @@ public partial class MainWindow : Window, INotifyPropertyChanged
             // Dispose TlkService to unsubscribe from settings events
             _tlkService?.Dispose();
 
+            // Dispose shared palette cache lock (#2034)
+            (_sharedCacheService as IDisposable)?.Dispose();
+
             if (e.Cancel)
             {
                 // HandleClosingAsync set Cancel=true, we need to re-close

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.86-alpha] - 2026-04-22
+**Branch**: `radoub/issue-2034-round2` | **PR**: #TBD
+
+### Fix: Memory leaks — round 2 top 3 (#2034)
+
+- `SharedPaletteCacheService` now implements `IDisposable` and disposes its `ReaderWriterLockSlim` (eliminates kernel-handle leak; affects all tools via Radoub.UI)
+- `ItemIconService` bitmap cache bounded with LRU eviction (was unbounded `ConcurrentDictionary`, could grow past the documented ~15–30 MB ceiling on large modules)
+- `AdvancedPanel` lambda closures unwired on `Unloaded` so prior `CurrentCreature` graphs can be garbage-collected between creature switches
+
+---
+
 ## [0.2.85-alpha] - 2026-04-25
 **Branch**: `radoub/issue-1526` | **PR**: #2141
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -13,6 +13,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 - `SharedPaletteCacheService` now implements `IDisposable` and disposes its `ReaderWriterLockSlim` (eliminates kernel-handle leak; affects all tools via Radoub.UI)
 - `ItemIconService` bitmap cache bounded with LRU eviction (was unbounded `ConcurrentDictionary`, could grow past the documented ~15–30 MB ceiling on large modules)
 - `AdvancedPanel` lambda closures unwired on `Unloaded` so prior `CurrentCreature` graphs can be garbage-collected between creature switches
+- Perf: demoted per-node/per-mesh MDL parser logs from DEBUG to TRACE (~165k log lines per creature-browser session at DEBUG level were causing visible app slowdown on startup and panel switches)
 
 ---
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,7 +5,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
-## [0.2.86-alpha] - 2026-04-22
+## [0.2.86-alpha] - 2026-04-25
 **Branch**: `radoub/issue-2034-round2` | **PR**: #2142
 
 ### Fix: Memory leaks — round 2 top 3 (#2034)

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.86-alpha] - 2026-04-22
-**Branch**: `radoub/issue-2034-round2` | **PR**: #TBD
+**Branch**: `radoub/issue-2034-round2` | **PR**: #2142
 
 ### Fix: Memory leaks — round 2 top 3 (#2034)
 

--- a/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
+++ b/Quartermaster/Quartermaster/Controls/ModelPreviewGLControl.cs
@@ -1094,7 +1094,7 @@ public class ModelPreviewGLControl : OpenGlControlBase
                 UnifiedLogger.LogApplication(LogLevel.WARN, $"  Mesh {meshIndex} '{mesh.Name}' UV count mismatch: {mesh.TextureCoords[0].Length} UVs vs {mesh.Vertices.Length} vertices");
             }
 
-            UnifiedLogger.LogApplication(LogLevel.DEBUG,
+            UnifiedLogger.LogApplication(LogLevel.TRACE,
                 $"  MESH '{mesh.Name}': bitmap='{mesh.Bitmap}', isSkin={isSkinMesh}, hasXform={hasWorldTransform}, " +
                 $"verts={mesh.Vertices.Length}, faces={mesh.Faces.Length}");
 
@@ -1228,7 +1228,7 @@ public class ModelPreviewGLControl : OpenGlControlBase
 
             if (weld.WeldedCount > 0)
             {
-                UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                UnifiedLogger.LogApplication(LogLevel.TRACE,
                     $"  Mesh '{mesh.Name}': welded {weld.WeldedCount}/{cornerCount} corners " +
                     $"-> {weld.OutputVertexCount} unique in GPU buffer");
             }

--- a/Quartermaster/Quartermaster/Views/MainWindow.Lifecycle.cs
+++ b/Quartermaster/Quartermaster/Views/MainWindow.Lifecycle.cs
@@ -193,6 +193,8 @@ public partial class MainWindow
             SaveWindowPosition();
             _audioService?.Dispose();
             _gameDataService?.Dispose();
+            _paletteCacheCts?.Dispose();
+            (_sharedCacheService as IDisposable)?.Dispose();
 
             if (e.Cancel)
             {

--- a/Quartermaster/Quartermaster/Views/Panels/AdvancedPanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AdvancedPanel.axaml.cs
@@ -156,6 +156,12 @@ public partial class AdvancedPanel : BasePanelControl
 
     private void OnPanelUnloaded(object? sender, RoutedEventArgs e)
     {
+        // PROBE (#2034 round 2 verification — REMOVE before merge): logs WARN whenever
+        // AdvancedPanel.Unloaded fires so we can see if visibility toggling during
+        // sidebar navigation incorrectly triggers tree detach. Expected: fires once
+        // on app shutdown only.
+        UnifiedLogger.LogApplication(LogLevel.WARN,
+            $"[#2034-PROBE] AdvancedPanel.OnPanelUnloaded fired at {DateTime.UtcNow:O}");
         Unloaded -= OnPanelUnloaded;
         _subs.DetachAll();
         ClearVariables(); // Releases per-VariableViewModel PropertyChanged subscriptions

--- a/Quartermaster/Quartermaster/Views/Panels/AdvancedPanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AdvancedPanel.axaml.cs
@@ -156,12 +156,6 @@ public partial class AdvancedPanel : BasePanelControl
 
     private void OnPanelUnloaded(object? sender, RoutedEventArgs e)
     {
-        // PROBE (#2034 round 2 verification — REMOVE before merge): logs WARN whenever
-        // AdvancedPanel.Unloaded fires so we can see if visibility toggling during
-        // sidebar navigation incorrectly triggers tree detach. Expected: fires once
-        // on app shutdown only.
-        UnifiedLogger.LogApplication(LogLevel.WARN,
-            $"[#2034-PROBE] AdvancedPanel.OnPanelUnloaded fired at {DateTime.UtcNow:O}");
         Unloaded -= OnPanelUnloaded;
         _subs.DetachAll();
         ClearVariables(); // Releases per-VariableViewModel PropertyChanged subscriptions

--- a/Quartermaster/Quartermaster/Views/Panels/AdvancedPanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AdvancedPanel.axaml.cs
@@ -71,6 +71,10 @@ public partial class AdvancedPanel : BasePanelControl
     public event EventHandler? VariablesChanged;
     public event EventHandler? RenameRequested;
 
+    // All event handler subscriptions tracked so we can release them on Unloaded
+    // and let the prior CurrentCreature graph be garbage-collected (#2034).
+    private readonly EventSubscriptions _subs = new();
+
     public AdvancedPanel()
     {
         InitializeComponent();
@@ -117,18 +121,28 @@ public partial class AdvancedPanel : BasePanelControl
         _removeVariableButton = this.FindControl<Button>("RemoveVariableButton");
         _variableValidationText = this.FindControl<TextBlock>("VariableValidationText");
 
-        // Wire up events
+        // Wire up events — track every subscription so DetachAll() can release them
         if (_copyResRefButton != null)
-            _copyResRefButton.Click += OnCopyResRefClick;
+            _subs.Track(
+                attach: () => _copyResRefButton.Click += OnCopyResRefClick,
+                detach: () => _copyResRefButton.Click -= OnCopyResRefClick);
         if (_copyTagButton != null)
-            _copyTagButton.Click += OnCopyTagClick;
+            _subs.Track(
+                attach: () => _copyTagButton.Click += OnCopyTagClick,
+                detach: () => _copyTagButton.Click -= OnCopyTagClick);
         if (_renameResRefButton != null)
-            _renameResRefButton.Click += OnRenameResRefClick;
+            _subs.Track(
+                attach: () => _renameResRefButton.Click += OnRenameResRefClick,
+                detach: () => _renameResRefButton.Click -= OnRenameResRefClick);
         if (_tagTextBox != null)
-            _tagTextBox.TextChanged += OnTagTextChanged;
+            _subs.Track(
+                attach: () => _tagTextBox.TextChanged += OnTagTextChanged,
+                detach: () => _tagTextBox.TextChanged -= OnTagTextChanged);
         if (_commentTextBox != null)
         {
-            _commentTextBox.TextChanged += OnCommentTextChanged;
+            _subs.Track(
+                attach: () => _commentTextBox.TextChanged += OnCommentTextChanged,
+                detach: () => _commentTextBox.TextChanged -= OnCommentTextChanged);
             WireTokenMenu(_commentTextBox);
         }
 
@@ -136,12 +150,23 @@ public partial class AdvancedPanel : BasePanelControl
         WireUpBehaviorCombos();
         WireUpIdentityCombos();
         WireUpVariables();
+
+        Unloaded += OnPanelUnloaded;
+    }
+
+    private void OnPanelUnloaded(object? sender, RoutedEventArgs e)
+    {
+        Unloaded -= OnPanelUnloaded;
+        _subs.DetachAll();
+        ClearVariables(); // Releases per-VariableViewModel PropertyChanged subscriptions
     }
 
     private void WireUpIdentityCombos()
     {
         if (_paletteCategoryComboBox != null)
-            _paletteCategoryComboBox.SelectionChanged += OnPaletteCategorySelectionChanged;
+            _subs.Track(
+                attach: () => _paletteCategoryComboBox.SelectionChanged += OnPaletteCategorySelectionChanged,
+                detach: () => _paletteCategoryComboBox.SelectionChanged -= OnPaletteCategorySelectionChanged);
     }
 
     private void OnPaletteCategorySelectionChanged(object? sender, SelectionChangedEventArgs e)
@@ -159,15 +184,25 @@ public partial class AdvancedPanel : BasePanelControl
     private void WireUpBehaviorCombos()
     {
         if (_factionBrowseButton != null)
-            _factionBrowseButton.Click += OnFactionBrowseClick;
+            _subs.Track(
+                attach: () => _factionBrowseButton.Click += OnFactionBrowseClick,
+                detach: () => _factionBrowseButton.Click -= OnFactionBrowseClick);
         if (_perceptionComboBox != null)
-            _perceptionComboBox.SelectionChanged += OnPerceptionSelectionChanged;
+            _subs.Track(
+                attach: () => _perceptionComboBox.SelectionChanged += OnPerceptionSelectionChanged,
+                detach: () => _perceptionComboBox.SelectionChanged -= OnPerceptionSelectionChanged);
         if (_walkRateComboBox != null)
-            _walkRateComboBox.SelectionChanged += OnWalkRateSelectionChanged;
+            _subs.Track(
+                attach: () => _walkRateComboBox.SelectionChanged += OnWalkRateSelectionChanged,
+                detach: () => _walkRateComboBox.SelectionChanged -= OnWalkRateSelectionChanged);
         if (_decayTimeComboBox != null)
-            _decayTimeComboBox.SelectionChanged += OnDecayTimeSelectionChanged;
+            _subs.Track(
+                attach: () => _decayTimeComboBox.SelectionChanged += OnDecayTimeSelectionChanged,
+                detach: () => _decayTimeComboBox.SelectionChanged -= OnDecayTimeSelectionChanged);
         if (_bodyBagComboBox != null)
-            _bodyBagComboBox.SelectionChanged += OnBodyBagSelectionChanged;
+            _subs.Track(
+                attach: () => _bodyBagComboBox.SelectionChanged += OnBodyBagSelectionChanged,
+                detach: () => _bodyBagComboBox.SelectionChanged -= OnBodyBagSelectionChanged);
     }
 
     private async void OnFactionBrowseClick(object? sender, RoutedEventArgs e)
@@ -242,17 +277,23 @@ public partial class AdvancedPanel : BasePanelControl
     {
         void WireFlag(CheckBox? cb, Action<bool> setter)
         {
-            if (cb != null)
+            if (cb == null) return;
+
+            // Capture the handler in a local so we can detach it on Unloaded —
+            // the previous inline lambda was unreachable and held `this` +
+            // `CurrentCreature` alive for the panel's lifetime (#2034).
+            void Handler(object? s, RoutedEventArgs e)
             {
-                cb.IsCheckedChanged += (s, e) =>
+                if (!IsLoading && CurrentCreature != null)
                 {
-                    if (!IsLoading && CurrentCreature != null)
-                    {
-                        setter(cb.IsChecked ?? false);
-                        FlagsChanged?.Invoke(this, EventArgs.Empty);
-                    }
-                };
+                    setter(cb.IsChecked ?? false);
+                    FlagsChanged?.Invoke(this, EventArgs.Empty);
+                }
             }
+
+            _subs.Track(
+                attach: () => cb.IsCheckedChanged += Handler,
+                detach: () => cb.IsCheckedChanged -= Handler);
         }
 
         WireFlag(_plotCheckBox, v => { if (CurrentCreature != null) CurrentCreature.Plot = v; });
@@ -535,9 +576,13 @@ public partial class AdvancedPanel : BasePanelControl
     private void WireUpVariables()
     {
         if (_addVariableButton != null)
-            _addVariableButton.Click += OnAddVariable;
+            _subs.Track(
+                attach: () => _addVariableButton.Click += OnAddVariable,
+                detach: () => _addVariableButton.Click -= OnAddVariable);
         if (_removeVariableButton != null)
-            _removeVariableButton.Click += OnRemoveVariable;
+            _subs.Track(
+                attach: () => _removeVariableButton.Click += OnRemoveVariable,
+                detach: () => _removeVariableButton.Click -= OnRemoveVariable);
         if (_variablesGrid != null)
             _variablesGrid.ItemsSource = Variables;
     }

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
@@ -116,11 +116,6 @@ public partial class AppearancePanel : UserControl
 
     private void OnPanelUnloaded(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
-        // PROBE (#2034 round 2 verification — REMOVE before merge): cross-checks
-        // whether sidebar navigation triggers Unloaded on AppearancePanel too.
-        // Expected: fires once on app shutdown only.
-        UnifiedLogger.LogApplication(LogLevel.WARN,
-            $"[#2034-PROBE] AppearancePanel.OnPanelUnloaded fired at {DateTime.UtcNow:O}");
         Unloaded -= OnPanelUnloaded;
         UnwireEvents();
     }

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
@@ -116,6 +116,11 @@ public partial class AppearancePanel : UserControl
 
     private void OnPanelUnloaded(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
+        // PROBE (#2034 round 2 verification — REMOVE before merge): cross-checks
+        // whether sidebar navigation triggers Unloaded on AppearancePanel too.
+        // Expected: fires once on app shutdown only.
+        UnifiedLogger.LogApplication(LogLevel.WARN,
+            $"[#2034-PROBE] AppearancePanel.OnPanelUnloaded fired at {DateTime.UtcNow:O}");
         Unloaded -= OnPanelUnloaded;
         UnwireEvents();
     }

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlAsciiReader.ListParsing.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlAsciiReader.ListParsing.cs
@@ -239,7 +239,7 @@ public partial class MdlAsciiReader
         mesh.TextureCoords = new[] { newUVs.ToArray() };
         mesh.Faces = newFaces;
 
-        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
             $"[MDL-ASCII] Unrolled mesh '{mesh.Name}': {origVertices.Length} verts + {origUVs.Length} tverts -> {newVertices.Count} unified vertices");
     }
 

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlAsciiReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlAsciiReader.cs
@@ -154,7 +154,7 @@ public partial class MdlAsciiReader
                             parentNames[nodeName] = parentName;
                         }
 
-                        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+                        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
                             $"[MDL-ASCII] Parsed node: name='{nodeName}', type='{nodeType}', parent='{parentName ?? "NULL"}'");
                     }
                     else

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader.DataReading.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader.DataReading.cs
@@ -48,7 +48,7 @@ public partial class MdlBinaryReader
             {
                 sb.Append(" [SUSPICIOUS - body parts should be < 2m]");
             }
-            Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG, sb.ToString());
+            Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE, sb.ToString());
         }
 
         return vertices;
@@ -91,7 +91,7 @@ public partial class MdlBinaryReader
             {
                 sb.Append($"[WARN: {outOfRange} UVs out of range]");
             }
-            Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG, sb.ToString());
+            Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE, sb.ToString());
         }
 
         return coords;

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader.MeshParsing.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader.MeshParsing.cs
@@ -16,7 +16,7 @@ public partial class MdlBinaryReader
 
         var meshHeaderStart = reader.BaseStream.Position;
 
-        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
             $"[MDL] ParseMeshNode '{mesh.Name}': meshHeaderStart=0x{meshHeaderStart:X4}");
 
         // 0x000: Skip mesh routines (2 uint32 = 8 bytes)
@@ -51,7 +51,7 @@ public partial class MdlBinaryReader
         // 0x078: Textures (4 x 64 bytes = 256 bytes)
         var textureOffset = reader.BaseStream.Position;
         mesh.Bitmap = ReadFixedString(reader, 64);   // Texture0
-        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
             $"[MDL] Mesh texture0 at 0x{textureOffset:X4} (relative 0x{textureOffset - meshHeaderStart:X4}): '{mesh.Bitmap}'");
         mesh.Bitmap2 = ReadFixedString(reader, 64);  // Texture1
         ReadFixedString(reader, 64);                  // Texture2
@@ -104,7 +104,7 @@ public partial class MdlBinaryReader
         var vertexRawOffset = PointerToRawOffset(vertexDataOffset);
         var normalsRawOffset = PointerToRawOffset(normalsOffset);
 
-        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
             $"[MDL] Mesh '{mesh.Name}': vertexDataPtr=0x{vertexDataOffset:X8} -> rawOffset={vertexRawOffset}, normalsPtr=0x{normalsOffset:X8} -> rawOffset={normalsRawOffset}, vertexCount={vertexCount}, faceCount={faceCount}, rawDataLen={_rawData.Length}");
 
         // Detect and skip average normal header if present.
@@ -121,7 +121,7 @@ public partial class MdlBinaryReader
         if (vertexCount > 0 && actualVertexOffset != 0xFFFFFFFF && actualVertexOffset != uint.MaxValue)
         {
             mesh.Vertices = ReadVertices(actualVertexOffset, vertexCount);
-            Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+            Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
                 $"[MDL] Mesh '{mesh.Name}': Read {mesh.Vertices?.Length ?? 0} vertices");
         }
 
@@ -129,7 +129,7 @@ public partial class MdlBinaryReader
         {
             // Apply same offset adjustment as vertices - normals array also has the avg normal header
             var adjustedNormalsOffset = actualNormalsOffset + avgNormalSkip;
-            Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+            Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
                 $"[MDL] Mesh '{mesh.Name}': Normals offset {actualNormalsOffset} + {avgNormalSkip} = {adjustedNormalsOffset}");
             mesh.Normals = ReadVertices(adjustedNormalsOffset, vertexCount);
         }
@@ -146,7 +146,7 @@ public partial class MdlBinaryReader
                 {
                     // Apply same offset adjustment as vertices
                     var adjustedTvertOffset = tvertRawOffset + avgNormalSkip;
-                    Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+                    Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
                         $"[MDL] Mesh '{mesh.Name}': UV[{i}] offset {tvertRawOffset} + {avgNormalSkip} = {adjustedTvertOffset}");
                     texCoordsList.Add(ReadTexCoords(adjustedTvertOffset, vertexCount));
                 }
@@ -200,7 +200,7 @@ public partial class MdlBinaryReader
                 {
                     var f0 = validFaces[0];
                     var v0 = mesh.Vertices[f0.VertexIndex0];
-                    Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+                    Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
                         $"[MDL] Mesh '{mesh.Name}': {validFaces.Count} valid faces, idx range [{minIdx},{maxIdx}], vtxCount={mesh.Vertices.Length}. Face0: [{f0.VertexIndex0},{f0.VertexIndex1},{f0.VertexIndex2}] -> v0=({v0.X:F3},{v0.Y:F3},{v0.Z:F3})");
                 }
             }
@@ -243,7 +243,7 @@ public partial class MdlBinaryReader
         var skinExtStart = meshHeaderStart + 0x200;
         reader.BaseStream.Position = skinExtStart;
 
-        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
             $"[MDL] ParseSkinNode '{skin.Name}': skinExtStart=0x{skinExtStart:X4}, vertexCount={vertexCount}");
 
         // 0x000: m_aWeights array header (12 bytes) — string-based weight data in model data, skip
@@ -271,7 +271,7 @@ public partial class MdlBinaryReader
         var tBoneCount = reader.ReadUInt32();
         reader.ReadUInt32(); // allocated
 
-        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
             $"[MDL] Skin '{skin.Name}': weightsPtr=0x{skinWeightsPtr:X8}, boneRefsPtr=0x{skinBoneRefsPtr:X8}, " +
             $"nodeToBonePtr=0x{nodeToBoneMapPtr:X8} count={nodeToBoneCount}, " +
             $"qBonePtr=0x{qBoneArrayOffset:X8} count={qBoneCount}, tBonePtr=0x{tBoneArrayOffset:X8} count={tBoneCount}");
@@ -290,7 +290,7 @@ public partial class MdlBinaryReader
 
                 // Log first entries for debugging
                 var mapPreview = string.Join(",", nodeToBoneMap.Take(10).Select(x => x.ToString()));
-                Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+                Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
                     $"[MDL] Skin '{skin.Name}': NodeToBoneMap[0..{Math.Min(10, nodeToBoneCount)-1}] = [{mapPreview}]");
             }
         }
@@ -302,7 +302,7 @@ public partial class MdlBinaryReader
         // For Dragon wings, slots 0-5 map directly to Q/T indices 0-5.
         var weightsRawOffset = PointerToRawOffset(skinWeightsPtr);
         var boneRefsRawOffset = PointerToRawOffset(skinBoneRefsPtr);
-        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
             $"[MDL] Skin '{skin.Name}': weightsRawOff={weightsRawOffset}, boneRefsRawOff={boneRefsRawOffset}, rawDataLen={_rawData.Length}");
 
         if (vertexCount > 0 && weightsRawOffset != uint.MaxValue && boneRefsRawOffset != uint.MaxValue)
@@ -341,7 +341,7 @@ public partial class MdlBinaryReader
 
                 skin.BoneWeights = boneWeights;
 
-                Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+                Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
                     $"[MDL] Skin '{skin.Name}': Read {vertexCount} bone weight entries");
             }
             else
@@ -377,7 +377,7 @@ public partial class MdlBinaryReader
                     skin.BoneQuaternions[i] = new Quaternion(f1, f2, f3, f0);
                 }
 
-                Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+                Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
                     $"[MDL] Skin '{skin.Name}': Read {qBoneCount} inverse bind-pose quaternions");
             }
         }
@@ -399,7 +399,7 @@ public partial class MdlBinaryReader
                     skin.BoneTranslations[i] = ReadVector3(tReader);
                 }
 
-                Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+                Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
                     $"[MDL] Skin '{skin.Name}': Read {tBoneCount} inverse bind-pose translations");
             }
         }
@@ -430,7 +430,7 @@ public partial class MdlBinaryReader
         float v2z = BitConverter.ToSingle(_rawData, (int)vertexRawOffset + 20);
         float v2Mag = (float)Math.Sqrt(v2x * v2x + v2y * v2y + v2z * v2z);
 
-        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
             $"[MDL] AvgNormal check at offset {vertexRawOffset}: v1=({vx:F4},{vy:F4},{vz:F4}) mag={vMag:F4}, v2=({v2x:F4},{v2y:F4},{v2z:F4}) mag={v2Mag:F4}");
 
         bool shouldSkip = false;
@@ -466,7 +466,7 @@ public partial class MdlBinaryReader
         if (shouldSkip)
         {
             vertexRawOffset += 12;
-            Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+            Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
                 $"[MDL] Skipping {skipReason} ({vx:F4},{vy:F4},{vz:F4}), actual positions start at offset {vertexRawOffset}");
         }
 

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader.NodeParsing.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader.NodeParsing.cs
@@ -54,7 +54,7 @@ public partial class MdlBinaryReader
         // Log first 16 bytes at this position for debugging
         var debugBytes = new byte[Math.Min(16, _modelData.Length - (int)nodeOffset)];
         Array.Copy(_modelData, nodeOffset, debugBytes, 0, debugBytes.Length);
-        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
             $"[MDL] ParseNode at {nodeOffset}: first16bytes={BitConverter.ToString(debugBytes)}");
 
         // Read node header
@@ -79,7 +79,7 @@ public partial class MdlBinaryReader
         // Convert pointer to buffer offset
         var childArrayBufferOffset = PointerToModelOffset(childArrayOffset);
 
-        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
             $"[MDL] Node '{nodeName}': childArrayPtr=0x{childArrayOffset:X8} -> bufferOffset={childArrayBufferOffset}, childCount={childCount}");
 
         // Controller arrays (these are also pointers)
@@ -96,7 +96,7 @@ public partial class MdlBinaryReader
         // Determine node type and create appropriate object
         MdlNode node = CreateNodeFromFlags(nodeFlags, nodeName);
 
-        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
             $"[MDL] ParseNode: name='{nodeName}', flags=0x{nodeFlags:X8}, type={node.NodeType}, childCount={childCount}");
 
         // Set common properties
@@ -195,7 +195,7 @@ public partial class MdlBinaryReader
 
     private void ParseChildren(MdlNode parent, uint arrayOffset, int count, int parentDepth, HashSet<uint> visitedNodeOffsets)
     {
-        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
             $"[MDL] ParseChildren START: parent='{parent.Name}', arrayOffset={arrayOffset}, count={count}, depth={parentDepth}, modelDataLen={_modelData.Length}");
 
         // Verify we can read the child array
@@ -225,7 +225,7 @@ public partial class MdlBinaryReader
             // Convert pointer to buffer offset
             var childOffset = PointerToModelOffset(childPointer);
 
-            Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+            Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
                 $"[MDL] ParseChildren: parent='{parent.Name}', i={i}, childPtr=0x{childPointer:X8} -> offset={childOffset}, valid={childOffset != 0xFFFFFFFF && childOffset != uint.MaxValue && childOffset < _modelData.Length}");
 
             if (childOffset != 0xFFFFFFFF && childOffset != uint.MaxValue && childOffset < _modelData.Length)
@@ -233,7 +233,7 @@ public partial class MdlBinaryReader
                 var child = ParseNodeInternal(childOffset, parentDepth + 1, visitedNodeOffsets);
                 child.Parent = parent;
                 parent.Children.Add(child);
-                Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+                Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
                     $"[MDL] ParseChildren: Added child '{child.Name}' to '{parent.Name}', parent now has {parent.Children.Count} children");
             }
             else
@@ -243,7 +243,7 @@ public partial class MdlBinaryReader
             }
         }
 
-        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
             $"[MDL] ParseChildren END: parent='{parent.Name}' now has {parent.Children.Count} children");
     }
 

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader.PointerHelpers.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader.PointerHelpers.cs
@@ -42,7 +42,7 @@ public partial class MdlBinaryReader
             if (result != uint.MaxValue) return result;
         }
 
-        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
             $"[MDL] PointerToModelOffset: ptr=0x{pointer:X8} FAILED (base=0x{_pointerBase:X8}, bufLen={_modelData.Length}, hasMem={HasMemoryPointers})");
         return uint.MaxValue; // Out of bounds
     }
@@ -78,7 +78,7 @@ public partial class MdlBinaryReader
             if (result != uint.MaxValue) return result;
         }
 
-        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.DEBUG,
+        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
             $"[MDL] PointerToRawOffset: ptr=0x{pointer:X8} FAILED (base=0x{_pointerBase:X8}, modelLen={_modelData.Length}, rawLen={rawLen}, hasMem={HasMemoryPointers})");
         return uint.MaxValue; // Out of bounds
     }

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader2.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader2.cs
@@ -178,7 +178,7 @@ public class MdlBinaryReader2
         // 0x6C: node flags
         uint flags = reader.ReadUInt32();
 
-        Log(LogLevel.DEBUG, $"Node '{name}' at {offset}: flags=0x{flags:X8}, children={childrenCount}");
+        Log(LogLevel.TRACE, $"Node '{name}' at {offset}: flags=0x{flags:X8}, children={childrenCount}");
 
         // Determine node type and create appropriate object
         MdlNode node;
@@ -236,26 +236,26 @@ public class MdlBinaryReader2
         reader.BaseStream.Position = meshHeaderStart + MESH_FACES_OFFSET;
         uint facesOffset = reader.ReadUInt32();
         uint facesCount = reader.ReadUInt32();
-        Log(LogLevel.DEBUG, $"Mesh '{mesh.Name}': faces at {facesOffset}, count={facesCount}");
+        Log(LogLevel.TRACE, $"Mesh '{mesh.Name}': faces at {facesOffset}, count={facesCount}");
 
         // === Texture name ===
         reader.BaseStream.Position = meshHeaderStart + MESH_TEXTURE0_OFFSET;
         mesh.Bitmap = ReadString(reader, 64);
-        Log(LogLevel.DEBUG, $"Mesh '{mesh.Name}': texture='{mesh.Bitmap}'");
+        Log(LogLevel.TRACE, $"Mesh '{mesh.Name}': texture='{mesh.Bitmap}'");
 
         // === Vertex data pointers ===
         reader.BaseStream.Position = meshHeaderStart + MESH_VERTEX_OFFSET;
         uint vertexOffset = reader.ReadUInt32();
         ushort vertexCount = reader.ReadUInt16();
         ushort textureCount = reader.ReadUInt16();
-        Log(LogLevel.DEBUG, $"Mesh '{mesh.Name}': vertexOffset={vertexOffset}, vertexCount={vertexCount}, textureCount={textureCount}");
+        Log(LogLevel.TRACE, $"Mesh '{mesh.Name}': vertexOffset={vertexOffset}, vertexCount={vertexCount}, textureCount={textureCount}");
 
         // === Texture coordinate offsets ===
         reader.BaseStream.Position = meshHeaderStart + MESH_TVERT0_OFFSET;
         uint[] tvertOffsets = new uint[4];
         for (int i = 0; i < 4; i++)
             tvertOffsets[i] = reader.ReadUInt32();
-        Log(LogLevel.DEBUG, $"Mesh '{mesh.Name}': tvert offsets={tvertOffsets[0]}, {tvertOffsets[1]}, {tvertOffsets[2]}, {tvertOffsets[3]}");
+        Log(LogLevel.TRACE, $"Mesh '{mesh.Name}': tvert offsets={tvertOffsets[0]}, {tvertOffsets[1]}, {tvertOffsets[2]}, {tvertOffsets[3]}");
 
         // === Normals offset ===
         reader.BaseStream.Position = meshHeaderStart + MESH_NORMALS_OFFSET;
@@ -281,7 +281,7 @@ public class MdlBinaryReader2
         if (vertexCount > 0 && normalsOffset != 0xFFFFFFFF && _rawData.Length > 0)
         {
             uint adjustedNormalsOffset = normalsOffset + avgNormalSkip;
-            Log(LogLevel.DEBUG, $"Mesh '{mesh.Name}': Normals offset {normalsOffset} + {avgNormalSkip} = {adjustedNormalsOffset}");
+            Log(LogLevel.TRACE, $"Mesh '{mesh.Name}': Normals offset {normalsOffset} + {avgNormalSkip} = {adjustedNormalsOffset}");
             mesh.Normals = ReadVerticesFromRaw(adjustedNormalsOffset, vertexCount);
         }
 
@@ -295,7 +295,7 @@ public class MdlBinaryReader2
                 if (tvertOffsets[i] != 0xFFFFFFFF)
                 {
                     uint adjustedTvertOffset = tvertOffsets[i] + avgNormalSkip;
-                    Log(LogLevel.DEBUG, $"Mesh '{mesh.Name}': UV[{i}] offset {tvertOffsets[i]} + {avgNormalSkip} = {adjustedTvertOffset}");
+                    Log(LogLevel.TRACE, $"Mesh '{mesh.Name}': UV[{i}] offset {tvertOffsets[i]} + {avgNormalSkip} = {adjustedTvertOffset}");
                     var uvs = ReadTexCoordsFromRaw(adjustedTvertOffset, vertexCount);
                     texCoordsList.Add(uvs);
                     if (i == 0)
@@ -420,7 +420,7 @@ public class MdlBinaryReader2
         float v2z = BitConverter.ToSingle(_rawData, (int)vertexRawOffset + 20);
         float v2Mag = (float)Math.Sqrt(v2x * v2x + v2y * v2y + v2z * v2z);
 
-        Log(LogLevel.DEBUG,
+        Log(LogLevel.TRACE,
             $"AvgNormal check at offset {vertexRawOffset}: v1=({vx:F4},{vy:F4},{vz:F4}) mag={vMag:F4}, v2=({v2x:F4},{v2y:F4},{v2z:F4}) mag={v2Mag:F4}");
 
         bool shouldSkip = false;
@@ -456,7 +456,7 @@ public class MdlBinaryReader2
         if (shouldSkip)
         {
             vertexRawOffset += 12;
-            Log(LogLevel.DEBUG,
+            Log(LogLevel.TRACE,
                 $"Skipping {skipReason} ({vx:F4},{vy:F4},{vz:F4}), actual positions start at offset {vertexRawOffset}");
         }
 

--- a/Radoub.UI/Radoub.UI.Tests/EventSubscriptionsTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/EventSubscriptionsTests.cs
@@ -1,0 +1,87 @@
+using Xunit;
+using Radoub.UI.Services;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Tests for EventSubscriptions — the helper that lets panels track lambda
+/// subscriptions so they can be unwired on Unloaded (#2034).
+/// </summary>
+public class EventSubscriptionsTests
+{
+    [Fact]
+    public void Track_ExecutesAttachImmediately()
+    {
+        var subs = new EventSubscriptions();
+        var attached = false;
+
+        subs.Track(attach: () => attached = true, detach: () => { });
+
+        Assert.True(attached);
+    }
+
+    [Fact]
+    public void Count_ReturnsTrackedSubscriptions()
+    {
+        var subs = new EventSubscriptions();
+        subs.Track(attach: () => { }, detach: () => { });
+        subs.Track(attach: () => { }, detach: () => { });
+        subs.Track(attach: () => { }, detach: () => { });
+
+        Assert.Equal(3, subs.Count);
+    }
+
+    [Fact]
+    public void DetachAll_RunsEveryDetachAction()
+    {
+        var subs = new EventSubscriptions();
+        var detachCount = 0;
+
+        subs.Track(attach: () => { }, detach: () => detachCount++);
+        subs.Track(attach: () => { }, detach: () => detachCount++);
+        subs.Track(attach: () => { }, detach: () => detachCount++);
+
+        subs.DetachAll();
+
+        Assert.Equal(3, detachCount);
+    }
+
+    [Fact]
+    public void DetachAll_ClearsTrackedSubscriptions()
+    {
+        var subs = new EventSubscriptions();
+        subs.Track(attach: () => { }, detach: () => { });
+        subs.Track(attach: () => { }, detach: () => { });
+
+        subs.DetachAll();
+
+        Assert.Equal(0, subs.Count);
+    }
+
+    [Fact]
+    public void DetachAll_IsIdempotent()
+    {
+        var subs = new EventSubscriptions();
+        var detachCount = 0;
+        subs.Track(attach: () => { }, detach: () => detachCount++);
+
+        subs.DetachAll();
+        subs.DetachAll();
+
+        Assert.Equal(1, detachCount);
+    }
+
+    [Fact]
+    public void Track_AfterDetachAll_StillWorks()
+    {
+        var subs = new EventSubscriptions();
+        subs.Track(attach: () => { }, detach: () => { });
+        subs.DetachAll();
+
+        var attached = false;
+        subs.Track(attach: () => attached = true, detach: () => { });
+
+        Assert.True(attached);
+        Assert.Equal(1, subs.Count);
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/HakPaletteScannerServiceTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/HakPaletteScannerServiceTests.cs
@@ -30,6 +30,7 @@ public class HakPaletteScannerServiceTests : IDisposable
 
     public void Dispose()
     {
+        _cacheService.Dispose();
         if (Directory.Exists(_testDir))
         {
             try { Directory.Delete(_testDir, recursive: true); }

--- a/Radoub.UI/Radoub.UI.Tests/ItemIconServiceTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/ItemIconServiceTests.cs
@@ -1,0 +1,84 @@
+using Xunit;
+using Radoub.TestUtilities.Mocks;
+using Radoub.UI.Services;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Tests for ItemIconService bitmap cache bounding (#2034 round 2).
+///
+/// The cache previously used an unbounded ConcurrentDictionary and grew without
+/// limit during long sessions. These tests pin the LRU eviction contract.
+///
+/// Note: ItemIconService can't decode real bitmaps in unit tests (requires game data
+/// with TGA assets). With a MockGameDataService that has no 2DAs, every Get*Icon call
+/// stores `null` in the cache — but the cache key is still added, which is exactly
+/// the behavior we want to bound.
+/// </summary>
+public class ItemIconServiceTests
+{
+    [Fact]
+    public void CacheCount_StartsAtZero()
+    {
+        var service = new ItemIconService(new MockGameDataService(includeSampleData: false));
+
+        Assert.Equal(0, service.CacheCount);
+    }
+
+    [Fact]
+    public void GetSpellIcon_AddsEntryToCache()
+    {
+        var service = new ItemIconService(new MockGameDataService(includeSampleData: false));
+
+        service.GetSpellIcon(1);
+
+        Assert.Equal(1, service.CacheCount);
+    }
+
+    [Fact]
+    public void GetSpellIcon_RepeatedCalls_DoNotGrowCache()
+    {
+        var service = new ItemIconService(new MockGameDataService(includeSampleData: false));
+
+        for (int i = 0; i < 50; i++)
+            service.GetSpellIcon(7);
+
+        Assert.Equal(1, service.CacheCount);
+    }
+
+    [Fact]
+    public void Cache_EvictsOldestEntry_WhenCapacityExceeded()
+    {
+        // Cap is 2000. Insert capacity + 100 entries; cache must not exceed capacity.
+        var service = new ItemIconService(new MockGameDataService(includeSampleData: false));
+        var capacity = service.CacheCapacity;
+
+        for (int i = 0; i < capacity + 100; i++)
+            service.GetSpellIcon(i);
+
+        Assert.Equal(capacity, service.CacheCount);
+    }
+
+    [Fact]
+    public void ClearCache_ResetsCount()
+    {
+        var service = new ItemIconService(new MockGameDataService(includeSampleData: false));
+        service.GetSpellIcon(1);
+        service.GetFeatIcon(2);
+        Assert.Equal(2, service.CacheCount);
+
+        service.ClearCache();
+
+        Assert.Equal(0, service.CacheCount);
+    }
+
+    [Fact]
+    public void CacheCapacity_IsBounded()
+    {
+        // Ensure we don't accidentally re-introduce an unbounded cache by setting
+        // capacity to something absurd. 10_000 is far more than any real session needs.
+        var service = new ItemIconService(new MockGameDataService(includeSampleData: false));
+
+        Assert.InRange(service.CacheCapacity, 100, 10_000);
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/SharedPaletteCacheServiceTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/SharedPaletteCacheServiceTests.cs
@@ -22,6 +22,7 @@ public class SharedPaletteCacheServiceTests : IDisposable
 
     public void Dispose()
     {
+        _service.Dispose();
         if (Directory.Exists(_testCacheDir))
         {
             try { Directory.Delete(_testCacheDir, recursive: true); }
@@ -609,6 +610,38 @@ public class SharedPaletteCacheServiceTests : IDisposable
 
     #endregion
 
+    #region Disposal (#2034 round 2)
+
+    [Fact]
+    public void SharedPaletteCacheService_ImplementsIDisposable()
+    {
+        // The service holds a ReaderWriterLockSlim — a kernel resource that must be disposed.
+        Assert.IsAssignableFrom<IDisposable>(_service);
+    }
+
+    [Fact]
+    public async Task Dispose_DisposesInternalLock()
+    {
+        // After dispose, any operation that takes the lock must fail with ObjectDisposedException —
+        // proving the underlying ReaderWriterLockSlim was actually released, not just nulled.
+        await _service.SaveSourceCacheAsync("bif", CreateTestItems(3), validationPath: "/game");
+
+        ((IDisposable)_service).Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => _service.GetAggregatedCache());
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        // Calling Dispose twice must not throw — standard IDisposable contract.
+        var disposable = (IDisposable)_service;
+        disposable.Dispose();
+        disposable.Dispose();
+    }
+
+    #endregion
+
     #region Build Lock Sentinels
 
     [Fact]
@@ -632,7 +665,7 @@ public class SharedPaletteCacheServiceTests : IDisposable
 
         // Create a new service instance (simulating another process, but same PID)
         // The lock is held by current PID which IS alive, so second acquire should fail
-        var service2 = new SharedPaletteCacheService(_testCacheDir);
+        using var service2 = new SharedPaletteCacheService(_testCacheDir);
         var second = service2.AcquireBuildLock("bif");
         Assert.False(second);
 

--- a/Radoub.UI/Radoub.UI/Services/EventSubscriptions.cs
+++ b/Radoub.UI/Radoub.UI/Services/EventSubscriptions.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+
+namespace Radoub.UI.Services;
+
+/// <summary>
+/// Tracks (attach, detach) pairs so a control can release every subscription
+/// in one call on <c>Unloaded</c>. Solves the lambda-closure leak from #2034 —
+/// inline <c>cb.IsCheckedChanged += (s,e) => ...</c> handlers can't be
+/// unsubscribed because the delegate reference is unreachable.
+///
+/// Usage:
+/// <code>
+/// var subs = new EventSubscriptions();
+/// EventHandler&lt;RoutedEventArgs&gt; handler = (s, e) => DoThing();
+/// subs.Track(
+///     attach: () => button.Click += handler,
+///     detach: () => button.Click -= handler);
+/// // ...later, on Unloaded:
+/// subs.DetachAll();
+/// </code>
+/// </summary>
+public sealed class EventSubscriptions
+{
+    private readonly List<Action> _detachActions = new();
+
+    public int Count => _detachActions.Count;
+
+    /// <summary>
+    /// Run <paramref name="attach"/> immediately and remember <paramref name="detach"/>
+    /// so it can be invoked by <see cref="DetachAll"/>.
+    /// </summary>
+    public void Track(Action attach, Action detach)
+    {
+        ArgumentNullException.ThrowIfNull(attach);
+        ArgumentNullException.ThrowIfNull(detach);
+
+        attach();
+        _detachActions.Add(detach);
+    }
+
+    /// <summary>
+    /// Run every tracked detach action and clear the list. Idempotent —
+    /// safe to call multiple times.
+    /// </summary>
+    public void DetachAll()
+    {
+        foreach (var detach in _detachActions)
+            detach();
+        _detachActions.Clear();
+    }
+}

--- a/Radoub.UI/Radoub.UI/Services/ItemIconService.cs
+++ b/Radoub.UI/Radoub.UI/Services/ItemIconService.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Collections.Concurrent;
 using Avalonia.Media.Imaging;
+using Radoub.Formats.Common;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Services;
 using Radoub.Formats.Uti;
@@ -15,18 +15,24 @@ namespace Radoub.UI.Services;
 /// </summary>
 public class ItemIconService
 {
+    // Cache cap. Was unbounded ConcurrentDictionary (#2034). 2000 entries is enough
+    // for the icons a real session touches and bounds memory at ~30-60 MB worst case.
+    private const int DefaultCacheCapacity = 2000;
+
     private readonly ImageService _imageService;
     private readonly IGameDataService _gameDataService;
-    private readonly ConcurrentDictionary<string, Bitmap?> _bitmapCache;
-    // No cache limit - keep icons for session lifetime (~15-30MB for 1500 icons is acceptable)
+    private readonly LruCache<string, Bitmap?> _bitmapCache;
 
     public ItemIconService(IGameDataService gameDataService)
     {
         ArgumentNullException.ThrowIfNull(gameDataService);
         _gameDataService = gameDataService;
         _imageService = new ImageService(gameDataService);
-        _bitmapCache = new ConcurrentDictionary<string, Bitmap?>();
+        _bitmapCache = new LruCache<string, Bitmap?>(DefaultCacheCapacity);
     }
+
+    public int CacheCount => _bitmapCache.Count;
+    public int CacheCapacity => _bitmapCache.Capacity;
 
     /// <summary>
     /// Get the icon for an item.
@@ -65,7 +71,7 @@ public class ItemIconService
             }
         }
 
-        _bitmapCache.TryAdd(cacheKey, bitmap);
+        _bitmapCache.Set(cacheKey, bitmap);
         return bitmap;
     }
 
@@ -90,7 +96,7 @@ public class ItemIconService
             bitmap = ImageDataToBitmap(imageData);
         }
 
-        _bitmapCache.TryAdd(cacheKey, bitmap);
+        _bitmapCache.Set(cacheKey, bitmap);
         return bitmap;
     }
 
@@ -144,13 +150,13 @@ public class ItemIconService
                 bitmap = ImageDataToBitmap(imageData);
             }
 
-            _bitmapCache.TryAdd(cacheKey, bitmap);
+            _bitmapCache.Set(cacheKey, bitmap);
             return bitmap;
         }
         catch (Exception ex)
         {
             UnifiedLogger.LogApplication(LogLevel.ERROR, $"ItemIconService: Exception for {cacheKey}: {ex.Message}");
-            _bitmapCache.TryAdd(cacheKey, null);
+            _bitmapCache.Set(cacheKey, null);
             return null;
         }
     }

--- a/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheService.cs
+++ b/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheService.cs
@@ -10,7 +10,7 @@ namespace Radoub.UI.Services;
 /// Cache location: ~/Radoub/Cache/ItemPalette/ (shared across all tools).
 /// Thread-safe for concurrent reads from multiple tools.
 /// </summary>
-public class SharedPaletteCacheService : ISharedPaletteCacheService
+public class SharedPaletteCacheService : ISharedPaletteCacheService, IDisposable
 {
     private const int CacheVersion = 3; // v3: Added SourceLocation
 
@@ -22,6 +22,7 @@ public class SharedPaletteCacheService : ISharedPaletteCacheService
     private readonly string _cacheDirectory;
     private readonly ReaderWriterLockSlim _lock = new();
     private List<SharedPaletteCacheItem>? _aggregatedCache;
+    private bool _disposed;
 
     /// <summary>
     /// Create a shared palette cache service using the default shared location.
@@ -595,5 +596,24 @@ public class SharedPaletteCacheService : ISharedPaletteCacheService
     {
         public int Pid { get; set; }
         public DateTime StartedAt { get; set; }
+    }
+
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+            return;
+
+        if (disposing)
+        {
+            _lock.Dispose();
+        }
+
+        _disposed = true;
     }
 }

--- a/Trebuchet/Trebuchet/Services/PaletteCacheWarmupService.cs
+++ b/Trebuchet/Trebuchet/Services/PaletteCacheWarmupService.cs
@@ -171,5 +171,6 @@ public class PaletteCacheWarmupService
     {
         _bifWarmCts?.Dispose();
         _hakWarmCts?.Dispose();
+        (_cacheService as IDisposable)?.Dispose();
     }
 }


### PR DESCRIPTION
## Summary

Round 2 of memory-leak fixes for #2034. Tackles the next top 3 leak points after PR #2129, plus a perf cleanup discovered during user testing:

- **#4** `SharedPaletteCacheService` — implement `IDisposable` and dispose `ReaderWriterLockSlim` (kernel-handle leak; shared lib affects QM, Fence, Trebuchet)
- **#5** `ItemIconService` — bound bitmap cache with `LruCache` (capacity 2000); previously unbounded `ConcurrentDictionary`
- **#6** `AdvancedPanel` — unwire lambda closures on `Unloaded` via new `EventSubscriptions` helper so prior `CurrentCreature` graphs can be GC'd
- **Perf** — demoted ~38 per-node/per-mesh MDL parser DEBUG logs to TRACE (was generating ~165k log lines per creature-browser session, visibly slowing startup)

Issue #2034 stays open after this PR — 4 medium-tier items remain (Trebuchet/Fence event unsubscription, duplicate `_cachedPaletteData`, MarlinspikePanel `_searchCts` disposal).

## Related Issues

- Relates to #2034 (issue stays open for remaining items)
- Follow-up to #2129 (round 1 top 3)

## Pre-Merge Results

| Check | Status |
|-------|--------|
| Privacy scan | ✅ No hardcoded paths |
| Tech debt | ⚠️ 1 over 1000 lines (ModelPreviewGLControl.cs 1347, **already tracked in #2127**, this PR added net 0 lines); 1 warning (Fence/MainWindow.axaml.cs 922, pre-existing, this PR added 3 lines) |
| Theme scan | ⚠️ 26 warnings (pre-existing — none introduced by this PR) |
| Radoub.Formats.Tests | ✅ 1161 passed, 0 failed |
| Radoub.UI.Tests | ✅ 496 passed, 0 failed (3 SharedPaletteCacheService disposal tests, 6 ItemIconService tests, 6 EventSubscriptions tests new) |
| Radoub.Dictionary.Tests | ✅ 54 passed, 0 failed |
| Quartermaster.Tests | ✅ 1267 passed, 0 failed |
| Fence.Tests | ✅ 128 passed, 0 failed |
| Trebuchet.Tests | ✅ 128 passed, 0 failed |
| **Total unit tests** | **3234 passed, 0 failed** |
| FlaUI smoke (QM + Fence) | ✅ 3 passed, 0 failed, 1 skipped (clean first-try run) |
| CHANGELOG | ✅ Versioned `[0.2.86-alpha]` 2026-04-25, PR #2142 filled in, perf bullet added |
| Wiki | ✅ Quartermaster-Developer-Architecture.md current (2026-04-25) |

## Manual Verification (user-confirmed)

User ran QM after the MDL log demote landed (commit `2f7c2207`) and reported "noticeably better; still a short hang in the beginning".

Probe-instrumented session (commit `f2e09015`, since removed) confirmed:
- `AdvancedPanel.OnPanelUnloaded` fired exactly once at app shutdown
- `AppearancePanel.OnPanelUnloaded` fired exactly once at app shutdown
- Neither panel's Unloaded handler fires during sidebar navigation

Conclusion: The Unloaded cleanup pattern in this PR is correct. The residual short startup hang is pre-existing (likely 137-creature browser scan, palette pre-warm, or initial appearance preview render) and not caused by this PR's changes.

## Manual Spot-Checks (recommended)

- [ ] Long Quartermaster session browsing many creatures — memory does not climb past previous baseline
- [ ] Cycle through several modules — no kernel-handle accumulation around the SharedPaletteCacheService lock
- [ ] AdvancedPanel checkboxes still toggle creature flags correctly (Plot, Immortal, NoPermDeath, IsPC, Disarmable, Lootable, Interruptable)

## Checklist

- [x] `SharedPaletteCacheService` implements `IDisposable`, disposes `_lock`
- [x] `ItemIconService` cache uses `LruCache` from Radoub.Formats (capacity 2000)
- [x] `AdvancedPanel` unsubscribes lambda closures on `Unloaded` via `EventSubscriptions` helper
- [x] Unit tests added for new disposal/eviction/subscription behavior (15 new tests)
- [x] Targeted tests pass (Quartermaster, Radoub.UI, Radoub.Formats, Radoub.Dictionary, Fence, Trebuchet)
- [x] FlaUI smoke tests pass (QM + Fence)
- [x] CHANGELOG updated with date + perf bullet
- [x] MDL log demote verified by user (noticeable improvement)
- [x] Probe verified Unloaded only fires at shutdown
- [ ] Manual spot-check: long QM session does not balloon memory

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)