### PR TITLE
[Relique] Feat: Item model 3D preview wiring (closes #1908)

### DIFF
--- a/Radoub.Formats/Radoub.Formats.Tests/PltReaderTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/PltReaderTests.cs
@@ -109,16 +109,18 @@ public class PltReaderTests
     [Fact]
     public void GetPaletteResRef_ReturnsCorrectNames()
     {
+        // Per Aurora item format spec Section 2.1.2.4: each material has ONE palette
+        // file shared between its "1" and "2" color slots. There is no pal_*02 in NWN.
         Assert.Equal("pal_skin01", PltLayers.GetPaletteResRef(PltLayers.Skin));
         Assert.Equal("pal_hair01", PltLayers.GetPaletteResRef(PltLayers.Hair));
         Assert.Equal("pal_armor01", PltLayers.GetPaletteResRef(PltLayers.Metal1));
-        Assert.Equal("pal_armor02", PltLayers.GetPaletteResRef(PltLayers.Metal2));
+        Assert.Equal("pal_armor01", PltLayers.GetPaletteResRef(PltLayers.Metal2));
         Assert.Equal("pal_cloth01", PltLayers.GetPaletteResRef(PltLayers.Cloth1));
-        Assert.Equal("pal_cloth02", PltLayers.GetPaletteResRef(PltLayers.Cloth2));
+        Assert.Equal("pal_cloth01", PltLayers.GetPaletteResRef(PltLayers.Cloth2));
         Assert.Equal("pal_leath01", PltLayers.GetPaletteResRef(PltLayers.Leather1));
-        Assert.Equal("pal_leath02", PltLayers.GetPaletteResRef(PltLayers.Leather2));
+        Assert.Equal("pal_leath01", PltLayers.GetPaletteResRef(PltLayers.Leather2));
         Assert.Equal("pal_tattoo01", PltLayers.GetPaletteResRef(PltLayers.Tattoo1));
-        Assert.Equal("pal_tattoo02", PltLayers.GetPaletteResRef(PltLayers.Tattoo2));
+        Assert.Equal("pal_tattoo01", PltLayers.GetPaletteResRef(PltLayers.Tattoo2));
     }
 
     [Fact]

--- a/Radoub.Formats/Radoub.Formats/Plt/PltReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Plt/PltReader.cs
@@ -166,18 +166,27 @@ public static class PltLayers
     /// <summary>
     /// Get the palette filename for a layer.
     /// </summary>
+    /// <summary>
+    /// Map a PLT layer ID to its palette TGA filename.
+    ///
+    /// Per the BioWare Aurora item format spec (Section 2.1.2.4): each material has a
+    /// SINGLE palette file used by both color slots (Metal1 and Metal2 both index
+    /// pal_armor01.tga, Cloth1/2 index pal_cloth01.tga, etc.). The "1" / "2" distinction
+    /// applies to which PLT layer pixel uses the looked-up color, not to a separate
+    /// palette file. There is no pal_*02 file in NWN.
+    /// </summary>
     public static string GetPaletteResRef(int layerId) => layerId switch
     {
         Skin => "pal_skin01",
         Hair => "pal_hair01",
         Metal1 => "pal_armor01",
-        Metal2 => "pal_armor02",
+        Metal2 => "pal_armor01",  // Same palette as Metal1
         Cloth1 => "pal_cloth01",
-        Cloth2 => "pal_cloth02",
+        Cloth2 => "pal_cloth01",  // Same palette as Cloth1
         Leather1 => "pal_leath01",
-        Leather2 => "pal_leath02",
+        Leather2 => "pal_leath01", // Same palette as Leather1
         Tattoo1 => "pal_tattoo01",
-        Tattoo2 => "pal_tattoo02",
+        Tattoo2 => "pal_tattoo01", // Same palette as Tattoo1
         _ => "pal_skin01"
     };
 }

--- a/Radoub.Formats/Radoub.Formats/Services/BaseItemTypeService.cs
+++ b/Radoub.Formats/Radoub.Formats/Services/BaseItemTypeService.cs
@@ -112,7 +112,19 @@ public class BaseItemTypeService
             if (invSlotHeightStr != null && invSlotHeightStr != "****" && int.TryParse(invSlotHeightStr, out var ish))
                 invSlotHeight = ish;
 
-            _cachedTypes.Add(new BaseItemTypeInfo(i, displayName, label, storePanel, modelType, descriptionText, stacking, chargesStarting, invSlotWidth, invSlotHeight));
+            // WeaponWield: BioWare uses **** as a sentinel meaning "default melee weapon
+            // held in one or two hands depending on creature size" — capture as -1 so the
+            // IsHeldWeapon flag can include this category.
+            var weaponWieldStr = baseItems.GetValue(i, "WeaponWield");
+            int weaponWield;
+            if (weaponWieldStr == "****")
+                weaponWield = -1;
+            else if (!string.IsNullOrEmpty(weaponWieldStr) && int.TryParse(weaponWieldStr, out var ww))
+                weaponWield = ww;
+            else
+                weaponWield = 1; // missing column or unparseable → treat as nonweapon
+
+            _cachedTypes.Add(new BaseItemTypeInfo(i, displayName, label, storePanel, modelType, descriptionText, stacking, chargesStarting, invSlotWidth, invSlotHeight, weaponWield));
         }
 
         _cachedTypes = _cachedTypes.OrderBy(t => t.DisplayName).ToList();
@@ -297,6 +309,14 @@ public class BaseItemTypeInfo
     /// <summary>Inventory slot height from baseitems.2da InvSlotHeight column. Default 1.</summary>
     public int InvSlotHeight { get; }
 
+    /// <summary>
+    /// WeaponWield style from baseitems.2da WeaponWield column.
+    /// Values: -1 (****) = melee weapon held in one or two hands; 1 = nonweapon;
+    /// 4 = pole; 5 = bow; 6 = crossbow; 7 = shield; 8 = two-bladed; 9 = creature weapon;
+    /// 10 = sling; 11 = thrown.
+    /// </summary>
+    public int WeaponWield { get; }
+
     // Computed convenience properties (used by Relique)
     public bool HasColorFields => ModelType is 1 or 3;
     public bool HasArmorParts => ModelType == 3;
@@ -305,11 +325,20 @@ public class BaseItemTypeInfo
     public bool IsStackable => Stacking > 1;
     public bool HasCharges => ChargesStarting > 0;
 
+    /// <summary>
+    /// True for items wielded as held weapons (sword, bow, crossbow, two-bladed, sling,
+    /// thrown, pole). Used by Relique's 3D preview to apply a vertical orientation
+    /// rotation; in-game these items get their orientation from the bone they attach to.
+    /// Excludes shields (held but not "linear") and creature weapons.
+    /// </summary>
+    public bool IsHeldWeapon => WeaponWield is -1 or 4 or 5 or 6 or 8 or 10 or 11;
+
     public BaseItemTypeInfo(
         int baseItemIndex, string displayName, string label,
         int storePanel = 4, int modelType = 0, string descriptionText = "",
         int stacking = 1, int chargesStarting = 0,
-        int invSlotWidth = 1, int invSlotHeight = 1)
+        int invSlotWidth = 1, int invSlotHeight = 1,
+        int weaponWield = 1)
     {
         BaseItemIndex = baseItemIndex;
         DisplayName = displayName;
@@ -321,6 +350,7 @@ public class BaseItemTypeInfo
         ChargesStarting = chargesStarting;
         InvSlotWidth = invSlotWidth;
         InvSlotHeight = invSlotHeight;
+        WeaponWield = weaponWield;
     }
 
     public override string ToString() => DisplayName;

--- a/Radoub.UI/Radoub.UI.Tests/PaletteColorServiceTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/PaletteColorServiceTests.cs
@@ -118,12 +118,14 @@ public class PaletteColorServiceTests
     [Fact]
     public void ItemPaletteConstants_AreCorrectFileNames()
     {
+        // Per Aurora item format spec Section 2.1.2.4: each material has ONE palette
+        // file shared between its "1" and "2" color slots. There is no pal_*02 in NWN.
         Assert.Equal("pal_cloth01", PaletteColorService.Palettes.Cloth1);
-        Assert.Equal("pal_cloth02", PaletteColorService.Palettes.Cloth2);
+        Assert.Equal("pal_cloth01", PaletteColorService.Palettes.Cloth2);
         Assert.Equal("pal_leath01", PaletteColorService.Palettes.Leather1);
-        Assert.Equal("pal_leath02", PaletteColorService.Palettes.Leather2);
+        Assert.Equal("pal_leath01", PaletteColorService.Palettes.Leather2);
         Assert.Equal("pal_armor01", PaletteColorService.Palettes.Metal1);
-        Assert.Equal("pal_armor02", PaletteColorService.Palettes.Metal2);
+        Assert.Equal("pal_armor01", PaletteColorService.Palettes.Metal2);
     }
 
     [Fact]

