### PR TITLE
[Radoub] Refactor: Extract MdlPartComposer to Radoub.UI (PR3a of #1908)

### DIFF
--- a/Fence/CHANGELOG.md
+++ b/Fence/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.1.31-alpha] - 2026-05-01
+**Branch**: `radoub/issue-2159` | **PR**: #2160
+
+### Fix: Replace hardcoded font sizes with themable DynamicResource bindings
+
+- Replace hardcoded `FontSize="11"` on MainWindow `VariableValidationText` and DataGrid error labels with `{DynamicResource FontSizeSmall}`
+- Required for low-vision users — hardcoded font sizes do not scale with the Trebuchet font-size slider
+
+---
+
 ## [0.1.30-alpha] - 2026-05-01
 **Branch**: `radoub/feat/promote-model-preview` | **PR**: #2156
 

--- a/Fence/Fence/Views/MainWindow.axaml
+++ b/Fence/Fence/Views/MainWindow.axaml
@@ -315,7 +315,7 @@
                             <TextBlock x:Name="VariableValidationText"
                                        DockPanel.Dock="Bottom"
                                        Foreground="{DynamicResource ThemeError}"
-                                       FontSize="11"
+                                       FontSize="{DynamicResource FontSizeSmall}"
                                        TextWrapping="Wrap"
                                        IsVisible="False"
                                        Margin="0,4,0,0"/>
@@ -345,7 +345,7 @@
                                                              BorderBrush="{Binding HasError, Converter={StaticResource BoolToErrorBrushConverter}}"/>
                                                     <TextBlock Text="{Binding ErrorMessage}"
                                                                Foreground="{DynamicResource ThemeError}"
-                                                               FontSize="11"
+                                                               FontSize="{DynamicResource FontSizeSmall}"
                                                                VerticalAlignment="Center"
                                                                IsVisible="{Binding HasError}"/>
                                                 </StackPanel>

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Parley. One-line highlights per version; full details in 
 
 ---
 
+## [0.1.167-alpha] - 2026-05-01
+**Branch**: `radoub/issue-2159` | **PR**: #2160
+
+### Fix: Replace hardcoded font sizes with themable DynamicResource bindings
+
+- Replace hardcoded `FontSize="11"` on `ModuleSearchWindow` ModulePathText and DurationText with `{DynamicResource FontSizeSmall}`
+- Required for low-vision users — hardcoded font sizes do not scale with the Trebuchet font-size slider
+
+---
+
 ## [0.1.166-alpha] - 2026-04-18
 **Branch**: `parley/issue-2063` | **PR**: #2108
 

--- a/Parley/Parley/Views/ModuleSearchWindow.axaml
+++ b/Parley/Parley/Views/ModuleSearchWindow.axaml
@@ -88,10 +88,10 @@
             <DockPanel>
                 <TextBlock x:Name="ModulePathText" DockPanel.Dock="Left"
                            Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
-                           VerticalAlignment="Center" FontSize="11"/>
+                           VerticalAlignment="Center" FontSize="{DynamicResource FontSizeSmall}"/>
                 <TextBlock x:Name="DurationText" DockPanel.Dock="Right"
                            Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
-                           VerticalAlignment="Center" FontSize="11"
+                           VerticalAlignment="Center" FontSize="{DynamicResource FontSizeSmall}"
                            HorizontalAlignment="Right"/>
             </DockPanel>
         </Border>

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.91-alpha] - 2026-05-01
-**Branch**: `radoub/issue-2159` | **PR**: #TBD
+**Branch**: `radoub/issue-2159` | **PR**: #2160
 
 ### Refactor: Extract MdlPartComposer to Radoub.UI (#1908 prep PR3a)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -15,6 +15,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 - No rendering behavior changes — QM creature preview renders identically (mesh re-parenting, texture-name overrides, #1557 seam-overlap nudge, bounds aggregation all preserved)
 - Enables Relique 3D item preview (#1908 PR3b) to compose composite weapons (3 parts) and armor (up to 19 parts) using the same mechanics
 
+### Fix: Replace hardcoded font sizes with themable DynamicResource bindings
+
+- Replace hardcoded `FontSize="11"` / `"12"` on `AppearancePanel.PreviewStateText` and `AdvancedPanel.VariableValidationText` / DataGrid error labels with `{DynamicResource FontSizeSmall}`
+- Required for low-vision users — hardcoded font sizes do not scale with the Trebuchet font-size slider
+
 ---
 
 ## [0.2.90-alpha] - 2026-05-01

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.91-alpha] - 2026-05-01
+**Branch**: `radoub/issue-2159` | **PR**: #TBD
+
+### Refactor: Extract MdlPartComposer to Radoub.UI (#1908 prep PR3a)
+
+- Move part-mesh-onto-skeleton composition logic from `ModelService.LoadPartBasedCreatureModel` into shared `MdlPartComposer` in `Radoub.UI`
+- `LoadPartBasedCreatureModel` becomes a thin adapter that resolves creature appearance + armor overrides + human fallback, then delegates to the composer
+- No rendering behavior changes — QM creature preview renders identically (mesh re-parenting, texture-name overrides, #1557 seam-overlap nudge, bounds aggregation all preserved)
+- Enables Relique 3D item preview (#1908 PR3b) to compose composite weapons (3 parts) and armor (up to 19 parts) using the same mechanics
+
+---
+
 ## [0.2.90-alpha] - 2026-05-01
 **Branch**: `radoub/feat/promote-model-preview` | **PR**: #2156
 

--- a/Quartermaster/Quartermaster.Tests/ModelNameConstructionTests.cs
+++ b/Quartermaster/Quartermaster.Tests/ModelNameConstructionTests.cs
@@ -4,8 +4,9 @@ using Xunit;
 namespace Quartermaster.Tests;
 
 /// <summary>
-/// Tests for model name construction helpers in ModelService.
-/// Fixture-free — tests pure string formatting logic.
+/// Tests for QM-specific creature-prefix construction (gender/race/phenotype → "pmh0", "pfe2", etc.).
+/// The generic BuildBodyPartName helper moved to Radoub.UI in PR3a (#2159) — see
+/// MdlPartNamingTests in Radoub.UI.Tests.
 /// </summary>
 public class ModelNameConstructionTests
 {
@@ -28,7 +29,6 @@ public class ModelNameConstructionTests
         var result = ModelService.BuildModelPrefix(0, "H", 0);
         Assert.Equal("pmh0", result);
 
-        // Already lowercase
         var result2 = ModelService.BuildModelPrefix(0, "h", 0);
         Assert.Equal("pmh0", result2);
     }
@@ -45,28 +45,5 @@ public class ModelNameConstructionTests
     {
         var result = ModelService.BuildModelPrefix(1, "h", 0);
         Assert.StartsWith("pf", result);
-    }
-
-    [Theory]
-    [InlineData("pfo0", "head", 1, "pfo0_head001")]
-    [InlineData("pmh0", "chest", 1, "pmh0_chest001")]
-    [InlineData("pmd0", "neck", 2, "pmd0_neck002")]
-    [InlineData("pfe0", "footl", 1, "pfe0_footl001")]
-    [InlineData("pmh0", "bicepl", 10, "pmh0_bicepl010")]
-    [InlineData("pmh0", "shinr", 100, "pmh0_shinr100")]
-    public void BuildBodyPartName_FormatsCorrectly(string prefix, string partType, byte partNumber, string expected)
-    {
-        var result = ModelService.BuildBodyPartName(prefix, partType, partNumber);
-        Assert.Equal(expected, result);
-    }
-
-    [Fact]
-    public void BuildBodyPartName_PartNumberPaddedToThreeDigits()
-    {
-        var result = ModelService.BuildBodyPartName("pmh0", "head", 1);
-        Assert.EndsWith("001", result);
-
-        var result2 = ModelService.BuildBodyPartName("pmh0", "head", 99);
-        Assert.EndsWith("099", result2);
     }
 }

--- a/Quartermaster/Quartermaster/Services/ModelService.cs
+++ b/Quartermaster/Quartermaster/Services/ModelService.cs
@@ -7,29 +7,26 @@ using Radoub.Formats.Mdl;
 using Radoub.Formats.Services;
 using Radoub.Formats.Utc;
 using Radoub.Formats.Uti;
+using Radoub.UI.Services;
 
 namespace Quartermaster.Services;
 
 /// <summary>
 /// Service for loading and managing 3D models for creature preview.
-/// Handles model resolution from appearance.2da and resource loading.
+/// Handles creature-specific resolution from appearance.2da and equipped-armor lookup,
+/// then delegates part composition to the shared <see cref="MdlPartComposer"/>.
 /// </summary>
 public class ModelService
 {
     private readonly IGameDataService _gameDataService;
     private readonly MdlReader _mdlReader = new();
     private readonly Dictionary<string, MdlModel?> _modelCache = new();
-    private MdlModel? _currentSkeleton;
-
-    /// <summary>
-    /// Maps mesh node names to their body part type (e.g., "head", "neck", "chest").
-    /// Populated during TryAddBodyPart, consumed by AdjustSeamOverlaps.
-    /// </summary>
-    private readonly Dictionary<string, string> _meshPartTypes = new();
+    private readonly MdlPartComposer _composer;
 
     public ModelService(IGameDataService gameDataService)
     {
         _gameDataService = gameDataService;
+        _composer = new MdlPartComposer(_gameDataService, (resRef, _) => LoadModel(resRef));
     }
 
     /// <summary>
@@ -40,15 +37,6 @@ public class ModelService
     {
         var genderChar = gender == 1 ? 'f' : 'm';
         return $"p{genderChar}{race.ToLowerInvariant()}{phenotype}";
-    }
-
-    /// <summary>
-    /// Build a body part model name from prefix, part type, and part number.
-    /// Format: {prefix}_{partType}{partNumber:D3} (e.g., "pfo0_head001")
-    /// </summary>
-    internal static string BuildBodyPartName(string prefix, string partType, byte partNumber)
-    {
-        return $"{prefix}_{partType}{partNumber:D3}";
     }
 
     /// <summary>
@@ -64,7 +52,6 @@ public class ModelService
             var gender = creature.Gender;
             var phenotype = creature.Phenotype;
 
-            // Log equipped items for debugging
             UnifiedLogger.LogApplication(LogLevel.INFO,
                 $"LoadCreatureModel: {creature.EquipItemList.Count} equipped items");
             foreach (var equip in creature.EquipItemList)
@@ -73,11 +60,9 @@ public class ModelService
                     $"  Slot {equip.Slot}: '{equip.EquipRes}'");
             }
 
-            // Check if this is a part-based model
             var modelType = _gameDataService.Get2DAValue("appearance", appearanceId, "MODELTYPE");
             if (modelType?.ToUpperInvariant().Contains("P") == true)
             {
-                // Get armor-provided body part overrides
                 var armorOverrides = GetArmorPartOverrides(creature);
 
                 if (armorOverrides != null)
@@ -91,11 +76,9 @@ public class ModelService
                         $"LoadCreatureModel: No armor overrides (naked creature or no chest armor)");
                 }
 
-                // Part-based model - load body parts with armor overrides
                 return LoadPartBasedCreatureModel(creature, armorOverrides);
             }
 
-            // Simple/Full model - load single model
             return LoadModelForAppearance(appearanceId, gender, phenotype);
         }
         catch (Exception ex)
@@ -136,8 +119,7 @@ public class ModelService
 
     /// <summary>
     /// Get armor colors from equipped chest armor.
-    /// Returns null if no armor equipped.
-    /// Note: Color index 0 is a valid color (first in palette), so we always return colors if armor exists.
+    /// Returns null if no armor equipped. Color index 0 is valid (first palette entry).
     /// </summary>
     public (byte metal1, byte metal2, byte cloth1, byte cloth2, byte leather1, byte leather2)? GetArmorColors(UtcFile creature)
     {
@@ -150,9 +132,6 @@ public class ModelService
                 armor.Leather1Color, armor.Leather2Color);
     }
 
-    /// <summary>
-    /// Load the equipped chest armor UTI.
-    /// </summary>
     private UtiFile? LoadEquippedArmor(UtcFile creature)
     {
         var chestItem = creature.EquipItemList.FirstOrDefault(e => e.Slot == EquipmentSlots.Chest);
@@ -178,7 +157,7 @@ public class ModelService
     }
 
     /// <summary>
-    /// Load a part-based creature model by combining body part models.
+    /// Load a part-based creature model by combining body part models via the shared composer.
     /// </summary>
     /// <param name="creature">The creature to load</param>
     /// <param name="armorOverrides">Optional armor-provided body part overrides</param>
@@ -190,539 +169,96 @@ public class ModelService
             return null;
 
         var basePrefix = BuildModelPrefix(creature.Gender, race, creature.Phenotype);
-
         UnifiedLogger.LogApplication(LogLevel.INFO, $"LoadPartBasedCreatureModel: basePrefix={basePrefix}");
 
