### PR TITLE
[Radoub] Refactor: Consolidate duplicate _cachedPaletteData (#2144)

### DIFF
--- a/Fence/CHANGELOG.md
+++ b/Fence/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.1.28-alpha] - 2026-04-29
+**Branch**: `radoub/issue-2144` | **PR**: #TBD
+
+### Refactor: Consolidate duplicate _cachedPaletteData (#2144)
+
+- Remove local `_cachedPaletteData` field; read from `SharedPaletteCacheService` directly (single source of truth)
+
+---
+
 ## [0.1.27-alpha] - 2026-04-26
 **Branch**: `radoub/issue-2034-round-3` | **PR**: #2143
 

--- a/Fence/CHANGELOG.md
+++ b/Fence/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.1.28-alpha] - 2026-04-29
-**Branch**: `radoub/issue-2144` | **PR**: #TBD
+**Branch**: `radoub/issue-2144` | **PR**: #2150
 
 ### Refactor: Consolidate duplicate _cachedPaletteData (#2144)
 

--- a/Fence/Fence/Views/MainWindow.ItemPalette.cs
+++ b/Fence/Fence/Views/MainWindow.ItemPalette.cs
@@ -41,11 +41,19 @@ public partial class MainWindow
     // HAK scanner for loading items from module-referenced HAK files
     private readonly HakPaletteScannerService _hakScanner = new();
 
-    private List<SharedPaletteCacheItem>? _cachedPaletteData;
     private string? _lastModuleDirectory;
 
     // Active HAK paths from current module's IFO (for filtered aggregation)
     private List<string>? _activeHakPaths;
+
+    // Read-through to the shared cache so callers always see fresh data after invalidation.
+    private List<SharedPaletteCacheItem>? GetFilteredPaletteData()
+    {
+        var aggregated = _sharedCacheService.GetAggregatedCache(_activeHakPaths);
+        return aggregated?
+            .Where(i => !ExcludedBaseItemTypes.Contains(i.BaseItemType))
+            .ToList();
+    }
 
     #region Item Palette
 
@@ -88,14 +96,10 @@ public partial class MainWindow
             _activeHakPaths = ResolveActiveHakPaths();
 
             // Try to load from shared cache (filtered to active HAKs)
-            var aggregated = await Task.Run(() => _sharedCacheService.GetAggregatedCache(_activeHakPaths), token);
-            if (aggregated != null)
+            var existing = await Task.Run(() => GetFilteredPaletteData(), token);
+            if (existing != null)
             {
-                // Filter out excluded base item types
-                _cachedPaletteData = aggregated
-                    .Where(i => !ExcludedBaseItemTypes.Contains(i.BaseItemType))
-                    .ToList();
-                UnifiedLogger.LogApplication(LogLevel.INFO, $"Cache pre-warmed from shared cache: {_cachedPaletteData.Count} items ready");
+                UnifiedLogger.LogApplication(LogLevel.INFO, $"Cache pre-warmed from shared cache: {existing.Count} items ready");
 
                 // Scan module HAKs in background (skips cached, refreshes stale)
                 _ = ScanModuleHaksAsync(token);
@@ -109,15 +113,8 @@ public partial class MainWindow
             var hakTask = ScanModuleHaksAsync(token);
             await Task.WhenAll(buildTask, hakTask);
 
-            // Re-aggregate after both complete to include HAK items
+            // Invalidate so next read includes HAK items just scanned
             _sharedCacheService.InvalidateAggregatedCache();
-            var freshAggregated = _sharedCacheService.GetAggregatedCache(_activeHakPaths);
-            if (freshAggregated != null)
-            {
-                _cachedPaletteData = freshAggregated
-                    .Where(i => !ExcludedBaseItemTypes.Contains(i.BaseItemType))
-                    .ToList();
-            }
         }
         catch (OperationCanceledException)
         {
@@ -164,15 +161,8 @@ public partial class MainWindow
 
         if (!needBif && !needOverride)
         {
-            // Both were built by other processes — reload from cache
+            // Both were built by other processes — invalidate so next read pulls fresh data
             _sharedCacheService.InvalidateAggregatedCache();
-            var cached = _sharedCacheService.GetAggregatedCache(_activeHakPaths);
-            if (cached != null)
-            {
-                _cachedPaletteData = cached
-                    .Where(i => !ExcludedBaseItemTypes.Contains(i.BaseItemType))
-                    .ToList();
-            }
             UnifiedLogger.LogApplication(LogLevel.INFO, "Cache built by another process, reloaded from disk");
             return;
         }
@@ -240,7 +230,6 @@ public partial class MainWindow
         if (customItems.Count > 0 && overrideLocked)
             await _sharedCacheService.SaveSourceCacheAsync("override", customItems, settings.NeverwinterNightsPath);
 
-        _cachedPaletteData = cacheItems;
         UnifiedLogger.LogApplication(LogLevel.INFO, $"Background cache complete: {cacheItems.Count} items");
         }
         finally