--- a/Radoub.UI/Radoub.UI.Tests/Services/ItemModelResolverTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/ItemModelResolverTests.cs
@@ -1,0 +1,266 @@
+using Radoub.Formats.Common;
+using Radoub.Formats.Services;
+using Radoub.Formats.TwoDA;
+using Radoub.Formats.Uti;
+using Radoub.TestUtilities.Mocks;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests.Services;
+
+public class ItemModelResolverTests
+{
+    private static MockGameDataService BuildGameData()
+    {
+        var game = new MockGameDataService(includeSampleData: false);
+
+        var baseItems = new TwoDAFile();
+        baseItems.Columns.AddRange(new[] { "Label", "ItemClass", "ModelType", "DefaultModel" });
+
+        // Row 0: Simple weapon (longsword)
+        baseItems.Rows.Add(new TwoDARow { Label = "0", Values = new() { "BASE_ITEM_LONGSWORD", "w_swrd", "0", "w_swrd_001" } });
+        // Row 1: Layered (cloak)
+        baseItems.Rows.Add(new TwoDARow { Label = "1", Values = new() { "BASE_ITEM_CLOAK", "cloak", "1", "cloak_001" } });
+        // Row 2: Composite weapon (twobladed sword)
+        baseItems.Rows.Add(new TwoDARow { Label = "2", Values = new() { "BASE_ITEM_TWOBLADEDSWORD", "wdbsw", "2", "wdbsw_b_001" } });
+        // Row 3: Armor
+        baseItems.Rows.Add(new TwoDARow { Label = "3", Values = new() { "BASE_ITEM_ARMOR", "armor", "3", "****" } });
+        // Row 4: Unknown ModelType
+        baseItems.Rows.Add(new TwoDARow { Label = "4", Values = new() { "BASE_ITEM_BOGUS", "bogus", "9", "****" } });
+
+        game.With2DA("baseitems", baseItems);
+        return game;
+    }
+
+    private static BaseItemTypeService BuildBaseItemService(MockGameDataService game) => new(game);
+
+    [Fact]
+    public void Resolve_SimpleWeapon_ReturnsSingleResRefAndNoColors()
+    {
+        var game = BuildGameData();
+        game.SetResource("w_swrd_005", ResourceTypes.Mdl, new byte[] { 1 });
+
+        var resolver = new ItemModelResolver(BuildBaseItemService(game), game);
+        var uti = new UtiFile { BaseItem = 0, ModelPart1 = 5 };
+
+        var result = resolver.Resolve(uti);
+
+        Assert.True(result.HasModel);
+        Assert.Single(result.MdlResRefs);
+        Assert.Equal("w_swrd_005", result.MdlResRefs[0]);
+        Assert.False(result.HasArmorParts);
+        Assert.False(result.HasColorFields);
+    }
+
+    [Fact]
+    public void Resolve_LayeredItem_ReturnsSingleResRefAndColorFields()
+    {
+        var game = BuildGameData();
+        game.SetResource("cloak_003", ResourceTypes.Mdl, new byte[] { 1 });
+
+        var resolver = new ItemModelResolver(BuildBaseItemService(game), game);
+        var uti = new UtiFile { BaseItem = 1, ModelPart1 = 3 };
+
+        var result = resolver.Resolve(uti);
+
+        Assert.True(result.HasModel);
+        Assert.Single(result.MdlResRefs);
+        Assert.Equal("cloak_003", result.MdlResRefs[0]);
+        Assert.False(result.HasArmorParts);
+        Assert.True(result.HasColorFields);
+    }
+
+    [Fact]
+    public void Resolve_CompositeWeapon_ReturnsThreeResRefsBmt()
+    {
+        var game = BuildGameData();
+        game.SetResource("wdbsw_b_011", ResourceTypes.Mdl, new byte[] { 1 });
+        game.SetResource("wdbsw_m_021", ResourceTypes.Mdl, new byte[] { 1 });
+        game.SetResource("wdbsw_t_031", ResourceTypes.Mdl, new byte[] { 1 });
+
+        var resolver = new ItemModelResolver(BuildBaseItemService(game), game);
+        var uti = new UtiFile { BaseItem = 2, ModelPart1 = 11, ModelPart2 = 21, ModelPart3 = 31 };
+
+        var result = resolver.Resolve(uti);
+
+        Assert.True(result.HasModel);
+        Assert.Equal(3, result.MdlResRefs.Count);
+        Assert.Contains("wdbsw_b_011", result.MdlResRefs);
+        Assert.Contains("wdbsw_m_021", result.MdlResRefs);
+        Assert.Contains("wdbsw_t_031", result.MdlResRefs);
+        Assert.False(result.HasArmorParts);
+        Assert.False(result.HasColorFields);
+    }
+
+    [Fact]
+    public void Resolve_Armor_ReturnsBodyPartResRefsWithMannequinPrefix()
+    {
+        var game = BuildGameData();
+        // Default mannequin prefix is pmh0 (playable male human, phenotype 0)
+        game.SetResource("pmh0_chest005", ResourceTypes.Mdl, new byte[] { 1 });
+        game.SetResource("pmh0_pelvis002", ResourceTypes.Mdl, new byte[] { 1 });
+        game.SetResource("pmh0_belt001", ResourceTypes.Mdl, new byte[] { 1 });
+
+        var resolver = new ItemModelResolver(BuildBaseItemService(game), game);
+        var uti = new UtiFile
+        {
+            BaseItem = 3,
+            ArmorParts = new()
+            {
+                ["Torso"] = 5,
+                ["Pelvis"] = 2,
+                ["Belt"] = 1,
+            },
+        };
+
+        var result = resolver.Resolve(uti);
+
+        Assert.True(result.HasModel);
+        Assert.True(result.HasArmorParts);
+        Assert.True(result.HasColorFields);
+        Assert.Contains("pmh0_chest005", result.MdlResRefs);
+        Assert.Contains("pmh0_pelvis002", result.MdlResRefs);
+        Assert.Contains("pmh0_belt001", result.MdlResRefs);
+    }
+
+    [Fact]
+    public void Resolve_Armor_PartialPartsExist_DropsMissingAndKeepsRest()
+    {
+        var game = BuildGameData();
+        game.SetResource("pmh0_chest005", ResourceTypes.Mdl, new byte[] { 1 });
+        // pelvis and belt MDLs intentionally not registered
+
+        var resolver = new ItemModelResolver(BuildBaseItemService(game), game);
+        var uti = new UtiFile
+        {
+            BaseItem = 3,
+            ArmorParts = new()
+            {
+                ["Torso"] = 5,
+                ["Pelvis"] = 2,
+                ["Belt"] = 1,
+            },
+        };
+
+        var result = resolver.Resolve(uti);
+
+        Assert.True(result.HasModel);
+        Assert.Single(result.MdlResRefs);
+        Assert.Equal("pmh0_chest005", result.MdlResRefs[0]);
+    }
+
+    [Fact]
+    public void Resolve_Armor_AllPartsMissing_ReturnsHasModelFalse()
+    {
+        var game = BuildGameData();
+        // No resources registered
+
+        var resolver = new ItemModelResolver(BuildBaseItemService(game), game);
+        var uti = new UtiFile
+        {
+            BaseItem = 3,
+            ArmorParts = new() { ["Torso"] = 5, ["Pelvis"] = 2 },
+        };
+
+        var result = resolver.Resolve(uti);
+
+        Assert.False(result.HasModel);
+        Assert.Empty(result.MdlResRefs);
+    }
+
+    [Fact]
+    public void Resolve_SimpleWeapon_PartZero_TreatedAsNoModel()
+    {
+        var game = BuildGameData();
+
+        var resolver = new ItemModelResolver(BuildBaseItemService(game), game);
+        var uti = new UtiFile { BaseItem = 0, ModelPart1 = 0 };
+
+        var result = resolver.Resolve(uti);
+
+        Assert.False(result.HasModel);
+        Assert.Empty(result.MdlResRefs);
+    }
+
+    [Fact]
+    public void Resolve_SimpleWeapon_MdlMissing_ReturnsHasModelFalse()
+    {
+        var game = BuildGameData();
+        // w_swrd_005 not registered as a resource
+
+        var resolver = new ItemModelResolver(BuildBaseItemService(game), game);
+        var uti = new UtiFile { BaseItem = 0, ModelPart1 = 5 };
+
+        var result = resolver.Resolve(uti);
+
+        Assert.False(result.HasModel);
+        Assert.Empty(result.MdlResRefs);
+    }
+
+    [Fact]
+    public void Resolve_BaseItemOutOfRange_ReturnsHasModelFalse()
+    {
+        var game = BuildGameData();
+        var resolver = new ItemModelResolver(BuildBaseItemService(game), game);
+        var uti = new UtiFile { BaseItem = 999, ModelPart1 = 1 };
+
+        var result = resolver.Resolve(uti);
+
+        Assert.False(result.HasModel);
+        Assert.Empty(result.MdlResRefs);
+        Assert.False(result.HasArmorParts);
+        Assert.False(result.HasColorFields);
+    }
+
+    [Fact]
+    public void Resolve_UnknownModelType_ReturnsHasModelFalse()
+    {
+        var game = BuildGameData();
+        var resolver = new ItemModelResolver(BuildBaseItemService(game), game);
+        var uti = new UtiFile { BaseItem = 4, ModelPart1 = 1 };
+
+        var result = resolver.Resolve(uti);
+
+        Assert.False(result.HasModel);
+    }
+
+    [Fact]
+    public void Resolve_Composite_OneOfThreePartsMissing_DropsMissingAndKeepsRest()
+    {
+        var game = BuildGameData();
+        game.SetResource("wdbsw_b_011", ResourceTypes.Mdl, new byte[] { 1 });
+        game.SetResource("wdbsw_t_031", ResourceTypes.Mdl, new byte[] { 1 });
+        // middle part absent
+
+        var resolver = new ItemModelResolver(BuildBaseItemService(game), game);
+        var uti = new UtiFile { BaseItem = 2, ModelPart1 = 11, ModelPart2 = 21, ModelPart3 = 31 };
+
+        var result = resolver.Resolve(uti);
+
+        Assert.True(result.HasModel);
+        Assert.Equal(2, result.MdlResRefs.Count);
+        Assert.DoesNotContain("wdbsw_m_021", result.MdlResRefs);
+    }
+
+    [Fact]
+    public void Resolve_NullUti_Throws()
+    {
+        var game = BuildGameData();
+        var resolver = new ItemModelResolver(BuildBaseItemService(game), game);
+
+        Assert.Throws<ArgumentNullException>(() => resolver.Resolve(null!));
+    }
+
+    [Fact]
+    public void Resolve_EmptyArmorPartsDictionary_ReturnsHasModelFalse()
+    {
+        var game = BuildGameData();
+        var resolver = new ItemModelResolver(BuildBaseItemService(game), game);
+        var uti = new UtiFile { BaseItem = 3, ArmorParts = new() };
+
+        var result = resolver.Resolve(uti);
+
+        Assert.False(result.HasModel);
+        Assert.Empty(result.MdlResRefs);
+    }
+}

--- a/Radoub.UI/Radoub.UI/Services/ItemModelResolver.cs
+++ b/Radoub.UI/Radoub.UI/Services/ItemModelResolver.cs
@@ -1,0 +1,153 @@
+using Radoub.Formats.Common;
+using Radoub.Formats.Services;
+using Radoub.Formats.Uti;
+
+namespace Radoub.UI.Services;
+
+/// <summary>
+/// Resolution result for an item's 3D model preview. Returned ResRefs are guaranteed
+/// to exist as MDL resources via <see cref="IGameDataService.FindResource"/>; callers
+/// can pass them straight to the MDL loader without further existence checks.
+/// </summary>
+public sealed record ItemModelResolution(
+    IReadOnlyList<string> MdlResRefs,
+    bool HasArmorParts,
+    bool HasColorFields,
+    bool HasModel);
+
+/// <summary>
+/// Maps a UTI item blueprint to the MDL ResRefs needed to render its 3D preview.
+/// Pure logic; no I/O beyond IGameDataService resource existence checks.
+///
+/// Naming conventions follow BioWare Aurora Item Format Section 4.1:
+/// - Simple/Layered: ItemClass_NNN (e.g., "w_swrd_005", "cloak_003")
+/// - Composite: ItemClass_p_NNN where p is b/m/t for ModelPart1/2/3 (e.g., "wdbsw_b_011")
+/// - Armor: prefix_bodypartNNN where prefix is creature-derived (e.g., "pmh0_chest005").
+///   Item editing has no creature context, so a configurable mannequin prefix is used.
+/// </summary>
+public sealed class ItemModelResolver
+{
+    private readonly BaseItemTypeService _baseItemTypeService;
+    private readonly IGameDataService _gameDataService;
+    private readonly string _armorMannequinPrefix;
+
+    private static readonly Dictionary<string, string> ArmorPartKeyToMdlSuffix =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Belt"] = "belt",
+            ["LBicep"] = "bicepl",
+            ["RBicep"] = "bicepr",
+            ["Torso"] = "chest",
+            ["LFoot"] = "footl",
+            ["RFoot"] = "footr",
+            ["LFArm"] = "forel",
+            ["RFArm"] = "forer",
+            ["LHand"] = "handl",
+            ["RHand"] = "handr",
+            ["LThigh"] = "legl",
+            ["RThigh"] = "legr",
+            ["Neck"] = "neck",
+            ["Pelvis"] = "pelvis",
+            ["Robe"] = "robe",
+            ["LShin"] = "shinl",
+            ["RShin"] = "shinr",
+            ["LShoul"] = "shol",
+            ["RShoul"] = "shor",
+        };
+
+    public ItemModelResolver(
+        BaseItemTypeService baseItemTypeService,
+        IGameDataService gameDataService,
+        string armorMannequinPrefix = "pmh0")
+    {
+        _baseItemTypeService = baseItemTypeService;
+        _gameDataService = gameDataService;
+        _armorMannequinPrefix = armorMannequinPrefix;
+    }
+
+    public ItemModelResolution Resolve(UtiFile uti)
+    {
+        ArgumentNullException.ThrowIfNull(uti);
+
+        var typeInfo = _baseItemTypeService
+            .GetBaseItemTypes()
+            .FirstOrDefault(t => t.BaseItemIndex == uti.BaseItem);
+
+        if (typeInfo == null)
+            return new ItemModelResolution(Array.Empty<string>(), false, false, false);
+
+        var itemClass = _gameDataService.Get2DAValue("baseitems", uti.BaseItem, "ItemClass");
+        var hasArmorParts = typeInfo.HasArmorParts;
+        var hasColorFields = typeInfo.HasColorFields;
+
+        IReadOnlyList<string> resRefs = typeInfo.ModelType switch
+        {
+            0 or 1 => ResolveSingle(itemClass, uti.ModelPart1),
+            2 => ResolveComposite(itemClass, uti.ModelPart1, uti.ModelPart2, uti.ModelPart3),
+            3 => ResolveArmor(uti.ArmorParts),
+            _ => Array.Empty<string>(),
+        };
+
+        return new ItemModelResolution(resRefs, hasArmorParts, hasColorFields, resRefs.Count > 0);
+    }
+
+    private IReadOnlyList<string> ResolveSingle(string? itemClass, byte partNumber)
+    {
+        if (string.IsNullOrEmpty(itemClass) || itemClass == "****" || partNumber == 0)
+            return Array.Empty<string>();
+
+        var resRef = $"{itemClass}_{partNumber:D3}".ToLowerInvariant();
+        return ResourceExists(resRef) ? new[] { resRef } : Array.Empty<string>();
+    }
+
+    private IReadOnlyList<string> ResolveComposite(string? itemClass, byte b, byte m, byte t)
+    {
+        if (string.IsNullOrEmpty(itemClass) || itemClass == "****")
+            return Array.Empty<string>();
+
+        var candidates = new[]
+        {
+            ("b", b),
+            ("m", m),
+            ("t", t),
+        };
+
+        var found = new List<string>();
+        foreach (var (position, partNumber) in candidates)
+        {
+            if (partNumber == 0)
+                continue;
+
+            var resRef = $"{itemClass}_{position}_{partNumber:D3}".ToLowerInvariant();
+            if (ResourceExists(resRef))
+                found.Add(resRef);
+        }
+
+        return found;
+    }
+
+    private IReadOnlyList<string> ResolveArmor(Dictionary<string, byte> armorParts)
+    {
+        if (armorParts.Count == 0)
+            return Array.Empty<string>();
+
+        var found = new List<string>();
+        foreach (var (key, partNumber) in armorParts)
+        {
+            if (partNumber == 0)
+                continue;
+
+            if (!ArmorPartKeyToMdlSuffix.TryGetValue(key, out var suffix))
+                continue;
+
+            var resRef = $"{_armorMannequinPrefix}_{suffix}{partNumber:D3}".ToLowerInvariant();
+            if (ResourceExists(resRef))
+                found.Add(resRef);
+        }
+
+        return found;
+    }
+
+    private bool ResourceExists(string resRef) =>
+        _gameDataService.FindResource(resRef, ResourceTypes.Mdl) != null;
+}

--- a/Radoub.UI/Radoub.UI/Services/PaletteColorService.cs
+++ b/Radoub.UI/Radoub.UI/Services/PaletteColorService.cs
@@ -19,6 +19,11 @@ public class PaletteColorService
 
     /// <summary>
     /// Palette file names for each color type.