-        // Clear part type tracking from previous load
-        _meshPartTypes.Clear();
-
-        // Load the base skeleton model first - it defines bone positions for body parts
-        // Use LoadSkeletonModel to prefer BIF over HAK — CEP HAKs override standard
-        // skeletons with incompatible versions (#1314)
-        UnifiedLogger.LogApplication(LogLevel.DEBUG, $"LoadPartBasedCreatureModel: Attempting to load skeleton model '{basePrefix}'...");
-        var skeletonModel = LoadModel(basePrefix);
-        UnifiedLogger.LogApplication(LogLevel.DEBUG, $"LoadPartBasedCreatureModel: LoadModel returned {(skeletonModel != null ? "model" : "null")}");
-        if (skeletonModel != null)
-        {
-            UnifiedLogger.LogApplication(LogLevel.INFO, $"LoadPartBasedCreatureModel: Loaded skeleton model {basePrefix}");
-            UnifiedLogger.LogApplication(LogLevel.INFO,
-                $"  GeometryRoot: {skeletonModel.GeometryRoot?.Name ?? "null"}, children={skeletonModel.GeometryRoot?.Children.Count ?? 0}");
-            // Log ALL skeleton nodes regardless of position
-            var nodeCount = 0;
-            foreach (var node in skeletonModel.EnumerateAllNodes())
-            {
-                nodeCount++;
-                UnifiedLogger.LogApplication(LogLevel.INFO,
-                    $"  Skeleton node '{node.Name}': type={node.NodeType}, pos={node.Position}, children={node.Children.Count}");
-            }
-            UnifiedLogger.LogApplication(LogLevel.INFO, $"  Total skeleton nodes: {nodeCount}");
-        }
-        else
-        {
-            UnifiedLogger.LogApplication(LogLevel.WARN, $"LoadPartBasedCreatureModel: Skeleton model {basePrefix} not found");
-        }
-
-        // Create a composite model to hold all parts
-        var compositeModel = new MdlModel
-        {
-            Name = basePrefix,
-            IsBinary = true
-        };
-
-        // Store skeleton for bone position lookup
-        _currentSkeleton = skeletonModel;
-
-        // Inherit the skeleton's animation list (and any already merged from
-        // its supermodel chain) so part-based creatures — humans, elves,
-        // halflings, dwarves, etc. — can play idle/walk/attack in the
-        // preview (#2124). Without this, composite models would have an
-        // empty Animations list because they skip the LoadModel code path.
-        if (skeletonModel?.Animations != null)
-        {
-            foreach (var anim in skeletonModel.Animations)
-                compositeModel.Animations.Add(anim);
-            compositeModel.SuperModel = skeletonModel.SuperModel;
-        }
-
-        // Use the skeleton's bone hierarchy as the composite root so animation
-        // pose lookup finds matching bone names through the full parent chain
-        // (#2124). Each body part mesh attaches under its target bone below.
-        if (skeletonModel?.GeometryRoot != null)
-        {
-            compositeModel.GeometryRoot = skeletonModel.GeometryRoot;
-        }
-
-        // Helper to get body part number.
-        // Creature value takes precedence — it reflects the user's explicit choice.
-        // Armor overrides only apply when the creature has the default part (non-zero)
-        // and the armor provides an alternative. Setting a body part to 0 = "invisible/none"
-        // and must always be honored regardless of armor.
+        // Helper: armor override beats creature value, but creature value of 0 (none/invisible)
+        // always wins regardless of armor.
         byte GetPartNumber(string armorKey, byte creatureValue)
         {
-            // If creature explicitly says 0 (none/invisible), honor that
             if (creatureValue == 0)
                 return 0;
 
-            // If armor provides an override for this part, use it
             if (armorOverrides != null && armorOverrides.TryGetValue(armorKey, out var armorValue) && armorValue > 0)
                 return armorValue;
 
             return creatureValue;
         }
 
-        // Load each body part (armor overrides take precedence where applicable)
-        // Head is special - uses AppearanceHead, not overridden by armor
-        TryAddBodyPart(compositeModel, basePrefix, "head", creature.AppearanceHead);
+        var parts = new List<(string PartType, string ResRef)>();
 
-        // Standard body parts (armor can override these)
-        // NWN body part naming: belt, bicepl/bicepr, chest, footl/footr, forel/forer,
-        // handl/handr, legl/legr, neck, pelvis, shinl/shinr, shol/shor
-        TryAddBodyPart(compositeModel, basePrefix, "neck", GetPartNumber("Neck", creature.BodyPart_Neck));
-        TryAddBodyPart(compositeModel, basePrefix, "chest", GetPartNumber("Torso", creature.BodyPart_Torso));
-        // Robe is armor-only (no creature body part) — use armor override or skip
+        // Head — special, uses AppearanceHead, never overridden by armor
+        AppendPart(parts, basePrefix, "head", creature.AppearanceHead);
+
+        AppendPart(parts, basePrefix, "neck", GetPartNumber("Neck", creature.BodyPart_Neck));
+        AppendPart(parts, basePrefix, "chest", GetPartNumber("Torso", creature.BodyPart_Torso));
+
+        // Robe is armor-only (no creature body part); only added if armor has a robe override
         var robePartNumber = (armorOverrides != null && armorOverrides.TryGetValue("Robe", out var robeValue) && robeValue > 0)
             ? robeValue : (byte)0;
-        TryAddBodyPart(compositeModel, basePrefix, "robe", robePartNumber);
-        TryAddBodyPart(compositeModel, basePrefix, "pelvis", GetPartNumber("Pelvis", creature.BodyPart_Pelvis));
-        TryAddBodyPart(compositeModel, basePrefix, "belt", GetPartNumber("Belt", creature.BodyPart_Belt));
+        AppendPart(parts, basePrefix, "robe", robePartNumber);
 
-        // Arms (armor can override these) - NWN uses shol/shor, bicepl/bicepr, forel/forer, handl/handr
-        TryAddBodyPart(compositeModel, basePrefix, "shol", GetPartNumber("LShoul", creature.BodyPart_LShoul));
-        TryAddBodyPart(compositeModel, basePrefix, "shor", GetPartNumber("RShoul", creature.BodyPart_RShoul));
-        TryAddBodyPart(compositeModel, basePrefix, "bicepl", GetPartNumber("LBicep", creature.BodyPart_LBicep));
-        TryAddBodyPart(compositeModel, basePrefix, "bicepr", GetPartNumber("RBicep", creature.BodyPart_RBicep));
-        TryAddBodyPart(compositeModel, basePrefix, "forel", GetPartNumber("LFArm", creature.BodyPart_LFArm));
-        TryAddBodyPart(compositeModel, basePrefix, "forer", GetPartNumber("RFArm", creature.BodyPart_RFArm));
-        TryAddBodyPart(compositeModel, basePrefix, "handl", GetPartNumber("LHand", creature.BodyPart_LHand));
-        TryAddBodyPart(compositeModel, basePrefix, "handr", GetPartNumber("RHand", creature.BodyPart_RHand));
+        AppendPart(parts, basePrefix, "pelvis", GetPartNumber("Pelvis", creature.BodyPart_Pelvis));
+        AppendPart(parts, basePrefix, "belt", GetPartNumber("Belt", creature.BodyPart_Belt));
 
-        // Legs (armor can override these) - NWN uses legl/legr (thighs), shinl/shinr, footl/footr
-        TryAddBodyPart(compositeModel, basePrefix, "legl", GetPartNumber("LThigh", creature.BodyPart_LThigh));
-        TryAddBodyPart(compositeModel, basePrefix, "legr", GetPartNumber("RThigh", creature.BodyPart_RThigh));
-        TryAddBodyPart(compositeModel, basePrefix, "shinl", GetPartNumber("LShin", creature.BodyPart_LShin));
-        TryAddBodyPart(compositeModel, basePrefix, "shinr", GetPartNumber("RShin", creature.BodyPart_RShin));
-        TryAddBodyPart(compositeModel, basePrefix, "footl", GetPartNumber("LFoot", creature.BodyPart_LFoot));
-        TryAddBodyPart(compositeModel, basePrefix, "footr", GetPartNumber("RFoot", creature.BodyPart_RFoot));
+        AppendPart(parts, basePrefix, "shol", GetPartNumber("LShoul", creature.BodyPart_LShoul));
+        AppendPart(parts, basePrefix, "shor", GetPartNumber("RShoul", creature.BodyPart_RShoul));
+        AppendPart(parts, basePrefix, "bicepl", GetPartNumber("LBicep", creature.BodyPart_LBicep));
+        AppendPart(parts, basePrefix, "bicepr", GetPartNumber("RBicep", creature.BodyPart_RBicep));
+        AppendPart(parts, basePrefix, "forel", GetPartNumber("LFArm", creature.BodyPart_LFArm));
+        AppendPart(parts, basePrefix, "forer", GetPartNumber("RFArm", creature.BodyPart_RFArm));
+        AppendPart(parts, basePrefix, "handl", GetPartNumber("LHand", creature.BodyPart_LHand));
+        AppendPart(parts, basePrefix, "handr", GetPartNumber("RHand", creature.BodyPart_RHand));
 
-        // Fix thin seams between adjacent body parts (#1557).
-        // NWN body parts rely on skeletal deformation for seamless joints, but our static
-        // preview places rigid meshes. Some races (elves) have very thin vertex overlap
-        // at joints that becomes visible under perspective projection. Nudge parts toward
-        // each other where overlap is too thin.
-        AdjustSeamOverlaps(compositeModel);
+        AppendPart(parts, basePrefix, "legl", GetPartNumber("LThigh", creature.BodyPart_LThigh));
+        AppendPart(parts, basePrefix, "legr", GetPartNumber("RThigh", creature.BodyPart_RThigh));
+        AppendPart(parts, basePrefix, "shinl", GetPartNumber("LShin", creature.BodyPart_LShin));
+        AppendPart(parts, basePrefix, "shinr", GetPartNumber("RShin", creature.BodyPart_RShin));
+        AppendPart(parts, basePrefix, "footl", GetPartNumber("LFoot", creature.BodyPart_LFoot));
+        AppendPart(parts, basePrefix, "footr", GetPartNumber("RFoot", creature.BodyPart_RFoot));
 
-        // Calculate combined bounding box
-        UpdateCompositeBounds(compositeModel);
-
-        var meshCount = compositeModel.GetMeshNodes().Count();
-        UnifiedLogger.LogApplication(LogLevel.INFO,
-            $"LoadPartBasedCreatureModel: Composite model has {meshCount} meshes, bounds={compositeModel.BoundingMin}-{compositeModel.BoundingMax}");
-
-        return meshCount > 0 ? compositeModel : null;
+        return _composer.Compose(basePrefix, parts);
     }
 
-    private void TryAddBodyPart(MdlModel compositeModel, string basePrefix, string partType, byte partNumber)
+    /// <summary>
+    /// Resolve a body part ResRef with race-specific lookup first, falling back to human
+    /// (pmh0/pfh0). Skips parts with partNumber=0 (none/invisible). Adds the resolved
+    /// (partType, resRef) tuple to the parts list if a model file exists.
+    /// </summary>
+    private void AppendPart(List<(string PartType, string ResRef)> parts, string basePrefix, string partType, byte partNumber)
     {
         if (partNumber == 0)
         {
-            UnifiedLogger.LogApplication(LogLevel.INFO, $"TryAddBodyPart: Skipping {partType} (partNumber=0)");
-            return; // 0 often means "none" for optional parts
+            UnifiedLogger.LogApplication(LogLevel.DEBUG, $"AppendPart: skipping {partType} (partNumber=0)");
+            return;
         }
 
-        try
+        var raceResRef = MdlPartNaming.BuildBodyPartName(basePrefix, partType, partNumber);
+        if (LoadModel(raceResRef) != null)
         {
-            TryAddBodyPartCore(compositeModel, basePrefix, partType, partNumber);
+            parts.Add((partType, raceResRef));
+            return;
         }
-        catch (Exception ex)
+
+        // Human fallback (pmh0/pfh0). NWN shares many body part models across races
+        // using the human models as the default reference set.
+        if (basePrefix.Length >= 2)
         {
-            UnifiedLogger.LogApplication(LogLevel.WARN,
-                $"TryAddBodyPart: Failed to add {partType}#{partNumber} for {basePrefix}: {ex.GetType().Name}: {ex.Message}");
-        }
-    }
-
-    private void TryAddBodyPartCore(MdlModel compositeModel, string basePrefix, string partType, byte partNumber)
-    {
-
-        var partName = BuildBodyPartName(basePrefix, partType, partNumber);
-        var partModel = LoadModel(partName);
-
-        // If not found with race-specific prefix, try human fallback
-        // NWN shares many body part models across races using pmh0/pfh0 (human male/female)
-        if (partModel == null && basePrefix.Length >= 2)
-        {
-            // Extract gender char (m/f) from position 1
             var genderChar = basePrefix[1];
-            var humanPrefix = $"p{genderChar}h0"; // e.g., pmh0 or pfh0
+            var humanPrefix = $"p{genderChar}h0";
             if (humanPrefix != basePrefix)
             {
-                var humanPartName = $"{humanPrefix}_{partType}{partNumber:D3}";
-                partModel = LoadModel(humanPartName);
-                if (partModel != null)
+                var humanResRef = MdlPartNaming.BuildBodyPartName(humanPrefix, partType, partNumber);
+                if (LoadModel(humanResRef) != null)
                 {
                     UnifiedLogger.LogApplication(LogLevel.INFO,
-                        $"TryAddBodyPart: Using human fallback '{humanPartName}' for '{partName}'");
-                    partName = humanPartName; // Update for logging
+                        $"AppendPart: using human fallback '{humanResRef}' for '{raceResRef}'");
+                    parts.Add((partType, humanResRef));
+                    return;
                 }
             }
         }
 
