### PR TITLE
[Radoub] Fix: Memory leaks round 3 — Trebuchet/Fence event unsubscription, MarlinspikePanel cleanup (#2034)

### DIFF
--- a/Fence/CHANGELOG.md
+++ b/Fence/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.1.27-alpha] - 2026-04-26
-**Branch**: `radoub/issue-2034-round-3` | **PR**: #TBD
+**Branch**: `radoub/issue-2034-round-3` | **PR**: #2143
 
 ### Fix: Memory leaks round 3 — event unsubscription (#2034)
 

--- a/Fence/CHANGELOG.md
+++ b/Fence/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.1.27-alpha] - 2026-04-26
+**Branch**: `radoub/issue-2034-round-3` | **PR**: #TBD
+
+### Fix: Memory leaks round 3 — event unsubscription (#2034)
+
+- Unsubscribe `CollectionChanged` and `DoubleTapped` handlers on window close
+
+---
+
 ## [0.1.26-alpha] - 2026-04-18
 **Branch**: `fence/issue-2065` | **PR**: #2097
 

--- a/Fence/Fence/Views/MainWindow.axaml.cs
+++ b/Fence/Fence/Views/MainWindow.axaml.cs
@@ -107,7 +107,7 @@ public partial class MainWindow : Window, INotifyPropertyChanged
         }
 
         // Wire up shared document state for title bar updates
-        _documentState.DirtyStateChanged += () => Title = _documentState.GetTitle();
+        _documentState.DirtyStateChanged += OnDocumentDirtyStateChanged;
 
         // Defer heavy I/O (GameDataService, palette loading) to Opened event
         // Only do fast, synchronous UI setup here
@@ -364,6 +364,12 @@ public partial class MainWindow : Window, INotifyPropertyChanged
             SaveStoreBrowserPanelSize();
             SaveItemDetailsPanelSize();
 
+            // Unsubscribe window-level event handlers (#2034 round 3)
+            StoreInventoryGrid.DoubleTapped -= OnStoreInventoryDoubleTapped;
+            ItemPaletteGrid.DoubleTapped -= OnItemPaletteDoubleTapped;
+            StoreItems.CollectionChanged -= OnStoreItemsCollectionChanged;
+            _documentState.DirtyStateChanged -= OnDocumentDirtyStateChanged;
+
             // Cancel all async operations
             _windowCts?.Cancel();
             _windowCts?.Dispose();
@@ -380,6 +386,11 @@ public partial class MainWindow : Window, INotifyPropertyChanged
                 Close();
             }
         }
+    }
+
+    private void OnDocumentDirtyStateChanged()
+    {
+        Title = _documentState.GetTitle();
     }
 
     #endregion

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [1.31.0-alpha] - 2026-04-26
-**Branch**: `radoub/issue-2034-round-3` | **PR**: #TBD
+**Branch**: `radoub/issue-2034-round-3` | **PR**: #2143
 
 ### Fix: Memory leaks round 3 — event unsubscription & MarlinspikePanel cleanup (#2034)
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.31.0-alpha] - 2026-04-26
+**Branch**: `radoub/issue-2034-round-3` | **PR**: #TBD
+
+### Fix: Memory leaks round 3 — event unsubscription & MarlinspikePanel cleanup (#2034)
+
+- Trebuchet: unsubscribe `KeyDown`, `PropertyChanged`, `SelectionChanged` on window close
+- MarlinspikePanel: dispose `_searchCts` on Unloaded
+- `MainWindowViewModel._cts` disposed in cleanup
+
+---
+
 ## [1.30.0-alpha] - 2026-04-11
 **Branch**: `trebuchet/issue-2067` | **PR**: #2071
 

--- a/Trebuchet/Trebuchet/Controls/FactionEditorPanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/FactionEditorPanel.axaml.cs
@@ -23,6 +23,7 @@ public partial class FactionEditorPanel : UserControl
     public FactionEditorPanel()
     {
         InitializeComponent();
+        Unloaded += OnPanelUnloaded;
     }
 
     /// <summary>
@@ -38,6 +39,16 @@ public partial class FactionEditorPanel : UserControl
 
         viewModel.MatrixChanged += OnMatrixChanged;
         viewModel.PropertyChanged += OnViewModelPropertyChanged;
+    }
+
+    private void OnPanelUnloaded(object? sender, RoutedEventArgs e)
+    {
+        Unloaded -= OnPanelUnloaded;
+        if (_viewModel != null)
+        {
+            _viewModel.MatrixChanged -= OnMatrixChanged;
+            _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+        }
     }
 
     private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/Trebuchet/Trebuchet/Controls/LaunchTestPanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/LaunchTestPanel.axaml.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using Radoub.UI.Services;
 using RadoubLauncher.ViewModels;
 