+    ///
+    /// Per the BioWare Aurora item format spec (Section 2.1.2.4): all six armor color
+    /// fields index into the SAME single palette per material — there is no <c>pal_*02</c>
+    /// in NWN. The "1" / "2" distinction is which PLT layer pixel they apply to in the
+    /// rendered armor texture, not which palette file. Same convention for tattoo1/2.
     /// </summary>
     public static class Palettes
     {
@@ -28,13 +33,14 @@ public class PaletteColorService
         public const string Tattoo1 = "pal_tattoo01";
         public const string Tattoo2 = "pal_tattoo01"; // Same palette as Tattoo1
 
-        // Item palettes
+        // Item palettes — all "2" slots use the same palette file as the matching "1" slot
+        // per the wiki spec (Cloth2 indexes pal_cloth01.tga, Leather2 → pal_leath01.tga, etc.)
         public const string Cloth1 = "pal_cloth01";
-        public const string Cloth2 = "pal_cloth02";
+        public const string Cloth2 = "pal_cloth01"; // Same palette as Cloth1 (pal_cloth02 does not exist)
         public const string Leather1 = "pal_leath01";
-        public const string Leather2 = "pal_leath02";
+        public const string Leather2 = "pal_leath01"; // Same palette as Leather1
         public const string Metal1 = "pal_armor01";
-        public const string Metal2 = "pal_armor02";
+        public const string Metal2 = "pal_armor01"; // Same palette as Metal1
     }
 
     public PaletteColorService(IGameDataService gameDataService)
@@ -130,14 +136,23 @@ public class PaletteColorService
         try
         {
             var data = _gameDataService.FindResource(paletteName, ResourceTypes.Tga);
-            if (data != null)
+            if (data == null)
+            {
+                Radoub.Formats.Logging.UnifiedLogger.LogApplication(
+                    Radoub.Formats.Logging.LogLevel.DEBUG,
+                    $"PaletteColorService: palette TGA '{paletteName}' not found in game resources");
+            }
+            else
             {
                 palette = TgaReader.Read(data);
             }
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            // Failed to load palette - will use fallback color
+            // Log so future "all gray" diagnoses don't require code reading.
+            Radoub.Formats.Logging.UnifiedLogger.LogApplication(
+                Radoub.Formats.Logging.LogLevel.DEBUG,
+                $"PaletteColorService: failed to parse palette '{paletteName}': {ex.GetType().Name}: {ex.Message}");
         }
 
         _paletteCache[paletteName] = palette;

--- a/Radoub.UI/Radoub.UI/Services/TextureService.cs
+++ b/Radoub.UI/Radoub.UI/Services/TextureService.cs
@@ -72,6 +72,11 @@ public class TextureService
 
             var layerColors = BuildLayerColors(colorIndices);
 
+            // Diagnostic: when TRACE level is enabled, count layer usage. Lets users
+            // confirm whether a "color spinner has no visible effect" complaint is a
+            // bug or just a content limitation (PLT painted with only layer-1 pixels).
+            LogLayerHistogram(pltResRef, pltFile);
+
             // Render the PLT and flip to OpenGL orientation (bottom-up)
             var pixels = PltReader.Render(pltFile, palettes, layerColors);
             FlipVertically(pixels, pltFile.Width, pltFile.Height);
@@ -449,6 +454,53 @@ public class TextureService
 
         return null;
     }
+
+    /// <summary>Set of PLT ResRefs whose layer histogram has already been logged.</summary>
+    private readonly HashSet<string> _layerHistogramLogged = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// One-time-per-ResRef PLT layer pixel count log at INFO level. Used to confirm
+    /// whether a particular texture actually paints the metal2/cloth2/leather2 layers —
+    /// many BioWare base-game armors only use layer-1 (single-tone), so changes to the
+    /// "2" color spinners have no visible effect on those textures.
+    /// </summary>
+    private void LogLayerHistogram(string pltResRef, PltFile plt)
+    {
+        if (!_layerHistogramLogged.Add(pltResRef.ToLowerInvariant())) return;
+
+        var counts = new int[10];
+        foreach (var pixel in plt.Pixels)
+        {
+            if (pixel.LayerId < counts.Length) counts[pixel.LayerId]++;
+        }
+        var nonZero = new System.Text.StringBuilder();
+        for (int i = 0; i < counts.Length; i++)
+        {
+            if (counts[i] == 0) continue;
+            if (nonZero.Length > 0) nonZero.Append(", ");
+            nonZero.Append($"{LayerName(i)}={counts[i]}");
+        }
+        if (nonZero.Length == 0) nonZero.Append("(no painted pixels)");
+
+        Radoub.Formats.Logging.UnifiedLogger.LogApplication(
+            Radoub.Formats.Logging.LogLevel.INFO,
+            $"PLT '{pltResRef}' layer pixel counts: {nonZero}");
+    }
+
+    private static string LayerName(int layerId) => layerId switch
+    {
+        PltLayers.Skin => "skin",
+        PltLayers.Hair => "hair",
+        PltLayers.Metal1 => "metal1",
+        PltLayers.Metal2 => "metal2",
+        PltLayers.Cloth1 => "cloth1",
+        PltLayers.Cloth2 => "cloth2",
+        PltLayers.Leather1 => "leather1",
+        PltLayers.Leather2 => "leather2",
+        PltLayers.Tattoo1 => "tattoo1",
+        PltLayers.Tattoo2 => "tattoo2",
+        _ => $"layer{layerId}",
+    };
 
     /// <summary>
     /// Build layer color mapping from PltColorIndices.

--- a/Radoub.UI/Radoub.UI/Views/ColorPickerWindow.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Views/ColorPickerWindow.axaml.cs
@@ -30,7 +30,16 @@ public partial class ColorPickerWindow : Window
     [Obsolete("Designer use only", error: true)]
     public ColorPickerWindow() => throw new NotSupportedException("Use parameterized constructor");
 
-    public ColorPickerWindow(PaletteColorService paletteColorService, string paletteName, byte currentColorIndex)
+    /// <param name="paletteName">Palette TGA file name (e.g. "pal_cloth01"). Per the
+    /// Aurora item format spec, both "1" and "2" slots for a material share one palette,
+    /// so this no longer uniquely identifies the slot — pass <paramref name="dialogTitle"/>
+    /// for slot-specific titling.</param>
+    /// <param name="dialogTitle">User-facing dialog title (e.g. "Select Cloth 2 Color").</param>
+    public ColorPickerWindow(
+        PaletteColorService paletteColorService,
+        string paletteName,
+        byte currentColorIndex,
+        string? dialogTitle = null)
     {
         InitializeComponent();
 
@@ -43,7 +52,7 @@ public partial class ColorPickerWindow : Window
         _currentColorLabel = this.FindControl<TextBlock>("CurrentColorLabel")!;
         _titleLabel = this.FindControl<TextBlock>("TitleLabel")!;
 
-        _titleLabel.Text = GetPaletteDisplayName(paletteName);
+        _titleLabel.Text = dialogTitle ?? GetPaletteDisplayName(paletteName);
 
         BuildColorGrid();
         SelectColor(currentColorIndex);
@@ -54,19 +63,21 @@ public partial class ColorPickerWindow : Window
         AvaloniaXamlLoader.Load(this);
     }
 
+    /// <summary>
+    /// Fallback title for callers that don't pass an explicit dialogTitle. Cannot
+    /// distinguish "1" from "2" slots since they share a palette file — callers should
+    /// pass <c>dialogTitle</c> for slot-specific labels.
+    /// </summary>
     private static string GetPaletteDisplayName(string paletteName)
     {
         return paletteName switch
         {
             PaletteColorService.Palettes.Skin => "Select Skin Color",
             PaletteColorService.Palettes.Hair => "Select Hair Color",
-            PaletteColorService.Palettes.Tattoo1 or PaletteColorService.Palettes.Tattoo2 => "Select Tattoo Color",
-            PaletteColorService.Palettes.Cloth1 => "Select Cloth 1 Color",
-            PaletteColorService.Palettes.Cloth2 => "Select Cloth 2 Color",
-            PaletteColorService.Palettes.Leather1 => "Select Leather 1 Color",
-            PaletteColorService.Palettes.Leather2 => "Select Leather 2 Color",
-            PaletteColorService.Palettes.Metal1 => "Select Metal 1 Color",
-            PaletteColorService.Palettes.Metal2 => "Select Metal 2 Color",
+            PaletteColorService.Palettes.Tattoo1 => "Select Tattoo Color",
+            PaletteColorService.Palettes.Cloth1 => "Select Cloth Color",
+            PaletteColorService.Palettes.Leather1 => "Select Leather Color",
+            PaletteColorService.Palettes.Metal1 => "Select Metal Color",
             _ => "Select Color"
         };
     }

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -11,11 +11,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Feature: Item Model 3D Preview (#1908, PR3b)
 
-- 3D preview of currently-edited item in the Appearance expander
+- 3D preview of currently-edited item in the Appearance expander, with view-preset buttons (Front/Back/Left/Right/Reset) and a "No 3D model" placeholder
 - Static rendering only (no animations) via shared `ModelPreviewGLControl`
 - ModelType coverage: Simple weapons (single MDL), Layered items (single MDL + Cloth1/2 PLT colors), Composite weapons (3 ResRefs joined via `MdlPartComposer.ComposeFlat`), Armor (full `ArmorParts` dict on `pmh0` mannequin via `MdlPartComposer.Compose` + all 6 PLT colors)
 - 100ms debounce on color spinner `PropertyChanged` so rapid edits coalesce into a single reload
 - Per-MainWindow `TextureService` ownership matching QM's pattern
+- Held weapons (sword, bow, crossbow, polearm, two-bladed, sling, thrown) get a 90° X-axis trophy rotation so they display blade-up; helmets, armor, and other non-held items keep their authored orientation
+- ArmorParts changes (Torso, Pelvis, Belt, etc.) now trigger preview reloads via prefix-matched `ArmorPart_*` PropertyChanged events
+
+### UI Polish
+
+- Armor Parts list reordered to match Aurora's anatomical top-to-bottom + left/right paired layout, with Robe last
+- User-friendly armor part labels ("Right Shoulder" instead of "RShoul")
+- New Armor Class display next to the Armor Parts header (read-only, derived from `parts_chest.2da[Torso].ACBONUS` per Aurora item format spec)
+
+### Shared Library Fixes (Radoub.Formats + Radoub.UI)
+
+- Layer-2 color slots (Cloth2/Leather2/Metal2/Tattoo2) now correctly index the `pal_*01.tga` palette files — the `_02` files don't exist in NWN per Aurora item format spec Section 2.1.2.4. Fixes ColorPickerWindow showing all-gray swatches for layer-2 slots and layer-2 color spinners having no visible effect on PLT-rendered armor textures.
+- `BaseItemTypeInfo.WeaponWield` + `IsHeldWeapon` exposed for tools that need to distinguish held weapons from other items.
+- `MdlPartComposer.Compose/ComposeFlat`, `MdlPartBoneMap`, `MdlPartNaming` and `ItemModelResolver` shipped earlier in PR3a (#2160) and PR1 (#2151); this PR is the consumer wiring.
+
+### Diagnostics
+
+- `TextureService.RenderPltTexture` logs a one-time-per-PLT layer pixel histogram at INFO level for diagnosis of "color slot has no visible effect" reports
+- `PaletteColorService.GetPalette` logs DEBUG entries on TGA load failure (was silently returning gray)
 
 ---
 

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.10.12-alpha] - 2026-05-03
+**Branch**: `relique/issue-1908` | **PR**: #2157
+
+### Feature: Item Model 3D Preview (#1908, PR3b)
+
+- 3D preview of currently-edited item in the Appearance expander
+- Static rendering only (no animations) via shared `ModelPreviewGLControl`
+- ModelType coverage: Simple weapons (single MDL), Layered items (single MDL + Cloth1/2 PLT colors), Composite weapons (3 ResRefs joined via `MdlPartComposer.ComposeFlat`), Armor (full `ArmorParts` dict on `pmh0` mannequin via `MdlPartComposer.Compose` + all 6 PLT colors)
+- 100ms debounce on color spinner `PropertyChanged` so rapid edits coalesce into a single reload
+- Per-MainWindow `TextureService` ownership matching QM's pattern
+
+---
+
 ## [0.10.11-alpha] - 2026-05-01
 **Branch**: `radoub/issue-2159` | **PR**: #2160
 

--- a/Relique/Relique.Tests/Services/ItemPreviewControllerTests.cs
+++ b/Relique/Relique.Tests/Services/ItemPreviewControllerTests.cs
@@ -38,10 +38,12 @@ public class ItemPreviewControllerTests
         public int ClearCount { get; private set; }
         public (int metal1, int metal2, int cloth1, int cloth2, int leather1, int leather2)? LastArmorColors { get; private set; }
         public int ArmorColorsCallCount { get; private set; }
+        public Quaternion LastModelRootOrientation { get; private set; } = Quaternion.Identity;
 
         public void SetModel(MdlModel model)
         {
             CurrentModel = model;
+            LastModelRootOrientation = model.GeometryRoot?.Orientation ?? Quaternion.Identity;
             PlaceholderVisible = false;
             LoadCount++;
         }
@@ -67,16 +69,20 @@ public class ItemPreviewControllerTests
         var game = new MockGameDataService(includeSampleData: false);
 
         var baseItems = new TwoDAFile();
-        baseItems.Columns.AddRange(new[] { "Label", "ItemClass", "ModelType", "DefaultModel" });
+        baseItems.Columns.AddRange(new[] { "Label", "ItemClass", "ModelType", "DefaultModel", "WeaponWield" });
 
-        // Row 0: Simple weapon
-        baseItems.Rows.Add(new TwoDARow { Label = "0", Values = new() { "BASE_ITEM_LONGSWORD", "w_swrd", "0", "w_swrd_001" } });
-        // Row 1: Layered (cloak)
-        baseItems.Rows.Add(new TwoDARow { Label = "1", Values = new() { "BASE_ITEM_CLOAK", "cloak", "1", "cloak_001" } });
-        // Row 2: Composite weapon
-        baseItems.Rows.Add(new TwoDARow { Label = "2", Values = new() { "BASE_ITEM_TWOBLADEDSWORD", "wdbsw", "2", "wdbsw_b_001" } });
-        // Row 3: Armor
-        baseItems.Rows.Add(new TwoDARow { Label = "3", Values = new() { "BASE_ITEM_ARMOR", "armor", "3", "****" } });
+        // Row 0: Simple weapon (longsword) — WeaponWield=**** (default melee held weapon)
+        baseItems.Rows.Add(new TwoDARow { Label = "0", Values = new() { "BASE_ITEM_LONGSWORD", "w_swrd", "0", "w_swrd_001", "****" } });
+        // Row 1: Layered (cloak) — WeaponWield=1 (nonweapon)
+        baseItems.Rows.Add(new TwoDARow { Label = "1", Values = new() { "BASE_ITEM_CLOAK", "cloak", "1", "cloak_001", "1" } });
+        // Row 2: Composite weapon (twobladed) — WeaponWield=8 (two-bladed)
+        baseItems.Rows.Add(new TwoDARow { Label = "2", Values = new() { "BASE_ITEM_TWOBLADEDSWORD", "wdbsw", "2", "wdbsw_b_001", "8" } });
+        // Row 3: Armor — WeaponWield=1 (nonweapon)
+        baseItems.Rows.Add(new TwoDARow { Label = "3", Values = new() { "BASE_ITEM_ARMOR", "armor", "3", "****", "1" } });
+        // Row 4: Helmet — ModelType=0, WeaponWield=1 (nonweapon — should NOT rotate even though ModelType matches simple weapon)
+        baseItems.Rows.Add(new TwoDARow { Label = "4", Values = new() { "BASE_ITEM_HELMET", "helm", "0", "helm_001", "1" } });
+        // Row 5: Bow — WeaponWield=5 (held; should rotate)
+        baseItems.Rows.Add(new TwoDARow { Label = "5", Values = new() { "BASE_ITEM_LONGBOW", "w_bow", "0", "w_bow_001", "5" } });
 
         game.With2DA("baseitems", baseItems);
         return game;
@@ -107,12 +113,13 @@ public class ItemPreviewControllerTests
         // Register a placeholder MDL byte for any ResRef — the loader func returns synthetic MdlModels
         setupResources?.Invoke(game);
 
-        var resolver = new ItemModelResolver(new BaseItemTypeService(game), game);
+        var baseItemSvc = new BaseItemTypeService(game);
+        var resolver = new ItemModelResolver(baseItemSvc, game);
         var composer = new MdlPartComposer(game, (resRef, _) => MakePartModel(resRef));
         var renderer = new FakePreviewRenderer();
 
         // Test mode: pump debounce manually via FlushDebounce()
-        var controller = new ItemPreviewController(resolver, composer, renderer, debounceManually: true);
+        var controller = new ItemPreviewController(resolver, composer, renderer, baseItemSvc, debounceManually: true);
         return (renderer, controller, game);
     }
 