-        if (partModel != null)
-        {
-            // Body part MDL files have geometry at local origin
-            // We need to position and orient them at the corresponding bone in the skeleton
-            var (bonePosition, _) = GetBoneTransformForPart(partType);
-            var boneName = GetBoneNameForPart(partType);
-
-            var meshCount = 0;
-            // Add all mesh nodes from this part to the composite model
-            foreach (var node in partModel.EnumerateAllNodes())
-            {
-                if (node is Radoub.Formats.Mdl.MdlTrimeshNode trimesh)
-                {
-                    // Position the mesh at the bone location.
-                    // NOTE: We intentionally DON'T set Orientation here. All NWN part-based
-                    // skeleton bones have identity orientation, so setting it is a no-op in theory.
-                    // In practice, Matrix4x4.Decompose can return slightly non-identity quaternions
-                    // from accumulated floating-point error, which causes visible displacement
-                    // when the rendering pipeline applies the rotation to mesh vertices.
-                    trimesh.Position = bonePosition;
-
-                    // ALWAYS derive texture name for body parts - the texture field in body part MDLs
-                    // often contains stale/garbage data from reused file structures. NWN expects
-                    // body part textures to follow the naming convention: {prefix}_{partType}{number:D3}
-                    // For race-specific parts (head), try the original race prefix first
-                    // For limbs (which use human fallback models), use human texture prefix
-                    var derivedTexture = partName; // Default to model name (e.g., pme0_head001)
-
-                    // Check if this is a fallback model (human prefix loaded for non-human creature)
-                    // If so, use the human texture; otherwise use race-specific texture
-                    var isHumanFallback = partName.StartsWith("pmh0_") || partName.StartsWith("pfh0_");
-                    if (!isHumanFallback)
-                    {
-                        // Race-specific model - use race texture first (e.g., pme0_head001)
-                        derivedTexture = $"{basePrefix}_{partType}{partNumber:D3}";
-                    }
-                    // else: human fallback model - partName already has correct texture name
-
-                    var oldBitmap = trimesh.Bitmap;
-                    trimesh.Bitmap = derivedTexture;
-                    if (!string.IsNullOrEmpty(oldBitmap) && oldBitmap != derivedTexture)
-                    {
-                        UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                            $"TryAddBodyPart: Overriding stale texture '{oldBitmap}' with '{derivedTexture}' for mesh '{trimesh.Name}'");
-                    }
-
-                    // Add to composite's root (or create root if needed)
-                    if (compositeModel.GeometryRoot == null)
-                    {
-                        compositeModel.GeometryRoot = new Radoub.Formats.Mdl.MdlNode { Name = "composite_root" };
-                    }
-
-                    // Parent the mesh under the target bone in the skeleton
-                    // so GetWorldTransform's parent-chain walk picks up
-                    // animated transforms from the supermodel (#2124). The
-                    // bone already holds the correct bind position; zero out
-                    // the mesh's own offset so it doesn't compound.
-                    Radoub.Formats.Mdl.MdlNode? bone = null;
-                    if (_currentSkeleton?.GeometryRoot != null)
-                        bone = FindBoneByName(_currentSkeleton.GeometryRoot, boneName);
-
-                    if (bone != null)
-                    {
-                        trimesh.Position = System.Numerics.Vector3.Zero;
-                        node.Parent = bone;
-                        bone.Children.Add(node);
-                    }
-                    else
-                    {
-                        // Fallback — skeleton bone missing, keep old flat behavior.
-                        trimesh.Position = bonePosition;
-                        node.Parent = compositeModel.GeometryRoot;
-                        compositeModel.GeometryRoot.Children.Add(node);
-                    }
-                    meshCount++;
-                    // Track which body part type this mesh belongs to (#1557)
-                    _meshPartTypes[trimesh.Name] = partType;
-                    // Log vertex bounds and texture info for debugging
-                    var hasUVs = trimesh.TextureCoords.Length > 0 && trimesh.TextureCoords[0].Length > 0;
-                    UnifiedLogger.LogApplication(LogLevel.INFO,
-                        $"TryAddBodyPart: Added mesh '{trimesh.Name}' from {partName}, " +
-                        $"bitmap='{trimesh.Bitmap}', hasUVs={hasUVs}, " +
-                        $"verts={trimesh.Vertices.Length}, faces={trimesh.Faces.Length}");
-                }
-            }
-            UnifiedLogger.LogApplication(LogLevel.INFO, $"TryAddBodyPart: {partName} added {meshCount} meshes");
-        }
-        else
-        {
-            UnifiedLogger.LogApplication(LogLevel.WARN, $"TryAddBodyPart: {partName} not found");
-        }
-    }
-
-    /// <summary>
-    /// Get the world transform for a body part by looking up its bone in the skeleton.
-    /// Returns both position and orientation so body parts are correctly placed and rotated.
-    /// Body part names map to skeleton bone names with _g suffix.
-    /// </summary>
-    private static string GetBoneNameForPart(string partType) => partType switch
-    {
-        "head" => "head_g",
-        "neck" => "neck_g",
-        "chest" => "torso_g",
-        "robe" => "torso_g",
-        "pelvis" => "pelvis_g",
-        "belt" => "belt_g",
-        "shol" => "lshoulder_g",
-        "shor" => "rshoulder_g",
-        "bicepl" => "lbicep_g",
-        "bicepr" => "rbicep_g",
-        "forel" => "lforearm_g",
-        "forer" => "rforearm_g",
-        "handl" => "lhand_g",
-        "handr" => "rhand_g",
-        "legl" => "lthigh_g",
-        "legr" => "rthigh_g",
-        "shinl" => "lshin_g",
-        "shinr" => "rshin_g",
-        "footl" => "lfoot_g",
-        "footr" => "rfoot_g",
-        _ => partType + "_g"
-    };
-
-    private (System.Numerics.Vector3 Position, System.Numerics.Quaternion Orientation) GetBoneTransformForPart(string partType)
-    {
-        var identity = (System.Numerics.Vector3.Zero, System.Numerics.Quaternion.Identity);
-
-        if (_currentSkeleton?.GeometryRoot == null)
-            return identity;
-
-        var boneName = GetBoneNameForPart(partType);
-
-        // Find the bone in the skeleton and calculate its world transform
-        var bone = FindBoneByName(_currentSkeleton.GeometryRoot, boneName);
-        if (bone == null)
-        {
-            UnifiedLogger.LogApplication(LogLevel.DEBUG, $"GetBoneTransformForPart: Bone '{boneName}' not found for part '{partType}'");
-            return identity;
-        }
-
-        // Compute full world transform matrix including rotations and scale
-        var worldMatrix = GetBoneWorldTransform(bone);
-
-        // Decompose to extract position and rotation
-        if (!System.Numerics.Matrix4x4.Decompose(worldMatrix, out _, out var rotation, out var translation))
-        {
-            UnifiedLogger.LogApplication(LogLevel.WARN, $"GetBoneTransformForPart: Matrix decompose failed for bone '{boneName}'");
-            return identity;
-        }
-
-        UnifiedLogger.LogApplication(LogLevel.DEBUG, $"GetBoneTransformForPart: '{partType}' -> bone '{boneName}' pos={translation}, rot={rotation}");
-        return (translation, rotation);
-    }
-
-    private MdlNode? FindBoneByName(MdlNode root, string name)
-    {
-        if (root.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
-            return root;
-
-        foreach (var child in root.Children)
-        {
-            var found = FindBoneByName(child, name);
-            if (found != null)
-                return found;
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Calculate the full world transform of a bone by accumulating S*R*T matrices up the hierarchy.
-    /// Mirrors ModelPreviewGLControl.GetWorldTransform() to properly handle parent bone rotations.
-    /// </summary>
-    internal static System.Numerics.Matrix4x4 GetBoneWorldTransform(MdlNode bone)
-    {
-        var worldTransform = System.Numerics.Matrix4x4.Identity;
-        var current = bone;
-
-        while (current != null)
-        {
-            var scale = System.Numerics.Matrix4x4.CreateScale(current.Scale);
-            var rotation = System.Numerics.Matrix4x4.CreateFromQuaternion(current.Orientation);
-            var translation = System.Numerics.Matrix4x4.CreateTranslation(current.Position);
-
-            // Row-major local transform: S * R * T (same as ModelPreviewGLControl.GetWorldTransform)
-            var localTransform = scale * rotation * translation;
-
-            // Accumulate: node * parent * grandparent * ... * root
-            worldTransform = worldTransform * localTransform;
-
-            current = current.Parent;
-        }
-
-        return worldTransform;
-    }
-
-    private void UpdateCompositeBounds(MdlModel model)
-    {
-        var minX = float.MaxValue;
-        var minY = float.MaxValue;
-        var minZ = float.MaxValue;
-        var maxX = float.MinValue;
-        var maxY = float.MinValue;
-        var maxZ = float.MinValue;
-
-        foreach (var mesh in model.GetMeshNodes())
-        {
-            // Apply the mesh's full local transform (S*R*T) to get world-space vertex positions.
-            // Body parts have both position and orientation set from skeleton bones.
-            var localTransform = System.Numerics.Matrix4x4.CreateScale(mesh.Scale)
-                * System.Numerics.Matrix4x4.CreateFromQuaternion(mesh.Orientation)
-                * System.Numerics.Matrix4x4.CreateTranslation(mesh.Position);
-
-            foreach (var vertex in mesh.Vertices)
-            {
-                var worldVert = System.Numerics.Vector3.Transform(vertex, localTransform);
-
-                minX = Math.Min(minX, worldVert.X);
-                minY = Math.Min(minY, worldVert.Y);
-                minZ = Math.Min(minZ, worldVert.Z);
-                maxX = Math.Max(maxX, worldVert.X);
-                maxY = Math.Max(maxY, worldVert.Y);
-                maxZ = Math.Max(maxZ, worldVert.Z);
-            }
-        }
-
-        if (minX != float.MaxValue)
-        {
-            model.BoundingMin = new System.Numerics.Vector3(minX, minY, minZ);
-            model.BoundingMax = new System.Numerics.Vector3(maxX, maxY, maxZ);
-            model.Radius = (model.BoundingMax - model.BoundingMin).Length() / 2f;
-
-            UnifiedLogger.LogApplication(LogLevel.INFO,
-                $"UpdateCompositeBounds: bounds=({minX:F2},{minY:F2},{minZ:F2}) to ({maxX:F2},{maxY:F2},{maxZ:F2}), radius={model.Radius:F2}");
-        }
-    }
-
-    /// <summary>
-    /// Adjust body part positions to ensure adequate overlap at joints (#1557).
-    /// NWN body parts rely on skeletal deformation for seamless connections. Our static
-    /// preview places rigid meshes at bone positions, which can leave thin seams between
-    /// adjacent parts. This method detects thin overlaps and nudges parts closer together.
-    /// </summary>
-    internal void AdjustSeamOverlaps(MdlModel compositeModel)
-    {
-        AdjustSeamOverlaps(compositeModel, _meshPartTypes);
-    }
-
-    /// <summary>
-    /// Overload accepting explicit part type map (for unit testing with synthetic data).
-    /// </summary>
-    internal static void AdjustSeamOverlaps(MdlModel compositeModel, Dictionary<string, string> meshPartTypes)
-    {
-        // Adjacent body part pairs that should overlap vertically.
-        // Format: (upper part type, lower part type)
-        // "Upper" = the part that is higher on the body (larger Z)
-        var adjacentPairs = new[]
-        {
-            ("head", "neck"),
-            ("neck", "chest"),
-        };
-
-        // Minimum overlap threshold in world units. Below this, parts get nudged.
-        // Measured overlaps: Human=0.112, Dwarf=0.090, Elf=0.048, Halfling=~0.05.
-        // NWN relies on skeletal deformation to close seams; our static preview needs
-        // enough raw vertex overlap to look seamless. Target human-like overlap.
-        const float minOverlap = 0.10f;
-
-        var meshes = compositeModel.GetMeshNodes().ToList();
-
-        // Log all mesh names and their part type mappings for diagnostics
-        UnifiedLogger.LogApplication(LogLevel.INFO,
-            $"AdjustSeamOverlaps: {meshes.Count} meshes, {meshPartTypes.Count} part type mappings");
-        foreach (var mesh in meshes)
-        {
-            meshPartTypes.TryGetValue(mesh.Name, out var pt);
-            UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                $"  mesh '{mesh.Name}' → partType='{pt ?? "(unmapped)"}', pos={mesh.Position}");
-        }
-
-        foreach (var (upperPartType, lowerPartType) in adjacentPairs)
-        {
-            // Match meshes by their tracked body part type, not by mesh node name
-            var upperMeshes = meshes.Where(m =>
-                meshPartTypes.TryGetValue(m.Name, out var pt) &&
-                string.Equals(pt, upperPartType, StringComparison.OrdinalIgnoreCase)).ToList();
-            var lowerMeshes = meshes.Where(m =>
-                meshPartTypes.TryGetValue(m.Name, out var pt) &&
-                string.Equals(pt, lowerPartType, StringComparison.OrdinalIgnoreCase)).ToList();
-
-            if (upperMeshes.Count == 0 || lowerMeshes.Count == 0)
-            {
-                UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                    $"AdjustSeamOverlaps: {upperPartType}/{lowerPartType} — upper={upperMeshes.Count}, lower={lowerMeshes.Count} — skipping");
-                continue;
-            }
-
-            // Compute world-space Z bounds for each set of meshes
-            float upperMinZ = float.MaxValue;
-            foreach (var mesh in upperMeshes)
-            {
-                var transform = System.Numerics.Matrix4x4.CreateScale(mesh.Scale)
-                    * System.Numerics.Matrix4x4.CreateFromQuaternion(mesh.Orientation)
-                    * System.Numerics.Matrix4x4.CreateTranslation(mesh.Position);
-                foreach (var vertex in mesh.Vertices)
-                {
-                    var wv = System.Numerics.Vector3.Transform(vertex, transform);
-                    if (!float.IsNaN(wv.Z))
-                        upperMinZ = Math.Min(upperMinZ, wv.Z);
-                }
-            }
-
-            float lowerMaxZ = float.MinValue;
-            foreach (var mesh in lowerMeshes)
-            {
-                var transform = System.Numerics.Matrix4x4.CreateScale(mesh.Scale)
-                    * System.Numerics.Matrix4x4.CreateFromQuaternion(mesh.Orientation)
-                    * System.Numerics.Matrix4x4.CreateTranslation(mesh.Position);
-                foreach (var vertex in mesh.Vertices)
-                {
-                    var wv = System.Numerics.Vector3.Transform(vertex, transform);
-                    if (!float.IsNaN(wv.Z))
-                        lowerMaxZ = Math.Max(lowerMaxZ, wv.Z);
-                }
-            }
-
-            if (upperMinZ == float.MaxValue || lowerMaxZ == float.MinValue)
-                continue;
-
-            float overlap = lowerMaxZ - upperMinZ;
-            if (overlap >= minOverlap)
-            {
-                UnifiedLogger.LogApplication(LogLevel.INFO,
-                    $"AdjustSeamOverlaps: {upperPartType}/{lowerPartType} overlap={overlap:F4} >= {minOverlap} — OK");
-                continue;
-            }
-
-            // Need to increase overlap. Split the deficit evenly:
-            // push upper part down and lower part up.
-            float deficit = minOverlap - overlap;
-            float halfDeficit = deficit / 2f;
-
-            foreach (var mesh in upperMeshes)
-            {
-                mesh.Position = new System.Numerics.Vector3(
-                    mesh.Position.X, mesh.Position.Y, mesh.Position.Z - halfDeficit);
-            }
-            foreach (var mesh in lowerMeshes)
-            {
-                mesh.Position = new System.Numerics.Vector3(
-                    mesh.Position.X, mesh.Position.Y, mesh.Position.Z + halfDeficit);
-            }
-
-            UnifiedLogger.LogApplication(LogLevel.INFO,
-                $"AdjustSeamOverlaps: {upperPartType}/{lowerPartType} overlap={overlap:F4} < {minOverlap} — " +
-                $"nudged ±{halfDeficit:F4} (new overlap≈{minOverlap:F4})");
-        }
+        UnifiedLogger.LogApplication(LogLevel.WARN, $"AppendPart: '{raceResRef}' not found (no human fallback either)");
     }
 
     /// <summary>
@@ -730,7 +266,6 @@ public class ModelService
     /// </summary>
     public MdlModel? LoadModelForAppearance(ushort appearanceId, byte gender = 0, int phenotype = 0)
     {
-        // Get the model type and race from appearance.2da
         var modelType = _gameDataService.Get2DAValue("appearance", appearanceId, "MODELTYPE");
         var race = _gameDataService.Get2DAValue("appearance", appearanceId, "RACE");
 
@@ -743,16 +278,13 @@ public class ModelService
             return null;
         }
 
-        // Determine model name based on model type
         string modelName;
         if (modelType?.ToUpperInvariant().Contains("P") == true)
         {
-            // Part-based model - RACE is just a letter (e.g., "O" for Half-Elf)
             modelName = BuildModelPrefix(gender, race, phenotype);
         }
         else
         {
-            // Simple/Full model - RACE is the model name directly
             modelName = race;
         }
 
@@ -761,7 +293,7 @@ public class ModelService
     }
 
     /// <summary>