@@ -12,6 +13,7 @@ public partial class LaunchTestPanel : UserControl
     public LaunchTestPanel()
     {
         InitializeComponent();
+        Unloaded += OnPanelUnloaded;
     }
 
     /// <summary>
@@ -28,6 +30,13 @@ public partial class LaunchTestPanel : UserControl
         UpdateFailedScriptsColors();
         UpdateStaleScriptText();
         UpdateModLockedWarningColor();
+    }
+
+    private void OnPanelUnloaded(object? sender, RoutedEventArgs e)
+    {
+        Unloaded -= OnPanelUnloaded;
+        if (_viewModel != null)
+            _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
@@ -45,6 +45,15 @@ public partial class MarlinspikePanel : UserControl
     public MarlinspikePanel()
     {
         InitializeComponent();
+        Unloaded += OnPanelUnloaded;
+    }
+
+    private void OnPanelUnloaded(object? sender, RoutedEventArgs e)
+    {
+        Unloaded -= OnPanelUnloaded;
+        _searchCts?.Cancel();
+        _searchCts?.Dispose();
+        _searchCts = null;
     }
 
     public void Initialize(MarlinspikePanelViewModel viewModel, MainWindowViewModel mainViewModel, Window parentWindow)
@@ -150,6 +159,7 @@ public partial class MarlinspikePanel : UserControl
         }
 
         _searchCts?.Cancel();
+        _searchCts?.Dispose();
         _searchCts = new CancellationTokenSource();
         var token = _searchCts.Token;
 

--- a/Trebuchet/Trebuchet/ViewModels/MainWindowViewModel.cs
+++ b/Trebuchet/Trebuchet/ViewModels/MainWindowViewModel.cs
@@ -434,17 +434,24 @@ public partial class MainWindowViewModel : ObservableObject
         _moduleEditorViewModel = viewModel;
 
         // Forward HasUnsavedChanges from module editor to build warning
-        viewModel.PropertyChanged += (_, e) =>
-        {
-            if (e.PropertyName == nameof(ModuleEditorViewModel.HasUnsavedChanges))
-            {
-                OnPropertyChanged(nameof(NeedsBuildWarning));
-                OnPropertyChanged(nameof(BuildWarningText));
-            }
-        };
+        viewModel.PropertyChanged += OnModuleEditorPropertyChanged;
 
         // Update status bar when TLK language changes
-        viewModel.TlkLanguageChanged += (_, _) => UpdateStatusFromSettings();
+        viewModel.TlkLanguageChanged += OnModuleEditorTlkLanguageChanged;
+    }
+
+    private void OnModuleEditorPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(ModuleEditorViewModel.HasUnsavedChanges))
+        {
+            OnPropertyChanged(nameof(NeedsBuildWarning));
+            OnPropertyChanged(nameof(BuildWarningText));
+        }
+    }
+
+    private void OnModuleEditorTlkLanguageChanged(object? sender, EventArgs e)
+    {
+        UpdateStatusFromSettings();
     }
 
     /// <summary>
@@ -456,14 +463,16 @@ public partial class MainWindowViewModel : ObservableObject
         _factionEditorViewModel = viewModel;
 
         // Forward HasUnsavedChanges from faction editor to build warning
-        viewModel.PropertyChanged += (_, e) =>
+        viewModel.PropertyChanged += OnFactionEditorPropertyChanged;
+    }
+
+    private void OnFactionEditorPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(FactionEditorViewModel.HasUnsavedChanges))
         {
-            if (e.PropertyName == nameof(FactionEditorViewModel.HasUnsavedChanges))
-            {
-                OnPropertyChanged(nameof(NeedsBuildWarning));
-                OnPropertyChanged(nameof(BuildWarningText));
-            }
-        };
+            OnPropertyChanged(nameof(NeedsBuildWarning));
+            OnPropertyChanged(nameof(BuildWarningText));
+        }
     }
 
     /// <summary>
@@ -487,6 +496,16 @@ public partial class MainWindowViewModel : ObservableObject
         _cts.Dispose();
         RadoubSettings.Instance.PropertyChanged -= OnSharedSettingsChanged;
         SettingsService.Instance.PropertyChanged -= OnLocalSettingsChanged;
+
+        if (_moduleEditorViewModel != null)
+        {
+            _moduleEditorViewModel.PropertyChanged -= OnModuleEditorPropertyChanged;
+            _moduleEditorViewModel.TlkLanguageChanged -= OnModuleEditorTlkLanguageChanged;
+        }
+        if (_factionEditorViewModel != null)
+        {
+            _factionEditorViewModel.PropertyChanged -= OnFactionEditorPropertyChanged;
+        }
     }
 
     // --- Status & Settings ---

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
@@ -17,6 +17,8 @@ public partial class MainWindow : Window
     private MainWindowViewModel? _viewModel;
     private PaletteCacheWarmupService? _paletteCacheWarmup;
     private CancellationTokenSource? _appShutdownCts;