@@ -338,5 +345,119 @@ public class ItemPreviewControllerTests
         controller.FlushDebounce();
 
         Assert.Equal(loadsAfterBind, renderer.LoadCount);
+    }
+
+    // ----- New tests for orientation + ArmorParts watching (#1908 PR3b follow-up) -----
+
+    [Fact]
+    public void ArmorPartChange_TriggersReload()
+    {
+        var (renderer, controller, game) = BuildController(g =>
+        {
+            g.SetResource("pmh0_chest005", ResourceTypes.Mdl, new byte[] { 1 });
+            g.SetResource("pmh0_chest010", ResourceTypes.Mdl, new byte[] { 1 });
+        });
+        var uti = new UtiFile { BaseItem = 3 };
+        uti.ArmorParts["Torso"] = 5;
+        var vm = new ItemViewModel(uti);
+
+        controller.BindViewModel(vm);
+        controller.FlushDebounce();
+        var loadsAfterInitial = renderer.LoadCount;
+
+        // Change Torso part — fires PropertyChanged("ArmorPart_Torso")
+        vm.SetArmorPart("Torso", 10);
+        controller.FlushDebounce();
+
+        Assert.Equal(loadsAfterInitial + 1, renderer.LoadCount);
+    }
+
+    [Fact]
+    public void Bind_HeldWeapon_AppliesXRotationToModelRoot()
+    {
+        var (renderer, controller, _) = BuildController(g =>
+            g.SetResource("w_swrd_001", ResourceTypes.Mdl, new byte[] { 1 }));
+        // BaseItem=0 → longsword in our test 2DA, WeaponWield=**** → IsHeldWeapon=true
+        var vm = new ItemViewModel(new UtiFile { BaseItem = 0, ModelPart1 = 1 });
+
+        controller.BindViewModel(vm);
+        controller.FlushDebounce();
+
+        Assert.NotNull(renderer.CurrentModel);
+        // Held weapons should be rotated 90° around X so Y-axis-up becomes Z-axis-up.
+        // The exact quaternion: (sin(45°), 0, 0, cos(45°)) ≈ (0.707, 0, 0, 0.707).
+        const float tol = 0.001f;
+        var expected = Quaternion.CreateFromAxisAngle(Vector3.UnitX, MathF.PI / 2f);
+        Assert.Equal(expected.X, renderer.LastModelRootOrientation.X, tol);
+        Assert.Equal(expected.Y, renderer.LastModelRootOrientation.Y, tol);
+        Assert.Equal(expected.Z, renderer.LastModelRootOrientation.Z, tol);
+        Assert.Equal(expected.W, renderer.LastModelRootOrientation.W, tol);
+    }
+
+    [Fact]
+    public void Bind_CompositeWeapon_AppliesXRotationToModelRoot()
+    {
+        var (renderer, controller, _) = BuildController(g =>
+        {
+            g.SetResource("wdbsw_b_011", ResourceTypes.Mdl, new byte[] { 1 });
+            g.SetResource("wdbsw_m_011", ResourceTypes.Mdl, new byte[] { 1 });
+            g.SetResource("wdbsw_t_011", ResourceTypes.Mdl, new byte[] { 1 });
+        });
+        // BaseItem=2 → twobladed sword, WeaponWield=8 → IsHeldWeapon=true
+        var vm = new ItemViewModel(new UtiFile { BaseItem = 2, ModelPart1 = 11, ModelPart2 = 11, ModelPart3 = 11 });
+
+        controller.BindViewModel(vm);
+        controller.FlushDebounce();
+
+        Assert.NotNull(renderer.CurrentModel);
+        Assert.NotEqual(Quaternion.Identity, renderer.LastModelRootOrientation);
+    }
+
+    [Fact]
+    public void Bind_Helmet_DoesNotApplyRotation()
+    {
+        var (renderer, controller, _) = BuildController(g =>
+            g.SetResource("helm_001", ResourceTypes.Mdl, new byte[] { 1 }));
+        // BaseItem=4 → helmet, ModelType=0 BUT WeaponWield=1 → IsHeldWeapon=false
+        var vm = new ItemViewModel(new UtiFile { BaseItem = 4, ModelPart1 = 1 });
+
+        controller.BindViewModel(vm);
+        controller.FlushDebounce();
+
+        Assert.NotNull(renderer.CurrentModel);
+        Assert.Equal(Quaternion.Identity, renderer.LastModelRootOrientation);
+    }
+
+    [Fact]
+    public void Bind_Armor_DoesNotApplyRotation()
+    {
+        var (renderer, controller, _) = BuildController(g =>
+        {
+            g.SetResource("pmh0_chest005", ResourceTypes.Mdl, new byte[] { 1 });
+        });
+        var uti = new UtiFile { BaseItem = 3 };
+        uti.ArmorParts["Torso"] = 5;
+        var vm = new ItemViewModel(uti);
+
+        controller.BindViewModel(vm);
+        controller.FlushDebounce();
+
+        Assert.NotNull(renderer.CurrentModel);
+        Assert.Equal(Quaternion.Identity, renderer.LastModelRootOrientation);
+    }
+
+    [Fact]
+    public void Bind_Bow_AppliesXRotation()
+    {
+        var (renderer, controller, _) = BuildController(g =>
+            g.SetResource("w_bow_001", ResourceTypes.Mdl, new byte[] { 1 }));
+        // BaseItem=5 → bow, WeaponWield=5 → IsHeldWeapon=true
+        var vm = new ItemViewModel(new UtiFile { BaseItem = 5, ModelPart1 = 1 });
+
+        controller.BindViewModel(vm);
+        controller.FlushDebounce();
+
+        Assert.NotNull(renderer.CurrentModel);
+        Assert.NotEqual(Quaternion.Identity, renderer.LastModelRootOrientation);
     }
 }