-    /// Load a model by ResRef name.
+    /// Load a model by ResRef name. Cached.
     /// </summary>
     public MdlModel? LoadModel(string resRef)
     {
@@ -770,18 +302,16 @@ public class ModelService
 
         resRef = resRef.ToLowerInvariant();
 
-        // Check cache
         if (_modelCache.TryGetValue(resRef, out var cached))
         {
-            UnifiedLogger.LogApplication(LogLevel.INFO, $"LoadModel: '{resRef}' from cache, hasModel={cached != null}");
+            UnifiedLogger.LogApplication(LogLevel.DEBUG, $"LoadModel: '{resRef}' from cache, hasModel={cached != null}");
             return cached;
         }
 
-        // Try to load from game resources (Override → HAK → BIF)
         var resourceResult = _gameDataService.FindResourceWithSource(resRef, ResourceTypes.Mdl);
         if (resourceResult == null || resourceResult.Data.Length == 0)
         {
-            UnifiedLogger.LogApplication(LogLevel.WARN, $"LoadModel: '{resRef}' not found in game resources");
+            UnifiedLogger.LogApplication(LogLevel.DEBUG, $"LoadModel: '{resRef}' not found in game resources");
             _modelCache[resRef] = null;
             return null;
         }
@@ -802,7 +332,6 @@ public class ModelService
         }
         catch (Exception ex)
         {
-            // Model parsing failed
             UnifiedLogger.LogApplication(LogLevel.WARN, $"LoadModel: '{resRef}' parse failed: {ex.Message}");
             _modelCache[resRef] = null;
             return null;
@@ -811,10 +340,8 @@ public class ModelService
 
     /// <summary>
     /// NWN creatures inherit animations from a supermodel chain (e.g. a_ba, a_fa).
-    /// The leaf creature MDL usually only overrides geometry; idle/walk/attack/etc.
-    /// live in the parent. This walks the chain and appends every animation it
-    /// finds to the leaf model so the preview can play them. Missing supermodels
-    /// are logged and skipped — they're optional at runtime (#2124).
+    /// Walk the chain and append every animation found to the leaf so the preview can play
+    /// idle/walk/attack. Missing supermodels are logged and skipped (#2124).
     /// </summary>
     private void MergeSuperModelAnimations(MdlModel model, HashSet<string> visited)
     {
@@ -839,7 +366,6 @@ public class ModelService
             return;
         }
 
-        // Append parent animations that the leaf doesn't already define.
         var existing = new HashSet<string>(
             model.Animations.Select(a => a.Name),
             StringComparer.OrdinalIgnoreCase);
@@ -856,13 +382,6 @@ public class ModelService
             $"MergeSuperModelAnimations: '{model.Name}' inherited {added} animations from '{parentName}'");
     }
 
-    // #1676: LoadModelPreferBIF removed. All model loading now uses the public LoadModel()
-    // method above, which uses standard resolution (Override → HAK → Module → BIF).
-    // Investigation verified that both binary and ASCII CEP HAK models parse correctly.
-
-    /// <summary>
-    /// Clear the model cache.
-    /// </summary>
     public void ClearCache()
     {
         _modelCache.Clear();

--- a/Quartermaster/Quartermaster/Views/Panels/AdvancedPanel.axaml
+++ b/Quartermaster/Quartermaster/Views/Panels/AdvancedPanel.axaml
@@ -184,7 +184,7 @@
                             <TextBlock x:Name="VariableValidationText"
                                        DockPanel.Dock="Bottom"
                                        Foreground="{DynamicResource ThemeError}"
-                                       FontSize="11"
+                                       FontSize="{DynamicResource FontSizeSmall}"
                                        TextWrapping="Wrap"
                                        IsVisible="False"
                                        Margin="0,4,0,0"/>
@@ -214,7 +214,7 @@
                                                              BorderBrush="{Binding HasError, Converter={StaticResource BoolToErrorBrushConverter}}"/>
                                                     <TextBlock Text="{Binding ErrorMessage}"
                                                                Foreground="{DynamicResource ThemeError}"
-                                                               FontSize="11"
+                                                               FontSize="{DynamicResource FontSizeSmall}"
                                                                VerticalAlignment="Center"
                                                                IsVisible="{Binding HasError}"/>
                                                 </StackPanel>

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
@@ -323,7 +323,7 @@
                                     IsVisible="False">
                                 <TextBlock x:Name="PreviewStateText"
                                            FontStyle="Italic"
-                                           FontSize="12"/>
+                                           FontSize="{DynamicResource FontSizeSmall}"/>
                             </Border>
                         </Grid>
                     </Border>

--- a/Radoub.UI/Radoub.UI.Tests/Services/MdlPartComposerBoneTransformTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/MdlPartComposerBoneTransformTests.cs
@@ -1,15 +1,17 @@
 using System.Numerics;
-using Quartermaster.Services;
 using Radoub.Formats.Mdl;
+using Radoub.UI.Services;
+using Xunit;
 
-namespace Quartermaster.Tests;
+namespace Radoub.UI.Tests.Services;
 
 /// <summary>
-/// Tests for ModelService.GetBoneWorldTransform — validates that bone world positions
+/// Tests for MdlPartComposer.GetBoneWorldTransform — validates that bone world positions
 /// correctly account for parent rotations, scale, and translation through the hierarchy.
-/// Fix for #1557: elf head/neck mismatch and halfling proportion issues.
+/// Originally added in Quartermaster for #1557 (elf head/neck mismatch); migrated to
+/// Radoub.UI.Tests when the bone-transform helper moved into MdlPartComposer (PR3a, #2159).
 /// </summary>
-public class ModelServiceBoneTransformTests
+public class MdlPartComposerBoneTransformTests
 {
     private const float Tolerance = 0.0001f;
 
@@ -24,7 +26,7 @@ public class ModelServiceBoneTransformTests
             Scale = 1.0f
         };
 
-        var result = ModelService.GetBoneWorldTransform(node);
+        var result = MdlPartComposer.GetBoneWorldTransform(node);
         Matrix4x4.Decompose(result, out _, out _, out var translation);
 
         Assert.Equal(1f, translation.X, Tolerance);
@@ -53,10 +55,9 @@ public class ModelServiceBoneTransformTests
         };
         parent.Children.Add(child);
 
-        var result = ModelService.GetBoneWorldTransform(child);
+        var result = MdlPartComposer.GetBoneWorldTransform(child);
         Matrix4x4.Decompose(result, out _, out _, out var translation);
 
-        // With identity rotation, world position is simply sum of positions
         Assert.Equal(10f, translation.X, Tolerance);
         Assert.Equal(0f, translation.Y, Tolerance);
         Assert.Equal(5f, translation.Z, Tolerance);
@@ -65,7 +66,6 @@ public class ModelServiceBoneTransformTests
     [Fact]
     public void GetBoneWorldTransform_RotatedParent_AppliesRotationToChildPosition()
     {
-        // Parent rotated 90 degrees around Z axis
         var rotation90Z = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, MathF.PI / 2f);
 
         var parent = new MdlNode
@@ -79,18 +79,16 @@ public class ModelServiceBoneTransformTests
         var child = new MdlNode
         {
             Name = "head_g",
-            Position = new Vector3(1, 0, 0), // Local: 1 unit along X
+            Position = new Vector3(1, 0, 0),
             Orientation = Quaternion.Identity,
             Scale = 1.0f,
             Parent = parent
         };
         parent.Children.Add(child);
 
-        var result = ModelService.GetBoneWorldTransform(child);
+        var result = MdlPartComposer.GetBoneWorldTransform(child);
         Matrix4x4.Decompose(result, out _, out _, out var translation);
 
-        // Parent rotation of 90° around Z should rotate child's local X-offset to Y direction
-        // (1,0,0) rotated 90° around Z = (0,1,0)
         Assert.Equal(0f, translation.X, Tolerance);
         Assert.Equal(1f, translation.Y, Tolerance);
         Assert.Equal(0f, translation.Z, Tolerance);
@@ -99,7 +97,6 @@ public class ModelServiceBoneTransformTests
     [Fact]
     public void GetBoneWorldTransform_RotatedParentWithOffset_CombinesCorrectly()
     {
-        // Parent at (5,0,0) rotated 90° around Z
         var rotation90Z = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, MathF.PI / 2f);
 
         var parent = new MdlNode
@@ -113,17 +110,16 @@ public class ModelServiceBoneTransformTests
         var child = new MdlNode
         {
             Name = "head_g",
-            Position = new Vector3(2, 0, 0), // 2 units along local X
+            Position = new Vector3(2, 0, 0),
             Orientation = Quaternion.Identity,
             Scale = 1.0f,
             Parent = parent
         };
         parent.Children.Add(child);
 
-        var result = ModelService.GetBoneWorldTransform(child);
+        var result = MdlPartComposer.GetBoneWorldTransform(child);
         Matrix4x4.Decompose(result, out _, out _, out var translation);
 
-        // Child position (2,0,0) rotated by parent's 90°Z = (0,2,0), then + parent pos (5,0,0)
         Assert.Equal(5f, translation.X, Tolerance);
         Assert.Equal(2f, translation.Y, Tolerance);
         Assert.Equal(0f, translation.Z, Tolerance);
@@ -150,10 +146,9 @@ public class ModelServiceBoneTransformTests
         };
         parent.Children.Add(child);
 
-        var result = ModelService.GetBoneWorldTransform(child);
+        var result = MdlPartComposer.GetBoneWorldTransform(child);
         Matrix4x4.Decompose(result, out _, out _, out var translation);
 
-        // Parent scale 2x should scale child's position
         Assert.Equal(2f, translation.X, Tolerance);
         Assert.Equal(2f, translation.Y, Tolerance);
         Assert.Equal(2f, translation.Z, Tolerance);
@@ -162,13 +157,12 @@ public class ModelServiceBoneTransformTests
     [Fact]
     public void GetBoneWorldTransform_ThreeLevelHierarchy_AccumulatesCorrectly()
     {
-        // Root at origin, parent rotated 90° around Z, child offset from parent
         var rotation90Z = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, MathF.PI / 2f);
 
         var root = new MdlNode
         {
             Name = "rootdummy",
-            Position = new Vector3(0, 0, 1), // 1 unit up
+            Position = new Vector3(0, 0, 1),
             Orientation = Quaternion.Identity,
             Scale = 1.0f
         };
@@ -176,7 +170,7 @@ public class ModelServiceBoneTransformTests
         var mid = new MdlNode
         {
             Name = "torso_g",
-            Position = new Vector3(0, 0, 2), // 2 units up from root
+            Position = new Vector3(0, 0, 2),
             Orientation = rotation90Z,
             Scale = 1.0f,
             Parent = root
@@ -186,17 +180,16 @@ public class ModelServiceBoneTransformTests
         var leaf = new MdlNode
         {
             Name = "head_g",
-            Position = new Vector3(1, 0, 0), // 1 unit along local X (will be rotated)
+            Position = new Vector3(1, 0, 0),
             Orientation = Quaternion.Identity,
             Scale = 1.0f,
             Parent = mid
         };
         mid.Children.Add(leaf);
 
-        var result = ModelService.GetBoneWorldTransform(leaf);
+        var result = MdlPartComposer.GetBoneWorldTransform(leaf);
         Matrix4x4.Decompose(result, out _, out _, out var translation);
 
-        // Leaf (1,0,0) → mid rotation 90°Z → (0,1,0) + mid pos (0,0,2) → (0,1,2) + root pos (0,0,1) → (0,1,3)
         Assert.Equal(0f, translation.X, Tolerance);
         Assert.Equal(1f, translation.Y, Tolerance);
         Assert.Equal(3f, translation.Z, Tolerance);
@@ -205,8 +198,6 @@ public class ModelServiceBoneTransformTests
     [Fact]
     public void GetBoneWorldTransform_IdentityHierarchy_EqualsPositionSum()
     {
-        // When all rotations are identity, the result should equal simple position addition
-        // This verifies the fix doesn't break races that worked before (human, dwarf)
         var root = new MdlNode
         {
             Name = "rootdummy",
@@ -235,10 +226,9 @@ public class ModelServiceBoneTransformTests
         };
         mid.Children.Add(leaf);
 
-        var result = ModelService.GetBoneWorldTransform(leaf);
+        var result = MdlPartComposer.GetBoneWorldTransform(leaf);
         Matrix4x4.Decompose(result, out _, out _, out var translation);
 
-        // Simple sum: (1,2,3) + (0,0,5) + (0,0,2) = (1,2,10)
         var expectedSum = root.Position + mid.Position + leaf.Position;
         Assert.Equal(expectedSum.X, translation.X, Tolerance);
         Assert.Equal(expectedSum.Y, translation.Y, Tolerance);
@@ -258,10 +248,9 @@ public class ModelServiceBoneTransformTests
             Scale = 1.0f
         };
 
-        var result = ModelService.GetBoneWorldTransform(node);
+        var result = MdlPartComposer.GetBoneWorldTransform(node);
         Matrix4x4.Decompose(result, out _, out var rotation, out _);
 
-        // Rotation should be preserved
         Assert.Equal(rotation45X.X, rotation.X, Tolerance);
         Assert.Equal(rotation45X.Y, rotation.Y, Tolerance);
         Assert.Equal(rotation45X.Z, rotation.Z, Tolerance);
@@ -280,7 +269,7 @@ public class ModelServiceBoneTransformTests
             Parent = null
         };
 
-        var result = ModelService.GetBoneWorldTransform(node);
+        var result = MdlPartComposer.GetBoneWorldTransform(node);
         Matrix4x4.Decompose(result, out _, out _, out var translation);
 
         Assert.Equal(3f, translation.X, Tolerance);

--- a/Radoub.UI/Radoub.UI.Tests/Services/MdlPartComposerSeamOverlapTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/MdlPartComposerSeamOverlapTests.cs
@@ -1,22 +1,23 @@
 using System.Numerics;
-using Quartermaster.Services;
 using Radoub.Formats.Mdl;
+using Radoub.UI.Services;
+using Xunit;
 
-namespace Quartermaster.Tests;
+namespace Radoub.UI.Tests.Services;
 
 /// <summary>
-/// Tests for ModelService.AdjustSeamOverlaps — validates that body parts with thin
-/// vertex overlap at joints get nudged closer together (#1557).
-/// Threshold is 0.10 world units (matching human-level overlap).
+/// Tests for MdlPartComposer.AdjustSeamOverlaps — body parts with thin vertex overlap
+/// at joints get nudged closer together (#1557). Threshold is 0.10 world units (matching
+/// human-level overlap). Originally added in Quartermaster; migrated when the seam-overlap
+/// helper moved into MdlPartComposer (PR3a, #2159).
 /// </summary>
