### PR TITLE
[Radoub] chore: Bump coverlet.collector 8.0.1 -> 10.0.0 (#2118)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,7 +52,7 @@
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
 
     <!-- Integration Testing -->
     <PackageVersion Include="FlaUI.Core" Version="5.0.0" />


### PR DESCRIPTION
## Summary

Consolidates dependabot PR #2118 — bumps `coverlet.collector` from `8.0.1` to `10.0.0` (test-only dependency, no runtime impact).

Other open dependabot PRs are deferred — cannot be actioned at this time.

## Changes

| Package | From | To | Risk |
|---------|------|----|------|
| coverlet.collector | 8.0.1 | 10.0.0 | Low (test-only, dev dependency) |

## Notable in 10.0.0

- Adds .NET 9/10 target support (we are net9.0 — compatible)
- Fixes coverage on `IAsyncEnumerable` generic types
- Fixes coverage when targeting .NET Framework
- Fixes empty reports when `Mediator.SourceGenerator` is referenced

Major version jump per release notes is a maintenance/MTP-tooling change, not a breaking API change for consumers.

## Test Results

- **Build**: 0 errors, 11 pre-existing warnings (no new warnings)
- **Unit tests**: 4470 passed, 0 failed, 1 skipped (pre-existing `JrlReaderTests.Read_XP2Chapter2ModuleJrl_DumpsContents` skip)
- All 9 test projects clean: Radoub.Dictionary, Relique, Fence, Manifest, Radoub.UI, Trebuchet, Quartermaster, Parley, Radoub.Formats

## Checklist

- [x] Build passes
- [x] Unit tests pass
- [x] No CHANGELOG impact (test infrastructure, not user-facing)
- [ ] Close superseded dependabot PR #2118 after merge

---

Closes #2118 (when merged)