### PR TITLE
[Quartermaster] Fix: Address general UI lag and performance (#2058)

### DIFF
--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.87-alpha] - 2026-04-27
+**Branch**: `quartermaster/issue-2058` | **PR**: #TBD
+
+### Fix: Address general UI lag and performance (#2058)
+
+- Move CharacterPanel race/portrait/soundset 2DA scans off the UI thread (spike measured 11.3s of synchronous load on first creature open)
+- Same off-thread treatment for AppearancePanel and AdvancedPanel SetDisplayService data loads
+- Cache `AppearanceService.GetAllPortraits` / `GetAllSoundSets` results so subsequent panel switches don't re-iterate the 2DAs
+
+---
+
 ## [0.2.86-alpha] - 2026-04-25
 **Branch**: `radoub/issue-2034-round2` | **PR**: #2142
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.87-alpha] - 2026-04-27
-**Branch**: `quartermaster/issue-2058` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2058` | **PR**: #2145
 
 ### Fix: Address general UI lag and performance (#2058)
 

--- a/Quartermaster/Quartermaster.Tests/AppearanceServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/AppearanceServiceTests.cs
@@ -427,6 +427,37 @@ public class AppearanceServiceTests
     }
 
     [Fact]
+    public void GetAllPortraits_SecondCall_ReturnsCachedResult()
+    {
+        // First call populates cache from mock 2DA
+        var first = _service.GetAllPortraits();
+        var firstCount = first.Count;
+
+        // Mutate underlying 2DA after first call
+        _mockGameData.Set2DAValue("portraits", 99, "BaseResRef", "added_after_cache_");
+
+        // Second call should return cached snapshot, not see the new row
+        var second = _service.GetAllPortraits();
+        Assert.Equal(firstCount, second.Count);
+        Assert.DoesNotContain(second, p => p.Name == "added_after_cache_");
+    }
+
+    [Fact]
+    public void GetAllPortraits_AfterInvalidate_ReturnsFreshResult()
+    {
+        // Prime the cache
+        _ = _service.GetAllPortraits();
+
+        // Mutate the underlying 2DA, then invalidate
+        _mockGameData.Set2DAValue("portraits", 99, "BaseResRef", "added_after_invalidate_");
+        _service.InvalidateCaches();
+
+        // After invalidation, the new row should appear
+        var fresh = _service.GetAllPortraits();
+        Assert.Contains(fresh, p => p.Name == "added_after_invalidate_");
+    }
+
+    [Fact]
     public void FindPortraitIdByResRef_PoPrefixCaseInsensitive_Matches()
     {
         // "PO_HU_M_01_" should match "hu_m_01_"
@@ -762,6 +793,31 @@ public class AppearanceServiceTests
         // Row 0 has STRREF=7000 → TLK "Male Voice 1", LABEL="Male_1"
         var first = soundSets.FirstOrDefault(s => s.Id == 0);
         Assert.Equal("Male Voice 1", first.Name);
+    }
+
+    [Fact]
+    public void GetAllSoundSets_SecondCall_ReturnsCachedResult()
+    {
+        var first = _service.GetAllSoundSets();
+        var firstCount = first.Count;
+
+        _mockGameData.Set2DAValue("soundset", 99, "LABEL", "AddedAfterCache");
+
+        var second = _service.GetAllSoundSets();
+        Assert.Equal(firstCount, second.Count);
+        Assert.DoesNotContain(second, s => s.Name == "AddedAfterCache" || s.Name == "Sound Set 99");
+    }
+
+    [Fact]
+    public void GetAllSoundSets_AfterInvalidate_ReturnsFreshResult()
+    {
+        _ = _service.GetAllSoundSets();
+
+        _mockGameData.Set2DAValue("soundset", 99, "LABEL", "AddedAfterInvalidate");
+        _service.InvalidateCaches();
+
+        var fresh = _service.GetAllSoundSets();
+        Assert.Contains(fresh, s => s.Id == 99);
     }
 
     #endregion

--- a/Quartermaster/Quartermaster/Services/AppearanceService.cs
+++ b/Quartermaster/Quartermaster/Services/AppearanceService.cs
@@ -15,9 +15,26 @@ public class AppearanceService
 {
     private readonly IGameDataService _gameDataService;
 
+    private readonly object _cacheLock = new();
+    private List<(ushort Id, string Name)>? _portraitsCache;
+    private List<(ushort Id, string Name)>? _soundSetsCache;
+
     public AppearanceService(IGameDataService gameDataService)
     {
         _gameDataService = gameDataService;
+    }
+
+    /// <summary>
+    /// Clears cached snapshots of 2DA-derived lists (portraits, sound sets).
+    /// Call after the underlying 2DA chain changes (HAK reconfigure, language switch, etc.).
+    /// </summary>
+    public void InvalidateCaches()
+    {
+        lock (_cacheLock)
+        {
+            _portraitsCache = null;
+            _soundSetsCache = null;
+        }
     }
 
     #region Appearance
@@ -318,12 +335,17 @@ public class AppearanceService
     }
 
     /// <summary>
-    /// Gets all portraits from portraits.2da.
+    /// Gets all portraits from portraits.2da. Result is cached until <see cref="InvalidateCaches"/> is called.
     /// </summary>
     public List<(ushort Id, string Name)> GetAllPortraits()
     {
-        var portraits = new List<(ushort Id, string Name)>();
+        lock (_cacheLock)
+        {
+            if (_portraitsCache != null)
+                return _portraitsCache;
+        }
 
+        var portraits = new List<(ushort Id, string Name)>();
         int rowCount = _gameDataService.Get2DA("portraits")?.RowCount ?? 500;
         for (int i = 0; i < rowCount; i++)
         {
@@ -334,7 +356,11 @@ public class AppearanceService
             portraits.Add(((ushort)i, baseResRef));
         }
 
-        return portraits;
+        lock (_cacheLock)
+        {
+            _portraitsCache ??= portraits;
+            return _portraitsCache;
+        }
     }
 
     /// <summary>
@@ -486,12 +512,17 @@ public class AppearanceService
     }
 
     /// <summary>
-    /// Gets all sound sets from soundset.2da.
+    /// Gets all sound sets from soundset.2da. Result is cached until <see cref="InvalidateCaches"/> is called.
     /// </summary>
     public List<(ushort Id, string Name)> GetAllSoundSets()
     {
-        var soundSets = new List<(ushort Id, string Name)>();
+        lock (_cacheLock)
+        {
+            if (_soundSetsCache != null)
+                return _soundSetsCache;
+        }
 
+        var soundSets = new List<(ushort Id, string Name)>();
         int rowCount = _gameDataService.Get2DA("soundset")?.RowCount ?? 500;
         for (int i = 0; i < rowCount; i++)
         {
@@ -503,7 +534,11 @@ public class AppearanceService
             soundSets.Add(((ushort)i, displayName));
         }
 
-        return soundSets;
+        lock (_cacheLock)
+        {
+            _soundSetsCache ??= soundSets;
+            return _soundSetsCache;
+        }
     }
 
     #endregion

--- a/Quartermaster/Quartermaster/Views/Panels/AdvancedPanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AdvancedPanel.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.Markup.Xaml;
 using Quartermaster.Services;
 using Quartermaster.ViewModels;
 using Quartermaster.Views.Dialogs;
+using Radoub.Formats.Services;
 using Radoub.Formats.Gff;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Utc;
@@ -308,8 +309,36 @@ public partial class AdvancedPanel : BasePanelControl
     public void SetDisplayService(CreatureDisplayService displayService)
     {
         _displayService = displayService;
+        // LoadBehaviorData is just hardcoded combo population — keep on UI thread.
         LoadBehaviorData();
-        LoadPaletteCategoryData();
+        // LoadPaletteCategoryData hits creaturepal.itp via GameDataService — push to
+        // background to keep ~700ms off the UI thread on startup (#2058).
+        _ = LoadPaletteCategoryDataInBackgroundAsync(displayService);
+    }
+
+    private async System.Threading.Tasks.Task LoadPaletteCategoryDataInBackgroundAsync(CreatureDisplayService displayService)
+    {
+        try
+        {
+            var categories = await System.Threading.Tasks.Task.Run(() =>
+                displayService.GetCreaturePaletteCategories().ToList());
+
+            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                PopulatePaletteCategoryCombo(categories);
+                // If a creature was loaded before the combo populated, re-select its category.
+                if (CurrentCreature != null)
+                {
+                    ComboBoxHelper.SelectByTag(_paletteCategoryComboBox, CurrentCreature.PaletteID);
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            Radoub.Formats.Logging.UnifiedLogger.LogApplication(
+                Radoub.Formats.Logging.LogLevel.WARN,
+                $"AdvancedPanel: palette category background load failed — {ex.Message}");
+        }
     }
 
     /// <summary>
@@ -416,14 +445,11 @@ public partial class AdvancedPanel : BasePanelControl
         }
     }
 
-    private void LoadPaletteCategoryData()
+    private void PopulatePaletteCategoryCombo(System.Collections.Generic.List<PaletteCategory> categories)
     {
-        if (_paletteCategoryComboBox == null || _displayService == null) return;
+        if (_paletteCategoryComboBox == null) return;
 
         _paletteCategoryComboBox.Items.Clear();
-
-        // Load categories from creaturepal.itp via GameDataService
-        var categories = _displayService.GetCreaturePaletteCategories().ToList();
 
         if (categories.Count == 0)
         {

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.DataLoading.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.DataLoading.cs
@@ -13,35 +13,18 @@ namespace Quartermaster.Views.Panels;
 
 public partial class AppearancePanel
 {
-    private void LoadAppearanceData()
+    private void PopulatePhenotypeCombo(System.Collections.Generic.List<PhenotypeInfo> phenotypes)
     {
-        if (_displayService == null) return;
-
-        _isLoading = true;
-
-        // Load appearances from 2DA
-        _appearances = _displayService.GetAllAppearances();
-        RefreshFilteredAppearanceList();
-
-        // Load genders (Male=0, Female=1)
-        LoadGenderData();
-
-        // Load phenotypes from 2DA
-        _phenotypes = _displayService.GetAllPhenotypes();
-        if (_phenotypeComboBox != null)
+        if (_phenotypeComboBox == null) return;
+        _phenotypeComboBox.Items.Clear();
+        foreach (var pheno in phenotypes)
         {
-            _phenotypeComboBox.Items.Clear();
-            foreach (var pheno in _phenotypes)
+            _phenotypeComboBox.Items.Add(new ComboBoxItem
             {
-                _phenotypeComboBox.Items.Add(new ComboBoxItem
-                {
-                    Content = pheno.Name,
-                    Tag = pheno.PhenotypeId
-                });
-            }
+                Content = pheno.Name,
+                Tag = pheno.PhenotypeId
+            });
         }
-
-        _isLoading = false;
     }
 
     /// <summary>
@@ -121,13 +104,11 @@ public partial class AppearancePanel
         _genderComboBox.Items.Add(new ComboBoxItem { Content = femaleName, Tag = (byte)1 });
     }
 
-    private void LoadBodyPartData()
+    private void LoadBodyPartDataExceptTailWings()
     {
-        if (_displayService == null) return;
-
-        // For now, populate with numeric values 0-20
+        // Pure 0..N numeric combos — fast, runs on UI thread.
         // TODO: Load from model_*.2da files when available
-        void PopulateBodyPartCombo(ComboBox? combo, int max = 20)
+        static void PopulateBodyPartCombo(ComboBox? combo, int max = 20)
         {
             if (combo == null) return;
             combo.Items.Clear();
@@ -143,10 +124,6 @@ public partial class AppearancePanel
         PopulateBodyPartCombo(_pelvisComboBox);
         PopulateBodyPartCombo(_beltComboBox);
 
-        // Tail/Wings from 2DA
-        LoadTailWingsData();
-
-        // Limbs
         PopulateBodyPartCombo(_lShoulComboBox);
         PopulateBodyPartCombo(_rShoulComboBox);
         PopulateBodyPartCombo(_lBicepComboBox);
@@ -163,28 +140,23 @@ public partial class AppearancePanel
         PopulateBodyPartCombo(_rFootComboBox);
     }
 
-    private void LoadTailWingsData()
+    private void PopulateTailCombo(System.Collections.Generic.List<(byte Id, string Name)> tails)
     {
-        if (_displayService == null) return;
-
-        if (_tailComboBox != null)
+        if (_tailComboBox == null) return;
+        _tailComboBox.Items.Clear();
+        foreach (var (id, name) in tails)
         {
-            _tailComboBox.Items.Clear();
-            var tails = _displayService.GetAllTails();
-            foreach (var (id, name) in tails)
-            {
-                _tailComboBox.Items.Add(new ComboBoxItem { Content = name, Tag = id });
-            }
+            _tailComboBox.Items.Add(new ComboBoxItem { Content = name, Tag = id });
         }
+    }
 
-        if (_wingsComboBox != null)
+    private void PopulateWingsCombo(System.Collections.Generic.List<(byte Id, string Name)> wings)
+    {
+        if (_wingsComboBox == null) return;
+        _wingsComboBox.Items.Clear();
+        foreach (var (id, name) in wings)
         {
-            _wingsComboBox.Items.Clear();
-            var wings = _displayService.GetAllWings();
-            foreach (var (id, name) in wings)
-            {
-                _wingsComboBox.Items.Add(new ComboBoxItem { Content = name, Tag = id });
-            }
+            _wingsComboBox.Items.Add(new ComboBoxItem { Content = name, Tag = id });
         }
     }
 

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
@@ -195,26 +195,72 @@ public partial class AppearancePanel : UserControl
     public void SetDisplayService(CreatureDisplayService displayService)
     {
         _displayService = displayService;
-        LoadAppearanceData();
-        LoadBodyPartData();
+        // Body-part combos are pure 0..20 loops — fast, stay on UI thread.
+        // The 2DA-scan portion of LoadAppearanceData / LoadTailWingsData runs
+        // on a background thread to keep ~940ms off the UI thread (#2058).
+        LoadBodyPartDataExceptTailWings();
+        _ = LoadAppearanceDataInBackgroundAsync(displayService);
+    }
 
-        // Resolve appearance sources asynchronously (non-blocking)
-        if (_appearances != null && _appearances.Count > 0)
+    private async System.Threading.Tasks.Task LoadAppearanceDataInBackgroundAsync(CreatureDisplayService displayService)
+    {
+        try
         {
-            _ = System.Threading.Tasks.Task.Run(() =>
+            var (appearances, phenotypes, tails, wings) = await System.Threading.Tasks.Task.Run(() =>
+                (displayService.GetAllAppearances(),
+                 displayService.GetAllPhenotypes(),
+                 displayService.GetAllTails(),
+                 displayService.GetAllWings()));
+
+            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
             {
-                try
+                _isLoading = true;
+                _appearances = appearances;
+                _phenotypes = phenotypes;
+                PopulatePhenotypeCombo(phenotypes);
+                PopulateTailCombo(tails);
+                PopulateWingsCombo(wings);
+                LoadGenderData();
+                RefreshFilteredAppearanceList();
+                _isLoading = false;
+
+                // If a creature was loaded before population, re-apply its appearance/phenotype/etc.
+                if (_currentCreature != null)
                 {
-                    displayService.Appearances.ResolveAppearanceSources(_appearances);
-                    Avalonia.Threading.Dispatcher.UIThread.Post(RefreshFilteredAppearanceList);
-                }
-                catch (Exception ex)
-                {
-                    Radoub.Formats.Logging.UnifiedLogger.LogApplication(
-                        Radoub.Formats.Logging.LogLevel.WARN,
-                        $"AppearancePanel: Source resolution failed: {ex.Message}");
+                    _isLoading = true;
+                    SelectAppearance(_currentCreature.AppearanceType);
+                    SelectGender(_currentCreature.Gender);
+                    SelectPhenotype(_currentCreature.Phenotype);
+                    var isPartBased = _displayService?.IsPartBasedAppearance(_currentCreature.AppearanceType) ?? false;
+                    UpdateBodyPartsEnabledState(isPartBased);
+                    LoadBodyPartValues(_currentCreature);
+                    _isLoading = false;
                 }
             });
+
+            // Resolve appearance sources asynchronously (non-blocking) — kept after the
+            // populate so the list shows immediately and source filters update later.
+            if (_appearances != null && _appearances.Count > 0)
+            {
+                await System.Threading.Tasks.Task.Run(() =>
+                {
+                    try
+                    {
+                        displayService.Appearances.ResolveAppearanceSources(_appearances);
+                        Avalonia.Threading.Dispatcher.UIThread.Post(RefreshFilteredAppearanceList);
+                    }
+                    catch (Exception ex)
+                    {
+                        UnifiedLogger.LogApplication(LogLevel.WARN,
+                            $"AppearancePanel: Source resolution failed: {ex.Message}");
+                    }
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"AppearancePanel: background data load failed — {ex.Message}");
         }
     }
 

--- a/Quartermaster/Quartermaster/Views/Panels/CharacterPanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/CharacterPanel.axaml.cs
@@ -200,9 +200,50 @@ public partial class CharacterPanel : UserControl
     public void SetDisplayService(CreatureDisplayService displayService)
     {
         _displayService = displayService;
-        LoadRaceData();
-        LoadPortraitData();
-        LoadSoundSetData();
+        // 2DA list scans (race, portrait, soundset) used to run on the UI thread here and
+        // accounted for ~11s of "Not Responding" on startup (#2058). Push to background
+        // and marshal back when each list is ready.
+        _ = LoadComboDataInBackgroundAsync(displayService);
+    }
+
+    private async System.Threading.Tasks.Task LoadComboDataInBackgroundAsync(CreatureDisplayService displayService)
+    {
+        try
+        {
+            var (races, portraits, soundSets) = await System.Threading.Tasks.Task.Run(() =>
+                (displayService.GetAllRaces(),
+                 displayService.GetAllPortraits(),
+                 displayService.GetAllSoundSets()));
+
+            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                PopulateRaceCombo(races);
+                PopulatePortraitCombo(portraits);
+                PopulateSoundSetCombo(soundSets);
+
+                // If a creature was loaded before the combos populated, re-apply its selections
+                // now that the lists exist.
+                if (_currentCreature != null)
+                {
+                    _isLoading = true;
+                    SelectRace(_currentCreature.Race);
+                    var portraitId = _currentCreature.PortraitId;
+                    if (portraitId == 0 && !string.IsNullOrEmpty(_currentCreature.Portrait))
+                    {
+                        var foundId = _displayService?.FindPortraitIdByResRef(_currentCreature.Portrait);
+                        if (foundId.HasValue) portraitId = foundId.Value;
+                    }
+                    SelectPortrait(portraitId, _currentCreature.Portrait);
+                    SelectSoundSet(_currentCreature.SoundSetFile);
+                    _isLoading = false;
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"CharacterPanel: background combo population failed — {ex.Message}");
+        }
     }
 
     public void SetGameDataService(IGameDataService? gameDataService)
@@ -279,36 +320,30 @@ public partial class CharacterPanel : UserControl
 
     #region Data Loading
 
-    private void LoadRaceData()
+    private void PopulateRaceCombo(List<(byte Id, string Name)> races)
     {
-        if (_displayService == null || _raceComboBox == null) return;
-
+        if (_raceComboBox == null) return;
         _raceComboBox.Items.Clear();
-        var races = _displayService.GetAllRaces();
         foreach (var (id, name) in races)
         {
             _raceComboBox.Items.Add(new ComboBoxItem { Content = name, Tag = id });
         }
     }
 
-    private void LoadPortraitData()
+    private void PopulatePortraitCombo(List<(ushort Id, string Name)> portraits)
     {
-        if (_displayService == null || _portraitComboBox == null) return;
-
+        if (_portraitComboBox == null) return;
         _portraitComboBox.Items.Clear();
-        var portraits = _displayService.GetAllPortraits();
         foreach (var (id, name) in portraits)
         {
             _portraitComboBox.Items.Add(new ComboBoxItem { Content = name, Tag = id });
         }
     }
 
-    private void LoadSoundSetData()
+    private void PopulateSoundSetCombo(List<(ushort Id, string Name)> soundSets)
     {
-        if (_displayService == null || _soundSetComboBox == null) return;
-
+        if (_soundSetComboBox == null) return;
         _soundSetComboBox.Items.Clear();
-        var soundSets = _displayService.GetAllSoundSets();
         foreach (var (id, name) in soundSets)
         {
             _soundSetComboBox.Items.Add(new ComboBoxItem { Content = name, Tag = id });


### PR DESCRIPTION
## Summary

Address QM startup hang / UI lag identified in spike research (`NonPublic/Quartermaster/Research/spike-startup-hang.md`).

Primary hotspot: `CharacterPanel.SetDisplayService` did ~11.3s of synchronous 2DA scans on the UI thread (race + portrait + soundset, with per-row TLK lookups). `AppearancePanel` and `AdvancedPanel` had the same antipattern at smaller scale.

## What changed

- **CharacterPanel** (#2058) — `LoadRaceData` / `LoadPortraitData` / `LoadSoundSetData` moved into a single `Task.Run` then marshalled back to the UI thread to populate combos. If a creature is loaded before the lists arrive, selections are re-applied once population completes. (~11.3s reclaimed)
- **AppearancePanel** (#2058) — `GetAllAppearances` / `GetAllPhenotypes` / `GetAllTails` / `GetAllWings` moved off-thread; trivial 0..20 body-part loops stay on UI thread. Source resolution happens after the list populates. (~940ms reclaimed)
- **AdvancedPanel** (#2058) — `GetCreaturePaletteCategories` (reads creaturepal.itp) moved off-thread; `LoadBehaviorData` is hardcoded combos and stays sync. (~720ms reclaimed)
- **AppearanceService** (#2058) — `GetAllPortraits` / `GetAllSoundSets` results are now cached behind a lock; new `InvalidateCaches()` hook for HAK reconfigure / language switch. Panel switches stop re-iterating portraits.2da / soundset.2da.

## Tests

- ✅ Privacy scan — no hardcoded paths
- ✅ Tech debt — no >800 line files
- ⚠️ Theme scan — 8 hardcoded values, all pre-existing (not introduced by this PR)
- ✅ Quartermaster.Tests — **1271 / 1271 passing**, including 4 new tests for the cache (cache hit + invalidation, both portraits and soundsets)
- ✅ Radoub.IntegrationTests.Quartermaster — **12 passed / 9 skipped (pre-existing) / 0 failed**; Navigation tests exercise every panel after our `SetDisplayService` changes

## Manual spot-checks

You'll want to verify these in the running app:

- [ ] Launch QM with no `--file` — window should become responsive much sooner; "Not Responding" period should be drastically shorter or gone
- [ ] Launch QM with `--file [path/to/file.utc]` — when panels arrive, the creature's race / portrait / soundset / appearance / palette category should all be selected correctly
- [ ] Switch between panels (Character → Appearance → Advanced) — combos should populate, no crashes
- [ ] Open Character panel during startup before combos populate — interact with race combo as it arrives — selection should land correctly when full list shows up

## Related

- Closes #2058
- Relates to #2128 (cross-tool perf umbrella)
- Builds on prior progress in PR #2112 (the appearance-list shared menu was already shipped there)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)