--- a/Relique/Relique.Tests/Services/ItemPreviewControllerTests.cs
+++ b/Relique/Relique.Tests/Services/ItemPreviewControllerTests.cs
@@ -1,0 +1,342 @@
+using ItemEditor.Services;
+using ItemEditor.ViewModels;
+using Radoub.Formats.Common;
+using Radoub.Formats.Mdl;
+using Radoub.Formats.Services;
+using Radoub.Formats.TwoDA;
+using Radoub.Formats.Uti;
+using Radoub.TestUtilities.Mocks;
+using Radoub.UI.Services;
+using System.Numerics;
+using Xunit;
+
+namespace ItemEditor.Tests.Services;
+
+/// <summary>
+/// Tests the wiring layer between ItemViewModel + ItemModelResolver + MdlPartComposer
+/// + the live preview renderer. Uses a FakePreviewRenderer to verify what gets pushed
+/// to the renderer in response to view-model property changes.
+///
+/// Per the plan (NonPublic/Plans/2026-04-30-1996-1908-plan.md, PR3b section), behavior to verify:
+///  - ModelType 0/1/2 (Simple/Layered/Composite) → renderer.Model set, no SetArmorColors
+///    (Layered uses Cloth1/2 colors via SetArmorColors, see plan)
+///  - ModelType 3 (Armor) → renderer.Model set + SetArmorColors with all six colors
+///  - PropertyChanged for non-tracked fields → no preview update
+///  - Rapid PropertyChanged bursts collapse to a single reload after debounce
+///  - HasModel=false → renderer cleared, placeholder visible
+///  - Unbind() detaches the PropertyChanged handler
+/// </summary>
+public class ItemPreviewControllerTests
+{
+    // ----- Fakes -----
+
+    private sealed class FakePreviewRenderer : IItemPreviewRenderer
+    {
+        public MdlModel? CurrentModel { get; private set; }
+        public bool PlaceholderVisible { get; private set; }
+        public int LoadCount { get; private set; }
+        public int ClearCount { get; private set; }
+        public (int metal1, int metal2, int cloth1, int cloth2, int leather1, int leather2)? LastArmorColors { get; private set; }
+        public int ArmorColorsCallCount { get; private set; }
+
+        public void SetModel(MdlModel model)
+        {
+            CurrentModel = model;
+            PlaceholderVisible = false;
+            LoadCount++;
+        }
+
+        public void Clear()
+        {
+            CurrentModel = null;
+            PlaceholderVisible = true;
+            ClearCount++;
+        }
+
+        public void SetArmorColors(int metal1, int metal2, int cloth1, int cloth2, int leather1, int leather2)
+        {
+            LastArmorColors = (metal1, metal2, cloth1, cloth2, leather1, leather2);
+            ArmorColorsCallCount++;
+        }
+    }
+
+    // ----- Setup helpers -----
+
+    private static MockGameDataService BuildGameData()
+    {
+        var game = new MockGameDataService(includeSampleData: false);
+
+        var baseItems = new TwoDAFile();
+        baseItems.Columns.AddRange(new[] { "Label", "ItemClass", "ModelType", "DefaultModel" });
+
+        // Row 0: Simple weapon
+        baseItems.Rows.Add(new TwoDARow { Label = "0", Values = new() { "BASE_ITEM_LONGSWORD", "w_swrd", "0", "w_swrd_001" } });
+        // Row 1: Layered (cloak)
+        baseItems.Rows.Add(new TwoDARow { Label = "1", Values = new() { "BASE_ITEM_CLOAK", "cloak", "1", "cloak_001" } });
+        // Row 2: Composite weapon
+        baseItems.Rows.Add(new TwoDARow { Label = "2", Values = new() { "BASE_ITEM_TWOBLADEDSWORD", "wdbsw", "2", "wdbsw_b_001" } });
+        // Row 3: Armor
+        baseItems.Rows.Add(new TwoDARow { Label = "3", Values = new() { "BASE_ITEM_ARMOR", "armor", "3", "****" } });
+
+        game.With2DA("baseitems", baseItems);
+        return game;
+    }
+
+    private static MdlModel MakePartModel(string name)
+    {
+        var root = new MdlNode { Name = name + "_root", Orientation = Quaternion.Identity, Scale = 1.0f };
+        var mesh = new MdlTrimeshNode
+        {
+            Name = name + "_mesh",
+            Position = Vector3.Zero,
+            Orientation = Quaternion.Identity,
+            Scale = 1.0f,
+            Vertices = new[] { new Vector3(1, 0, 0) },
+            Faces = System.Array.Empty<MdlFace>(),
+            Parent = root,
+        };
+        root.Children.Add(mesh);
+        return new MdlModel { Name = name, GeometryRoot = root, IsBinary = true };
+    }
+
+    private static (FakePreviewRenderer renderer, ItemPreviewController controller, MockGameDataService game)
+        BuildController(System.Action<MockGameDataService>? setupResources = null)
+    {
+        var game = BuildGameData();
+
+        // Register a placeholder MDL byte for any ResRef — the loader func returns synthetic MdlModels
+        setupResources?.Invoke(game);
+
+        var resolver = new ItemModelResolver(new BaseItemTypeService(game), game);
+        var composer = new MdlPartComposer(game, (resRef, _) => MakePartModel(resRef));
+        var renderer = new FakePreviewRenderer();
+
+        // Test mode: pump debounce manually via FlushDebounce()
+        var controller = new ItemPreviewController(resolver, composer, renderer, debounceManually: true);
+        return (renderer, controller, game);
+    }
+
+    // ----- Tests -----
+
+    [Fact]
+    public void Bind_NullViewModel_ClearsPreview()
+    {
+        var (renderer, controller, _) = BuildController();
+
+        controller.BindViewModel(null);
+        controller.FlushDebounce();
+
+        Assert.True(renderer.PlaceholderVisible);
+        Assert.Null(renderer.CurrentModel);
+    }
+
+    [Fact]
+    public void Bind_SimpleWeapon_LoadsSingleModelAndDoesNotApplyColors()
+    {
+        var (renderer, controller, game) = BuildController(g =>
+            g.SetResource("w_swrd_005", ResourceTypes.Mdl, new byte[] { 1 }));
+        var vm = new ItemViewModel(new UtiFile { BaseItem = 0, ModelPart1 = 5 });
+
+        controller.BindViewModel(vm);
+        controller.FlushDebounce();
+
+        Assert.NotNull(renderer.CurrentModel);
+        Assert.False(renderer.PlaceholderVisible);
+        Assert.Equal(0, renderer.ArmorColorsCallCount);
+    }
+
+    [Fact]
+    public void Bind_LayeredItem_LoadsModelAndAppliesClothColorsOnly()
+    {
+        var (renderer, controller, game) = BuildController(g =>
+            g.SetResource("cloak_003", ResourceTypes.Mdl, new byte[] { 1 }));
+        var vm = new ItemViewModel(new UtiFile
+        {
+            BaseItem = 1,
+            ModelPart1 = 3,
+            Cloth1Color = 7,
+            Cloth2Color = 11,
+            Metal1Color = 99,   // should be ignored for ModelType 1
+            Leather1Color = 99, // should be ignored for ModelType 1
+        });
+
+        controller.BindViewModel(vm);
+        controller.FlushDebounce();
+
+        Assert.NotNull(renderer.CurrentModel);
+        Assert.NotNull(renderer.LastArmorColors);
+        // Cloth1/2 set; metal/leather forced to 0 to avoid recoloring non-cloth layers
+        Assert.Equal(7, renderer.LastArmorColors!.Value.cloth1);
+        Assert.Equal(11, renderer.LastArmorColors.Value.cloth2);
+        Assert.Equal(0, renderer.LastArmorColors.Value.metal1);
+        Assert.Equal(0, renderer.LastArmorColors.Value.leather1);
+    }
+
+    [Fact]
+    public void Bind_CompositeWeapon_LoadsThreePartsViaComposeFlatNoColors()
+    {
+        var (renderer, controller, game) = BuildController(g =>
+        {
+            g.SetResource("wdbsw_b_011", ResourceTypes.Mdl, new byte[] { 1 });
+            g.SetResource("wdbsw_m_021", ResourceTypes.Mdl, new byte[] { 1 });
+            g.SetResource("wdbsw_t_031", ResourceTypes.Mdl, new byte[] { 1 });
+        });
+        var vm = new ItemViewModel(new UtiFile
+        {
+            BaseItem = 2,
+            ModelPart1 = 11,
+            ModelPart2 = 21,
+            ModelPart3 = 31,
+            Cloth1Color = 99, // should be ignored for ModelType 2
+        });
+
+        controller.BindViewModel(vm);
+        controller.FlushDebounce();
+
+        Assert.NotNull(renderer.CurrentModel);
+        Assert.Equal(3, renderer.CurrentModel!.GetMeshNodes().Count());
+        Assert.Equal(0, renderer.ArmorColorsCallCount);
+    }
+
+    [Fact]
+    public void Bind_Armor_LoadsCompositeAndAppliesAllSixColors()
+    {
+        var (renderer, controller, game) = BuildController(g =>
+        {
+            g.SetResource("pmh0_chest005", ResourceTypes.Mdl, new byte[] { 1 });
+            g.SetResource("pmh0_pelvis002", ResourceTypes.Mdl, new byte[] { 1 });
+        });
+        var uti = new UtiFile
+        {
+            BaseItem = 3,
+            Cloth1Color = 1,
+            Cloth2Color = 2,
+            Leather1Color = 3,
+            Leather2Color = 4,
+            Metal1Color = 5,
+            Metal2Color = 6,
+        };
+        uti.ArmorParts["Torso"] = 5;
+        uti.ArmorParts["Pelvis"] = 2;
+        var vm = new ItemViewModel(uti);
+
+        controller.BindViewModel(vm);
+        controller.FlushDebounce();
+
+        Assert.NotNull(renderer.CurrentModel);
+        Assert.NotNull(renderer.LastArmorColors);
+        Assert.Equal(5, renderer.LastArmorColors!.Value.metal1);
+        Assert.Equal(6, renderer.LastArmorColors.Value.metal2);
+        Assert.Equal(1, renderer.LastArmorColors.Value.cloth1);
+        Assert.Equal(2, renderer.LastArmorColors.Value.cloth2);
+        Assert.Equal(3, renderer.LastArmorColors.Value.leather1);
+        Assert.Equal(4, renderer.LastArmorColors.Value.leather2);
+    }
+
+    [Fact]
+    public void ModelPartChange_TriggersReload()
+    {
+        var (renderer, controller, game) = BuildController(g =>
+        {
+            g.SetResource("w_swrd_005", ResourceTypes.Mdl, new byte[] { 1 });
+            g.SetResource("w_swrd_010", ResourceTypes.Mdl, new byte[] { 1 });
+        });
+        var vm = new ItemViewModel(new UtiFile { BaseItem = 0, ModelPart1 = 5 });
+
+        controller.BindViewModel(vm);
+        controller.FlushDebounce();
+        var initialLoads = renderer.LoadCount;
+
+        vm.ModelPart1 = 10;
+        controller.FlushDebounce();
+
+        Assert.Equal(initialLoads + 1, renderer.LoadCount);
+    }
+
+    [Fact]
+    public void RapidPropertyChanges_CollapseToSingleReload()
+    {
+        var (renderer, controller, game) = BuildController(g =>
+        {
+            g.SetResource("pmh0_chest001", ResourceTypes.Mdl, new byte[] { 1 });
+        });
+        var uti = new UtiFile { BaseItem = 3 };
+        uti.ArmorParts["Torso"] = 1;
+        var vm = new ItemViewModel(uti);
+
+        controller.BindViewModel(vm);
+        controller.FlushDebounce();
+        var loadsAfterInitial = renderer.LoadCount;
+
+        // Burst of 5 color changes — debounce should collapse them
+        vm.Cloth1Color = 1;
+        vm.Cloth2Color = 2;
+        vm.Leather1Color = 3;
+        vm.Metal1Color = 4;
+        vm.Metal2Color = 5;
+        controller.FlushDebounce();
+
+        Assert.Equal(loadsAfterInitial + 1, renderer.LoadCount);
+    }
+
+    [Fact]
+    public void IrrelevantPropertyChange_DoesNotTriggerReload()
+    {
+        var (renderer, controller, game) = BuildController(g =>
+            g.SetResource("w_swrd_005", ResourceTypes.Mdl, new byte[] { 1 }));
+        var vm = new ItemViewModel(new UtiFile { BaseItem = 0, ModelPart1 = 5, Tag = "old" });
+
+        controller.BindViewModel(vm);
+        controller.FlushDebounce();
+        var loadsAfterInitial = renderer.LoadCount;
+
+        vm.Tag = "new"; // Tag is not in the watched property set
+        controller.FlushDebounce();
+
+        Assert.Equal(loadsAfterInitial, renderer.LoadCount);
+    }
+
+    [Fact]
+    public void HasModelFalse_ShowsPlaceholder()
+    {
+        var (renderer, controller, _) = BuildController();
+        // No MDL resources registered → resolver returns HasModel=false
+        var vm = new ItemViewModel(new UtiFile { BaseItem = 0, ModelPart1 = 5 });
+
+        controller.BindViewModel(vm);
+        controller.FlushDebounce();
+
+        Assert.True(renderer.PlaceholderVisible);
+        Assert.Null(renderer.CurrentModel);
+    }
+
+    [Fact]
+    public void BaseItemOutOfRange_ShowsPlaceholderNoCrash()
+    {
+        var (renderer, controller, _) = BuildController();
+        var vm = new ItemViewModel(new UtiFile { BaseItem = 999 });
+
+        controller.BindViewModel(vm);
+        controller.FlushDebounce();
+
+        Assert.True(renderer.PlaceholderVisible);
+    }
+
+    [Fact]
+    public void Unbind_DetachesPropertyChangedHandler()
+    {
+        var (renderer, controller, game) = BuildController(g =>
+            g.SetResource("w_swrd_005", ResourceTypes.Mdl, new byte[] { 1 }));
+        var vm = new ItemViewModel(new UtiFile { BaseItem = 0, ModelPart1 = 5 });
+
+        controller.BindViewModel(vm);
+        controller.FlushDebounce();
+        var loadsAfterBind = renderer.LoadCount;
+
+        controller.Unbind();
+        vm.ModelPart1 = 10; // should NOT trigger a reload now
+        controller.FlushDebounce();
+
+        Assert.Equal(loadsAfterBind, renderer.LoadCount);
+    }
+}

--- a/Relique/Relique/Services/IItemPreviewRenderer.cs
+++ b/Relique/Relique/Services/IItemPreviewRenderer.cs
@@ -1,0 +1,24 @@
+using Radoub.Formats.Mdl;
+
+namespace ItemEditor.Services;
+
+/// <summary>
+/// Seam between <see cref="ItemPreviewController"/> and the live OpenGL preview control.
+/// The controller owns the load/recolor/debounce decisions; the renderer just executes.
+/// A fake implementation is used for unit tests; the real production adapter wraps
+/// <c>Radoub.UI.Controls.ModelPreviewGLControl</c>.
+/// </summary>
+public interface IItemPreviewRenderer
+{
+    /// <summary>Hand the renderer a composed model to display.</summary>
+    void SetModel(MdlModel model);
+
+    /// <summary>Hide the model and show the "No 3D model" placeholder.</summary>
+    void Clear();
+
+    /// <summary>
+    /// Apply PLT colors. The controller passes 0 for any color category that does not
+    /// apply to the current ModelType (e.g. layered items only use Cloth1/2).
+    /// </summary>
+    void SetArmorColors(int metal1, int metal2, int cloth1, int cloth2, int leather1, int leather2);
+}

--- a/Relique/Relique/Services/ItemPreviewController.cs
+++ b/Relique/Relique/Services/ItemPreviewController.cs
@@ -1,11 +1,14 @@
 using ItemEditor.ViewModels;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Mdl;
+using Radoub.Formats.Services;
 using Radoub.Formats.Uti;
 using Radoub.UI.Services;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
+using System.Numerics;
 
 namespace ItemEditor.Services;
 
@@ -39,8 +42,17 @@ public sealed class ItemPreviewController
     private readonly ItemModelResolver _resolver;
     private readonly MdlPartComposer _composer;
     private readonly IItemPreviewRenderer _renderer;
+    private readonly BaseItemTypeService _baseItemTypeService;
     private readonly string _armorMannequinPrefix;
     private readonly bool _debounceManually;
+
+    /// <summary>
+    /// Held-weapon vertical orientation: rotate 90° around X so the MDL's +Y "forward"
+    /// axis (the blade) becomes +Z (up), giving a hilt-down/blade-up trophy view.
+    /// In-game this rotation comes from the rhand/lhand bone the weapon attaches to.
+    /// </summary>
+    private static readonly Quaternion HeldWeaponRotation =
+        Quaternion.CreateFromAxisAngle(Vector3.UnitX, MathF.PI / 2f);
 
     private ItemViewModel? _viewModel;
     private bool _pendingUpdate;
@@ -49,12 +61,14 @@ public sealed class ItemPreviewController
         ItemModelResolver resolver,
         MdlPartComposer composer,
         IItemPreviewRenderer renderer,
+        BaseItemTypeService baseItemTypeService,
         string armorMannequinPrefix = "pmh0",
         bool debounceManually = false)
     {
         _resolver = resolver;
         _composer = composer;
         _renderer = renderer;
+        _baseItemTypeService = baseItemTypeService;
         _armorMannequinPrefix = armorMannequinPrefix;
         _debounceManually = debounceManually;
     }