+    private TabControl? _workspaceTabs;
+    private ModuleEditorViewModel? _moduleEditorVm;
 
     public MainWindow()
     {
@@ -29,9 +31,9 @@ public partial class MainWindow : Window
         var moduleEditorPanel = this.FindControl<Controls.ModuleEditorPanel>("ModuleEditorPanel");
         if (moduleEditorPanel != null)
         {
-            var moduleEditorVm = new ModuleEditorViewModel();
-            moduleEditorPanel.Initialize(moduleEditorVm, this);
-            _viewModel.SetModuleEditorViewModel(moduleEditorVm);
+            _moduleEditorVm = new ModuleEditorViewModel();
+            moduleEditorPanel.Initialize(_moduleEditorVm, this);
+            _viewModel.SetModuleEditorViewModel(_moduleEditorVm);
 
             // Wire palette cache pre-warming (#1633)
             _appShutdownCts = new CancellationTokenSource();
@@ -39,28 +41,8 @@ public partial class MainWindow : Window
             var hakScanner = new HakPaletteScannerService();
             _paletteCacheWarmup = new PaletteCacheWarmupService(cacheService, hakScanner);
 
-            moduleEditorVm.GameDataServiceInitialized += (_, _) =>
-            {
-                if (moduleEditorVm.GameDataService?.IsConfigured == true)
-                {
-                    _ = _paletteCacheWarmup.WarmBifCacheAsync(
-                        moduleEditorVm.GameDataService, _appShutdownCts.Token);
-                }
-            };
-
-            moduleEditorVm.ModuleLoaded += (_, _) =>
-            {
-                if (moduleEditorVm.GameDataService?.IsConfigured == true &&
-                    moduleEditorVm.ModuleDirectory != null)
-                {
-                    var hakSearchPaths = RadoubSettings.Instance.GetAllHakSearchPaths();
-                    _ = _paletteCacheWarmup.WarmModuleHakCacheAsync(
-                        moduleEditorVm.GameDataService,
-                        moduleEditorVm.ModuleDirectory,
-                        hakSearchPaths,
-                        _appShutdownCts.Token);
-                }
-            };
+            _moduleEditorVm.GameDataServiceInitialized += OnGameDataServiceInitialized;
+            _moduleEditorVm.ModuleLoaded += OnModuleLoaded;
         }
 
         // Initialize the embedded faction editor panel
@@ -91,10 +73,10 @@ public partial class MainWindow : Window
         KeyDown += OnKeyDown;
 
         // Tab change updates title and status bar context
-        var workspaceTabs = this.FindControl<TabControl>("WorkspaceTabs");
-        if (workspaceTabs != null)
+        _workspaceTabs = this.FindControl<TabControl>("WorkspaceTabs");
+        if (_workspaceTabs != null)
         {
-            workspaceTabs.SelectionChanged += OnWorkspaceTabChanged;
+            _workspaceTabs.SelectionChanged += OnWorkspaceTabChanged;
         }
 
         // Save window state on close
@@ -144,6 +126,19 @@ public partial class MainWindow : Window
     {
         SaveWindowState();
 
+        // Unsubscribe window-level event handlers (#2034 round 3)
+        KeyDown -= OnKeyDown;
+        Closing -= OnWindowClosing;
+        if (_workspaceTabs != null)
+            _workspaceTabs.SelectionChanged -= OnWorkspaceTabChanged;
+        if (_viewModel != null)
+            _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+        if (_moduleEditorVm != null)
+        {
+            _moduleEditorVm.GameDataServiceInitialized -= OnGameDataServiceInitialized;
+            _moduleEditorVm.ModuleLoaded -= OnModuleLoaded;
+        }
+
         // Cancel palette cache warm-up operations (#1633)
         _paletteCacheWarmup?.CancelAll();
         _appShutdownCts?.Cancel();
@@ -151,6 +146,30 @@ public partial class MainWindow : Window
         _appShutdownCts?.Dispose();
 
         (_viewModel)?.Cleanup();
+    }
+
+    private void OnGameDataServiceInitialized(object? sender, System.EventArgs e)
+    {
+        if (_moduleEditorVm?.GameDataService?.IsConfigured == true && _appShutdownCts != null)
+        {
+            _ = _paletteCacheWarmup!.WarmBifCacheAsync(
+                _moduleEditorVm.GameDataService, _appShutdownCts.Token);
+        }
+    }
+
+    private void OnModuleLoaded(object? sender, System.EventArgs e)
+    {
+        if (_moduleEditorVm?.GameDataService?.IsConfigured == true &&
+            _moduleEditorVm.ModuleDirectory != null &&
+            _appShutdownCts != null)
+        {
+            var hakSearchPaths = RadoubSettings.Instance.GetAllHakSearchPaths();
+            _ = _paletteCacheWarmup!.WarmModuleHakCacheAsync(
+                _moduleEditorVm.GameDataService,
+                _moduleEditorVm.ModuleDirectory,
+                hakSearchPaths,
+                _appShutdownCts.Token);
+        }
     }
 
     private void SaveWindowState()


### PR DESCRIPTION
## Summary

Round 3 of the #2034 memory-leak cleanup. Closes 3 of the 4 remaining round-3 items from the pre-warm plan ([NonPublic/Plans/2026-04-20-2034-plan.md](https://github.com/LordOfMyatar/Radoub/blob/main/NonPublic/Plans/2026-04-20-2034-plan.md)) after rounds 1 (#2129) and 2 (#2142):

| # | Leak | Tool | Status |
|---|------|------|--------|
| 7 | Trebuchet event unsubscription | Trebuchet | ✅ Fixed (commit db9d76b0) |
| 8 | Fence event unsubscription | Fence | ✅ Fixed (commit eac04ffe) |
| 9 | Duplicate `_cachedPaletteData` (architectural) | QM, Fence | 📋 Filed as #2144 (deferred per plan) |
| 10 | `MarlinspikePanel._searchCts` explicit disposal | Trebuchet (Marlinspike) | ✅ Fixed (commit c6a28fb8) |

### What changed

**Trebuchet (#7)**:
- `MainWindow.axaml.cs`: unwire `KeyDown`, `Closing`, `WorkspaceTabs.SelectionChanged`, `_viewModel.PropertyChanged`, `_moduleEditorVm.GameDataServiceInitialized`, `_moduleEditorVm.ModuleLoaded` in `OnWindowClosing`
- `MainWindowViewModel.cs`: convert lambda subscriptions on module/faction editor VMs to named methods; unwire in `Cleanup()`
- `FactionEditorPanel.axaml.cs` + `LaunchTestPanel.axaml.cs`: add `Unloaded` hooks that unwire VM `PropertyChanged` (and `MatrixChanged` for FactionEditorPanel)

**Fence (#8)**:
- `MainWindow.axaml.cs`: unwire `StoreInventoryGrid.DoubleTapped`, `ItemPaletteGrid.DoubleTapped`, `StoreItems.CollectionChanged`, `_documentState.DirtyStateChanged` in `OnWindowClosing`
- Convert inline `DirtyStateChanged` lambda to named method `OnDocumentDirtyStateChanged`

**Marlinspike (#10)**:
- `MarlinspikePanel.axaml.cs`: dispose `_searchCts` before reassignment in `ExecuteSearchAsync`, and add `Unloaded` handler that disposes the active token source on panel teardown

### Item #9 deferred

Per the pre-warm plan (line 237): "Architectural change — single-source-of-truth refactor. Deserves its own issue." Filed as #2144. Round 3 explicitly skipped per the plan's scope decision.

## Pre-Merge

- ✅ Privacy scan clean (no hardcoded paths)
- ✅ Trebuchet + shared unit tests: **1839/1839 pass**
- ✅ Fence unit tests: **128/128 pass**
- ✅ Full solution build clean (only pre-existing xunit analyzer warnings)
- ✅ CHANGELOGs: Trebuchet 1.31.0-alpha, Fence 0.1.27-alpha (both dated 2026-04-26, PR #2143 filled, no `[Unreleased]` items)
- ✅ Wiki freshness: Trebuchet 14 days, Fence 8 days (both <30)
- ⚠️ Tech-debt warning: `Fence/Fence/Views/MainWindow.axaml.cs` 931 lines (warn tier, no issue required; this PR added 12 lines)
- ⏭️ FlaUI skipped (per maintainer direction) — manual spot-checks below

## Manual Spot-Checks

- [ ] Open Trebuchet, switch workspace tabs (Ctrl+1/2/3), close — no exceptions in logs
- [ ] Open Trebuchet, run a Marlinspike search, cancel mid-search, close — no exceptions
- [ ] Open Fence with a UTM file, edit store inventory (double-click items), close — no exceptions
- [ ] Open/close each app 10× — observe RAM in Task Manager returns near baseline (not growing per cycle)

## Related Issues

- Closes round 3 scope of #2034 (parent issue stays open for items #4, #5 from the deferred-tier list)
- Filed #2144 for the deferred `_cachedPaletteData` consolidation

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)