@@ -256,7 +245,8 @@ public partial class MainWindow
     /// </summary>
     private async Task LoadAllPaletteItemsAsync(CancellationToken token = default)
     {
-        if (_cachedPaletteData == null || _cachedPaletteData.Count == 0)
+        var paletteData = GetFilteredPaletteData();
+        if (paletteData == null || paletteData.Count == 0)
         {
             await Dispatcher.UIThread.InvokeAsync(() =>
                 UpdateStatusBar("Ready (no items available)"));
@@ -265,8 +255,8 @@ public partial class MainWindow
 
         var viewModels = await Task.Run(() =>
         {
-            var vms = new List<ItemViewModel>(_cachedPaletteData.Count);
-            foreach (var cached in _cachedPaletteData)
+            var vms = new List<ItemViewModel>(paletteData.Count);
+            foreach (var cached in paletteData)
             {
                 token.ThrowIfCancellationRequested();
                 var vm = new ItemViewModel
@@ -320,7 +310,6 @@ public partial class MainWindow
     public async Task ClearAndReloadPaletteCacheAsync()
     {
         _sharedCacheService.ClearAllCaches();
-        _cachedPaletteData = null;
         _activeHakPaths = null;
         PaletteItems.Clear();
 
@@ -467,18 +456,11 @@ public partial class MainWindow
                 UnifiedLogger.LogApplication(LogLevel.INFO,
                     $"HAK scan: {result.HaksScanned} scanned, {result.HaksSkipped} cached, {result.TotalItemsScanned} items");
 
-                // Refresh aggregated cache to include HAK items (filtered to active HAKs)
+                // Invalidate aggregated cache so LoadAll pulls a fresh snapshot
                 _sharedCacheService.InvalidateAggregatedCache();
-                var aggregated = _sharedCacheService.GetAggregatedCache(_activeHakPaths);
-                if (aggregated != null)
-                {
-                    _cachedPaletteData = aggregated
-                        .Where(i => !ExcludedBaseItemTypes.Contains(i.BaseItemType))
-                        .ToList();
 
-                    // Reload palette UI to include newly discovered HAK items and their icons
-                    await LoadAllPaletteItemsAsync(token);
-                }
+                // Reload palette UI to include newly discovered HAK items and their icons
+                await LoadAllPaletteItemsAsync(token);
             }
         }
         catch (OperationCanceledException)

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.88-alpha] - 2026-04-29
-**Branch**: `radoub/issue-2144` | **PR**: #TBD
+**Branch**: `radoub/issue-2144` | **PR**: #2150
 
 ### Refactor: Consolidate duplicate _cachedPaletteData (#2144)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.88-alpha] - 2026-04-29
+**Branch**: `radoub/issue-2144` | **PR**: #TBD
+
+### Refactor: Consolidate duplicate _cachedPaletteData (#2144)
+
+- Remove local `_cachedPaletteData` field; read from `SharedPaletteCacheService` directly (single source of truth)
+
+---
+
 ## [0.2.87-alpha] - 2026-04-27
 **Branch**: `quartermaster/issue-2058` | **PR**: #2145
 

--- a/Quartermaster/Quartermaster/Views/MainWindow.ItemPalette.cs
+++ b/Quartermaster/Quartermaster/Views/MainWindow.ItemPalette.cs
@@ -32,7 +32,7 @@ public partial class MainWindow
     private CancellationTokenSource? _paletteCacheCts;
 
     // Track loaded state
-    private List<SharedPaletteCacheItem>? _cachedPaletteData;
+    private bool _cachePreWarmed;
     private bool _paletteLoaded;
 
     // Active HAK paths from current module's IFO (for filtered aggregation)
@@ -75,11 +75,12 @@ public partial class MainWindow
             _activeHakPaths = ResolveActiveHakPaths();
 
             // Try to load aggregated cache from existing source caches (filtered to active HAKs)
-            _cachedPaletteData = await Task.Run(() => _sharedCacheService.GetAggregatedCache(_activeHakPaths), token);
+            var existing = await Task.Run(() => _sharedCacheService.GetAggregatedCache(_activeHakPaths), token);
 
-            if (_cachedPaletteData != null && _cachedPaletteData.Count > 0)
+            if (existing != null && existing.Count > 0)
             {
-                UnifiedLogger.LogInventory(LogLevel.INFO, $"Cache pre-warmed from existing sources: {_cachedPaletteData.Count} items");
+                _cachePreWarmed = true;
+                UnifiedLogger.LogInventory(LogLevel.INFO, $"Cache pre-warmed from existing sources: {existing.Count} items");
 
                 // Check if any sources need rebuilding
                 _ = RebuildStaleCachesAsync(token);
@@ -91,6 +92,7 @@ public partial class MainWindow
             // No valid caches - build all from scratch
             UnifiedLogger.LogInventory(LogLevel.INFO, "Building palette caches in background...");
             await BuildAllCachesAsync(token);
+            _cachePreWarmed = true;
         }
         catch (OperationCanceledException)
         {
@@ -149,11 +151,10 @@ public partial class MainWindow
                 await ScanModuleHaksAsync(token);
             }
 
-            // Refresh aggregated cache (filtered to active HAKs)
+            // Invalidate aggregated cache so next read rebuilds from refreshed sources
             if (!token.IsCancellationRequested)
             {
                 _sharedCacheService.InvalidateAggregatedCache();
-                _cachedPaletteData = _sharedCacheService.GetAggregatedCache(_activeHakPaths);
             }
         }
         catch (OperationCanceledException)
@@ -184,9 +185,9 @@ public partial class MainWindow
             // Scan module HAKs (outside Task.Run — scanner manages its own threading)
             await ScanModuleHaksAsync(token);
 
-            // Load aggregated result (filtered to active HAKs)
-            _cachedPaletteData = _sharedCacheService.GetAggregatedCache(_activeHakPaths);
-            UnifiedLogger.LogInventory(LogLevel.INFO, $"All caches built: {_cachedPaletteData?.Count ?? 0} total items");
+            // Log aggregated result (filtered to active HAKs)
+            var aggregated = _sharedCacheService.GetAggregatedCache(_activeHakPaths);
+            UnifiedLogger.LogInventory(LogLevel.INFO, $"All caches built: {aggregated?.Count ?? 0} total items");
         }
         catch (OperationCanceledException)
         {
@@ -298,15 +299,18 @@ public partial class MainWindow
 
         try
         {
-            // Wait for cache if not ready
-            if (_cachedPaletteData == null)
+            // Wait for cache if not pre-warmed yet
+            if (!_cachePreWarmed)
             {
                 await PreWarmCacheAsync(token);
             }
 
             token.ThrowIfCancellationRequested();
 
-            if (_cachedPaletteData == null || _cachedPaletteData.Count == 0)
+            // Snapshot the aggregated cache once for this load operation
+            var paletteData = _sharedCacheService.GetAggregatedCache(_activeHakPaths);
+
+            if (paletteData == null || paletteData.Count == 0)
             {
                 UpdateStatus("Ready (no items available)");
                 _paletteLoaded = true;
@@ -314,16 +318,16 @@ public partial class MainWindow
             }
 
             // Load all items at once (no batching - faster)
-            var standardItems = _cachedPaletteData.Where(i => i.IsStandard).ToList();
-            var customItems = _cachedPaletteData.Where(i => !i.IsStandard).ToList();
+            var standardItems = paletteData.Where(i => i.IsStandard).ToList();
+            var customItems = paletteData.Where(i => !i.IsStandard).ToList();
 
             UnifiedLogger.LogInventory(LogLevel.INFO, $"Loading {standardItems.Count} standard + {customItems.Count} custom items");
 
             // Create all view models on background thread
             var viewModels = await Task.Run(() =>
             {
-                var vms = new List<ItemViewModel>(_cachedPaletteData.Count);
-                foreach (var cached in _cachedPaletteData)
+                var vms = new List<ItemViewModel>(paletteData.Count);
+                foreach (var cached in paletteData)
                 {
                     token.ThrowIfCancellationRequested();
                     var vm = new ItemViewModel
@@ -492,7 +496,7 @@ public partial class MainWindow
         var token = _paletteCacheCts.Token;
 
         _sharedCacheService.ClearAllCaches();
-        _cachedPaletteData = null;
+        _cachePreWarmed = false;
         _paletteLoaded = false;
         _lastModuleDirectory = null;
         _activeHakPaths = null;
@@ -538,9 +542,8 @@ public partial class MainWindow
             UnifiedLogger.LogInventory(LogLevel.INFO,
                 $"HAK scan: {result.HaksScanned} scanned, {result.HaksSkipped} cached, {result.TotalItemsScanned} items");
 
-            // Refresh aggregated cache to include HAK items (filtered to active HAKs)
+            // Invalidate aggregated cache so next read includes HAK items
             _sharedCacheService.InvalidateAggregatedCache();
-            _cachedPaletteData = _sharedCacheService.GetAggregatedCache(_activeHakPaths);
         }
     }
 


### PR DESCRIPTION
## Summary

Architectural follow-up for #2034 item #9 — removed the local `_cachedPaletteData` field from QM and Fence MainWindows. Both tools now read directly through `SharedPaletteCacheService` so there is a single source of truth for palette data.

Eliminates ~4 MB of duplicated palette state (~8500 items × 2 tools) and the stale-cache foot-gun where the local field could disagree with the upstream service after invalidation.

## Approach

**QM** (~14 references): Replaced `_cachedPaletteData = ...` assignments with local snapshots from `_sharedCacheService.GetAggregatedCache(_activeHakPaths)` at consumption sites. Added a `_cachePreWarmed` bool to gate first-time pre-warm (replaces the old "is the field null?" signal).

**Fence** (~10 references): Added a private `GetFilteredPaletteData()` helper that centralizes the `ExcludedBaseItemTypes` filter on each read-through. Fence's local field had been a *transformed view* of the service output, so a helper preserves the abstraction without keeping the mirror.

After-the-fact `_sharedCacheService.InvalidateAggregatedCache()` calls remain — the next read just rebuilds, instead of pre-emptively re-aggregating into the local field.

## Files

- `Quartermaster/Quartermaster/Views/MainWindow.ItemPalette.cs`
- `Fence/Fence/Views/MainWindow.ItemPalette.cs`

Net diff: 43 insertions, 58 deletions.

## Related Issues

- Closes #2144
- Relates to #2034 (parent tech-debt issue, remains open for items #4, #5)
- Follow-up to PR #2143 (round 3 deferred this item)

## Tests

| Suite | Result |
|-------|--------|
| Quartermaster.Tests (unit) | ✅ 1271 / 1271 |
| Fence.Tests (unit) | ✅ 128 / 128 |
| Radoub.UI.Tests (shared lib) | ✅ 496 / 496 |
| QM FlaUI smoke | ✅ 1 / 1 |
| Fence FlaUI smoke | ✅ 2 / 2 (1 pre-existing skip — Avalonia StackPanel UIA limitation, unrelated) |
| Privacy scan (both tools) | ✅ |
| Tech debt scan (both tools) | ✅ no large files |

## Manual spot-checks (recommended)

- [ ] QM: Open a UTC creature, navigate to Inventory — palette items appear (BIF + custom + module)
- [ ] QM: Settings → Refresh Item Palette — cache rebuilds and palette repopulates
- [ ] Fence: Open a UTM merchant from a module with HAKs — palette shows BIF + module + HAK items, creature weapons (BaseItemType 69-73, 255) stay excluded
- [ ] Fence: Cache rebuild from Settings — palette repopulates correctly

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)