@@ -103,7 +117,13 @@ public sealed class ItemPreviewController
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == null || !WatchedProperties.Contains(e.PropertyName))
+        if (e.PropertyName == null) return;
+
+        // ItemViewModel.SetArmorPart fires PropertyChanged("ArmorPart_{partName}") for each
+        // of the 19 NWN body part keys (Belt, Torso, LBicep, etc.). Match the prefix instead
+        // of enumerating all 19 here so renames or additions stay in sync automatically.
+        bool isArmorPart = e.PropertyName.StartsWith("ArmorPart_", StringComparison.Ordinal);
+        if (!isArmorPart && !WatchedProperties.Contains(e.PropertyName))
             return;
 
         _pendingUpdate = true;
@@ -140,6 +160,8 @@ public sealed class ItemPreviewController
                 return;
             }
 
+            ApplyTrophyRotationIfHeldWeapon(uti, composed);
+
             _renderer.SetModel(composed);
 
             if (resolution.HasColorFields)
@@ -153,6 +175,25 @@ public sealed class ItemPreviewController
                 $"ItemPreviewController.ApplyUpdate failed: {ex.GetType().Name}: {ex.Message}");
             _renderer.Clear();
         }
+    }
+
+    /// <summary>
+    /// For held weapons (sword, bow, crossbow, pole, two-bladed, sling, thrown), apply a
+    /// 90° X-axis rotation to the composed model's root so the +Y "forward" axis the MDL
+    /// was authored on becomes +Z up. Without this, weapons display lying horizontally
+    /// because in-game the rhand/lhand bone supplies the rotation. Items that aren't held
+    /// weapons (helmets, amulets, armor parts) keep identity rotation.
+    /// </summary>
+    private void ApplyTrophyRotationIfHeldWeapon(UtiFile uti, MdlModel composed)
+    {
+        var typeInfo = _baseItemTypeService
+            .GetBaseItemTypes()
+            .FirstOrDefault(t => t.BaseItemIndex == uti.BaseItem);
+
+        if (typeInfo == null || !typeInfo.IsHeldWeapon) return;
+        if (composed.GeometryRoot == null) return;
+
+        composed.GeometryRoot.Orientation = HeldWeaponRotation;
     }
 
     private void ApplyColors(bool isArmor, ItemViewModel vm)

--- a/Relique/Relique/Services/ItemPreviewController.cs
+++ b/Relique/Relique/Services/ItemPreviewController.cs
@@ -1,0 +1,204 @@
+using ItemEditor.ViewModels;
+using Radoub.Formats.Logging;
+using Radoub.Formats.Mdl;
+using Radoub.Formats.Uti;
+using Radoub.UI.Services;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace ItemEditor.Services;
+
+/// <summary>
+/// Wires <see cref="ItemViewModel"/> property changes to the 3D preview renderer for
+/// the currently-edited item. Handles ModelType-specific load and recolor decisions and
+/// debounces rapid bursts (e.g. color spinner drags) so the renderer reloads at most
+/// once per quiet window. UI-thread-agnostic: the production caller schedules
+/// <see cref="FlushDebounce"/> through a <c>DispatcherTimer</c>, tests pump it manually.
+///
+/// Per the four-PR plan (NonPublic/Plans/2026-04-30-1996-1908-plan.md, PR3b section):
+/// no animations, mannequin-prefixed armor composition, debounce 100 ms.
+/// </summary>
+public sealed class ItemPreviewController
+{
+    /// <summary>VM properties that should trigger a preview reload when they change.</summary>
+    private static readonly HashSet<string> WatchedProperties = new(StringComparer.Ordinal)
+    {
+        nameof(ItemViewModel.BaseItem),
+        nameof(ItemViewModel.ModelPart1),
+        nameof(ItemViewModel.ModelPart2),
+        nameof(ItemViewModel.ModelPart3),
+        nameof(ItemViewModel.Cloth1Color),
+        nameof(ItemViewModel.Cloth2Color),
+        nameof(ItemViewModel.Leather1Color),
+        nameof(ItemViewModel.Leather2Color),
+        nameof(ItemViewModel.Metal1Color),
+        nameof(ItemViewModel.Metal2Color),
+    };
+
+    private readonly ItemModelResolver _resolver;
+    private readonly MdlPartComposer _composer;
+    private readonly IItemPreviewRenderer _renderer;
+    private readonly string _armorMannequinPrefix;
+    private readonly bool _debounceManually;
+
+    private ItemViewModel? _viewModel;
+    private bool _pendingUpdate;
+
+    public ItemPreviewController(
+        ItemModelResolver resolver,
+        MdlPartComposer composer,
+        IItemPreviewRenderer renderer,
+        string armorMannequinPrefix = "pmh0",
+        bool debounceManually = false)
+    {
+        _resolver = resolver;
+        _composer = composer;
+        _renderer = renderer;
+        _armorMannequinPrefix = armorMannequinPrefix;
+        _debounceManually = debounceManually;
+    }
+
+    public bool HasPendingUpdate => _pendingUpdate;
+
+    public void BindViewModel(ItemViewModel? vm)
+    {
+        Unbind();
+
+        _viewModel = vm;
+        if (vm == null)
+        {
+            _renderer.Clear();
+            return;
+        }
+
+        vm.PropertyChanged += OnViewModelPropertyChanged;
+        _pendingUpdate = true;
+    }
+
+    public void Unbind()
+    {
+        if (_viewModel != null)
+        {
+            _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+            _viewModel = null;
+        }
+        _pendingUpdate = false;
+    }
+
+    public void FlushDebounce()
+    {
+        if (!_pendingUpdate) return;
+        _pendingUpdate = false;
+
+        var vm = _viewModel;
+        if (vm == null)
+        {
+            _renderer.Clear();
+            return;
+        }
+
+        ApplyUpdate(vm);
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == null || !WatchedProperties.Contains(e.PropertyName))
+            return;
+
+        _pendingUpdate = true;
+        // Production hook: the code-behind owns a DispatcherTimer that observes
+        // _pendingUpdate and calls FlushDebounce after the quiet window. Tests pass
+        // debounceManually=true and call FlushDebounce directly.
+        _ = _debounceManually;
+    }
+
+    private void ApplyUpdate(ItemViewModel vm)
+    {
+        try
+        {
+            var uti = vm.Uti;
+            var resolution = _resolver.Resolve(uti);
+
+            if (!resolution.HasModel)
+            {
+                _renderer.Clear();
+                return;
+            }
+
+            // ModelType is implied by the resolver's flags + result count:
+            //   armor (3): HasArmorParts=true → Compose with skeleton+parts
+            //   simple (0) / composite (2): HasColorFields=false → ComposeFlat
+            //   layered (1): HasColorFields=true && HasArmorParts=false → ComposeFlat + cloth-only colors
+            MdlModel? composed = resolution.HasArmorParts
+                ? _composer.Compose(_armorMannequinPrefix, BuildArmorParts(resolution.MdlResRefs))
+                : _composer.ComposeFlat(resolution.MdlResRefs, $"item_{uti.BaseItem}");
+
+            if (composed == null)
+            {
+                _renderer.Clear();
+                return;
+            }
+
+            _renderer.SetModel(composed);
+
+            if (resolution.HasColorFields)
+            {
+                ApplyColors(resolution.HasArmorParts, vm);
+            }
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"ItemPreviewController.ApplyUpdate failed: {ex.GetType().Name}: {ex.Message}");
+            _renderer.Clear();
+        }
+    }
+
+    private void ApplyColors(bool isArmor, ItemViewModel vm)
+    {
+        if (isArmor)
+        {
+            // ModelType 3 — all six color slots apply
+            _renderer.SetArmorColors(
+                metal1: vm.Metal1Color,
+                metal2: vm.Metal2Color,
+                cloth1: vm.Cloth1Color,
+                cloth2: vm.Cloth2Color,
+                leather1: vm.Leather1Color,
+                leather2: vm.Leather2Color);
+        }
+        else
+        {
+            // ModelType 1 (Layered) — Cloth1/2 only. Pass 0 for the others so the
+            // renderer does not recolor metal/leather layers that don't exist on layered items.
+            _renderer.SetArmorColors(
+                metal1: 0,
+                metal2: 0,
+                cloth1: vm.Cloth1Color,
+                cloth2: vm.Cloth2Color,
+                leather1: 0,
+                leather2: 0);
+        }
+    }
+
+    /// <summary>
+    /// Recover (partType, resRef) tuples from the resolver's flat ResRef list.
+    /// The resolver produced ResRefs of the form <c>{prefix}_{partType}{partNumber:D3}</c>
+    /// (e.g. <c>pmh0_chest005</c>); peel off the prefix and the trailing 3 digits.
+    /// </summary>
+    private static List<(string PartType, string ResRef)> BuildArmorParts(IReadOnlyList<string> resolvedResRefs)
+    {
+        var parts = new List<(string, string)>(resolvedResRefs.Count);
+        foreach (var resRef in resolvedResRefs)
+        {
+            var underscore = resRef.IndexOf('_');
+            if (underscore < 0) continue;
+            var afterPrefix = resRef.AsSpan(underscore + 1);
+            if (afterPrefix.Length < 4) continue; // need at least 1-char partType + 3 digits
+            var partType = afterPrefix[..^3].ToString();
+            parts.Add((partType, resRef));
+        }
+        return parts;
+    }
+}

--- a/Relique/Relique/ViewModels/ItemViewModel.cs
+++ b/Relique/Relique/ViewModels/ItemViewModel.cs
@@ -25,6 +25,13 @@ public class ItemViewModel : INotifyPropertyChanged
         _tlkResolver = tlkResolver;
     }
 
+    /// <summary>
+    /// The underlying UTI being edited. Returned by reference (the VM does not deep-copy
+    /// on every property change) so the preview controller can pass it to
+    /// <c>ItemModelResolver.Resolve</c> directly.
+    /// </summary>
+    public UtiFile Uti => _uti;
+
     public string Name
     {
         get => GetLocString(_uti.LocalizedName);

--- a/Relique/Relique/Views/MainWindow.EditorPopulation.cs
+++ b/Relique/Relique/Views/MainWindow.EditorPopulation.cs
@@ -596,11 +596,11 @@ public partial class MainWindow
         swatch.Background = _paletteColorService.CreateGradientBrush(paletteName, colorIndex);
     }
 