-public class ModelServiceSeamOverlapTests
+public class MdlPartComposerSeamOverlapTests
 {
     private const float Tolerance = 0.001f;
-    private const float Threshold = 0.10f; // Must match ModelService.AdjustSeamOverlaps
+    private const float Threshold = 0.10f; // Must match MdlPartComposer.MinSeamOverlap
 
     /// <summary>
     /// Create a synthetic composite model with head and neck meshes at given Z positions.
-    /// Head mesh vertices span [headMinZ, headMaxZ], neck vertices span [neckMinZ, neckMaxZ].
     /// </summary>
     private static (MdlModel model, Dictionary<string, string> partTypes) CreateHeadNeckModel(
         float headMinZ, float headMaxZ, Vector3 headPosition,
@@ -76,20 +77,18 @@ public class ModelServiceSeamOverlapTests
     [Fact]
     public void AdjustSeamOverlaps_ThinOverlap_NudgesPartsCloser()
     {
-        // Head bottom at Z=1.0, neck top at Z=1.05 → overlap = 0.05 (below 0.10 threshold)
         var (model, partTypes) = CreateHeadNeckModel(
             headMinZ: 1.0f, headMaxZ: 1.5f, headPosition: new Vector3(0, 0, 1.25f),
             neckMinZ: 0.5f, neckMaxZ: 1.05f, neckPosition: new Vector3(0, 0, 0.75f));
 
-        float overlapBefore = 1.05f - 1.0f; // 0.05
+        float overlapBefore = 1.05f - 1.0f;
         Assert.True(overlapBefore < Threshold, "Precondition: overlap should be below threshold");
 
-        ModelService.AdjustSeamOverlaps(model, partTypes);
+        MdlPartComposer.AdjustSeamOverlaps(model, partTypes);
 
         var headMesh = model.GetMeshNodes().First(m => m.Name == "headmesh01");
         var neckMesh = model.GetMeshNodes().First(m => m.Name == "neckmesh01");
 
-        // Head moved down (Z decreased), neck moved up (Z increased)
         Assert.True(headMesh.Position.Z < 1.25f, "Head should have moved down");
         Assert.True(neckMesh.Position.Z > 0.75f, "Neck should have moved up");
     }
@@ -97,19 +96,17 @@ public class ModelServiceSeamOverlapTests
     [Fact]
     public void AdjustSeamOverlaps_AdequateOverlap_NoChange()
     {
-        // Head bottom at Z=1.0, neck top at Z=1.12 → overlap = 0.12 (above 0.10 threshold)
         var headPos = new Vector3(0, 0, 1.25f);
         var neckPos = new Vector3(0, 0, 0.75f);
         var (model, partTypes) = CreateHeadNeckModel(
             headMinZ: 1.0f, headMaxZ: 1.5f, headPosition: headPos,
             neckMinZ: 0.5f, neckMaxZ: 1.12f, neckPosition: neckPos);
 
-        ModelService.AdjustSeamOverlaps(model, partTypes);
+        MdlPartComposer.AdjustSeamOverlaps(model, partTypes);
 
         var headMesh = model.GetMeshNodes().First(m => m.Name == "headmesh01");
         var neckMesh = model.GetMeshNodes().First(m => m.Name == "neckmesh01");
 
-        // Positions should be unchanged
         Assert.Equal(headPos.Z, headMesh.Position.Z, Tolerance);
         Assert.Equal(neckPos.Z, neckMesh.Position.Z, Tolerance);
     }
@@ -117,37 +114,33 @@ public class ModelServiceSeamOverlapTests
     [Fact]
     public void AdjustSeamOverlaps_NegativeOverlap_NudgesPartsCloser()
     {
-        // Head bottom at Z=1.0, neck top at Z=0.99 → overlap = -0.01 (gap!)
         var (model, partTypes) = CreateHeadNeckModel(
             headMinZ: 1.0f, headMaxZ: 1.5f, headPosition: new Vector3(0, 0, 1.25f),
             neckMinZ: 0.5f, neckMaxZ: 0.99f, neckPosition: new Vector3(0, 0, 0.75f));
 
-        float overlapBefore = 0.99f - 1.0f; // -0.01 (gap)
+        float overlapBefore = 0.99f - 1.0f;
         Assert.True(overlapBefore < 0f, "Precondition: should be a gap");
 
-        ModelService.AdjustSeamOverlaps(model, partTypes);
+        MdlPartComposer.AdjustSeamOverlaps(model, partTypes);
 
         var headMesh = model.GetMeshNodes().First(m => m.Name == "headmesh01");
         var neckMesh = model.GetMeshNodes().First(m => m.Name == "neckmesh01");
 
-        // Both should have been nudged
         Assert.True(headMesh.Position.Z < 1.25f, "Head should have moved down");
         Assert.True(neckMesh.Position.Z > 0.75f, "Neck should have moved up");
 
-        // Total nudge should close the 0.01 gap plus reach the 0.10 threshold
         float totalNudge = (1.25f - headMesh.Position.Z) + (neckMesh.Position.Z - 0.75f);
-        Assert.Equal(0.11f, totalNudge, Tolerance); // deficit = 0.10 - (-0.01) = 0.11
+        Assert.Equal(0.11f, totalNudge, Tolerance);
     }
 
     [Fact]
     public void AdjustSeamOverlaps_SplitsDeficitEvenly()
     {
-        // Overlap = 0.05, threshold = 0.10, deficit = 0.05, half = 0.025
         var (model, partTypes) = CreateHeadNeckModel(
             headMinZ: 1.0f, headMaxZ: 1.5f, headPosition: new Vector3(0, 0, 1.25f),
             neckMinZ: 0.5f, neckMaxZ: 1.05f, neckPosition: new Vector3(0, 0, 0.75f));
 
-        ModelService.AdjustSeamOverlaps(model, partTypes);
+        MdlPartComposer.AdjustSeamOverlaps(model, partTypes);
 
         var headMesh = model.GetMeshNodes().First(m => m.Name == "headmesh01");
         var neckMesh = model.GetMeshNodes().First(m => m.Name == "neckmesh01");
@@ -155,15 +148,13 @@ public class ModelServiceSeamOverlapTests
         float headDelta = 1.25f - headMesh.Position.Z;
         float neckDelta = neckMesh.Position.Z - 0.75f;
 
-        // Both should move by the same amount
         Assert.Equal(headDelta, neckDelta, Tolerance);
-        Assert.Equal(0.025f, headDelta, Tolerance); // half of 0.05 deficit
+        Assert.Equal(0.025f, headDelta, Tolerance);
     }
 
     [Fact]
     public void AdjustSeamOverlaps_UnmappedMeshes_Ignored()
     {
-        // Mesh exists but isn't in the part type dictionary — should be skipped
         var root = new MdlNode { Name = "composite_root" };
         var mesh = new MdlTrimeshNode
         {
@@ -176,10 +167,9 @@ public class ModelServiceSeamOverlapTests
         root.Children.Add(mesh);
 
         var model = new MdlModel { Name = "test", GeometryRoot = root };
-        var partTypes = new Dictionary<string, string>(); // empty — nothing mapped
+        var partTypes = new Dictionary<string, string>();
 
-        // Should not throw, should not modify anything
-        ModelService.AdjustSeamOverlaps(model, partTypes);
+        MdlPartComposer.AdjustSeamOverlaps(model, partTypes);
 
         Assert.Equal(Vector3.Zero, mesh.Position);
     }
@@ -187,26 +177,23 @@ public class ModelServiceSeamOverlapTests
     [Fact]
     public void AdjustSeamOverlaps_ElfLikeOverlap_GetsNudged()
     {
-        // Simulate elf-like overlap: 0.048 (real measured value), below 0.10 threshold
+        // Real measured elf overlap: 0.048
         var (model, partTypes) = CreateHeadNeckModel(
             headMinZ: 1.655f, headMaxZ: 1.85f, headPosition: new Vector3(0, 0, 1.703f),
             neckMinZ: 1.50f, neckMaxZ: 1.703f, neckPosition: new Vector3(0, 0, 1.622f));
 
-        // Overlap = neckMaxZ - headMinZ = 1.703 - 1.655 = 0.048
         float overlapBefore = 1.703f - 1.655f;
         Assert.Equal(0.048f, overlapBefore, Tolerance);
         Assert.True(overlapBefore < Threshold);
 
-        ModelService.AdjustSeamOverlaps(model, partTypes);
+        MdlPartComposer.AdjustSeamOverlaps(model, partTypes);
 
         var headMesh = model.GetMeshNodes().First(m => m.Name == "headmesh01");
         var neckMesh = model.GetMeshNodes().First(m => m.Name == "neckmesh01");
 
-        // Head should move down, neck should move up
         Assert.True(headMesh.Position.Z < 1.703f, "Elf head should have moved down");
         Assert.True(neckMesh.Position.Z > 1.622f, "Elf neck should have moved up");
 
-        // Deficit = 0.10 - 0.048 = 0.052, each part moves 0.026
         float headDelta = 1.703f - headMesh.Position.Z;
         Assert.Equal(0.026f, headDelta, Tolerance);
     }

--- a/Radoub.UI/Radoub.UI.Tests/Services/MdlPartComposerTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/MdlPartComposerTests.cs
@@ -1,0 +1,275 @@
+using System.Numerics;
+using Radoub.Formats.Common;
+using Radoub.Formats.Mdl;
+using Radoub.TestUtilities.Mocks;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests.Services;
+
+/// <summary>
+/// Tests the public Compose / ComposeFlat surface of MdlPartComposer.
+/// Internal helpers (seam-overlap, bone-transform) are covered by their own
+/// dedicated test files migrated from QM (see MdlPartComposerSeamOverlapTests
+/// and MdlPartComposerBoneTransformTests).
+/// </summary>
+public class MdlPartComposerTests
+{
+    private static MockGameDataService BuildGameDataWith(params (string resRef, MdlModel model)[] models)
+    {
+        var game = new MockGameDataService(includeSampleData: false);
+        foreach (var (resRef, model) in models)
+        {
+            // Mock parser doesn't actually parse — we hand the composer a pre-built model
+            // via the factory injection point so the resource bytes here are placeholder
+            game.SetResource(resRef, ResourceTypes.Mdl, new byte[] { 0x42 });
+        }
+        return game;
+    }
+
+    private static MdlModel MakeSkeleton(params (string boneName, Vector3 position)[] bones)
+    {
+        var root = new MdlNode
+        {
+            Name = "skeleton_root",
+            Position = Vector3.Zero,
+            Orientation = Quaternion.Identity,
+            Scale = 1.0f,
+        };
+        foreach (var (boneName, position) in bones)
+        {
+            var bone = new MdlNode
+            {
+                Name = boneName,
+                Position = position,
+                Orientation = Quaternion.Identity,
+                Scale = 1.0f,
+                Parent = root,
+            };
+            root.Children.Add(bone);
+        }
+
+        return new MdlModel
+        {
+            Name = "skeleton",
+            GeometryRoot = root,
+            IsBinary = true,
+        };
+    }
+
+    private static MdlModel MakePartModel(string name, string meshName, Vector3 vertex)
+    {
+        var root = new MdlNode { Name = $"{name}_root", Orientation = Quaternion.Identity, Scale = 1.0f };
+        var mesh = new MdlTrimeshNode
+        {
+            Name = meshName,
+            Position = Vector3.Zero,
+            Orientation = Quaternion.Identity,
+            Scale = 1.0f,
+            Vertices = new[] { vertex },
+            Faces = Array.Empty<MdlFace>(),
+            Bitmap = "stale_bitmap_field",  // verify composer overrides this
+            Parent = root,
+        };
+        root.Children.Add(mesh);
+        return new MdlModel { Name = name, GeometryRoot = root, IsBinary = true };
+    }
+
+    [Fact]
+    public void Compose_NoParts_ReturnsNull()
+    {
+        var composer = new MdlPartComposer(BuildGameDataWith(), (_, _) => null);
+        var result = composer.Compose("pmh0", Array.Empty<(string, string)>());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Compose_AllPartsMissingFromGameData_ReturnsNull()
+    {
+        var game = new MockGameDataService(includeSampleData: false);
+        // No resources registered
+        var composer = new MdlPartComposer(game, (_, _) => null);
+
+        var result = composer.Compose("pmh0", new[] { ("chest", "pmh0_chest005") });
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Compose_AttachesPartMeshUnderNamedBone()
+    {
+        var skeleton = MakeSkeleton(("torso_g", new Vector3(0, 0, 1)));
+        var chestPart = MakePartModel("pmh0_chest005", "chest_mesh", new Vector3(0.5f, 0, 0));
+
+        MdlModel? Loader(string resRef, bool _)
+        {
+            return resRef switch
+            {
+                "pmh0" => skeleton,
+                "pmh0_chest005" => chestPart,
+                _ => null,
+            };
+        }
+
+        var game = BuildGameDataWith(("pmh0", skeleton), ("pmh0_chest005", chestPart));
+        var composer = new MdlPartComposer(game, Loader);
+
+        var result = composer.Compose("pmh0", new[] { ("chest", "pmh0_chest005") });
+
+        Assert.NotNull(result);
+        var meshes = result!.GetMeshNodes().ToList();
+        Assert.Single(meshes);
+        Assert.Equal("chest_mesh", meshes[0].Name);
+
+        // Mesh should be parented under the bone, not the composite root directly
+        Assert.NotNull(meshes[0].Parent);
+        Assert.Equal("torso_g", meshes[0].Parent!.Name);
+    }
+
+    [Fact]
+    public void Compose_OverridesStaleBitmapWithDerivedTextureName()
+    {
+        var skeleton = MakeSkeleton(("torso_g", new Vector3(0, 0, 1)));
+        var chestPart = MakePartModel("pmh0_chest005", "chest_mesh", new Vector3(0.5f, 0, 0));
+
+        var game = BuildGameDataWith(("pmh0", skeleton), ("pmh0_chest005", chestPart));
+        var composer = new MdlPartComposer(game, (resRef, _) => resRef switch
+        {
+            "pmh0" => skeleton,
+            "pmh0_chest005" => chestPart,
+            _ => null,
+        });
+
+        var result = composer.Compose("pmh0", new[] { ("chest", "pmh0_chest005") });
+
+        var mesh = result!.GetMeshNodes().First();
+
+        // Stale bitmap must be replaced with the part ResRef (texture naming convention)
+        Assert.NotEqual("stale_bitmap_field", mesh.Bitmap);
+        Assert.Equal("pmh0_chest005", mesh.Bitmap);
+    }
+
+    [Fact]
+    public void Compose_PartWithUnknownBoneName_StillIncludesMesh()
+    {
+        // boneNameForPart returns a bone not in the skeleton — should fall back to composite root
+        var skeleton = MakeSkeleton(("torso_g", Vector3.Zero));
+        var weirdPart = MakePartModel("pmh0_xyz001", "xyz_mesh", new Vector3(1, 0, 0));
+
+        var game = BuildGameDataWith(("pmh0", skeleton), ("pmh0_xyz001", weirdPart));
+        var composer = new MdlPartComposer(
+            game,
+            (resRef, _) => resRef switch
+            {
+                "pmh0" => skeleton,
+                "pmh0_xyz001" => weirdPart,
+                _ => null,
+            },
+            partType => "missing_bone_g");  // every part maps to a missing bone
+
+        var result = composer.Compose("pmh0", new[] { ("xyz", "pmh0_xyz001") });
+
+        Assert.NotNull(result);
+        Assert.Single(result!.GetMeshNodes());
+    }
+
+    [Fact]
+    public void Compose_UpdatesBoundingBoxFromAllMeshes()
+    {
+        var skeleton = MakeSkeleton(
+            ("torso_g", new Vector3(0, 0, 1)),
+            ("pelvis_g", new Vector3(0, 0, 0)));
+
+        var chestPart = MakePartModel("pmh0_chest001", "chest_mesh", new Vector3(0, 0, 0.5f));
+        var pelvisPart = MakePartModel("pmh0_pelvis001", "pelvis_mesh", new Vector3(0, 0, -0.5f));
+
+        var game = BuildGameDataWith(("pmh0", skeleton), ("pmh0_chest001", chestPart), ("pmh0_pelvis001", pelvisPart));
+        var composer = new MdlPartComposer(game, (resRef, _) => resRef switch
+        {
+            "pmh0" => skeleton,
+            "pmh0_chest001" => chestPart,
+            "pmh0_pelvis001" => pelvisPart,
+            _ => null,
+        });
+
+        var result = composer.Compose("pmh0", new[]
+        {
+            ("chest", "pmh0_chest001"),
+            ("pelvis", "pmh0_pelvis001"),
+        });
+
+        Assert.NotNull(result);
+        Assert.True(result!.BoundingMax.Z > result.BoundingMin.Z, "Bounds must span chest+pelvis");
+        Assert.True(result.Radius > 0f);
+    }
+
+    [Fact]
+    public void ComposeFlat_AggregatesPartsUnderSyntheticRoot()
+    {
+        // Composite-weapon path: no skeleton, three MDLs joined under a flat root
+        var bottom = MakePartModel("wdbsw_b_011", "wdbsw_b_mesh", new Vector3(0, 0, -1));
+        var middle = MakePartModel("wdbsw_m_011", "wdbsw_m_mesh", new Vector3(0, 0, 0));
+        var top = MakePartModel("wdbsw_t_011", "wdbsw_t_mesh", new Vector3(0, 0, 1));
+
+        var game = BuildGameDataWith(("wdbsw_b_011", bottom), ("wdbsw_m_011", middle), ("wdbsw_t_011", top));
+        var composer = new MdlPartComposer(game, (resRef, _) => resRef switch
+        {
+            "wdbsw_b_011" => bottom,
+            "wdbsw_m_011" => middle,
+            "wdbsw_t_011" => top,
+            _ => null,
+        });
+
+        var result = composer.ComposeFlat(new[] { "wdbsw_b_011", "wdbsw_m_011", "wdbsw_t_011" });
+
+        Assert.NotNull(result);
+        Assert.Equal(3, result!.GetMeshNodes().Count());
+        Assert.NotNull(result.GeometryRoot);
+    }
+
+    [Fact]
+    public void ComposeFlat_NoParts_ReturnsNull()
+    {
+        var composer = new MdlPartComposer(new MockGameDataService(includeSampleData: false), (_, _) => null);
+        Assert.Null(composer.ComposeFlat(Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void ComposeFlat_AllPartsMissing_ReturnsNull()
+    {
+        var game = new MockGameDataService(includeSampleData: false);
+        var composer = new MdlPartComposer(game, (_, _) => null);
+
+        Assert.Null(composer.ComposeFlat(new[] { "missing_001", "missing_002" }));
+    }
+
+    [Fact]
+    public void Compose_PartialPartsMissing_KeepsRemainingMeshes()
+    {
+        var skeleton = MakeSkeleton(
+            ("torso_g", new Vector3(0, 0, 1)),
+            ("pelvis_g", Vector3.Zero));
+
+        var chestPart = MakePartModel("pmh0_chest001", "chest_mesh", new Vector3(0, 0, 0.5f));
+        // pelvis intentionally missing
+
+        var game = BuildGameDataWith(("pmh0", skeleton), ("pmh0_chest001", chestPart));
+        var composer = new MdlPartComposer(game, (resRef, _) => resRef switch
+        {
+            "pmh0" => skeleton,
+            "pmh0_chest001" => chestPart,
+            _ => null,
+        });
+
+        var result = composer.Compose("pmh0", new[]
+        {
+            ("chest", "pmh0_chest001"),
+            ("pelvis", "pmh0_pelvis999"),  // missing
+        });
+
+        Assert.NotNull(result);
+        Assert.Single(result!.GetMeshNodes());
+        Assert.Equal("chest_mesh", result.GetMeshNodes().First().Name);
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/Services/MdlPartNamingTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/MdlPartNamingTests.cs
@@ -1,0 +1,36 @@
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests.Services;
+
+/// <summary>
+/// Tests for MdlPartNaming.BuildBodyPartName — pure string formatting.
+/// Originally in Quartermaster's ModelNameConstructionTests; migrated to Radoub.UI.Tests
+/// when the helper moved into MdlPartNaming (PR3a, #2159). The QM-specific
+/// BuildModelPrefix helper (gender/race/phenotype) stays in QM with its own tests.
+/// </summary>
+public class MdlPartNamingTests
+{
+    [Theory]
+    [InlineData("pfo0", "head", 1, "pfo0_head001")]
+    [InlineData("pmh0", "chest", 1, "pmh0_chest001")]
+    [InlineData("pmd0", "neck", 2, "pmd0_neck002")]
+    [InlineData("pfe0", "footl", 1, "pfe0_footl001")]
+    [InlineData("pmh0", "bicepl", 10, "pmh0_bicepl010")]
+    [InlineData("pmh0", "shinr", 100, "pmh0_shinr100")]
+    public void BuildBodyPartName_FormatsCorrectly(string prefix, string partType, byte partNumber, string expected)
+    {
+        var result = MdlPartNaming.BuildBodyPartName(prefix, partType, partNumber);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void BuildBodyPartName_PartNumberPaddedToThreeDigits()
+    {
+        var result = MdlPartNaming.BuildBodyPartName("pmh0", "head", 1);
+        Assert.EndsWith("001", result);
+
+        var result2 = MdlPartNaming.BuildBodyPartName("pmh0", "head", 99);
+        Assert.EndsWith("099", result2);
+    }
+}

--- a/Radoub.UI/Radoub.UI/Controls/EquipmentSlotControl.axaml
+++ b/Radoub.UI/Radoub.UI/Controls/EquipmentSlotControl.axaml
@@ -78,7 +78,7 @@
                       Width="20"
                       Height="20">
                 <TextBlock Text="⚠"
-                           FontSize="12"
+                           FontSize="{DynamicResource FontSizeSmall}"
                            HorizontalAlignment="Center"
                            VerticalAlignment="Center"/>
               </Border>

--- a/Radoub.UI/Radoub.UI/Services/MdlPartBoneMap.cs
+++ b/Radoub.UI/Radoub.UI/Services/MdlPartBoneMap.cs
@@ -1,0 +1,54 @@
+namespace Radoub.UI.Services;
+
+/// <summary>
+/// Maps NWN body-part type names (e.g., "head", "chest", "shol") to the corresponding
+/// skeleton bone names (with the "_g" suffix used by Aurora Engine MDL skeletons).
+///
+/// Used by <see cref="MdlPartComposer"/> to attach part meshes onto the correct bone
+/// in a creature or armor mannequin skeleton, so that animation pose lookup walks the
+/// parent chain through the supermodel correctly (#2124).
+/// </summary>
+public static class MdlPartBoneMap
+{
+    /// <summary>
+    /// Default mapping from part type to skeleton bone name.
+    /// Unknown part types fall back to <c>{partType}_g</c>.
+    /// </summary>
+    public static string GetBoneNameForPart(string partType) => partType switch
+    {
+        "head" => "head_g",
+        "neck" => "neck_g",
+        "chest" => "torso_g",
+        "robe" => "torso_g",
+        "pelvis" => "pelvis_g",
+        "belt" => "belt_g",
+        "shol" => "lshoulder_g",
+        "shor" => "rshoulder_g",
+        "bicepl" => "lbicep_g",
+        "bicepr" => "rbicep_g",
+        "forel" => "lforearm_g",
+        "forer" => "rforearm_g",
+        "handl" => "lhand_g",
+        "handr" => "rhand_g",
+        "legl" => "lthigh_g",
+        "legr" => "rthigh_g",
+        "shinl" => "lshin_g",
+        "shinr" => "rshin_g",
+        "footl" => "lfoot_g",
+        "footr" => "rfoot_g",
+        _ => partType + "_g"
+    };
+}
+
+/// <summary>
+/// String-formatting helpers for NWN body-part MDL ResRefs.
+/// </summary>
+public static class MdlPartNaming
+{
+    /// <summary>
+    /// Build a body-part MDL ResRef from a creature/mannequin prefix, part type, and part number.
+    /// Format: <c>{prefix}_{partType}{partNumber:D3}</c>, e.g., <c>pmh0_chest005</c>.
+    /// </summary>
+    public static string BuildBodyPartName(string prefix, string partType, byte partNumber)
+        => $"{prefix}_{partType}{partNumber:D3}";
+}

--- a/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
+++ b/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
@@ -1,0 +1,397 @@
+using System.Numerics;
+using Radoub.Formats.Common;
+using Radoub.Formats.Logging;
+using Radoub.Formats.Mdl;
+using Radoub.Formats.Services;
+
+namespace Radoub.UI.Services;
+
+/// <summary>
+/// Composes a single <see cref="MdlModel"/> from a skeleton + body-part MDLs (armor, creature body)
+/// or from a flat list of part MDLs (composite weapons). Generic over the source of parts —
+/// callers handle resolution (creature appearance, item ArmorParts dict, composite weapon parts)
+/// and pass the resolved <c>(partType, resRef)</c> tuples to <see cref="Compose"/>.
+///
+/// Behavior preserved from QM's prior creature-renderer:
+/// <list type="bullet">
+/// <item>Mesh re-parenting under skeleton bones (so animation pose lookup walks the parent chain — #2124)</item>
+/// <item>Body-part texture-name override (the "stale Bitmap field" workaround for body parts)</item>
+/// <item>Head/neck/chest seam-overlap nudge for thin-overlap races (#1557)</item>
+/// <item>Composite-bounds aggregation across all attached meshes</item>
+/// </list>
+/// </summary>
+public sealed class MdlPartComposer
+{
+    private readonly IGameDataService _gameDataService;
+    private readonly Func<string, bool, MdlModel?> _modelLoader;
+    private readonly Func<string, string> _boneNameForPart;
+
+    /// <summary>
+    /// Minimum overlap in world units between adjacent body parts before the seam nudge kicks in.
+    /// Measured: human=0.112, dwarf=0.090, elf=0.048, halfling≈0.05. Target = human-like.
+    /// </summary>
+    public const float MinSeamOverlap = 0.10f;
+
+    /// <summary>Adjacent (upper, lower) part-type pairs that get the seam-overlap nudge.</summary>
+    private static readonly (string Upper, string Lower)[] SeamPairs =
+    {
+        ("head", "neck"),
+        ("neck", "chest"),
+    };
+
+    /// <param name="gameDataService">Used to check resource existence (resolution priority Override→HAK→BIF).</param>
+    /// <param name="modelLoader">
+    ///     Loads a parsed <see cref="MdlModel"/> from a ResRef. Bool argument is "include supermodel
+    ///     animations" — true for the skeleton, false for body parts. Returns null if missing or unparseable.
+    ///     Injected to allow callers (QM) to share a model cache across multiple composer calls.
+    /// </param>
+    /// <param name="boneNameForPart">
+    ///     Maps a part type (e.g., "chest") to its target skeleton bone name (e.g., "torso_g").
+    ///     Defaults to <see cref="MdlPartBoneMap.GetBoneNameForPart"/>.
+    /// </param>
+    public MdlPartComposer(
+        IGameDataService gameDataService,
+        Func<string, bool, MdlModel?> modelLoader,
+        Func<string, string>? boneNameForPart = null)
+    {
+        _gameDataService = gameDataService;
+        _modelLoader = modelLoader;
+        _boneNameForPart = boneNameForPart ?? MdlPartBoneMap.GetBoneNameForPart;
+    }
+
+    /// <summary>
+    /// Compose a multi-part model with parts attached to a skeleton's bones.
+    /// Used for armor, creature body, and any other part-on-skeleton composition.
+    /// </summary>
+    /// <param name="skeletonResRef">Skeleton MDL ResRef (e.g., "pmh0"). Drives bone hierarchy + animations.</param>
+    /// <param name="parts">Resolved (partType, partResRef) tuples. Skip already done — callers pass only existing parts.</param>
+    /// <param name="adjustSeams">When true, nudges adjacent body parts together where overlap is below <see cref="MinSeamOverlap"/>.</param>
+    /// <returns>Composite model, or null if no meshes were successfully attached.</returns>
+    public MdlModel? Compose(
+        string skeletonResRef,
+        IReadOnlyList<(string PartType, string ResRef)> parts,
+        bool adjustSeams = true)
+    {
+        if (parts.Count == 0)
+            return null;
+
+        var skeletonModel = _modelLoader(skeletonResRef, /* withSupermodelAnims */ true);
+        var compositeModel = new MdlModel
+        {
+            Name = skeletonResRef,
+            IsBinary = true,
+        };
+
+        // Inherit skeleton's animation list (and any merged from supermodel chain) so the
+        // composite can play idle/walk/attack in the preview (#2124).
+        if (skeletonModel?.Animations != null)
+        {
+            foreach (var anim in skeletonModel.Animations)
+                compositeModel.Animations.Add(anim);
+            compositeModel.SuperModel = skeletonModel.SuperModel;
+        }
+
+        // Use the skeleton's bone hierarchy as the composite root so animation pose lookup
+        // finds matching bone names through the full parent chain (#2124).
+        if (skeletonModel?.GeometryRoot != null)
+            compositeModel.GeometryRoot = skeletonModel.GeometryRoot;
+
+        var meshPartTypes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (partType, resRef) in parts)
+        {
+            TryAddBodyPart(compositeModel, skeletonModel, partType, resRef, meshPartTypes);
+        }
+
+        if (adjustSeams)
+            AdjustSeamOverlaps(compositeModel, meshPartTypes);
+
+        UpdateCompositeBounds(compositeModel);
+
+        var meshCount = compositeModel.GetMeshNodes().Count();
+        UnifiedLogger.LogApplication(LogLevel.INFO,
+            $"MdlPartComposer.Compose: skeleton={skeletonResRef}, parts={parts.Count}, meshes={meshCount}, bounds={compositeModel.BoundingMin}-{compositeModel.BoundingMax}");
+
+        return meshCount > 0 ? compositeModel : null;
+    }
+
+    /// <summary>
+    /// Compose a multi-part model without a skeleton — meshes aggregated under a synthetic root.
+    /// Used for composite weapons (twobladed sword, quarterstaff, double axe, dire mace) which
+    /// have no skeletal animation; the three parts are fixed-position pieces of one weapon.
+    /// </summary>
+    public MdlModel? ComposeFlat(IReadOnlyList<string> partResRefs, string compositeName = "composite")
+    {
+        if (partResRefs.Count == 0)
+            return null;
+
+        var compositeModel = new MdlModel
+        {
+            Name = compositeName,
+            IsBinary = true,
+            GeometryRoot = new MdlNode
+            {
+                Name = "composite_root",
+                Position = Vector3.Zero,
+                Orientation = Quaternion.Identity,
+                Scale = 1.0f,
+            },
+        };
+
+        foreach (var resRef in partResRefs)
+        {
+            var partModel = _modelLoader(resRef, /* withSupermodelAnims */ false);
+            if (partModel == null)
+            {
+                UnifiedLogger.LogApplication(LogLevel.WARN, $"MdlPartComposer.ComposeFlat: '{resRef}' not loadable");
+                continue;
+            }
+
+            foreach (var node in partModel.EnumerateAllNodes())
+            {
+                if (node is MdlTrimeshNode trimesh)
+                {
+                    node.Parent = compositeModel.GeometryRoot;
+                    compositeModel.GeometryRoot!.Children.Add(node);
+                }
+            }
+        }
+
+        UpdateCompositeBounds(compositeModel);
+
+        var meshCount = compositeModel.GetMeshNodes().Count();
+        UnifiedLogger.LogApplication(LogLevel.INFO,
+            $"MdlPartComposer.ComposeFlat: parts={partResRefs.Count}, meshes={meshCount}");
+
+        return meshCount > 0 ? compositeModel : null;
+    }
+
+    private void TryAddBodyPart(
+        MdlModel compositeModel,
+        MdlModel? skeletonModel,
+        string partType,
+        string partResRef,
+        Dictionary<string, string> meshPartTypes)
+    {
+        try
+        {
+            var partModel = _modelLoader(partResRef, /* withSupermodelAnims */ false);
+            if (partModel == null)
+            {
+                UnifiedLogger.LogApplication(LogLevel.WARN, $"MdlPartComposer: part '{partResRef}' not loadable");
+                return;
+            }
+
+            var boneName = _boneNameForPart(partType);
+            MdlNode? bone = null;
+            if (skeletonModel?.GeometryRoot != null)
+                bone = FindBoneByName(skeletonModel.GeometryRoot, boneName);
+
+            // Compute a fallback world position for parts whose bones can't be found.
+            // (The skeleton lookup may miss in synthetic test models or partial skeletons.)
+            var fallbackPosition = Vector3.Zero;
+            if (bone != null)
+            {
+                var worldMatrix = GetBoneWorldTransform(bone);
+                if (Matrix4x4.Decompose(worldMatrix, out _, out _, out var translation))
+                    fallbackPosition = translation;
+            }
+
+            foreach (var node in partModel.EnumerateAllNodes())
+            {
+                if (node is not MdlTrimeshNode trimesh) continue;
+
+                // Body part MDL files have geometry at local origin. Body part bitmap fields
+                // often contain stale data from reused file structures — derive the texture
+                // name from the part ResRef instead.
+                trimesh.Bitmap = partResRef;
+
+                if (compositeModel.GeometryRoot == null)
+                {
+                    compositeModel.GeometryRoot = new MdlNode
+                    {
+                        Name = "composite_root",
+                        Orientation = Quaternion.Identity,
+                        Scale = 1.0f,
+                    };
+                }
+
+                if (bone != null)
+                {
+                    // Parent under the bone — its bind position carries the world transform,
+                    // so zero out the mesh's own offset to avoid double-application.
+                    trimesh.Position = Vector3.Zero;
+                    node.Parent = bone;
+                    bone.Children.Add(node);
+                }
+                else
+                {
+                    // Fallback: skeleton bone missing, attach at the bone's would-be world
+                    // position under the composite root.
+                    trimesh.Position = fallbackPosition;
+                    node.Parent = compositeModel.GeometryRoot;
+                    compositeModel.GeometryRoot.Children.Add(node);
+                }
+
+                meshPartTypes[trimesh.Name] = partType;
+            }
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"MdlPartComposer.TryAddBodyPart: failed to add '{partType}' from '{partResRef}': {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Find a node in the bone hierarchy by name (case-insensitive).
+    /// Public for tests and for QM's adapter that needs the same lookup.
+    /// </summary>
+    public static MdlNode? FindBoneByName(MdlNode root, string name)
+    {
+        if (root.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+            return root;
+
+        foreach (var child in root.Children)
+        {
+            var found = FindBoneByName(child, name);
+            if (found != null)
+                return found;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Calculate the full world transform of a bone by accumulating S*R*T matrices up the hierarchy.
+    /// Mirrors <c>ModelPreviewGLControl.GetWorldTransform()</c> to handle parent rotations correctly.
+    /// </summary>
+    public static Matrix4x4 GetBoneWorldTransform(MdlNode bone)
+    {
+        var worldTransform = Matrix4x4.Identity;
+        var current = bone;
+
+        while (current != null)
+        {
+            var scale = Matrix4x4.CreateScale(current.Scale);
+            var rotation = Matrix4x4.CreateFromQuaternion(current.Orientation);
+            var translation = Matrix4x4.CreateTranslation(current.Position);
+
+            // Row-major local transform: S * R * T (same as ModelPreviewGLControl.GetWorldTransform)
+            var localTransform = scale * rotation * translation;
+
+            // Accumulate: node * parent * grandparent * ... * root
+            worldTransform = worldTransform * localTransform;
+
+            current = current.Parent;
+        }
+
+        return worldTransform;
+    }
+
+    /// <summary>
+    /// Adjust adjacent body parts (head/neck, neck/chest) so they overlap by at least
+    /// <see cref="MinSeamOverlap"/> world units (#1557). NWN body parts rely on skeletal
+    /// deformation for seamless joints; our static preview places rigid meshes that
+    /// can leave thin seams visible under perspective projection.
+    /// </summary>
+    public static void AdjustSeamOverlaps(MdlModel compositeModel, Dictionary<string, string> meshPartTypes)
+    {
+        var meshes = compositeModel.GetMeshNodes().ToList();
+
+        foreach (var (upperPartType, lowerPartType) in SeamPairs)
+        {
+            var upperMeshes = meshes.Where(m =>
+                meshPartTypes.TryGetValue(m.Name, out var pt) &&
+                string.Equals(pt, upperPartType, StringComparison.OrdinalIgnoreCase)).ToList();
+            var lowerMeshes = meshes.Where(m =>
+                meshPartTypes.TryGetValue(m.Name, out var pt) &&
+                string.Equals(pt, lowerPartType, StringComparison.OrdinalIgnoreCase)).ToList();
+
+            if (upperMeshes.Count == 0 || lowerMeshes.Count == 0)
+                continue;
+
+            float upperMinZ = float.MaxValue;
+            foreach (var mesh in upperMeshes)
+            {
+                var transform = Matrix4x4.CreateScale(mesh.Scale)
+                    * Matrix4x4.CreateFromQuaternion(mesh.Orientation)
+                    * Matrix4x4.CreateTranslation(mesh.Position);
+                foreach (var vertex in mesh.Vertices)
+                {
+                    var wv = Vector3.Transform(vertex, transform);
+                    if (!float.IsNaN(wv.Z))
+                        upperMinZ = Math.Min(upperMinZ, wv.Z);
+                }
+            }
+
+            float lowerMaxZ = float.MinValue;
+            foreach (var mesh in lowerMeshes)
+            {
+                var transform = Matrix4x4.CreateScale(mesh.Scale)
+                    * Matrix4x4.CreateFromQuaternion(mesh.Orientation)
+                    * Matrix4x4.CreateTranslation(mesh.Position);
+                foreach (var vertex in mesh.Vertices)
+                {
+                    var wv = Vector3.Transform(vertex, transform);
+                    if (!float.IsNaN(wv.Z))
+                        lowerMaxZ = Math.Max(lowerMaxZ, wv.Z);
+                }
+            }
+
+            if (upperMinZ == float.MaxValue || lowerMaxZ == float.MinValue)
+                continue;
+
+            float overlap = lowerMaxZ - upperMinZ;
+            if (overlap >= MinSeamOverlap)
+                continue;
+
+            float deficit = MinSeamOverlap - overlap;
+            float halfDeficit = deficit / 2f;
+
+            foreach (var mesh in upperMeshes)
+                mesh.Position = new Vector3(mesh.Position.X, mesh.Position.Y, mesh.Position.Z - halfDeficit);
+            foreach (var mesh in lowerMeshes)
+                mesh.Position = new Vector3(mesh.Position.X, mesh.Position.Y, mesh.Position.Z + halfDeficit);
+        }
+    }
+
+    /// <summary>
+    /// Aggregate the bounding box across all attached meshes, using each mesh's local S*R*T transform.
+    /// </summary>
+    public static void UpdateCompositeBounds(MdlModel model)
+    {
+        var minX = float.MaxValue;
+        var minY = float.MaxValue;
+        var minZ = float.MaxValue;
+        var maxX = float.MinValue;
+        var maxY = float.MinValue;
+        var maxZ = float.MinValue;
+
+        foreach (var mesh in model.GetMeshNodes())
+        {
+            var localTransform = Matrix4x4.CreateScale(mesh.Scale)
+                * Matrix4x4.CreateFromQuaternion(mesh.Orientation)
+                * Matrix4x4.CreateTranslation(mesh.Position);
+
+            foreach (var vertex in mesh.Vertices)
+            {
+                var worldVert = Vector3.Transform(vertex, localTransform);
+
+                minX = Math.Min(minX, worldVert.X);
+                minY = Math.Min(minY, worldVert.Y);
+                minZ = Math.Min(minZ, worldVert.Z);
+                maxX = Math.Max(maxX, worldVert.X);
+                maxY = Math.Max(maxY, worldVert.Y);
+                maxZ = Math.Max(maxZ, worldVert.Z);
+            }
+        }
+
+        if (minX != float.MaxValue)
+        {
+            model.BoundingMin = new Vector3(minX, minY, minZ);
+            model.BoundingMax = new Vector3(maxX, maxY, maxZ);
+            model.Radius = (model.BoundingMax - model.BoundingMin).Length() / 2f;
+        }
+    }
+}

--- a/Radoub.UI/Radoub.UI/Views/TokenInsertionWindow.axaml
+++ b/Radoub.UI/Radoub.UI/Views/TokenInsertionWindow.axaml
@@ -12,7 +12,7 @@
             <!-- Quick Slots -->
             <Border BorderBrush="Gray" BorderThickness="1" CornerRadius="4" Padding="8" Margin="0,8,0,0">
                 <StackPanel Spacing="4">
-                    <TextBlock Text="Quick Access Slots" FontWeight="SemiBold" FontSize="12"/>
+                    <TextBlock Text="Quick Access Slots" FontWeight="SemiBold" FontSize="{DynamicResource FontSizeSmall}"/>
                     <Grid ColumnDefinitions="Auto,*,Auto" RowDefinitions="Auto,Auto,Auto" Margin="0,4,0,0">
                         <TextBlock Grid.Row="0" Grid.Column="0" Text="&#x2605; 1:" VerticalAlignment="Center" Margin="0,0,8,4"/>
                         <TextBlock Grid.Row="0" Grid.Column="1" x:Name="QuickSlot1Label" Text="(empty)" VerticalAlignment="Center" Margin="0,0,8,4"/>

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.10.11-alpha] - 2026-05-01
+**Branch**: `radoub/issue-2159` | **PR**: #2160
+
+### Fix: Replace hardcoded font sizes with themable DynamicResource bindings
+
+- Replace ~14 hardcoded `FontSize="11" / "16" / "20"` instances on MainWindow (Basic Properties, Descriptions, Flags and Quantities, Item Statistics, Item Properties section headers; description hint text; validation labels) and NewItemWizardWindow (step headers, validation, char counts, helper labels) with `{DynamicResource FontSizeSmall|FontSizeLarge|FontSizeXLarge}`
+- Required for low-vision users — hardcoded font sizes do not scale with the Trebuchet font-size slider
+
+---
+
 ## [0.10.10-alpha] - 2026-04-18
 **Branch**: `relique/sprint/1905-categories` | **PR**: #2107
 

--- a/Relique/Relique/Views/MainWindow.axaml
+++ b/Relique/Relique/Views/MainWindow.axaml
@@ -100,7 +100,7 @@
                                 VerticalAlignment="Center"
                                 IsVisible="True">
                         <TextBlock Text="No item loaded"
-                                   FontSize="20"
+                                   FontSize="{DynamicResource FontSizeXLarge}"
                                    HorizontalAlignment="Center"
                                    Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
                         <TextBlock Text="Open a .uti file to begin editing"
@@ -118,7 +118,7 @@
                         <StackPanel Margin="16" Spacing="16">
 
                             <!-- Basic Properties -->
-                            <TextBlock Text="Basic Properties" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                            <TextBlock Text="Basic Properties" FontSize="{DynamicResource FontSizeLarge}" FontWeight="SemiBold" Margin="0,0,0,4"/>
 
                             <Grid ColumnDefinitions="120,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto"
                                   Margin="0,0,0,8">
@@ -214,13 +214,13 @@
                             </Grid>
 
                             <!-- Descriptions (side-by-side) -->
-                            <TextBlock Text="Descriptions" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                            <TextBlock Text="Descriptions" FontSize="{DynamicResource FontSizeLarge}" FontWeight="SemiBold" Margin="0,0,0,4"/>
                             <Grid ColumnDefinitions="*,16,*" Margin="0,0,0,8">
                                 <!-- Unidentified Description -->
                                 <StackPanel Grid.Column="0" x:Name="UnidentifiedDescriptionPanel">
                                     <TextBlock Text="Unidentified" FontWeight="SemiBold" Margin="0,0,0,2"/>
                                     <TextBlock Text="Shown before the item is identified"
-                                               FontSize="11"
+                                               FontSize="{DynamicResource FontSizeSmall}"
                                                Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                                Margin="0,0,0,4"/>
                                     <controls:SpellCheckTextBox
@@ -233,7 +233,7 @@
                                         Watermark="Unidentified description"/>
                                     <TextBlock x:Name="IdentifiedHintLabel"
                                                Text="This item is flagged identified. Uncheck identified to be mysterious."
-                                               FontSize="11"
+                                               FontSize="{DynamicResource FontSizeSmall}"
                                                FontStyle="Italic"
                                                Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                                TextWrapping="Wrap"
@@ -245,7 +245,7 @@
                                 <StackPanel Grid.Column="2">
                                     <TextBlock Text="Identified" FontWeight="SemiBold" Margin="0,0,0,2"/>
                                     <TextBlock Text="Shown after the item is identified"
-                                               FontSize="11"
+                                               FontSize="{DynamicResource FontSizeSmall}"
                                                Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                                Margin="0,0,0,4"/>
                                     <controls:SpellCheckTextBox
@@ -262,7 +262,7 @@
                             <Separator/>
 
                             <!-- Flags & Quantities -->
-                            <TextBlock Text="Flags and Quantities" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                            <TextBlock Text="Flags and Quantities" FontSize="{DynamicResource FontSizeLarge}" FontWeight="SemiBold" Margin="0,0,0,4"/>
 
                             <Grid ColumnDefinitions="120,*" RowDefinitions="Auto,Auto,Auto"
                                   Margin="0,0,0,8">
@@ -518,7 +518,7 @@
 
                             <!-- Item Statistics (above Item Properties for visibility without scrolling) -->
                             <StackPanel x:Name="ItemStatisticsPanel" IsVisible="False">
-                                <TextBlock Text="Item Statistics" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                                <TextBlock Text="Item Statistics" FontSize="{DynamicResource FontSizeLarge}" FontWeight="SemiBold" Margin="0,0,0,4"/>
                                 <TextBox x:Name="ItemStatisticsText"
                                          IsReadOnly="True"
                                          AcceptsReturn="True"
@@ -530,7 +530,7 @@
                             </StackPanel>
 
                             <!-- Item Properties Editor -->
-                            <TextBlock Text="Item Properties" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                            <TextBlock Text="Item Properties" FontSize="{DynamicResource FontSizeLarge}" FontWeight="SemiBold" Margin="0,0,0,4"/>
 
                             <Grid ColumnDefinitions="*,Auto,*" RowDefinitions="Auto,*" MinHeight="300" Margin="0,0,0,8">
                                 <!-- Left: Available Properties header -->
@@ -688,7 +688,7 @@
                                             </StackPanel>
                                             <TextBlock x:Name="VariableValidationText"
                                                        Foreground="{DynamicResource ThemeError}"
-                                                       FontSize="11"
+                                                       FontSize="{DynamicResource FontSizeSmall}"
                                                        TextWrapping="Wrap"
                                                        IsVisible="False"/>
                                         </StackPanel>
@@ -716,7 +716,7 @@
                                                                          BorderBrush="{Binding HasError, Converter={StaticResource BoolToErrorBrushConverter}}"/>
                                                                 <TextBlock Text="{Binding ErrorMessage}"
                                                                            Foreground="{DynamicResource ThemeError}"
-                                                                           FontSize="11"
+                                                                           FontSize="{DynamicResource FontSizeSmall}"
                                                                            VerticalAlignment="Center"
                                                                            IsVisible="{Binding HasError}"/>
                                                             </StackPanel>

--- a/Relique/Relique/Views/NewItemWizardWindow.axaml
+++ b/Relique/Relique/Views/NewItemWizardWindow.axaml
@@ -19,7 +19,7 @@
                 <TextBlock Grid.Column="0" x:Name="ValidationText"
                            VerticalAlignment="Center"
                            Foreground="{DynamicResource ThemeError}"
-                           FontSize="11"
+                           FontSize="{DynamicResource FontSizeSmall}"
                            TextWrapping="Wrap"/>
                 <Button Grid.Column="1" x:Name="BackButton"
                         Content="← Back" Click="OnBackClick"
@@ -40,7 +40,7 @@
             <!-- Step 1: Item Type Selection -->
             <DockPanel x:Name="Step1Panel" IsVisible="True">
                 <TextBlock DockPanel.Dock="Top" Text="Select Base Item Type"
-                           FontSize="16" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                           FontSize="{DynamicResource FontSizeLarge}" FontWeight="SemiBold" Margin="0,0,0,8"/>
 
                 <!-- Category filter -->
                 <Grid DockPanel.Dock="Top" ColumnDefinitions="Auto,*" Margin="0,0,0,4">
@@ -68,7 +68,7 @@
 
                 <!-- Counter -->
                 <TextBlock DockPanel.Dock="Top" x:Name="TypeCountText"
-                           FontSize="11"
+                           FontSize="{DynamicResource FontSizeSmall}"
                            Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                            Margin="0,0,0,4"/>
 
@@ -87,7 +87,7 @@
                         <DockPanel>
                             <TextBlock DockPanel.Dock="Top" x:Name="IconPanelTitle"
                                        Text="Select an item type to browse icons"
-                                       FontSize="11" Margin="8,4"
+                                       FontSize="{DynamicResource FontSizeSmall}" Margin="8,4"
                                        Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
                             <ScrollViewer>
                                 <WrapPanel x:Name="IconGridPanel" Margin="4"/>
@@ -100,7 +100,7 @@
             <!-- Step 2: Name & Identity -->
             <StackPanel x:Name="Step2Panel" IsVisible="False" Spacing="8">
                 <TextBlock Text="Name and Identity"
-                           FontSize="16" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                           FontSize="{DynamicResource FontSizeLarge}" FontWeight="SemiBold" Margin="0,0,0,4"/>
 
                 <!-- Selected type (read-only) -->
                 <Grid ColumnDefinitions="100,*">
@@ -127,7 +127,7 @@
                     <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal" Spacing="8">
                         <CheckBox x:Name="AutoTagCheckBox" Content="Auto-generate from name"
                                   IsChecked="True" Click="OnAutoTagCheckChanged"/>
-                        <TextBlock x:Name="TagCharCount" FontSize="11"
+                        <TextBlock x:Name="TagCharCount" FontSize="{DynamicResource FontSizeSmall}"
                                    Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                    VerticalAlignment="Center"/>
                     </StackPanel>
@@ -143,7 +143,7 @@
                     <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal" Spacing="8">
                         <CheckBox x:Name="AutoResRefCheckBox" Content="Auto-generate from name"
                                   IsChecked="True" Click="OnAutoResRefCheckChanged"/>
-                        <TextBlock x:Name="ResRefCharCount" FontSize="11"
+                        <TextBlock x:Name="ResRefCharCount" FontSize="{DynamicResource FontSizeSmall}"
                                    Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                    VerticalAlignment="Center"/>
                     </StackPanel>
@@ -153,7 +153,7 @@
             <!-- Step 3: Save & Finish -->
             <StackPanel x:Name="Step3Panel" IsVisible="False" Spacing="8">
                 <TextBlock Text="Save and Finish"
-                           FontSize="16" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                           FontSize="{DynamicResource FontSizeLarge}" FontWeight="SemiBold" Margin="0,0,0,4"/>
 
                 <!-- Summary -->
                 <Border BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.32.0-alpha] - 2026-05-01
+**Branch**: `radoub/issue-2159` | **PR**: #2160
+
+### Fix: Replace hardcoded font sizes with themable DynamicResource bindings
+
+- Replace hardcoded `FontSize="11"` on `MarlinspikePanel` ModulePathText/DurationText and `ReplacePreviewWindow` backup notice with `{DynamicResource FontSizeSmall}`
+- Required for low-vision users — hardcoded font sizes do not scale with Trebuchet's own font-size slider
+
+---
+
 ## [1.31.0-alpha] - 2026-04-26
 **Branch**: `radoub/issue-2034-round-3` | **PR**: #2143
 

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml
@@ -130,10 +130,10 @@
             <DockPanel>
                 <TextBlock x:Name="ModulePathText" DockPanel.Dock="Left"
                            Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
-                           VerticalAlignment="Center" FontSize="11"/>
+                           VerticalAlignment="Center" FontSize="{DynamicResource FontSizeSmall}"/>
                 <TextBlock x:Name="DurationText" DockPanel.Dock="Right"
                            Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
-                           VerticalAlignment="Center" FontSize="11"
+                           VerticalAlignment="Center" FontSize="{DynamicResource FontSizeSmall}"
                            HorizontalAlignment="Right"/>
             </DockPanel>
         </Border>

--- a/Trebuchet/Trebuchet/Views/ReplacePreviewWindow.axaml
+++ b/Trebuchet/Trebuchet/Views/ReplacePreviewWindow.axaml
@@ -44,7 +44,7 @@
                 BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
                 BorderThickness="0,1,0,0">
             <TextBlock Text="⚠ Backup will be created in ~/Radoub/Backups/ before replacing."
-                       FontSize="11"
+                       FontSize="{DynamicResource FontSizeSmall}"
                        Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
         </Border>
 


### PR DESCRIPTION
## Summary

PR3a of the 3-PR plan (PR1 #2151 ✅, PR2 #2156 ✅, **PR3a this PR**, PR3b #2157 ⏳).

Pure structural move + generalization. **No new behavior.** QM creature preview renders identically after this PR.

Extracts the part-mesh-onto-skeleton composition logic from `Quartermaster.Services.ModelService.LoadPartBasedCreatureModel` into a generic `MdlPartComposer` service in `Radoub.UI`. PR3b (Relique 3D item preview, #1908) consumes this for composite weapons (3 parts) and armor (up to 19 parts).

Plan: `NonPublic/Plans/2026-04-30-1996-1908-plan.md` (PR3a section)

## Scope

**New** (`Radoub.UI`):
- `Services/MdlPartComposer.cs` — generic skeleton+parts composer:
  - `Compose(skeletonResRef, parts, adjustSeams)` for armor / creature body
  - `ComposeFlat(partResRefs, compositeName)` for composite weapons (no skeleton)
- `Services/MdlPartBoneMap.cs` — partType → `bone_g` mapping (from QM's `GetBoneNameForPart`)
- `Services/MdlPartNaming.cs` — pure-string `BuildBodyPartName` helper (factored out of QM)
- `Tests/Services/MdlPartComposerTests.cs` (10 new tests)
- `Tests/Services/MdlPartComposerBoneTransformTests.cs` (9 tests, migrated from QM)
- `Tests/Services/MdlPartComposerSeamOverlapTests.cs` (6 tests, migrated from QM)
- `Tests/Services/MdlPartNamingTests.cs` (7 tests, migrated from QM)

**Modified** (`Quartermaster`):
- `Services/ModelService.cs` — shrunk from **870 to 389 lines** (-481 net). `LoadPartBasedCreatureModel` becomes a thin adapter that resolves creature appearance + armor overrides + human fallback, then delegates to the composer.
- `Quartermaster.Tests/ModelNameConstructionTests.cs` — kept the QM-specific `BuildModelPrefix` tests; removed `BuildBodyPartName_*` tests (migrated to Radoub.UI.Tests)

**Bonus fix in this PR** — also closes the long-standing hard-rule violation: hardcoded font sizes don't scale with the Trebuchet font-size slider, blocking low-vision accessibility. Replaces 31 `FontSize="N"` instances across 10 axaml files in 6 tools (Quartermaster, Fence, Trebuchet, Parley, Relique, Radoub.UI) with `{DynamicResource FontSizeSmall|FontSizeLarge|FontSizeXLarge}`. Tracked separately: #2152 (Trebuchet → QM slider propagation, settings flow bug, not in this PR's scope).

## Behavior Preserved (Must Not Regress)

- Mesh re-parenting under skeleton bones (animation pose lookup #2124)
- Body-part bitmap-field override (stale-bitmap workaround for body parts)
- Head/neck/chest seam-overlap nudge (#1557, threshold 0.10 world units)
- Composite bounds aggregation across all attached meshes
- Race-specific → human (`pmh0`/`pfh0`) MDL fallback (resolved at name-construction time before the composer is called)

## Behavior Staying in QM

- Creature gender/race/phenotype prefix construction (`BuildModelPrefix`)
- `appearance.2da` lookups
- Equipped-armor override resolution from `UtcFile.EquipItemList`
- Equipped-armor color resolution

## Pre-Merge Results

| Check | Result |
|-------|--------|
| Privacy scan | ✅ Pass |
| Tech debt scan | ✅ Pass — no files >800 lines (PR3a actually shrunk `ModelService.cs` from 870 → 389) |
| Theme compatibility | ⚠️ 22 hardcoded theme warnings — all pre-existing in unrelated files (verified via `git diff main`); none introduced by this PR |
| Radoub.Formats.Tests | ✅ 1161/1162 (1 skipped) |
| Radoub.UI.Tests | ✅ 594/594 (562 existing + 32 new/migrated) |
| Radoub.Dictionary.Tests | ✅ 54/54 |
| Trebuchet.Tests | ✅ 128/128 |
| Manifest.Tests | ✅ 104/104 |
| **Quartermaster.Tests** | ✅ **1195/1195** (was 1217 before PR3a; -22 = exactly the count migrated to `Radoub.UI.Tests`) |
| Fence.Tests | ✅ 138/138 |
| Parley.Tests | ✅ 838/838 |
| Relique.Tests | ✅ 290/290 |
| **Solution total** | ✅ **4502 passed, 1 skipped, 0 failed** |
| **QM FlaUI regression** | ✅ **12/21 passed, 0 failed** — same skipped set as pre-PR; exact match to PR2 #2156 baseline (one initial flake on smoke test, clean on rerun) |
| CHANGELOGs (QM 0.2.91, Fence 0.1.31, Trebuchet 1.32.0, Parley 0.1.167, Relique 0.10.11) | ✅ Versioned, dated 2026-05-01, PR# filled, no `[Unreleased]` items |
| Wiki freshness | ✅ Both architecture pages dated 2026-05-01 (updated by PR2 #2156) |

## Manual Spot-Checks (Pre-Merge)

User noted two visual issues during spot-checks; both verified pre-existing on `main`, not caused by PR3a:

- 🐛 #2161 — Head sits too high above neck on part-based creature preview (filed separately, pre-existing, distinct from #1557)
- 🐛 #2162 — Appearance name displays as `Appearance N` instead of label for some 2DA rows (filed separately, pre-existing, `AppearanceService.cs` unchanged on this branch)

## Related Issues

- Closes #2159
- Prep for #1908 (Relique 3D item preview, PR3b in #2157)

## Risk

Highest-risk PR of the four. Touches QM's working creature preview surface. Mitigation: ships alone, FlaUI QM regression matches PR2 baseline exactly, clean revert path if needed.

## Out of Scope

- Any rendering changes
- API changes on `ModelPreviewGLControl`
- Item-related code (PR3b)
- Trebuchet font-size slider propagation (#2152, separate settings-flow bug)
- Pre-existing head-placement gap (#2161, pre-existing on main)
- Pre-existing appearance-name fallback (#2162, pre-existing on main)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)