-    private async void OpenColorPicker(string paletteName, byte currentIndex, Action<byte> onColorSelected)
+    private async void OpenColorPicker(string paletteName, byte currentIndex, string dialogTitle, Action<byte> onColorSelected)
     {
         if (_paletteColorService == null) return;
 
-        var picker = new Radoub.UI.Views.ColorPickerWindow(_paletteColorService, paletteName, currentIndex);
+        var picker = new Radoub.UI.Views.ColorPickerWindow(_paletteColorService, paletteName, currentIndex, dialogTitle);
         await picker.ShowDialog(this);
 
         if (picker.Confirmed)
@@ -612,7 +612,7 @@ public partial class MainWindow
     private void OnCloth1ColorBrowse(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
         if (_itemViewModel == null) return;
-        OpenColorPicker(PaletteColorService.Palettes.Cloth1, _itemViewModel.Cloth1Color, newIndex =>
+        OpenColorPicker(PaletteColorService.Palettes.Cloth1, _itemViewModel.Cloth1Color, "Select Cloth 1 Color", newIndex =>
         {
             _itemViewModel.Cloth1Color = newIndex;
             UpdateColorSwatch(Cloth1ColorSwatch, PaletteColorService.Palettes.Cloth1, newIndex);
@@ -622,7 +622,7 @@ public partial class MainWindow
     private void OnCloth2ColorBrowse(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
         if (_itemViewModel == null) return;
-        OpenColorPicker(PaletteColorService.Palettes.Cloth2, _itemViewModel.Cloth2Color, newIndex =>
+        OpenColorPicker(PaletteColorService.Palettes.Cloth2, _itemViewModel.Cloth2Color, "Select Cloth 2 Color", newIndex =>
         {
             _itemViewModel.Cloth2Color = newIndex;
             UpdateColorSwatch(Cloth2ColorSwatch, PaletteColorService.Palettes.Cloth2, newIndex);
@@ -632,7 +632,7 @@ public partial class MainWindow
     private void OnLeather1ColorBrowse(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
         if (_itemViewModel == null) return;
-        OpenColorPicker(PaletteColorService.Palettes.Leather1, _itemViewModel.Leather1Color, newIndex =>
+        OpenColorPicker(PaletteColorService.Palettes.Leather1, _itemViewModel.Leather1Color, "Select Leather 1 Color", newIndex =>
         {
             _itemViewModel.Leather1Color = newIndex;
             UpdateColorSwatch(Leather1ColorSwatch, PaletteColorService.Palettes.Leather1, newIndex);
@@ -642,7 +642,7 @@ public partial class MainWindow
     private void OnLeather2ColorBrowse(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
         if (_itemViewModel == null) return;
-        OpenColorPicker(PaletteColorService.Palettes.Leather2, _itemViewModel.Leather2Color, newIndex =>
+        OpenColorPicker(PaletteColorService.Palettes.Leather2, _itemViewModel.Leather2Color, "Select Leather 2 Color", newIndex =>
         {
             _itemViewModel.Leather2Color = newIndex;
             UpdateColorSwatch(Leather2ColorSwatch, PaletteColorService.Palettes.Leather2, newIndex);
@@ -652,7 +652,7 @@ public partial class MainWindow
     private void OnMetal1ColorBrowse(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
         if (_itemViewModel == null) return;
-        OpenColorPicker(PaletteColorService.Palettes.Metal1, _itemViewModel.Metal1Color, newIndex =>
+        OpenColorPicker(PaletteColorService.Palettes.Metal1, _itemViewModel.Metal1Color, "Select Metal 1 Color", newIndex =>
         {
             _itemViewModel.Metal1Color = newIndex;
             UpdateColorSwatch(Metal1ColorSwatch, PaletteColorService.Palettes.Metal1, newIndex);
@@ -662,7 +662,7 @@ public partial class MainWindow
     private void OnMetal2ColorBrowse(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
         if (_itemViewModel == null) return;
-        OpenColorPicker(PaletteColorService.Palettes.Metal2, _itemViewModel.Metal2Color, newIndex =>
+        OpenColorPicker(PaletteColorService.Palettes.Metal2, _itemViewModel.Metal2Color, "Select Metal 2 Color", newIndex =>
         {
             _itemViewModel.Metal2Color = newIndex;
             UpdateColorSwatch(Metal2ColorSwatch, PaletteColorService.Palettes.Metal2, newIndex);

--- a/Relique/Relique/Views/MainWindow.EditorPopulation.cs
+++ b/Relique/Relique/Views/MainWindow.EditorPopulation.cs
@@ -6,6 +6,7 @@ using Radoub.Formats.Gff;
 using Radoub.Formats.Logging;
 using Radoub.UI.Services;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 
@@ -93,7 +94,38 @@ public partial class MainWindow
             {
                 UpdateIdentifiedVisualCue();
             }
+
+            // Recompute Armor Class when the Torso part changes (#1908 follow-up).
+            if (e.PropertyName == "ArmorPart_Torso")
+            {
+                UpdateArmorClassDisplay();
+            }
         }
+    }
+
+    /// <summary>
+    /// Show derived Armor Class for the current item. Per the Aurora item format spec,
+    /// armor AC = ACBONUS column of parts_chest.2da at the row indicated by ArmorPart_Torso.
+    /// Read-only — AC is derived, not stored on the UTI.
+    /// </summary>
+    private void UpdateArmorClassDisplay()
+    {
+        if (_itemViewModel == null || _gameDataService == null || !_gameDataService.IsConfigured)
+        {
+            ArmorClassText.Text = "—";
+            return;
+        }
+
+        var torsoPart = _itemViewModel.GetArmorPart("Torso");
+        var acBonus = _gameDataService.Get2DAValue("parts_chest", torsoPart, "ACBONUS");
+
+        if (string.IsNullOrEmpty(acBonus) || acBonus == "****")
+        {
+            ArmorClassText.Text = "—";
+            return;
+        }
+
+        ArmorClassText.Text = acBonus;
     }
 
     private void DisplayBaseItemType(int baseItemIndex)
@@ -222,13 +254,47 @@ public partial class MainWindow
         }
     }
 
+    // Order matches the BioWare Aurora toolset's Appearance tab: anatomical top-to-bottom,
+    // left/right paired, robe last. Each entry is the GFF armor-part field key (UTI stores
+    // these as ArmorPart_<Name> fields).
     private static readonly string[] ArmorPartNames = new[]
     {
-        "Torso", "Belt", "Pelvis", "Neck", "Robe",
-        "LBicep", "RBicep", "LFArm", "RFArm",
-        "LHand", "RHand", "LShoul", "RShoul",
-        "LThigh", "RThigh", "LShin", "RShin",
-        "LFoot", "RFoot"
+        "Neck",
+        "Torso",
+        "Belt",
+        "Pelvis",
+        "RShoul", "LShoul",
+        "RBicep", "LBicep",
+        "RFArm",  "LFArm",
+        "RHand",  "LHand",
+        "RThigh", "LThigh",
+        "RShin",  "LShin",
+        "RFoot",  "LFoot",
+        "Robe",
+    };
+
+    // User-friendly display labels for armor part dropdown rows.
+    private static readonly Dictionary<string, string> ArmorPartLabels = new(StringComparer.Ordinal)
+    {
+        ["Neck"] = "Neck",
+        ["Torso"] = "Torso",
+        ["Belt"] = "Belt",
+        ["Pelvis"] = "Pelvis",
+        ["RShoul"] = "Right Shoulder",
+        ["LShoul"] = "Left Shoulder",
+        ["RBicep"] = "Right Bicep",
+        ["LBicep"] = "Left Bicep",
+        ["RFArm"] = "Right Forearm",
+        ["LFArm"] = "Left Forearm",
+        ["RHand"] = "Right Hand",
+        ["LHand"] = "Left Hand",
+        ["RThigh"] = "Right Thigh",
+        ["LThigh"] = "Left Thigh",
+        ["RShin"] = "Right Shin",
+        ["LShin"] = "Left Shin",
+        ["RFoot"] = "Right Foot",
+        ["LFoot"] = "Left Foot",
+        ["Robe"] = "Robe",
     };
 
     private void PopulateArmorPartsGrid()
@@ -251,7 +317,7 @@ public partial class MainWindow
 
             var label = new TextBlock
             {
-                Text = partName,
+                Text = ArmorPartLabels.TryGetValue(partName, out var friendly) ? friendly : partName,
                 VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
                 Margin = new Thickness(0, 0, 8, 8)
             };
@@ -281,6 +347,8 @@ public partial class MainWindow
         }
         // Handle odd count
         if (ArmorPartNames.Length % 2 == 1) row++;
+
+        UpdateArmorClassDisplay();
     }
 
     // --- Icon Preview + Picker ---

--- a/Relique/Relique/Views/MainWindow.EditorPopulation.cs
+++ b/Relique/Relique/Views/MainWindow.EditorPopulation.cs
@@ -39,6 +39,7 @@ public partial class MainWindow
             ItemStatisticsPanel.IsVisible = false;
             _itemViewModel = null;
             EditorContent.DataContext = null;
+            BindItemPreview(null);
             return;
         }
 
@@ -54,6 +55,9 @@ public partial class MainWindow
 
         // Wire up dirty tracking from ViewModel property changes
         _itemViewModel.PropertyChanged += OnItemPropertyChanged;
+
+        // Wire 3D preview to the new VM (#1908 PR3b)
+        BindItemPreview(_itemViewModel);
 
         // Display the correct base item type and palette category
         DisplayBaseItemType(_currentItem.BaseItem);

--- a/Relique/Relique/Views/MainWindow.ItemPreview.cs
+++ b/Relique/Relique/Views/MainWindow.ItemPreview.cs
@@ -1,0 +1,175 @@
+using Avalonia.Controls;
+using Avalonia.Threading;
+using ItemEditor.Services;
+using Radoub.Formats.Logging;
+using Radoub.Formats.Mdl;
+using Radoub.UI.Controls;
+using Radoub.UI.Services;
+using System;
+using ViewPreset = Radoub.UI.Services.ViewPreset;
+
+namespace ItemEditor.Views;
+
+/// <summary>
+/// 3D item preview wiring (#1908 PR3b). Owns the per-window <see cref="TextureService"/>
+/// + <see cref="MdlPartComposer"/> + <see cref="ItemPreviewController"/> + the renderer
+/// adapter, and pumps the controller's debounce timer.
+/// </summary>
+public partial class MainWindow
+{
+    private const int PreviewDebounceMs = 100;
+
+    private TextureService? _previewTextureService;
+    private MdlPartComposer? _previewComposer;
+    private ItemModelResolver? _previewResolver;
+    private ItemPreviewController? _previewController;
+    private RendererAdapter? _previewRendererAdapter;
+    private DispatcherTimer? _previewDebounceTimer;
+
+    /// <summary>
+    /// Construct the preview pipeline once game data has finished loading. Called from
+    /// <see cref="InitializeGameDataAsync"/>'s UI-thread continuation.
+    /// </summary>
+    private void InitializeItemPreview()
+    {
+        if (_gameDataService == null) return;
+        if (_previewController != null) return; // already initialized
+
+        var baseItemSvc = new Radoub.Formats.Services.BaseItemTypeService(_gameDataService);
+
+        _previewTextureService = new TextureService(_gameDataService);
+
+        // Reuse texture cache when the renderer asks for body-part MDLs through the composer
+        _previewComposer = new MdlPartComposer(
+            _gameDataService,
+            (resRef, _) => LoadMdlForPreview(resRef));
+
+        _previewResolver = new ItemModelResolver(baseItemSvc, _gameDataService);
+
+        _previewRendererAdapter = new RendererAdapter(ItemPreviewGL, ItemPreviewPlaceholder, ItemPreviewControls);
+        ItemPreviewGL.SetTextureService(_previewTextureService);
+
+        _previewController = new ItemPreviewController(
+            _previewResolver,
+            _previewComposer,
+            _previewRendererAdapter);
+
+        _previewDebounceTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(PreviewDebounceMs) };
+        _previewDebounceTimer.Tick += (_, _) =>
+        {
+            if (_previewController?.HasPendingUpdate == true)
+            {
+                _previewController.FlushDebounce();
+            }
+        };
+        _previewDebounceTimer.Start();
+
+        UnifiedLogger.LogApplication(LogLevel.DEBUG, "ItemPreview pipeline initialized");
+    }
+
+    private MdlReader? _previewMdlReader;
+
+    private MdlModel? LoadMdlForPreview(string resRef)
+    {
+        if (_gameDataService == null || string.IsNullOrEmpty(resRef)) return null;
+        try
+        {
+            var data = _gameDataService.FindResource(resRef.ToLowerInvariant(), Radoub.Formats.Common.ResourceTypes.Mdl);
+            if (data == null || data.Length == 0) return null;
+            _previewMdlReader ??= new MdlReader();
+            return _previewMdlReader.Parse(data);
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN, $"LoadMdlForPreview('{resRef}') failed: {ex.GetType().Name}: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Bind the preview to the currently-loaded item ViewModel, or unbind when the item
+    /// is closed. Called from <see cref="PopulateEditor"/>.
+    /// </summary>
+    private void BindItemPreview(ItemEditor.ViewModels.ItemViewModel? vm)
+    {
+        _previewController?.BindViewModel(vm);
+    }
+
+    /// <summary>
+    /// Tear down the preview pipeline on window close. Stops the debounce timer,
+    /// unbinds the controller, and disposes the texture service so its caches release.
+    /// </summary>
+    private void DisposeItemPreview()
+    {
+        _previewDebounceTimer?.Stop();
+        _previewDebounceTimer = null;
+
+        _previewController?.Unbind();
+        _previewController = null;
+
+        _previewTextureService?.ClearCache();
+        _previewTextureService = null;
+
+        _previewComposer = null;
+        _previewResolver = null;
+        _previewRendererAdapter = null;
+        _previewMdlReader = null;
+    }
+
+    // --- View preset button handlers ---
+
+    private void OnItemPreviewFrontClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        => ItemPreviewGL.SetViewPreset(ViewPreset.Front);
+
+    private void OnItemPreviewBackClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        => ItemPreviewGL.SetViewPreset(ViewPreset.Back);
+
+    private void OnItemPreviewLeftClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        => ItemPreviewGL.SetViewPreset(ViewPreset.Side);
+
+    private void OnItemPreviewRightClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        => ItemPreviewGL.SetViewPreset(ViewPreset.SideRight);
+
+    private void OnItemPreviewResetClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        => ItemPreviewGL.ResetView();
+
+    /// <summary>
+    /// Adapter that drives the live <see cref="ModelPreviewGLControl"/> from
+    /// <see cref="IItemPreviewRenderer"/> calls. Toggles the placeholder and view-controls
+    /// visibility as the model loads/clears.
+    /// </summary>
+    private sealed class RendererAdapter : IItemPreviewRenderer
+    {
+        private readonly ModelPreviewGLControl _gl;
+        private readonly Control _placeholder;
+        private readonly Control _viewControls;
+
+        public RendererAdapter(ModelPreviewGLControl gl, Control placeholder, Control viewControls)
+        {
+            _gl = gl;
+            _placeholder = placeholder;
+            _viewControls = viewControls;
+        }
+
+        public void SetModel(MdlModel model)
+        {
+            _gl.Model = model;
+            _gl.IsVisible = true;
+            _placeholder.IsVisible = false;
+            _viewControls.IsVisible = true;
+        }
+
+        public void Clear()
+        {
+            _gl.Model = null;
+            _gl.IsVisible = false;
+            _placeholder.IsVisible = true;
+            _viewControls.IsVisible = false;
+        }
+
+        public void SetArmorColors(int metal1, int metal2, int cloth1, int cloth2, int leather1, int leather2)
+        {
+            _gl.SetArmorColors(metal1, metal2, cloth1, cloth2, leather1, leather2);
+        }
+    }
+}

--- a/Relique/Relique/Views/MainWindow.ItemPreview.cs
+++ b/Relique/Relique/Views/MainWindow.ItemPreview.cs
@@ -52,7 +52,8 @@ public partial class MainWindow
         _previewController = new ItemPreviewController(
             _previewResolver,
             _previewComposer,
-            _previewRendererAdapter);
+            _previewRendererAdapter,
+            baseItemSvc);
 
         _previewDebounceTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(PreviewDebounceMs) };
         _previewDebounceTimer.Tick += (_, _) =>

--- a/Relique/Relique/Views/MainWindow.Lifecycle.cs
+++ b/Relique/Relique/Views/MainWindow.Lifecycle.cs
@@ -23,6 +23,9 @@ public partial class MainWindow
         // Initialize game data service on background thread (#1959)
         await InitializeGameDataAsync();
 
+        // Initialize 3D item preview pipeline (#1908 PR3b) — needs game data ready
+        InitializeItemPreview();
+
         // Initialize item browser panel
         InitializeItemBrowserPanel();
 
@@ -358,6 +361,7 @@ public partial class MainWindow
         }
 
         RadoubSettings.Instance.PropertyChanged -= OnRadoubSettingsChanged;
+        DisposeItemPreview();
         FileSessionLockService.ReleaseAllLocks();
         SaveWindowPosition();
     }

--- a/Relique/Relique/Views/MainWindow.axaml
+++ b/Relique/Relique/Views/MainWindow.axaml
@@ -321,7 +321,8 @@
 
                             <!-- Appearance (collapsible, conditional on base item type) -->
                             <Expander x:Name="AppearanceExpander" Header="Appearance" IsExpanded="True" IsVisible="False" Margin="0,0,0,8">
-                                <StackPanel Spacing="8" Margin="0,4,0,0">
+                                <Grid ColumnDefinitions="*,16,Auto" Margin="0,4,0,0">
+                                <StackPanel Grid.Column="0" Spacing="8">
 
                                     <!-- Icon Preview + Browse Button -->
                                     <StackPanel x:Name="IconChooserPanel" IsVisible="False">
@@ -514,6 +515,34 @@
                                     </StackPanel>
 
                                 </StackPanel>
+
+                                <!-- Right column: 3D preview + view controls (#1908 PR3b) -->
+                                <StackPanel Grid.Column="2" Width="280" Spacing="6">
+                                    <Border BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                                            BorderThickness="1" CornerRadius="2"
+                                            Width="280" Height="280">
+                                        <Grid>
+                                            <controls:ModelPreviewGLControl x:Name="ItemPreviewGL"
+                                                                            IsVisible="False"/>
+                                            <TextBlock x:Name="ItemPreviewPlaceholder"
+                                                       Text="No 3D model for this item type"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center"
+                                                       TextWrapping="Wrap"
+                                                       TextAlignment="Center"
+                                                       Margin="16"
+                                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                                        </Grid>
+                                    </Border>
+                                    <UniformGrid x:Name="ItemPreviewControls" Columns="5" IsVisible="False">
+                                        <Button Content="F" ToolTip.Tip="Front view" Click="OnItemPreviewFrontClick" Padding="6,2"/>
+                                        <Button Content="B" ToolTip.Tip="Back view" Click="OnItemPreviewBackClick" Padding="6,2"/>
+                                        <Button Content="L" ToolTip.Tip="Left view" Click="OnItemPreviewLeftClick" Padding="6,2"/>
+                                        <Button Content="R" ToolTip.Tip="Right view" Click="OnItemPreviewRightClick" Padding="6,2"/>
+                                        <Button Content="↺" ToolTip.Tip="Reset view" Click="OnItemPreviewResetClick" Padding="6,2"/>
+                                    </UniformGrid>
+                                </StackPanel>
+                                </Grid>
                             </Expander>
 
                             <!-- Item Statistics (above Item Properties for visibility without scrolling) -->

--- a/Relique/Relique/Views/MainWindow.axaml
+++ b/Relique/Relique/Views/MainWindow.axaml
@@ -508,7 +508,17 @@
 
                                     <!-- Armor Parts (ModelType 3 only) -->
                                     <StackPanel x:Name="ArmorPartsPanel" IsVisible="False">
-                                        <TextBlock Text="Armor Parts" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                                        <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,4">
+                                            <TextBlock Grid.Column="0" Text="Armor Parts" FontWeight="SemiBold"
+                                                       VerticalAlignment="Center"/>
+                                            <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6"
+                                                        VerticalAlignment="Center">
+                                                <TextBlock Text="Armor Class:" FontWeight="SemiBold"
+                                                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                                                <TextBlock x:Name="ArmorClassText" Text="—"
+                                                           ToolTip.Tip="Derived from parts_chest.2da ACBONUS for the current Torso part"/>
+                                            </StackPanel>
+                                        </Grid>
                                         <Grid x:Name="ArmorPartsGrid" ColumnDefinitions="120,*,16,120,*" Margin="0,0,0,8">
                                             <!-- Populated dynamically in code-behind -->
                                         </Grid>


### PR DESCRIPTION
## Summary

PR3b of the 3-PR plan (PR1 #2151 ✅, PR2 #2156 ✅, PR3a #2160 ✅, **PR3b this PR**).

Adds the live 3D item preview to Relique's Appearance expander, consuming the shared `ItemModelResolver` (PR3b first commit) and `MdlPartComposer` (PR3a #2160) to render every supported `ModelType`. Also includes follow-up fixes that surfaced during iterative manual spot-checks: held-weapon trophy orientation, ArmorPart_* event watching, layer-2 palette correctness, Armor Class display, and Aurora-style armor part order.

Plan: `NonPublic/Plans/2026-04-30-1996-1908-plan.md` (PR3b section)

## Scope

**New** (`Radoub.UI/Services/`):
- `ItemModelResolver` + `ItemModelResolution` record — UTI → MDL ResRef mapping per `BaseItemTypeService.ModelType` (0/1/2/3); 13 tests covering all 4 types + partial-availability + missing MDL + out-of-range BaseItem + null UTI + empty ArmorParts dict

**New** (`Relique/Services/`):
- `IItemPreviewRenderer` — seam between the controller and the live OpenGL preview
- `ItemPreviewController` — wires `ItemViewModel` PropertyChanged to ModelType-specific load + recolor + 100ms debounce; 17 tests (per-ModelType, ArmorPart_* watching, debounce coalescing, held-weapon rotation for sword/composite/bow vs. helmet/armor identity, BaseItem out-of-range, Unbind detaches handler)

**New** (`Relique/Views/`):
- `MainWindow.ItemPreview.cs` partial — owns per-window `TextureService` + `MdlPartComposer` + controller + `RendererAdapter`; pumps a 100ms `DispatcherTimer`; wires F/B/L/R/Reset view-preset buttons

**Modified** (`Relique/Views/`):
- `MainWindow.axaml` — Appearance expander wrapped in 2-column grid, right column hosts `ModelPreviewGLControl` + view buttons + placeholder; new "Armor Class:" display next to the Armor Parts header
- `MainWindow.EditorPopulation.cs` — armor part order matches Aurora (anatomical, R/L paired, Robe last); friendly labels ("Right Shoulder" instead of "RShoul"); read-only AC field updates on Torso changes via `parts_chest.2da[Torso].ACBONUS` lookup; new `dialogTitle` parameter passed through to `ColorPickerWindow`
- `MainWindow.Lifecycle.cs` — `InitializeItemPreview()` after game data loads; `DisposeItemPreview()` in `OnWindowClosing`

**Modified** (`Radoub.Formats/Services/BaseItemTypeService.cs`):
- Added `WeaponWield` int field + `IsHeldWeapon` computed flag (true for `WeaponWield ∈ {-1 (****), 4, 5, 6, 8, 10, 11}` = melee/pole/bow/crossbow/two-bladed/sling/thrown). Drives the controller's trophy-rotation decision.

**Modified** (`Radoub.Formats/Plt/PltReader.cs` + `Radoub.UI/Services/PaletteColorService.cs`):
- Layer-2 color slots (Cloth2/Leather2/Metal2/Tattoo2) now correctly index `pal_*01.tga` per Aurora item format spec § 2.1.2.4. There is no `pal_*02.tga` in NWN; the "1"/"2" distinction applies to which PLT layer pixel uses the looked-up color, not to a separate palette file. Fixes the ColorPickerWindow showing all-gray swatches for layer-2 slots and layer-2 spinner changes having no visible effect on PLT-rendered armor.

**Modified** (`Radoub.UI/Services/TextureService.cs`):
- New diagnostic: `RenderPltTexture` logs a one-time-per-PLT layer pixel histogram at INFO level (e.g. `PLT 'pmh0_chest020' layer pixel counts: cloth1=17696, cloth2=43469, metal1=4150`). Lets users diagnose "color slot has no visible effect" reports without speculation.

**Modified** (`Radoub.UI/Services/PaletteColorService.cs`):
- `GetPalette` now logs DEBUG entries on TGA load failure (was silently returning gray).

**Modified** (`Radoub.UI/Views/ColorPickerWindow.axaml.cs`):
- Optional `dialogTitle` parameter added since palette names no longer uniquely identify slots after the layer-2 fix (Cloth1Color and Cloth2Color both pass `pal_cloth01`). Backward compatible — old QM call sites keep working via `GetPaletteDisplayName` fallback.

## ModelType Coverage

| ModelType | Behavior | Rotation |
|---|---|---|
| 0 Simple — weapon | `MdlPartComposer.ComposeFlat([single])` | held weapon → 90° X |
| 0 Simple — non-weapon (helmet, amulet, etc.) | `ComposeFlat([single])` | identity |
| 1 Layered (cloak, robe, etc.) | `ComposeFlat([single])` + Cloth1/2 only | identity |
| 2 Composite (twobladed, quarterstaff, dire mace) | `ComposeFlat([b, m, t])` | 90° X (always held) |
| 3 Armor | `Compose("pmh0", parts)` + all 6 PLT colors | identity |
| Other / out-of-range | `HasModel=false` → placeholder | n/a |

## Memory Discipline (#2034 lesson)

- Subscribe in `Loaded`, unsubscribe in `Unloaded` via `controller.Unbind()`
- 100ms debounce on color spinner `PropertyChanged` to avoid reload thrash
- Per-MainWindow `TextureService` ownership (not singleton); cache cleared on close

## Pre-Merge Results

| Check | Result |
|-------|--------|
| Privacy scan | ✅ Pass |
| Tech debt scan | ✅ No files >800 lines |
| Theme compatibility | ⚠️ 22 hardcoded warnings — all pre-existing in unrelated files (verified `PaletteColorService.cs` warnings are from main, unchanged by this PR) |
| Radoub.Formats.Tests | ✅ 1161/1162 (1 skipped, pre-existing) |
| Radoub.UI.Tests | ✅ 607/607 |
| Radoub.Dictionary.Tests | ✅ 54/54 |
| Trebuchet.Tests | ✅ 128/128 |
| Manifest.Tests | ✅ 104/104 |
| Quartermaster.Tests | ✅ 1195/1195 |
| Fence.Tests | ✅ 138/138 |
| Parley.Tests | ✅ 838/838 |
| **Relique.Tests** | ✅ **307/307** (was 290 before PR3b: +13 ItemModelResolver, +17 ItemPreviewController) |
| **Solution total** | ✅ **4532 passed, 1 skipped, 0 failed** |
| FlaUI Relique smoke | ⏭️ Skipped — UI changes verified manually across multiple iteration cycles; PR3a already paid the FlaUI tax for the underlying renderer; Relique has minimal FlaUI coverage |
| CHANGELOG (Relique 0.10.12-alpha) | ✅ Versioned, dated 2026-05-03, PR# filled, no `[Unreleased]` items |
| Wiki freshness | ✅ `Radoub-UI-Developer.md` current; `Relique-Developer-Architecture.md` 15 days old (within 30-day threshold) — arch update via `/documentation` recommended post-merge to capture new ItemPreviewController/IItemPreviewRenderer |

## Manual Spot-Checks Performed Across Iteration

User-confirmed during iterative testing:
- ✅ Armor renders on `pmh0` mannequin with all parts assembled
- ✅ Composite weapons (twobladed sword, quarterstaff, dire mace, magic rod) assemble all 3 parts
- ✅ Simple weapons display in trophy orientation (blade up)
- ✅ Helmets, armor, cloaks keep upright orientation
- ✅ ArmorPart spinner changes trigger preview reload
- ✅ Color spinners update preview within 100ms
- ✅ All 6 color pickers show real palette colors (post layer-2 fix)
- ✅ Layer-2 (Cloth2/Leather2/Metal2) spinner changes visibly affect armor where the PLT has those pixels
- ✅ Armor Class field displays correct ACBONUS for current Torso part
- ✅ Robe field appears at the bottom of the armor parts list
- ✅ Out-of-range BaseItem shows placeholder, no crash

## Related Issues

- Closes #1908 (Item model 3D preview rendering)
- Built on PR3a (#2160): `MdlPartComposer` + `MdlPartBoneMap` + `MdlPartNaming` + `BaseItemTypeInfo.IsHeldWeapon`
- Built on PR2 (#2156): `ModelPreviewGLControl` + `TextureService` promoted to `Radoub.UI`
- Built on PR1 (#2151): `ItemDetailsPanel` extracted to `Radoub.UI`
- Surfaced follow-ups (filed separately):
  - #2106 — base-game (BIF) items in `ItemBrowserPanel` (existing FR; bumped via comment)
  - #2164 — Aurora-style filtered Part dropdowns (new FR)
- Pre-existing bugs noticed but ruled out as PR3b causes (filed separately):
  - #2161 — head sits too high above neck on part-based creature preview
  - #2162 — appearance name displays as "Appearance N" for some 2DA rows
  - #2163 — feat ordering should be chosen > granted > available

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)