### PR TITLE
[Trebuchet] Feat: ResRef replace with file rename — batch rename support (#1926)

### DIFF
--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/UtcSearchProviderTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/UtcSearchProviderTests.cs
@@ -366,4 +366,81 @@ public class UtcSearchProviderTests
         Assert.Contains(".utc", provider.Extensions);
         Assert.Contains(".bic", provider.Extensions);
     }
+
+    // --- ResRef replace bypass (AllowResRefReplace) ---
+
+    [Fact]
+    public void Replace_ResRefField_WithAllowResRefReplace_Succeeds()
+    {
+        var provider = new UtcSearchProvider();
+        var gff = UtcToGff(CreateTestUtc());
+
+        var match = new SearchMatch
+        {
+            Field = new FieldDefinition
+            {
+                Name = "Conversation",
+                GffPath = "Conversation",
+                FieldType = SearchFieldType.ResRef,
+                Category = SearchFieldCategory.Metadata,
+                IsReplaceable = false
+            },
+            MatchedText = "louis_conv",
+            FullFieldValue = "louis_conv",
+            MatchOffset = 0,
+            MatchLength = "louis_conv".Length,
+            Location = "Conversation"
+        };
+
+        var op = new ReplaceOperation
+        {
+            Match = match,
+            ReplacementText = "louis",
+            AllowResRefReplace = true
+        };
+
+        var results = provider.Replace(gff, new[] { op });
+
+        Assert.Single(results);
+        Assert.True(results[0].Success);
+        Assert.Equal("louis_conv", results[0].OldValue);
+        Assert.Equal("louis", results[0].NewValue);
+    }
+
+    [Fact]
+    public void Replace_ResRefField_WithoutAllowResRefReplace_Skipped()
+    {
+        var provider = new UtcSearchProvider();
+        var gff = UtcToGff(CreateTestUtc());
+
+        var match = new SearchMatch
+        {
+            Field = new FieldDefinition
+            {
+                Name = "Conversation",
+                GffPath = "Conversation",
+                FieldType = SearchFieldType.ResRef,
+                Category = SearchFieldCategory.Metadata,
+                IsReplaceable = false
+            },
+            MatchedText = "louis_conv",
+            FullFieldValue = "louis_conv",
+            MatchOffset = 0,
+            MatchLength = "louis_conv".Length,
+            Location = "Conversation"
+        };
+
+        var op = new ReplaceOperation
+        {
+            Match = match,
+            ReplacementText = "louis"
+            // AllowResRefReplace defaults to false
+        };
+
+        var results = provider.Replace(gff, new[] { op });
+
+        Assert.Single(results);
+        Assert.False(results[0].Success);
+        Assert.True(results[0].Skipped);
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
@@ -177,4 +177,17 @@ public class ResRefReferenceScannerTests
         Assert.Equal(2, refs.Count);
         Assert.All(refs, r => Assert.Contains("ItemList", r.Location));
     }
+
+    [Fact]
+    public void Scan_UtmStorePanelItems_FindsReference()
+    {
+        var gff = TestGffBuilder.MakeUtmWithItems("Weapons", "louis_sword", "key3", "louis_sword");
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, ResourceTypes.Utm, oldResRef: "louis_sword", filePath: "/m/store.utm");
+
+        Assert.Equal(2, refs.Count);
+        Assert.All(refs, r => Assert.Contains("Weapons", r.Location));
+        Assert.All(refs, r => Assert.Contains("InventoryRes", r.Location));
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
@@ -104,4 +104,18 @@ public class ResRefReferenceScannerTests
         Assert.Single(refs);
         Assert.Equal(fieldName, refs[0].Field?.Name);
     }
+
+    [Fact]
+    public void Scan_GitCreatureListInstances_FindsAllReferences()
+    {
+        var gff = TestGffBuilder.MakeGitWithList("Creature List", "TemplateResRef",
+            "louis", "alice", "louis", "bob");
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, ResourceTypes.Git, oldResRef: "louis", filePath: "/m/area.git");
+
+        Assert.Equal(2, refs.Count);
+        Assert.All(refs, r => Assert.Equal("louis", r.OldValue.ToLowerInvariant()));
+        Assert.All(refs, r => Assert.Contains("Creature List", r.Location));
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
@@ -153,4 +153,16 @@ public class ResRefReferenceScannerTests
         Assert.Equal(2, refs.Count);
         Assert.All(refs, r => Assert.Contains("Equip_ItemList", r.Location));
     }
+
+    [Fact]
+    public void Scan_UtcInventoryItems_FindsReference()
+    {
+        var gff = TestGffBuilder.MakeUtc(inventoryResRefs: new[] { "louis_potion", "key1", "louis_potion" });
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, ResourceTypes.Utc, oldResRef: "louis_potion", filePath: "/m/test.utc");
+
+        Assert.Equal(2, refs.Count);
+        Assert.All(refs, r => Assert.Contains("ItemList", r.Location));
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
@@ -1,0 +1,24 @@
+using Radoub.Formats.Common;
+using Radoub.Formats.Gff;
+using Radoub.Formats.Search;
+using Radoub.Formats.Search.Rename;
+using Xunit;
+
+namespace Radoub.Formats.Tests.Search.Rename;
+
+public class ResRefReferenceScannerTests
+{
+    [Fact]
+    public void Scan_UtcConversationField_FindsReference()
+    {
+        var gff = TestGffBuilder.MakeUtc(conversation: "louis_roumain");
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, ResourceTypes.Utc, oldResRef: "louis_roumain", filePath: "/m/test.utc");
+
+        Assert.Single(refs);
+        Assert.Equal("Conversation", refs[0].Field?.Name);
+        Assert.Equal("louis_roumain", refs[0].OldValue);
+        Assert.Equal(ResRefScopeTier.TypedGffField, refs[0].ScopeTier);
+    }
+}

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
@@ -202,4 +202,28 @@ public class ResRefReferenceScannerTests
         Assert.Single(refs);
         Assert.Contains("Entry 2", refs[0].Location);
     }
+
+    [Fact]
+    public void Scan_DlgActionParam_FindsSubstringMatch()
+    {
+        // Param value contains "louis" as substring (typical: "target_resref=louis")
+        var gff = TestGffBuilder.MakeDlgWithActionParam(0, "target_resref", "louis");
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, ResourceTypes.Dlg, oldResRef: "louis", filePath: "/m/x.dlg");
+
+        Assert.Contains(refs, r => r.ScopeTier == ResRefScopeTier.DlgScriptParam);
+    }
+
+    [Fact]
+    public void Scan_DlgActionParam_DoesNotMatchKey()
+    {
+        // Match in KEY (not value) — should NOT be returned per spec
+        var gff = TestGffBuilder.MakeDlgWithActionParam(0, "louis_target", "alice");
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, ResourceTypes.Dlg, oldResRef: "louis", filePath: "/m/x.dlg");
+
+        Assert.DoesNotContain(refs, r => r.ScopeTier == ResRefScopeTier.DlgScriptParam);
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
@@ -275,4 +275,31 @@ public class ResRefReferenceScannerTests
         Assert.Single(refs);
         Assert.Contains("Mod_HakList", refs[0].Location);
     }
+
+    public static IEnumerable<object[]> CoverageMatrixData() => new[]
+    {
+        // resourceType, builder factory, oldResRef
+        new object[] { ResourceTypes.Utc, (Func<GffFile>)(() => TestGffBuilder.MakeUtc(conversation: "rr")), "rr" },
+        new object[] { ResourceTypes.Bic, (Func<GffFile>)(() => TestGffBuilder.MakeUtc(conversation: "rr")), "rr" },  // BIC == UTC
+        new object[] { ResourceTypes.Uti, (Func<GffFile>)(() => TestGffBuilder.MakeUti(onAcquireScript: "rr")), "rr" },
+        new object[] { ResourceTypes.Utm, (Func<GffFile>)(() => TestGffBuilder.MakeUtmWithItems("Weapons", "rr")), "rr" },
+        new object[] { ResourceTypes.Utp, (Func<GffFile>)(() => TestGffBuilder.MakeUtpWithInventory("rr")), "rr" },
+        new object[] { ResourceTypes.Utd, (Func<GffFile>)(() => TestGffBuilder.MakeUtd(conversation: "rr")), "rr" },
+        new object[] { ResourceTypes.Dlg, (Func<GffFile>)(() => TestGffBuilder.MakeDlgWithSound(0, "rr")), "rr" },
+        new object[] { ResourceTypes.Git, (Func<GffFile>)(() => TestGffBuilder.MakeGitWithList("Creature List", "TemplateResRef", "rr")), "rr" },
+        new object[] { ResourceTypes.Are, (Func<GffFile>)(() => TestGffBuilder.MakeAreWithScriptField("OnEnter", "rr")), "rr" },
+        new object[] { ResourceTypes.Ifo, (Func<GffFile>)(() => TestGffBuilder.MakeIfo(entryArea: "rr")), "rr" }
+    };
+
+    [Theory]
+    [MemberData(nameof(CoverageMatrixData))]
+    public void Scan_CoversAllSpecTier1FileTypes(ushort resourceType, Func<GffFile> builder, string oldResRef)
+    {
+        var gff = builder();
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, resourceType, oldResRef, filePath: $"/m/test.{resourceType}");
+
+        Assert.NotEmpty(refs);
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
@@ -118,4 +118,24 @@ public class ResRefReferenceScannerTests
         Assert.All(refs, r => Assert.Equal("louis", r.OldValue.ToLowerInvariant()));
         Assert.All(refs, r => Assert.Contains("Creature List", r.Location));
     }
+
+    [Theory]
+    [InlineData("Creature List",  "TemplateResRef")]
+    [InlineData("Door List",      "TemplateResRef")]
+    [InlineData("Placeable List", "TemplateResRef")]
+    [InlineData("StoreList",      "ResRef")]
+    [InlineData("WaypointList",   "TemplateResRef")]
+    [InlineData("Encounter List", "TemplateResRef")]
+    [InlineData("TriggerList",    "TemplateResRef")]
+    [InlineData("SoundList",      "TemplateResRef")]
+    public void Scan_GitAllInstanceLists_FindsReference(string listName, string resRefField)
+    {
+        var gff = TestGffBuilder.MakeGitWithList(listName, resRefField, "louis");
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, ResourceTypes.Git, oldResRef: "louis", filePath: "/m/area.git");
+
+        Assert.Single(refs);
+        Assert.Contains(listName, refs[0].Location);
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
@@ -77,4 +77,31 @@ public class ResRefReferenceScannerTests
         Assert.Single(refs);
         Assert.Equal(fieldName, refs[0].Field?.Name);
     }
+
+    [Fact]
+    public void Scan_UtdConversation_FindsReference()
+    {
+        var gff = TestGffBuilder.MakeUtd(conversation: "door_dialog");
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, ResourceTypes.Utd, oldResRef: "door_dialog", filePath: "/m/door.utd");
+
+        Assert.Single(refs);
+        Assert.Equal("Conversation", refs[0].Field?.Name);
+    }
+
+    [Theory]
+    [InlineData("OnOpen")]
+    [InlineData("OnLock")]
+    [InlineData("OnUnlock")]
+    public void Scan_UtdScriptField_FindsReference(string fieldName)
+    {
+        var gff = TestGffBuilder.MakeUtdWithScriptField(fieldName, "door_script");
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, ResourceTypes.Utd, oldResRef: "door_script", filePath: "/m/door.utd");
+
+        Assert.Single(refs);
+        Assert.Equal(fieldName, refs[0].Field?.Name);
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
@@ -48,19 +48,10 @@ public class ResRefReferenceScannerTests
         Assert.Empty(refs);
     }
 
-    [Fact]
-    public void Scan_UtiOnAcquireScript_FindsReference()
-    {
-        var gff = TestGffBuilder.MakeUti(onAcquireScript: "open_door");
-        var scanner = new ResRefReferenceScanner();
-
-        var refs = scanner.Scan(gff, ResourceTypes.Uti, oldResRef: "open_door", filePath: "/m/key.uti");
-
-        Assert.Single(refs);
-        Assert.NotNull(refs[0].Field);
-        Assert.Equal(SearchFieldType.Script, refs[0].Field!.FieldType);
-        Assert.Equal(SearchFieldCategory.Script, refs[0].Field!.Category);
-    }
+    // UTI files have no script-event fields per BioWare spec — items use
+    // ItemProperty slots, not script events. No scanner test needed for UTI
+    // beyond TemplateResRef (which is a self-identifier, not a reference TO
+    // something else, and is therefore not in the scanner's scope).
 
     [Theory]
     [InlineData("OnEnter")]
@@ -281,7 +272,7 @@ public class ResRefReferenceScannerTests
         // resourceType, builder factory, oldResRef
         new object[] { ResourceTypes.Utc, (Func<GffFile>)(() => TestGffBuilder.MakeUtc(conversation: "rr")), "rr" },
         new object[] { ResourceTypes.Bic, (Func<GffFile>)(() => TestGffBuilder.MakeUtc(conversation: "rr")), "rr" },  // BIC == UTC
-        new object[] { ResourceTypes.Uti, (Func<GffFile>)(() => TestGffBuilder.MakeUti(onAcquireScript: "rr")), "rr" },
+        // UTI omitted: no script-event fields per BioWare spec; items use ItemProperty slots
         new object[] { ResourceTypes.Utm, (Func<GffFile>)(() => TestGffBuilder.MakeUtmWithItems("Weapons", "rr")), "rr" },
         new object[] { ResourceTypes.Utp, (Func<GffFile>)(() => TestGffBuilder.MakeUtpWithInventory("rr")), "rr" },
         new object[] { ResourceTypes.Utd, (Func<GffFile>)(() => TestGffBuilder.MakeUtd(conversation: "rr")), "rr" },

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
@@ -21,4 +21,19 @@ public class ResRefReferenceScannerTests
         Assert.Equal("louis_roumain", refs[0].OldValue);
         Assert.Equal(ResRefScopeTier.TypedGffField, refs[0].ScopeTier);
     }
+
+    [Theory]
+    [InlineData("Louis_Roumain")]
+    [InlineData("LOUIS_ROUMAIN")]
+    [InlineData("louis_roumain")]
+    public void Scan_FindsCaseInsensitiveMatches(string actualValueInGff)
+    {
+        var gff = TestGffBuilder.MakeUtc(conversation: actualValueInGff);
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, ResourceTypes.Utc, oldResRef: "louis_roumain", filePath: "/m/test.utc");
+
+        Assert.Single(refs);
+        Assert.Equal(actualValueInGff, refs[0].OldValue);  // preserves original case in OldValue
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
@@ -138,4 +138,19 @@ public class ResRefReferenceScannerTests
         Assert.Single(refs);
         Assert.Contains(listName, refs[0].Location);
     }
+
+    [Theory]
+    [InlineData("utc")]  // standard UTC creature blueprint
+    [InlineData("bic")]  // BIC player character — same structure
+    public void Scan_UtcEquipmentSlots_FindsReference(string ext)
+    {
+        var resourceType = ext == "utc" ? ResourceTypes.Utc : ResourceTypes.Bic;
+        var gff = TestGffBuilder.MakeUtc(equipResRefs: new[] { "louis_sword", "alice_shield", "louis_sword" });
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, resourceType, oldResRef: "louis_sword", filePath: $"/m/test.{ext}");
+
+        Assert.Equal(2, refs.Count);
+        Assert.All(refs, r => Assert.Contains("Equip_ItemList", r.Location));
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
@@ -226,4 +226,16 @@ public class ResRefReferenceScannerTests
 
         Assert.DoesNotContain(refs, r => r.ScopeTier == ResRefScopeTier.DlgScriptParam);
     }
+
+    [Fact]
+    public void Scan_DlgConditionParam_FindsSubstringMatch()
+    {
+        var gff = TestGffBuilder.MakeDlgWithConditionParam(0, "check_resref", "louis");
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, ResourceTypes.Dlg, oldResRef: "louis", filePath: "/m/x.dlg");
+
+        Assert.Contains(refs, r => r.ScopeTier == ResRefScopeTier.DlgScriptParam
+            && r.Location.Contains("ConditionParams"));
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
@@ -36,4 +36,15 @@ public class ResRefReferenceScannerTests
         Assert.Single(refs);
         Assert.Equal(actualValueInGff, refs[0].OldValue);  // preserves original case in OldValue
     }
+
+    [Fact]
+    public void Scan_TypedField_DoesNotMatchSubstrings()
+    {
+        var gff = TestGffBuilder.MakeUtc(conversation: "louis_roumain_extra");
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, ResourceTypes.Utc, oldResRef: "louis_roumain", filePath: "/m/test.utc");
+
+        Assert.Empty(refs);
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
@@ -190,4 +190,16 @@ public class ResRefReferenceScannerTests
         Assert.All(refs, r => Assert.Contains("Weapons", r.Location));
         Assert.All(refs, r => Assert.Contains("InventoryRes", r.Location));
     }
+
+    [Fact]
+    public void Scan_DlgEntrySound_FindsReference()
+    {
+        var gff = TestGffBuilder.MakeDlgWithSound(entryIndex: 2, sound: "louis_voice");
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, ResourceTypes.Dlg, oldResRef: "louis_voice", filePath: "/m/x.dlg");
+
+        Assert.Single(refs);
+        Assert.Contains("Entry 2", refs[0].Location);
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
@@ -61,4 +61,20 @@ public class ResRefReferenceScannerTests
         Assert.Equal(SearchFieldType.Script, refs[0].Field!.FieldType);
         Assert.Equal(SearchFieldCategory.Script, refs[0].Field!.Category);
     }
+
+    [Theory]
+    [InlineData("OnEnter")]
+    [InlineData("OnExit")]
+    [InlineData("OnHeartbeat")]
+    [InlineData("OnUserDefined")]
+    public void Scan_AreScriptField_FindsReference(string fieldName)
+    {
+        var gff = TestGffBuilder.MakeAreWithScriptField(fieldName, "test_script");
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, ResourceTypes.Are, oldResRef: "test_script", filePath: "/m/area.are");
+
+        Assert.Single(refs);
+        Assert.Equal(fieldName, refs[0].Field?.Name);
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
@@ -238,4 +238,29 @@ public class ResRefReferenceScannerTests
         Assert.Contains(refs, r => r.ScopeTier == ResRefScopeTier.DlgScriptParam
             && r.Location.Contains("ConditionParams"));
     }
+
+    public static IEnumerable<object[]> IfoScalarFieldData() => new[]
+    {
+        new object[] { "Mod_Entry_Area", (Func<string, GffFile>)((string s) => TestGffBuilder.MakeIfo(entryArea: s)) },
+        new object[] { "Mod_DefaultBic", (Func<string, GffFile>)((string s) => TestGffBuilder.MakeIfo(defaultBic: s)) },
+        new object[] { "Mod_StartMovie", (Func<string, GffFile>)((string s) => TestGffBuilder.MakeIfo(startMovie: s)) },
+        new object[] { "Mod_CustomTlk",  (Func<string, GffFile>)((string s) => TestGffBuilder.MakeIfo(customTlk: s)) },
+        new object[] { "Mod_OnHeartbeat", (Func<string, GffFile>)((string s) => TestGffBuilder.MakeIfo(onHeartbeat: s)) }
+    };
+
+    [Theory]
+    [MemberData(nameof(IfoScalarFieldData))]
+    public void Scan_IfoScalarField_FindsReference(string registeredGffPath, Func<string, GffFile> builder)
+    {
+        var gff = builder("test_target");
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, ResourceTypes.Ifo, oldResRef: "test_target", filePath: "/m/module.ifo");
+
+        Assert.Single(refs);
+        // The registered Field.Name often differs from the GFF path — match on GffPath for robustness
+        Assert.True(
+            refs[0].Field?.GffPath == registeredGffPath || refs[0].Field?.Name == registeredGffPath,
+            $"Expected field GffPath or Name '{registeredGffPath}', got Name='{refs[0].Field?.Name}' GffPath='{refs[0].Field?.GffPath}'");
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
@@ -47,4 +47,18 @@ public class ResRefReferenceScannerTests
 
         Assert.Empty(refs);
     }
+
+    [Fact]
+    public void Scan_UtiOnAcquireScript_FindsReference()
+    {
+        var gff = TestGffBuilder.MakeUti(onAcquireScript: "open_door");
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, ResourceTypes.Uti, oldResRef: "open_door", filePath: "/m/key.uti");
+
+        Assert.Single(refs);
+        Assert.NotNull(refs[0].Field);
+        Assert.Equal(SearchFieldType.Script, refs[0].Field!.FieldType);
+        Assert.Equal(SearchFieldCategory.Script, refs[0].Field!.Category);
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
@@ -263,4 +263,16 @@ public class ResRefReferenceScannerTests
             refs[0].Field?.GffPath == registeredGffPath || refs[0].Field?.Name == registeredGffPath,
             $"Expected field GffPath or Name '{registeredGffPath}', got Name='{refs[0].Field?.Name}' GffPath='{refs[0].Field?.GffPath}'");
     }
+
+    [Fact]
+    public void Scan_IfoModHakList_FindsReference()
+    {
+        var gff = TestGffBuilder.MakeIfoWithHakList("base_hak", "louis_hak", "extra_hak");
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, ResourceTypes.Ifo, oldResRef: "louis_hak", filePath: "/m/module.ifo");
+
+        Assert.Single(refs);
+        Assert.Contains("Mod_HakList", refs[0].Location);
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefReferenceScannerTests.cs
@@ -165,4 +165,16 @@ public class ResRefReferenceScannerTests
         Assert.Equal(2, refs.Count);
         Assert.All(refs, r => Assert.Contains("ItemList", r.Location));
     }
+
+    [Fact]
+    public void Scan_UtpInventory_FindsReference()
+    {
+        var gff = TestGffBuilder.MakeUtpWithInventory("trap_part", "key2", "trap_part");
+        var scanner = new ResRefReferenceScanner();
+
+        var refs = scanner.Scan(gff, ResourceTypes.Utp, oldResRef: "trap_part", filePath: "/m/chest.utp");
+
+        Assert.Equal(2, refs.Count);
+        Assert.All(refs, r => Assert.Contains("ItemList", r.Location));
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefRenamePlanTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefRenamePlanTests.cs
@@ -1,0 +1,55 @@
+using Radoub.Formats.Common;
+using Radoub.Formats.Search.Rename;
+using Xunit;
+
+namespace Radoub.Formats.Tests.Search.Rename;
+
+public class ResRefRenamePlanTests
+{
+    private static ResRefRenamePlan MakePlan() => new()
+    {
+        OldName = "louis",
+        NewName = "bob",
+        ResourceType = ResourceTypes.Dlg,
+        Validation = ResRefValidationResult.Ok("bob"),
+        SourceFilePath = "/m/louis.dlg",
+        TargetFilePath = "/m/bob.dlg"
+    };
+
+    [Fact]
+    public void NewPlan_HasNoReferences()
+    {
+        var plan = MakePlan();
+        Assert.Empty(plan.References);
+        Assert.Empty(plan.SelectedReferences);
+    }
+
+    [Fact]
+    public void IsSelected_DefaultsTrue()
+    {
+        var plan = MakePlan();
+        Assert.True(plan.IsSelected);
+    }
+
+    [Fact]
+    public void SelectedReferences_FiltersUntickedRows()
+    {
+        var plan = MakePlan();
+        plan.References.Add(MakeRef(selected: true));
+        plan.References.Add(MakeRef(selected: false));
+        plan.References.Add(MakeRef(selected: true));
+
+        Assert.Equal(2, plan.SelectedReferences.Count());
+    }
+
+    private static ResRefReference MakeRef(bool selected) => new()
+    {
+        FilePath = "/m/file.utc",
+        ResourceType = ResourceTypes.Utc,
+        Location = "Conversation",
+        OldValue = "louis",
+        NewValue = "bob",
+        ScopeTier = ResRefScopeTier.TypedGffField,
+        IsSelected = selected
+    };
+}

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefValidatorTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefValidatorTests.cs
@@ -1,0 +1,153 @@
+using Radoub.Formats.Search.Rename;
+using Xunit;
+
+namespace Radoub.Formats.Tests.Search.Rename;
+
+public class ResRefValidatorTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void Validate_EmptyOrWhitespace_ReturnsFailWithEmptyError(string input)
+    {
+        var validator = new ResRefValidator();
+        var result = validator.Validate(input, existingNames: new HashSet<string>(), extension: ".dlg");
+        Assert.False(result.IsValid);
+        Assert.Equal("ResRef cannot be empty", result.Error);
+    }
+
+    [Theory]
+    [InlineData("louis.dlg", "louis")]
+    [InlineData("louis.DLG", "louis")]
+    [InlineData("louis", "louis")]
+    public void Validate_StripsExtension(string input, string expectedName)
+    {
+        var validator = new ResRefValidator();
+        var result = validator.Validate(input, new HashSet<string>(), ".dlg");
+        Assert.True(result.IsValid);
+        Assert.Equal(expectedName, result.NormalizedName);
+    }
+
+    [Fact]
+    public void Validate_TooLong_ReturnsFailWithLengthInError()
+    {
+        var validator = new ResRefValidator();
+        var result = validator.Validate("12345678901234567", new HashSet<string>(), ".dlg");
+        Assert.False(result.IsValid);
+        Assert.NotNull(result.Error);
+        Assert.Contains("17", result.Error);
+        Assert.Contains("16", result.Error);
+    }
+
+    [Theory]
+    [InlineData("louis-roumain")]   // hyphen
+    [InlineData("louis roumain")]   // space
+    [InlineData("louis.roumain")]   // internal dot — fails because .roumain is not the extension being stripped
+    [InlineData("louis@home")]      // symbol
+    [InlineData("louisé")]          // non-ASCII
+    public void Validate_InvalidCharacters_ReturnsFail(string input)
+    {
+        var validator = new ResRefValidator();
+        var result = validator.Validate(input, new HashSet<string>(), ".dlg");
+        Assert.False(result.IsValid);
+        Assert.NotNull(result.Error);
+        Assert.Contains("lowercase letters, digits, and underscores", result.Error);
+    }
+
+    [Fact]
+    public void Validate_StartsWithDigit_ReturnsOkWithWarning()
+    {
+        var validator = new ResRefValidator();
+        var result = validator.Validate("9lives", new HashSet<string>(), ".dlg");
+        Assert.True(result.IsValid);
+        Assert.Equal("9lives", result.NormalizedName);
+        Assert.NotNull(result.Warning);
+        Assert.Contains("starts with a digit", result.Warning);
+    }
+
+    [Fact]
+    public void Validate_NoCollision_ReturnsOkWithNoSuffix()
+    {
+        var validator = new ResRefValidator();
+        var existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "alice", "bob" };
+        var result = validator.Validate("charlie", existing, ".dlg");
+        Assert.True(result.IsValid);
+        Assert.Equal("charlie", result.NormalizedName);
+        Assert.False(result.AutoSuffixApplied);
+    }
+
+    [Fact]
+    public void Validate_CollisionExists_AppliesUnderscore2Suffix()
+    {
+        var validator = new ResRefValidator();
+        var existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "louis" };
+        var result = validator.Validate("louis", existing, ".dlg");
+        Assert.True(result.IsValid);
+        Assert.Equal("louis_2", result.NormalizedName);
+        Assert.True(result.AutoSuffixApplied);
+    }
+
+    [Fact]
+    public void Validate_CollisionIsCaseInsensitive()
+    {
+        var validator = new ResRefValidator();
+        var existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "louis" };
+        var result = validator.Validate("LOUIS", existing, ".dlg");
+        Assert.True(result.IsValid);
+        Assert.Equal("louis_2", result.NormalizedName);
+        Assert.True(result.AutoSuffixApplied);
+    }
+
+    [Fact]
+    public void Validate_MultipleCollisions_FindsLowestAvailableSuffix()
+    {
+        var validator = new ResRefValidator();
+        var existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "louis", "louis_2", "louis_3", "louis_4", "louis_5"
+        };
+        var result = validator.Validate("louis", existing, ".dlg");
+        Assert.True(result.IsValid);
+        Assert.Equal("louis_6", result.NormalizedName);
+        Assert.True(result.AutoSuffixApplied);
+    }
+
+    [Fact]
+    public void Validate_AllSuffixesTaken_ReturnsFail()
+    {
+        var validator = new ResRefValidator();
+        var existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "louis" };
+        for (int i = 2; i <= 99; i++) existing.Add($"louis_{i}");
+        var result = validator.Validate("louis", existing, ".dlg");
+        Assert.False(result.IsValid);
+        Assert.NotNull(result.Error);
+        Assert.Contains("_99", result.Error);
+    }
+
+    [Fact]
+    public void Validate_LongBaseName_TruncatesToFitSuffix()
+    {
+        var validator = new ResRefValidator();
+        var existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "abcdefghijklmnop" };
+        var result = validator.Validate("abcdefghijklmnop", existing, ".dlg");
+        Assert.True(result.IsValid);
+        Assert.Equal("abcdefghijklmn_2", result.NormalizedName);  // 14 chars + _2 = 16
+        Assert.True(result.AutoSuffixApplied);
+    }
+
+    [Fact]
+    public void Validate_TruncatedNameAlsoCollides_TriesNextSuffix()
+    {
+        var validator = new ResRefValidator();
+        var existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "abcdefghijklmnop",
+            "abcdefghijklmn_2"
+        };
+        var result = validator.Validate("abcdefghijklmnop", existing, ".dlg");
+        Assert.True(result.IsValid);
+        Assert.Equal("abcdefghijklmn_3", result.NormalizedName);
+        Assert.True(result.AutoSuffixApplied);
+    }
+}

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefValidatorTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefValidatorTests.cs
@@ -150,4 +150,21 @@ public class ResRefValidatorTests
         Assert.Equal("abcdefghijklmn_3", result.NormalizedName);
         Assert.True(result.AutoSuffixApplied);
     }
+
+    [Fact]
+    public void Validate_RenameToSameName_NoCollisionWhenCallerExcludesOldName()
+    {
+        // Contract: caller is responsible for excluding the name being renamed
+        // from existingNames. When the caller does so, "renaming" louis -> louis
+        // is a no-op rename and validates without auto-suffix.
+        var validator = new ResRefValidator();
+        var existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "alice", "bob" };
+        // Note: "louis" is intentionally NOT in `existing` (caller filtered it out)
+
+        var result = validator.Validate("louis", existing, ".dlg");
+
+        Assert.True(result.IsValid);
+        Assert.Equal("louis", result.NormalizedName);
+        Assert.False(result.AutoSuffixApplied);
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
@@ -86,7 +86,19 @@ internal static class TestGffBuilder
     public static GffFile MakeDlgWithConditionParam(int entryIndex, string key, string value) => throw new NotImplementedException();
 
     // --- GIT ---
-    public static GffFile MakeGitWithList(string listName, string resRefField, params string[] resRefs) => throw new NotImplementedException();
+    public static GffFile MakeGitWithList(string listName, string resRefField, params string[] resRefs)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        var instances = new List<GffStruct>();
+        foreach (var rr in resRefs)
+        {
+            var instance = new GffStruct { Type = 0 };
+            GffFieldBuilder.AddCResRefField(instance, resRefField, rr);
+            instances.Add(instance);
+        }
+        GffFieldBuilder.AddListField(root, listName, instances);
+        return new GffFile { FileType = "GIT ", FileVersion = "V3.2", RootStruct = root };
+    }
 
     // --- ARE ---
     public static GffFile MakeAre(string? onEnterScript = null)

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
@@ -8,7 +8,7 @@ namespace Radoub.Formats.Tests.Search.Rename;
 /// other fields are left absent.
 /// All ResRef-carrier fields use lowercase values per Aurora convention.
 /// </summary>
-internal static class TestGffBuilder
+public static class TestGffBuilder
 {
     // --- UTC ---
     public static GffFile MakeUtc(

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
@@ -65,9 +65,20 @@ internal static class TestGffBuilder
     public static GffFile MakeUtpWithInventory(params string[] inventoryResRefs) => throw new NotImplementedException();
 
     // --- UTD ---
-    public static GffFile MakeUtd(string? conversation = null) => throw new NotImplementedException();
+    public static GffFile MakeUtd(string? conversation = null)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        if (conversation != null)
+            GffFieldBuilder.AddCResRefField(root, "Conversation", conversation);
+        return new GffFile { FileType = "UTD ", FileVersion = "V3.2", RootStruct = root };
+    }
 
-    public static GffFile MakeUtdWithScriptField(string fieldName, string scriptResRef) => throw new NotImplementedException();
+    public static GffFile MakeUtdWithScriptField(string fieldName, string scriptResRef)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        GffFieldBuilder.AddCResRefField(root, fieldName, scriptResRef);
+        return new GffFile { FileType = "UTD ", FileVersion = "V3.2", RootStruct = root };
+    }
 
     // --- DLG ---
     public static GffFile MakeDlgWithSound(int entryIndex, string sound) => throw new NotImplementedException();

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
@@ -122,9 +122,70 @@ internal static class TestGffBuilder
     }
 
     // --- DLG ---
-    public static GffFile MakeDlgWithSound(int entryIndex, string sound) => throw new NotImplementedException();
-    public static GffFile MakeDlgWithActionParam(int entryIndex, string key, string value) => throw new NotImplementedException();
-    public static GffFile MakeDlgWithConditionParam(int entryIndex, string key, string value) => throw new NotImplementedException();
+    public static GffFile MakeDlgWithSound(int entryIndex, string sound)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        var entries = new List<GffStruct>();
+        for (int i = 0; i <= entryIndex; i++)
+        {
+            var entry = new GffStruct { Type = 0 };
+            if (i == entryIndex)
+                GffFieldBuilder.AddCResRefField(entry, "Sound", sound);
+            entries.Add(entry);
+        }
+        GffFieldBuilder.AddListField(root, "EntryList", entries);
+        return new GffFile { FileType = "DLG ", FileVersion = "V3.2", RootStruct = root };
+    }
+
+    public static GffFile MakeDlgWithActionParam(int entryIndex, string key, string value)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        var entries = new List<GffStruct>();
+        for (int i = 0; i <= entryIndex; i++)
+        {
+            var entry = new GffStruct { Type = 0 };
+            var actionParams = new List<GffStruct>();
+            if (i == entryIndex)
+            {
+                var param = new GffStruct { Type = 0 };
+                GffFieldBuilder.AddCExoStringField(param, "Key", key);
+                GffFieldBuilder.AddCExoStringField(param, "Value", value);
+                actionParams.Add(param);
+            }
+            GffFieldBuilder.AddListField(entry, "ActionParams", actionParams);
+            entries.Add(entry);
+        }
+        GffFieldBuilder.AddListField(root, "EntryList", entries);
+        return new GffFile { FileType = "DLG ", FileVersion = "V3.2", RootStruct = root };
+    }
+
+    public static GffFile MakeDlgWithConditionParam(int entryIndex, string key, string value)
+    {
+        // ConditionParams live on link structs inside RepliesList (per DLG spec).
+        // Build an entry with a single reply link that carries the condition param.
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        var entries = new List<GffStruct>();
+        for (int i = 0; i <= entryIndex; i++)
+        {
+            var entry = new GffStruct { Type = 0 };
+            var repliesList = new List<GffStruct>();
+            if (i == entryIndex)
+            {
+                var link = new GffStruct { Type = 0 };
+                var condParams = new List<GffStruct>();
+                var param = new GffStruct { Type = 0 };
+                GffFieldBuilder.AddCExoStringField(param, "Key", key);
+                GffFieldBuilder.AddCExoStringField(param, "Value", value);
+                condParams.Add(param);
+                GffFieldBuilder.AddListField(link, "ConditionParams", condParams);
+                repliesList.Add(link);
+            }
+            GffFieldBuilder.AddListField(entry, "RepliesList", repliesList);
+            entries.Add(entry);
+        }
+        GffFieldBuilder.AddListField(root, "EntryList", entries);
+        return new GffFile { FileType = "DLG ", FileVersion = "V3.2", RootStruct = root };
+    }
 
     // --- GIT ---
     public static GffFile MakeGitWithList(string listName, string resRefField, params string[] resRefs)

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
@@ -14,7 +14,38 @@ internal static class TestGffBuilder
     public static GffFile MakeUtc(
         string? conversation = null,
         IReadOnlyList<string>? equipResRefs = null,
-        IReadOnlyList<string>? inventoryResRefs = null) => throw new NotImplementedException();
+        IReadOnlyList<string>? inventoryResRefs = null)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        if (conversation != null)
+            GffFieldBuilder.AddCResRefField(root, "Conversation", conversation);
+
+        if (equipResRefs != null)
+        {
+            var slots = new List<GffStruct>();
+            foreach (var rr in equipResRefs)
+            {
+                var slot = new GffStruct { Type = 0 };
+                GffFieldBuilder.AddCResRefField(slot, "EquipRes", rr);
+                slots.Add(slot);
+            }
+            GffFieldBuilder.AddListField(root, "Equip_ItemList", slots);
+        }
+
+        if (inventoryResRefs != null)
+        {
+            var items = new List<GffStruct>();
+            foreach (var rr in inventoryResRefs)
+            {
+                var item = new GffStruct { Type = 0 };
+                GffFieldBuilder.AddCResRefField(item, "InventoryRes", rr);
+                items.Add(item);
+            }
+            GffFieldBuilder.AddListField(root, "ItemList", items);
+        }
+
+        return new GffFile { FileType = "UTC ", FileVersion = "V3.2", RootStruct = root };
+    }
 
     // --- UTI ---
     public static GffFile MakeUti(string? onAcquireScript = null) => throw new NotImplementedException();

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
@@ -224,7 +224,28 @@ internal static class TestGffBuilder
         string? defaultBic = null,
         string? startMovie = null,
         string? customTlk = null,
-        string? onPlayerHeartbeat = null) => throw new NotImplementedException();
+        string? onHeartbeat = null)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        if (entryArea != null) GffFieldBuilder.AddCResRefField(root, "Mod_Entry_Area", entryArea);
+        if (defaultBic != null) GffFieldBuilder.AddCResRefField(root, "Mod_DefaultBic", defaultBic);
+        if (startMovie != null) GffFieldBuilder.AddCResRefField(root, "Mod_StartMovie", startMovie);
+        if (customTlk != null) GffFieldBuilder.AddCResRefField(root, "Mod_CustomTlk", customTlk);
+        if (onHeartbeat != null) GffFieldBuilder.AddCResRefField(root, "Mod_OnHeartbeat", onHeartbeat);
+        return new GffFile { FileType = "IFO ", FileVersion = "V3.2", RootStruct = root };
+    }
 
-    public static GffFile MakeIfoWithHakList(params string[] hakResRefs) => throw new NotImplementedException();
+    public static GffFile MakeIfoWithHakList(params string[] hakResRefs)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        var haks = new List<GffStruct>();
+        foreach (var rr in hakResRefs)
+        {
+            var hakStruct = new GffStruct { Type = 0 };
+            GffFieldBuilder.AddCResRefField(hakStruct, "Mod_Hak", rr);
+            haks.Add(hakStruct);
+        }
+        GffFieldBuilder.AddListField(root, "Mod_HakList", haks);
+        return new GffFile { FileType = "IFO ", FileVersion = "V3.2", RootStruct = root };
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
@@ -48,7 +48,13 @@ internal static class TestGffBuilder
     }
 
     // --- UTI ---
-    public static GffFile MakeUti(string? onAcquireScript = null) => throw new NotImplementedException();
+    public static GffFile MakeUti(string? onAcquireScript = null)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        if (onAcquireScript != null)
+            GffFieldBuilder.AddCResRefField(root, "OnAcquireItem", onAcquireScript);
+        return new GffFile { FileType = "UTI ", FileVersion = "V3.2", RootStruct = root };
+    }
 
     // --- UTM ---
     public static GffFile MakeUtmWithItems(

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
@@ -48,13 +48,8 @@ internal static class TestGffBuilder
     }
 
     // --- UTI ---
-    public static GffFile MakeUti(string? onAcquireScript = null)
-    {
-        var root = new GffStruct { Type = 0xFFFFFFFF };
-        if (onAcquireScript != null)
-            GffFieldBuilder.AddCResRefField(root, "OnAcquireItem", onAcquireScript);
-        return new GffFile { FileType = "UTI ", FileVersion = "V3.2", RootStruct = root };
-    }
+    // UTI files have no script-event fields per BioWare spec — items use
+    // ItemProperty slots, not script events. No builder needed for UTI scanning.
 
     // --- UTM ---
     public static GffFile MakeUtmWithItems(

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
@@ -59,7 +59,36 @@ internal static class TestGffBuilder
     // --- UTM ---
     public static GffFile MakeUtmWithItems(
         string panelName,
-        params string[] itemResRefs) => throw new NotImplementedException();
+        params string[] itemResRefs)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        var storeList = new List<GffStruct>();
+
+        // Map panel name to canonical store panel ID (used as struct.Type per UtmReader/Writer)
+        var panelId = panelName switch
+        {
+            "Armor" => Radoub.Formats.Utm.StorePanels.Armor,
+            "Miscellaneous" => Radoub.Formats.Utm.StorePanels.Miscellaneous,
+            "Potions/Scrolls" => Radoub.Formats.Utm.StorePanels.Potions,
+            "Rings/Amulets" => Radoub.Formats.Utm.StorePanels.RingsAmulets,
+            "Weapons" => Radoub.Formats.Utm.StorePanels.Weapons,
+            _ => 0
+        };
+        var panel = new GffStruct { Type = (uint)panelId };
+
+        var items = new List<GffStruct>();
+        foreach (var rr in itemResRefs)
+        {
+            var item = new GffStruct { Type = 0 };
+            GffFieldBuilder.AddCResRefField(item, "InventoryRes", rr);
+            items.Add(item);
+        }
+        GffFieldBuilder.AddListField(panel, "ItemList", items);
+        storeList.Add(panel);
+        GffFieldBuilder.AddListField(root, "StoreList", storeList);
+
+        return new GffFile { FileType = "UTM ", FileVersion = "V3.2", RootStruct = root };
+    }
 
     // --- UTP ---
     public static GffFile MakeUtpWithInventory(params string[] inventoryResRefs)

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
@@ -1,0 +1,56 @@
+using Radoub.Formats.Gff;
+
+namespace Radoub.Formats.Tests.Search.Rename;
+
+/// <summary>
+/// Builds in-memory GFF structures for ResRefReferenceScanner tests.
+/// Each builder populates only the fields a specific test cares about;
+/// other fields are left absent.
+/// All ResRef-carrier fields use lowercase values per Aurora convention.
+/// </summary>
+internal static class TestGffBuilder
+{
+    // --- UTC ---
+    public static GffFile MakeUtc(
+        string? conversation = null,
+        IReadOnlyList<string>? equipResRefs = null,
+        IReadOnlyList<string>? inventoryResRefs = null) => throw new NotImplementedException();
+
+    // --- UTI ---
+    public static GffFile MakeUti(string? onAcquireScript = null) => throw new NotImplementedException();
+
+    // --- UTM ---
+    public static GffFile MakeUtmWithItems(
+        string panelName,
+        params string[] itemResRefs) => throw new NotImplementedException();
+
+    // --- UTP ---
+    public static GffFile MakeUtpWithInventory(params string[] inventoryResRefs) => throw new NotImplementedException();
+
+    // --- UTD ---
+    public static GffFile MakeUtd(string? conversation = null) => throw new NotImplementedException();
+
+    public static GffFile MakeUtdWithScriptField(string fieldName, string scriptResRef) => throw new NotImplementedException();
+
+    // --- DLG ---
+    public static GffFile MakeDlgWithSound(int entryIndex, string sound) => throw new NotImplementedException();
+    public static GffFile MakeDlgWithActionParam(int entryIndex, string key, string value) => throw new NotImplementedException();
+    public static GffFile MakeDlgWithConditionParam(int entryIndex, string key, string value) => throw new NotImplementedException();
+
+    // --- GIT ---
+    public static GffFile MakeGitWithList(string listName, string resRefField, params string[] resRefs) => throw new NotImplementedException();
+
+    // --- ARE ---
+    public static GffFile MakeAre(string? onEnterScript = null) => throw new NotImplementedException();
+    public static GffFile MakeAreWithScriptField(string fieldName, string scriptResRef) => throw new NotImplementedException();
+
+    // --- IFO ---
+    public static GffFile MakeIfo(
+        string? entryArea = null,
+        string? defaultBic = null,
+        string? startMovie = null,
+        string? customTlk = null,
+        string? onPlayerHeartbeat = null) => throw new NotImplementedException();
+
+    public static GffFile MakeIfoWithHakList(params string[] hakResRefs) => throw new NotImplementedException();
+}

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
@@ -78,8 +78,20 @@ internal static class TestGffBuilder
     public static GffFile MakeGitWithList(string listName, string resRefField, params string[] resRefs) => throw new NotImplementedException();
 
     // --- ARE ---
-    public static GffFile MakeAre(string? onEnterScript = null) => throw new NotImplementedException();
-    public static GffFile MakeAreWithScriptField(string fieldName, string scriptResRef) => throw new NotImplementedException();
+    public static GffFile MakeAre(string? onEnterScript = null)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        if (onEnterScript != null)
+            GffFieldBuilder.AddCResRefField(root, "OnEnter", onEnterScript);
+        return new GffFile { FileType = "ARE ", FileVersion = "V3.2", RootStruct = root };
+    }
+
+    public static GffFile MakeAreWithScriptField(string fieldName, string scriptResRef)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        GffFieldBuilder.AddCResRefField(root, fieldName, scriptResRef);
+        return new GffFile { FileType = "ARE ", FileVersion = "V3.2", RootStruct = root };
+    }
 
     // --- IFO ---
     public static GffFile MakeIfo(

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/TestGffBuilder.cs
@@ -62,7 +62,19 @@ internal static class TestGffBuilder
         params string[] itemResRefs) => throw new NotImplementedException();
 
     // --- UTP ---
-    public static GffFile MakeUtpWithInventory(params string[] inventoryResRefs) => throw new NotImplementedException();
+    public static GffFile MakeUtpWithInventory(params string[] inventoryResRefs)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        var items = new List<GffStruct>();
+        foreach (var rr in inventoryResRefs)
+        {
+            var item = new GffStruct { Type = 0 };
+            GffFieldBuilder.AddCResRefField(item, "InventoryRes", rr);
+            items.Add(item);
+        }
+        GffFieldBuilder.AddListField(root, "ItemList", items);
+        return new GffFile { FileType = "UTP ", FileVersion = "V3.2", RootStruct = root };
+    }
 
     // --- UTD ---
     public static GffFile MakeUtd(string? conversation = null)

--- a/Radoub.Formats/Radoub.Formats/Search/Models/ReplaceOperation.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Models/ReplaceOperation.cs
@@ -13,4 +13,11 @@ public class ReplaceOperation
 
     /// <summary>Use regex substitution (capture groups)</summary>
     public bool IsRegex { get; init; }
+
+    /// <summary>
+    /// When true, ResRef fields with IsReplaceable=false are still replaced.
+    /// Default false. Set by ResRefRenameOrchestrator (Chunk 3) when applying
+    /// reference updates as part of a rename operation.
+    /// </summary>
+    public bool AllowResRefReplace { get; init; }
 }

--- a/Radoub.Formats/Radoub.Formats/Search/Models/SearchCriteria.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Models/SearchCriteria.cs
@@ -46,6 +46,13 @@ public class SearchCriteria
     public bool SearchStrRefs { get; init; }
 
     /// <summary>
+    /// When true, the search additionally includes filename matches (via FilenameSearchProvider)
+    /// AND ResRef field matches become replaceable in the preview. Off by default.
+    /// See spec Section 5 (NonPublic/Trebuchet/2026-05-03-resref-rename-design.md).
+    /// </summary>
+    public bool IncludeFilenameResRef { get; init; }
+
+    /// <summary>
     /// Callback that resolves a StrRef to its TLK string. Set by the caller
     /// (e.g., Marlinspike panel) when SearchStrRefs is enabled.
     /// Providers pass this to SearchLocString when SearchStrRefs is true.

--- a/Radoub.Formats/Radoub.Formats/Search/Providers/SearchProviderBase.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Providers/SearchProviderBase.cs
@@ -185,7 +185,12 @@ public abstract class SearchProviderBase
     {
         // ResRef fields are not replaceable — changing a ResRef without renaming
         // the referenced file on disk would silently break the reference.
-        if (!op.Match.Field.IsReplaceable)
+        // The rename orchestrator (Chunk 3) sets AllowResRefReplace=true on operations
+        // that update ResRef references as part of an atomic rename.
+        var allowResRef = op.AllowResRefReplace
+            && op.Match.Field.FieldType == SearchFieldType.ResRef;
+
+        if (!op.Match.Field.IsReplaceable && !allowResRef)
         {
             return new ReplaceResult
             {

--- a/Radoub.Formats/Radoub.Formats/Search/Registry/FieldRegistrations.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Registry/FieldRegistrations.cs
@@ -151,7 +151,9 @@ public static class FieldRegistrations
             new FieldDefinition { Name = "Identified Description", GffPath = "DescIdentified", FieldType = SearchFieldType.LocString, Category = SearchFieldCategory.Content, Description = "Identified item description" },
             new FieldDefinition { Name = "Tag", GffPath = "Tag", FieldType = SearchFieldType.Tag, Category = SearchFieldCategory.Identity, Description = "Item tag" },
             new FieldDefinition { Name = "Template ResRef", GffPath = "TemplateResRef", FieldType = SearchFieldType.ResRef, Category = SearchFieldCategory.Identity, Description = "Blueprint resource reference", IsReplaceable = false },
-            new FieldDefinition { Name = "Comment", GffPath = "Comment", FieldType = SearchFieldType.Text, Category = SearchFieldCategory.Metadata, Description = "Toolset comment" }
+            new FieldDefinition { Name = "Comment", GffPath = "Comment", FieldType = SearchFieldType.Text, Category = SearchFieldCategory.Metadata, Description = "Toolset comment" },
+            // Item event scripts (#1926)
+            new FieldDefinition { Name = "OnAcquireItem", GffPath = "OnAcquireItem", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "OnAcquired event script" }
         );
     }
 

--- a/Radoub.Formats/Radoub.Formats/Search/Registry/FieldRegistrations.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Registry/FieldRegistrations.cs
@@ -151,9 +151,10 @@ public static class FieldRegistrations
             new FieldDefinition { Name = "Identified Description", GffPath = "DescIdentified", FieldType = SearchFieldType.LocString, Category = SearchFieldCategory.Content, Description = "Identified item description" },
             new FieldDefinition { Name = "Tag", GffPath = "Tag", FieldType = SearchFieldType.Tag, Category = SearchFieldCategory.Identity, Description = "Item tag" },
             new FieldDefinition { Name = "Template ResRef", GffPath = "TemplateResRef", FieldType = SearchFieldType.ResRef, Category = SearchFieldCategory.Identity, Description = "Blueprint resource reference", IsReplaceable = false },
-            new FieldDefinition { Name = "Comment", GffPath = "Comment", FieldType = SearchFieldType.Text, Category = SearchFieldCategory.Metadata, Description = "Toolset comment" },
-            // Item event scripts (#1926)
-            new FieldDefinition { Name = "OnAcquireItem", GffPath = "OnAcquireItem", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "OnAcquired event script" }
+            new FieldDefinition { Name = "Comment", GffPath = "Comment", FieldType = SearchFieldType.Text, Category = SearchFieldCategory.Metadata, Description = "Toolset comment" }
+            // UTI files have no script-event fields per BioWare spec — items use ItemProperty
+            // slots, not script events. Plan spec Section 4 listing "all UTI script-event fields"
+            // is therefore vacuous; no fields registered here. (#1926)
         );
     }
 

--- a/Radoub.Formats/Radoub.Formats/Search/Registry/FieldRegistrations.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Registry/FieldRegistrations.cs
@@ -262,7 +262,40 @@ public static class FieldRegistrations
         registry.RegisterFileType(ResourceTypes.Ifo,
             new FieldDefinition { Name = "Module Name", GffPath = "Mod_Name", FieldType = SearchFieldType.LocString, Category = SearchFieldCategory.Content, Description = "Module display name" },
             new FieldDefinition { Name = "Module Description", GffPath = "Mod_Description", FieldType = SearchFieldType.LocString, Category = SearchFieldCategory.Content, Description = "Module description" },
-            new FieldDefinition { Name = "Tag", GffPath = "Mod_Tag", FieldType = SearchFieldType.Tag, Category = SearchFieldCategory.Identity, Description = "Module tag" }
+            new FieldDefinition { Name = "Tag", GffPath = "Mod_Tag", FieldType = SearchFieldType.Tag, Category = SearchFieldCategory.Identity, Description = "Module tag" },
+
+            // ResRef fields (#1926)
+            new FieldDefinition { Name = "Entry Area", GffPath = "Mod_Entry_Area", FieldType = SearchFieldType.ResRef, Category = SearchFieldCategory.Identity, Description = "Area ResRef where players start", IsReplaceable = false },
+            new FieldDefinition { Name = "Default BIC", GffPath = "Mod_DefaultBic", FieldType = SearchFieldType.ResRef, Category = SearchFieldCategory.Identity, Description = "Default character (.bic) for new players", IsReplaceable = false },
+            new FieldDefinition { Name = "Start Movie", GffPath = "Mod_StartMovie", FieldType = SearchFieldType.ResRef, Category = SearchFieldCategory.Metadata, Description = "Startup movie (.bik) ResRef", IsReplaceable = false },
+            new FieldDefinition { Name = "Custom TLK", GffPath = "Mod_CustomTlk", FieldType = SearchFieldType.ResRef, Category = SearchFieldCategory.Metadata, Description = "Custom TLK file ResRef", IsReplaceable = false },
+            new FieldDefinition { Name = "HAK", GffPath = "Mod_Hak", FieldType = SearchFieldType.ResRef, Category = SearchFieldCategory.Metadata, Description = "HAK file ResRef (per entry in Mod_HakList)", IsReplaceable = false },
+
+            // Module event scripts (classic NWN)
+            new FieldDefinition { Name = "OnModuleLoad", GffPath = "Mod_OnModLoad", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run when module loads" },
+            new FieldDefinition { Name = "OnClientEnter", GffPath = "Mod_OnClientEntr", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run when a client enters" },
+            new FieldDefinition { Name = "OnClientLeave", GffPath = "Mod_OnClientLeav", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run when a client leaves" },
+            new FieldDefinition { Name = "OnHeartbeat", GffPath = "Mod_OnHeartbeat", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Module heartbeat script" },
+            new FieldDefinition { Name = "OnAcquireItem", GffPath = "Mod_OnAcquirItem", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run when an item is acquired" },
+            new FieldDefinition { Name = "OnActivateItem", GffPath = "Mod_OnActvtItem", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run when an item is activated" },
+            new FieldDefinition { Name = "OnUnacquireItem", GffPath = "Mod_OnUnAqreItem", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run when an item is unacquired" },
+            new FieldDefinition { Name = "OnPlayerDeath", GffPath = "Mod_OnPlrDeath", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run when a player dies" },
+            new FieldDefinition { Name = "OnPlayerDying", GffPath = "Mod_OnPlrDying", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run when a player is dying" },
+            new FieldDefinition { Name = "OnPlayerRest", GffPath = "Mod_OnPlrRest", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run when a player rests" },
+            new FieldDefinition { Name = "OnPlayerEquipItem", GffPath = "Mod_OnPlrEqItm", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run when a player equips an item" },
+            new FieldDefinition { Name = "OnPlayerUnequipItem", GffPath = "Mod_OnPlrUnEqItm", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run when a player unequips an item" },
+            new FieldDefinition { Name = "OnPlayerLevelUp", GffPath = "Mod_OnPlrLvlUp", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run when a player levels up" },
+            new FieldDefinition { Name = "OnUserDefined", GffPath = "Mod_OnUsrDefined", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run on user-defined event" },
+            new FieldDefinition { Name = "OnSpawnButtonDown", GffPath = "Mod_OnSpawnBtnDn", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run when respawn button is pressed" },
+            new FieldDefinition { Name = "OnCutsceneAbort", GffPath = "Mod_OnCutsnAbort", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run when a cutscene is aborted" },
+
+            // Module event scripts (NWN:EE)
+            new FieldDefinition { Name = "OnModuleStart", GffPath = "Mod_OnModStart", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run after OnModuleLoad (NWN:EE)" },
+            new FieldDefinition { Name = "OnPlayerChat", GffPath = "Mod_OnPlrChat", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run when a player chats (NWN:EE)" },
+            new FieldDefinition { Name = "OnPlayerTarget", GffPath = "Mod_OnPlrTarget", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run when a player targets something (NWN:EE)" },
+            new FieldDefinition { Name = "OnPlayerGuiEvent", GffPath = "Mod_OnPlrGuiEvt", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run on player GUI event (NWN:EE)" },
+            new FieldDefinition { Name = "OnPlayerTileAction", GffPath = "Mod_OnPlrTileAct", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run on player tile action (NWN:EE)" },
+            new FieldDefinition { Name = "OnNuiEvent", GffPath = "Mod_OnNuiEvent", FieldType = SearchFieldType.Script, Category = SearchFieldCategory.Script, Description = "Script run on NUI event (NWN:EE 1.80+)" }
         );
     }
 }

--- a/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReference.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReference.cs
@@ -1,0 +1,49 @@
+namespace Radoub.Formats.Search.Rename;
+
+/// <summary>
+/// One reference to a ResRef discovered by the scanner.
+/// Each reference becomes a row in the rename preview UI;
+/// users can untick rows to skip individual updates.
+/// </summary>
+public class ResRefReference
+{
+    /// <summary>Absolute path to the file containing this reference.</summary>
+    public required string FilePath { get; init; }
+
+    /// <summary>Resource type of the file (used for provider dispatch).
+    /// For .nss matches this is set to ResourceTypes.Nss (added in registry if not already present).</summary>
+    public required ushort ResourceType { get; init; }
+
+    /// <summary>Field where this reference lives (registered FieldDefinition).
+    /// Null for .nss matches and DLG script-param substring matches.</summary>
+    public FieldDefinition? Field { get; init; }
+
+    /// <summary>Human-readable location within the file
+    /// (e.g., "Creature List > Item 3 > TemplateResRef" or "Line 42 (script source)").</summary>
+    public required string Location { get; init; }
+
+    /// <summary>Current value at this reference site (the old ResRef, possibly mixed-case).</summary>
+    public required string OldValue { get; init; }
+
+    /// <summary>The new value to write (lowercased target ResRef).</summary>
+    public required string NewValue { get; init; }
+
+    /// <summary>Where this reference was found and how confident the match is.</summary>
+    public required ResRefScopeTier ScopeTier { get; init; }
+
+    /// <summary>True for any non-typed-GFF match (.nss source or DLG script params).
+    /// Convenience flag derived from ScopeTier; orchestrator branches on this.</summary>
+    public bool IsTextMatch => ScopeTier != ResRefScopeTier.TypedGffField;
+
+    /// <summary>For .nss/DLG-param matches: byte offset of the match in the source.
+    /// For typed GFF fields: 0 (entire field value is replaced).</summary>
+    public int MatchOffset { get; init; }
+
+    /// <summary>For .nss/DLG-param matches: length of the matched text.
+    /// For typed GFF fields: full field length.</summary>
+    public int MatchLength { get; init; }
+
+    /// <summary>User-controllable: whether this reference will be applied during execute.
+    /// Default true; users untick false positives in the preview UI.</summary>
+    public bool IsSelected { get; set; } = true;
+}

--- a/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
@@ -38,9 +38,73 @@ public class ResRefReferenceScanner
         var results = new List<ResRefReference>();
 
         ScanTopLevelScalarFields(gffFile, resourceType, oldResRef, filePath, results);
-        // Per-type nested handlers added in subsequent tasks
+
+        if (resourceType == ResourceTypes.Git)
+            ScanGitInstanceLists(gffFile, oldResRef, filePath, results);
 
         return results;
+    }
+
+    private static readonly (string ListName, string ResRefField)[] GitInstanceLists =
+    {
+        ("Creature List",  "TemplateResRef"),
+        ("Door List",      "TemplateResRef"),
+        ("Placeable List", "TemplateResRef"),
+        ("StoreList",      "ResRef"),
+        ("WaypointList",   "TemplateResRef"),
+        ("Encounter List", "TemplateResRef"),
+        ("TriggerList",    "TemplateResRef"),
+        ("SoundList",      "TemplateResRef")
+    };
+
+    private static readonly FieldDefinition GitTemplateResRefField = new()
+    {
+        Name = "Template ResRef",
+        GffPath = "TemplateResRef",
+        FieldType = SearchFieldType.ResRef,
+        Category = SearchFieldCategory.Identity,
+        Description = "Blueprint resource reference",
+        IsReplaceable = false
+    };
+
+    private static readonly FieldDefinition GitStoreResRefField = new()
+    {
+        Name = "ResRef",
+        GffPath = "ResRef",
+        FieldType = SearchFieldType.ResRef,
+        Category = SearchFieldCategory.Identity,
+        Description = "Store resource reference",
+        IsReplaceable = false
+    };
+
+    private void ScanGitInstanceLists(
+        GffFile gff, string oldResRef, string filePath, List<ResRefReference> results)
+    {
+        foreach (var (listName, resRefField) in GitInstanceLists)
+        {
+            var listField = gff.RootStruct.GetField(listName);
+            if (listField?.Value is not GffList list) continue;
+
+            for (int i = 0; i < list.Elements.Count; i++)
+            {
+                var rrField = list.Elements[i].GetField(resRefField);
+                if (rrField?.Value is string value
+                    && string.Equals(value, oldResRef, StringComparison.OrdinalIgnoreCase))
+                {
+                    var fieldDef = resRefField == "ResRef" ? GitStoreResRefField : GitTemplateResRefField;
+                    results.Add(new ResRefReference
+                    {
+                        FilePath = filePath,
+                        ResourceType = ResourceTypes.Git,
+                        Field = fieldDef,
+                        Location = $"{listName} > Item {i} > {resRefField}",
+                        OldValue = value,
+                        NewValue = string.Empty,
+                        ScopeTier = ResRefScopeTier.TypedGffField
+                    });
+                }
+            }
+        }
     }
 
     private void ScanTopLevelScalarFields(

--- a/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
@@ -48,7 +48,37 @@ public class ResRefReferenceScanner
         if (resourceType == ResourceTypes.Utp)
             ScanUtpInventory(gffFile, oldResRef, filePath, results);
 
+        if (resourceType == ResourceTypes.Utm)
+            ScanUtmStorePanels(gffFile, oldResRef, filePath, results);
+
         return results;
+    }
+
+    private void ScanUtmStorePanels(
+        GffFile gff, string oldResRef, string filePath, List<ResRefReference> results)
+    {
+        var storeListField = gff.RootStruct.GetField("StoreList");
+        if (storeListField?.Value is not GffList storeList) return;
+
+        foreach (var panel in storeList.Elements)
+        {
+            // UTM panel name comes from the struct Type discriminator (StorePanels constants).
+            var panelName = Utm.StorePanels.GetPanelName((int)panel.Type);
+
+            var itemListField = panel.GetField("ItemList");
+            if (itemListField?.Value is not GffList itemList) continue;
+
+            for (int i = 0; i < itemList.Elements.Count; i++)
+            {
+                var f = itemList.Elements[i].GetField("InventoryRes");
+                if (f?.Value is string v
+                    && string.Equals(v, oldResRef, StringComparison.OrdinalIgnoreCase))
+                {
+                    results.Add(MakeRef(filePath, ResourceTypes.Utm, InventoryResField,
+                        $"{panelName} > Item {i} > InventoryRes", v));
+                }
+            }
+        }
     }
 
     private void ScanUtpInventory(

--- a/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
@@ -93,6 +93,62 @@ public class ResRefReferenceScanner
                 results.Add(MakeRef(filePath, ResourceTypes.Dlg, SoundField,
                     $"{nodeKind} {i} > Sound", v));
             }
+
+            // ActionParams live directly on entry/reply nodes
+            ScanDlgParams(node, "ActionParams", nodeKind, i, oldResRef, filePath, results);
+
+            // ConditionParams live on link structs inside RepliesList (for entries)
+            // or EntriesList (for replies). Walk those links per node.
+            var linkListName = nodeKind == "Entry" ? "RepliesList" : "EntriesList";
+            var linkListField = node.GetField(linkListName);
+            if (linkListField?.Value is GffList linkList)
+            {
+                for (int linkIdx = 0; linkIdx < linkList.Elements.Count; linkIdx++)
+                {
+                    var link = linkList.Elements[linkIdx];
+                    ScanDlgParams(
+                        link, "ConditionParams",
+                        $"{nodeKind} {i} > {linkListName}[{linkIdx}]", -1,
+                        oldResRef, filePath, results);
+                }
+            }
+        }
+    }
+
+    private void ScanDlgParams(
+        GffStruct container, string paramFieldName, string nodeKind, int nodeIndex,
+        string oldResRef, string filePath, List<ResRefReference> results)
+    {
+        var paramListField = container.GetField(paramFieldName);
+        if (paramListField?.Value is not GffList paramList) return;
+
+        for (int p = 0; p < paramList.Elements.Count; p++)
+        {
+            var key = paramList.Elements[p].GetField("Key")?.Value as string ?? string.Empty;
+            var value = paramList.Elements[p].GetField("Value")?.Value as string ?? string.Empty;
+
+            // Substring match in VALUE only (per spec Tier 2 — keys are parameter names)
+            var idx = value.IndexOf(oldResRef, StringComparison.OrdinalIgnoreCase);
+            if (idx < 0) continue;
+
+            // Location format: when nodeIndex >= 0 (direct on node), use "{Kind} {N} > {field}..."
+            // When nodeIndex < 0, the caller already provided the full prefix in nodeKind.
+            var locationPrefix = nodeIndex >= 0
+                ? $"{nodeKind} {nodeIndex} > {paramFieldName}[{p}] ({key})"
+                : $"{nodeKind} > {paramFieldName}[{p}] ({key})";
+
+            results.Add(new ResRefReference
+            {
+                FilePath = filePath,
+                ResourceType = ResourceTypes.Dlg,
+                Field = null,  // no registered FieldDefinition for params; orchestrator branches on ScopeTier
+                Location = locationPrefix,
+                OldValue = value,
+                NewValue = string.Empty,
+                ScopeTier = ResRefScopeTier.DlgScriptParam,
+                MatchOffset = idx,
+                MatchLength = oldResRef.Length
+            });
         }
     }
 

--- a/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
@@ -45,7 +45,28 @@ public class ResRefReferenceScanner
         if (resourceType == ResourceTypes.Utc || resourceType == ResourceTypes.Bic)
             ScanUtcEquipAndInventory(gffFile, resourceType, oldResRef, filePath, results);
 
+        if (resourceType == ResourceTypes.Utp)
+            ScanUtpInventory(gffFile, oldResRef, filePath, results);
+
         return results;
+    }
+
+    private void ScanUtpInventory(
+        GffFile gff, string oldResRef, string filePath, List<ResRefReference> results)
+    {
+        var itemListField = gff.RootStruct.GetField("ItemList");
+        if (itemListField?.Value is not GffList itemList) return;
+
+        for (int i = 0; i < itemList.Elements.Count; i++)
+        {
+            var f = itemList.Elements[i].GetField("InventoryRes");
+            if (f?.Value is string v
+                && string.Equals(v, oldResRef, StringComparison.OrdinalIgnoreCase))
+            {
+                results.Add(MakeRef(filePath, ResourceTypes.Utp, InventoryResField,
+                    $"ItemList > Item {i} > InventoryRes", v));
+            }
+        }
     }
 
     private static readonly FieldDefinition EquipResField = new()

--- a/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
@@ -1,0 +1,76 @@
+using Radoub.Formats.Common;
+using Radoub.Formats.Gff;
+
+namespace Radoub.Formats.Search.Rename;
+
+/// <summary>
+/// Pure logic: given a parsed GFF and an old ResRef, returns every
+/// reference site to that ResRef inside the file. No I/O.
+/// See spec Section 4 (NonPublic/Trebuchet/2026-05-03-resref-rename-design.md).
+///
+/// Top-level scalar ResRef fields are discovered via SearchFieldRegistry.
+/// Nested structures (GIT instance lists, UTC equipment/inventory, UTM store
+/// panels, IFO HAK list, DLG node walks) are handled by per-resource-type
+/// methods because they require list traversal that the registry doesn't model.
+/// </summary>
+public class ResRefReferenceScanner
+{
+    private readonly SearchFieldRegistry _registry;
+
+    public ResRefReferenceScanner(SearchFieldRegistry? registry = null)
+    {
+        _registry = registry ?? CreateDefault();
+    }
+
+    private static SearchFieldRegistry CreateDefault()
+    {
+        var registry = new SearchFieldRegistry();
+        FieldRegistrations.RegisterAll(registry);
+        return registry;
+    }
+
+    public IReadOnlyList<ResRefReference> Scan(
+        GffFile gffFile,
+        ushort resourceType,
+        string oldResRef,
+        string filePath)
+    {
+        var results = new List<ResRefReference>();
+
+        ScanTopLevelScalarFields(gffFile, resourceType, oldResRef, filePath, results);
+        // Per-type nested handlers added in subsequent tasks
+
+        return results;
+    }
+
+    private void ScanTopLevelScalarFields(
+        GffFile gff, ushort resourceType, string oldResRef, string filePath,
+        List<ResRefReference> results)
+    {
+        var fields = _registry.GetSearchableFields(resourceType);
+
+        foreach (var field in fields)
+        {
+            // ResRef-carrier types: ResRef and Script (scripts are .nss/.ncs ResRefs)
+            if (field.FieldType != SearchFieldType.ResRef && field.FieldType != SearchFieldType.Script)
+                continue;
+
+            // Top-level lookup only. Nested traversal is per-type below.
+            var gffField = gff.RootStruct.GetField(field.GffPath);
+            if (gffField?.Value is string value
+                && string.Equals(value, oldResRef, StringComparison.OrdinalIgnoreCase))
+            {
+                results.Add(new ResRefReference
+                {
+                    FilePath = filePath,
+                    ResourceType = resourceType,
+                    Field = field,
+                    Location = field.Name,
+                    OldValue = value,
+                    NewValue = string.Empty,  // orchestrator fills NewValue at plan-build time
+                    ScopeTier = ResRefScopeTier.TypedGffField
+                });
+            }
+        }
+    }
+}

--- a/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
@@ -54,7 +54,38 @@ public class ResRefReferenceScanner
         if (resourceType == ResourceTypes.Dlg)
             ScanDlgNodes(gffFile, oldResRef, filePath, results);
 
+        if (resourceType == ResourceTypes.Ifo)
+            ScanIfoHakList(gffFile, oldResRef, filePath, results);
+
         return results;
+    }
+
+    private static readonly FieldDefinition ModHakField = new()
+    {
+        Name = "HAK",
+        GffPath = "Mod_Hak",
+        FieldType = SearchFieldType.ResRef,
+        Category = SearchFieldCategory.Metadata,
+        Description = "HAK file ResRef (per entry in Mod_HakList)",
+        IsReplaceable = false
+    };
+
+    private void ScanIfoHakList(
+        GffFile gff, string oldResRef, string filePath, List<ResRefReference> results)
+    {
+        var hakListField = gff.RootStruct.GetField("Mod_HakList");
+        if (hakListField?.Value is not GffList hakList) return;
+
+        for (int i = 0; i < hakList.Elements.Count; i++)
+        {
+            var f = hakList.Elements[i].GetField("Mod_Hak");
+            if (f?.Value is string v
+                && string.Equals(v, oldResRef, StringComparison.OrdinalIgnoreCase))
+            {
+                results.Add(MakeRef(filePath, ResourceTypes.Ifo, ModHakField,
+                    $"Mod_HakList > Item {i} > Mod_Hak", v));
+            }
+        }
     }
 
     private static readonly FieldDefinition SoundField = new()

--- a/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
@@ -51,7 +51,49 @@ public class ResRefReferenceScanner
         if (resourceType == ResourceTypes.Utm)
             ScanUtmStorePanels(gffFile, oldResRef, filePath, results);
 
+        if (resourceType == ResourceTypes.Dlg)
+            ScanDlgNodes(gffFile, oldResRef, filePath, results);
+
         return results;
+    }
+
+    private static readonly FieldDefinition SoundField = new()
+    {
+        Name = "Sound",
+        GffPath = "Sound",
+        FieldType = SearchFieldType.ResRef,
+        Category = SearchFieldCategory.Metadata,
+        Description = "Sound file reference",
+        IsReplaceable = false
+    };
+
+    private void ScanDlgNodes(
+        GffFile gff, string oldResRef, string filePath, List<ResRefReference> results)
+    {
+        ScanDlgNodeList(gff, "EntryList", "Entry", oldResRef, filePath, results);
+        ScanDlgNodeList(gff, "ReplyList", "Reply", oldResRef, filePath, results);
+    }
+
+    private void ScanDlgNodeList(
+        GffFile gff, string listFieldName, string nodeKind,
+        string oldResRef, string filePath, List<ResRefReference> results)
+    {
+        var listField = gff.RootStruct.GetField(listFieldName);
+        if (listField?.Value is not GffList nodes) return;
+
+        for (int i = 0; i < nodes.Elements.Count; i++)
+        {
+            var node = nodes.Elements[i];
+
+            // Sound field on the node itself
+            var soundField = node.GetField("Sound");
+            if (soundField?.Value is string v
+                && string.Equals(v, oldResRef, StringComparison.OrdinalIgnoreCase))
+            {
+                results.Add(MakeRef(filePath, ResourceTypes.Dlg, SoundField,
+                    $"{nodeKind} {i} > Sound", v));
+            }
+        }
     }
 
     private void ScanUtmStorePanels(

--- a/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
@@ -99,7 +99,20 @@ public class ResRefReferenceScanner
             }
         }
 
-        // Inventory ItemList walked in Task 1b.12
+        var itemListField = gff.RootStruct.GetField("ItemList");
+        if (itemListField?.Value is GffList itemList)
+        {
+            for (int i = 0; i < itemList.Elements.Count; i++)
+            {
+                var f = itemList.Elements[i].GetField("InventoryRes");
+                if (f?.Value is string v
+                    && string.Equals(v, oldResRef, StringComparison.OrdinalIgnoreCase))
+                {
+                    results.Add(MakeRef(filePath, resourceType, InventoryResField,
+                        $"ItemList > Item {i} > InventoryRes", v));
+                }
+            }
+        }
     }
 
     private static readonly (string ListName, string ResRefField)[] GitInstanceLists =

--- a/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
@@ -42,7 +42,64 @@ public class ResRefReferenceScanner
         if (resourceType == ResourceTypes.Git)
             ScanGitInstanceLists(gffFile, oldResRef, filePath, results);
 
+        if (resourceType == ResourceTypes.Utc || resourceType == ResourceTypes.Bic)
+            ScanUtcEquipAndInventory(gffFile, resourceType, oldResRef, filePath, results);
+
         return results;
+    }
+
+    private static readonly FieldDefinition EquipResField = new()
+    {
+        Name = "EquipRes",
+        GffPath = "EquipRes",
+        FieldType = SearchFieldType.ResRef,
+        Category = SearchFieldCategory.Identity,
+        Description = "Equipped item ResRef",
+        IsReplaceable = false
+    };
+
+    private static readonly FieldDefinition InventoryResField = new()
+    {
+        Name = "InventoryRes",
+        GffPath = "InventoryRes",
+        FieldType = SearchFieldType.ResRef,
+        Category = SearchFieldCategory.Identity,
+        Description = "Inventory item ResRef",
+        IsReplaceable = false
+    };
+
+    private static ResRefReference MakeRef(
+        string filePath, ushort resourceType, FieldDefinition field,
+        string location, string oldValue) => new()
+    {
+        FilePath = filePath,
+        ResourceType = resourceType,
+        Field = field,
+        Location = location,
+        OldValue = oldValue,
+        NewValue = string.Empty,
+        ScopeTier = ResRefScopeTier.TypedGffField
+    };
+
+    private void ScanUtcEquipAndInventory(
+        GffFile gff, ushort resourceType, string oldResRef, string filePath, List<ResRefReference> results)
+    {
+        var equipField = gff.RootStruct.GetField("Equip_ItemList");
+        if (equipField?.Value is GffList equipList)
+        {
+            for (int i = 0; i < equipList.Elements.Count; i++)
+            {
+                var f = equipList.Elements[i].GetField("EquipRes");
+                if (f?.Value is string v
+                    && string.Equals(v, oldResRef, StringComparison.OrdinalIgnoreCase))
+                {
+                    results.Add(MakeRef(filePath, resourceType, EquipResField,
+                        $"Equip_ItemList > Slot {i} > EquipRes", v));
+                }
+            }
+        }
+
+        // Inventory ItemList walked in Task 1b.12
     }
 
     private static readonly (string ListName, string ResRefField)[] GitInstanceLists =

--- a/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefRenamePlan.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefRenamePlan.cs
@@ -1,0 +1,38 @@
+namespace Radoub.Formats.Search.Rename;
+
+/// <summary>
+/// Captures one rename operation: old name, new name (validated), and all
+/// references that will be updated. The orchestrator consumes this directly.
+/// </summary>
+public class ResRefRenamePlan
+{
+    /// <summary>Original ResRef being renamed (lowercased for matching).</summary>
+    public required string OldName { get; init; }
+
+    /// <summary>Validated new ResRef name.</summary>
+    public required string NewName { get; init; }
+
+    /// <summary>Resource type / extension of the file being renamed.</summary>
+    public required ushort ResourceType { get; init; }
+
+    /// <summary>Validation result for the new name (collisions, warnings).</summary>
+    public required ResRefValidationResult Validation { get; init; }
+
+    /// <summary>All discovered references to the old name. Each row has IsSelected.</summary>
+    public List<ResRefReference> References { get; init; } = new();
+
+    /// <summary>Source file path being renamed (the file whose name is changing).</summary>
+    public required string SourceFilePath { get; init; }
+
+    /// <summary>Target file path after rename (computed: directory + NewName + extension).</summary>
+    public required string TargetFilePath { get; init; }
+
+    /// <summary>True if the user has not unticked this rename in the preview.
+    /// When false, the file rename is skipped but the user may still apply
+    /// individual reference updates from References.</summary>
+    public bool IsSelected { get; set; } = true;
+
+    /// <summary>References user has chosen to apply (IsSelected == true).</summary>
+    public IEnumerable<ResRefReference> SelectedReferences =>
+        References.Where(r => r.IsSelected);
+}

--- a/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefScopeTier.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefScopeTier.cs
@@ -1,0 +1,21 @@
+namespace Radoub.Formats.Search.Rename;
+
+/// <summary>
+/// Classifies a ResRef reference by where it was found and how confident
+/// the match is. Used by the rename preview to render appropriate visual
+/// treatment (e.g., low-confidence .nss matches get a warning badge).
+/// </summary>
+public enum ResRefScopeTier
+{
+    /// <summary>Typed GFF ResRef field (e.g., UTC.Conversation, GIT.TemplateResRef).</summary>
+    TypedGffField,
+
+    /// <summary>DLG ActionParams or ConditionParams value substring match.</summary>
+    DlgScriptParam,
+
+    /// <summary>.nss source with surrounding quotes — high confidence.</summary>
+    NssQuotedString,
+
+    /// <summary>.nss source as bare substring (no quotes) — low confidence; user should verify.</summary>
+    NssBareSubstring
+}

--- a/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefValidationResult.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefValidationResult.cs
@@ -1,0 +1,34 @@
+namespace Radoub.Formats.Search.Rename;
+
+/// <summary>
+/// Outcome of validating and normalizing a proposed ResRef name.
+/// </summary>
+public record ResRefValidationResult
+{
+    /// <summary>True if the name is acceptable (possibly with a warning or auto-suffix).</summary>
+    public required bool IsValid { get; init; }
+
+    /// <summary>The normalized, validated name. Lowercase, extension stripped,
+    /// possibly suffixed for collision resolution. Empty when IsValid is false.</summary>
+    public required string NormalizedName { get; init; }
+
+    /// <summary>Hard-fail error message when IsValid is false. Null when IsValid is true.</summary>
+    public string? Error { get; init; }
+
+    /// <summary>Non-blocking advisory (e.g., "starts with a digit"). Null if no warning.</summary>
+    public string? Warning { get; init; }
+
+    /// <summary>True when collision resolution applied an auto-suffix (e.g., _2, _3).
+    /// UI must surface a confirmation dialog before proceeding.</summary>
+    public bool AutoSuffixApplied { get; init; }
+
+    public static ResRefValidationResult Fail(string error) => new()
+    {
+        IsValid = false, NormalizedName = string.Empty, Error = error
+    };
+
+    public static ResRefValidationResult Ok(string name, string? warning = null, bool autoSuffix = false) => new()
+    {
+        IsValid = true, NormalizedName = name, Warning = warning, AutoSuffixApplied = autoSuffix
+    };
+}

--- a/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefValidator.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefValidator.cs
@@ -1,0 +1,68 @@
+namespace Radoub.Formats.Search.Rename;
+
+/// <summary>
+/// Validates and normalizes proposed ResRef names. Pure logic — no I/O.
+/// See spec Section 6 (NonPublic/Trebuchet/2026-05-03-resref-rename-design.md).
+/// </summary>
+public class ResRefValidator
+{
+    private const int MaxLength = 16;
+
+    public ResRefValidationResult Validate(
+        string proposedName,
+        IReadOnlySet<string> existingNames,
+        string extension)
+    {
+        var trimmed = (proposedName ?? string.Empty).Trim();
+        if (string.IsNullOrEmpty(trimmed))
+            return ResRefValidationResult.Fail("ResRef cannot be empty");
+
+        // Strip user-typed extension (any case) if it matches the target extension
+        var ext = extension.TrimStart('.');
+        if (trimmed.EndsWith($".{ext}", StringComparison.OrdinalIgnoreCase))
+            trimmed = trimmed[..^(ext.Length + 1)];
+
+        var normalized = trimmed.ToLowerInvariant();
+
+        if (normalized.Length > MaxLength)
+            return ResRefValidationResult.Fail(
+                $"ResRef '{normalized}' is {normalized.Length} characters ({MaxLength} max)");
+
+        if (!System.Text.RegularExpressions.Regex.IsMatch(normalized, @"^[a-z0-9_]+$"))
+            return ResRefValidationResult.Fail(
+                "ResRef can only contain lowercase letters, digits, and underscores");
+
+        string? warning = null;
+        if (char.IsDigit(normalized[0]))
+            warning = "ResRef starts with a digit — confirm this is intentional";
+
+        return ResolveCollision(normalized, warning, existingNames);
+    }
+
+    private static ResRefValidationResult ResolveCollision(
+        string baseName,
+        string? warning,
+        IReadOnlySet<string> existing)
+    {
+        if (!existing.Contains(baseName))
+            return ResRefValidationResult.Ok(baseName, warning);
+
+        for (int suffix = 2; suffix <= 99; suffix++)
+        {
+            var candidate = BuildCandidate(baseName, suffix);
+            if (!existing.Contains(candidate))
+                return ResRefValidationResult.Ok(candidate, warning, autoSuffix: true);
+        }
+
+        return ResRefValidationResult.Fail(
+            $"Cannot find available filename — {baseName} and all suffixes _2 through _99 are taken");
+    }
+
+    private static string BuildCandidate(string baseName, int suffix)
+    {
+        var suffixStr = $"_{suffix}";
+        var maxBaseLen = MaxLength - suffixStr.Length;
+        var truncatedBase = baseName.Length > maxBaseLen ? baseName[..maxBaseLen] : baseName;
+        return truncatedBase + suffixStr;
+    }
+}

--- a/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefValidator.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefValidator.cs
@@ -8,6 +8,17 @@ public class ResRefValidator
 {
     private const int MaxLength = 16;
 
+    /// <summary>
+    /// Validates and normalizes a proposed ResRef name.
+    /// </summary>
+    /// <param name="proposedName">Raw user input. May include extension; will be trimmed and lowercased.</param>
+    /// <param name="existingNames">Existing ResRefs in the target scope, used for collision detection.
+    /// Caller must EXCLUDE the name being renamed — otherwise renaming "louis" → "louis" would falsely
+    /// trigger an auto-suffix.</param>
+    /// <param name="extension">Target file extension (e.g., ".dlg"). Used to detect and strip a user-typed
+    /// extension from <paramref name="proposedName"/>.</param>
+    /// <returns>A <see cref="ResRefValidationResult"/>. On collision, auto-suffixes _2.._99 are tried;
+    /// if all are taken, returns a Fail result.</returns>
     public ResRefValidationResult Validate(
         string proposedName,
         IReadOnlySet<string> existingNames,

--- a/Radoub.IntegrationTests/Trebuchet/MarlinspikeRenameSmokeTest.cs
+++ b/Radoub.IntegrationTests/Trebuchet/MarlinspikeRenameSmokeTest.cs
@@ -1,0 +1,97 @@
+using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Definitions;
+using Radoub.IntegrationTests.Shared;
+using Xunit;
+
+namespace Radoub.IntegrationTests.Trebuchet;
+
+/// <summary>
+/// Smoke test for the Marlinspike Filename/ResRef Rename mode UI wiring (#1926).
+///
+/// Validates the visible auto-toggle behavior:
+///  - "Include filename/ResRef" checkbox starts unchecked
+///  - Toggling it on auto-checks all file-type checkboxes (including NSS)
+///  - The reverse toggle preserves prior file-type selections (no bounce)
+///
+/// The full rename pipeline is exercised by orchestrator-level integration
+/// tests in Radoub.UI.Tests; FlaUI's job here is to confirm UI wiring works.
+/// </summary>
+[Collection("TrebuchetSequential")]
+[Trait("Category", "Marlinspike")]
+public class MarlinspikeRenameSmokeTest : TrebuchetTestBase
+{
+    [Fact]
+    public void MarlinspikeRenameMode_TogglingCheckboxAutoSelectsAllFileTypes()
+    {
+        StartApplication();
+        var ready = WaitForTitleContains("Trebuchet", DefaultTimeout);
+        Assert.True(ready, "Trebuchet window should be ready");
+
+        // Wait for tabs to load
+        Thread.Sleep(1500);
+
+        // Navigate to Marlinspike workspace tab. The tab is the 4th workspace tab
+        // and is named "Marlinspike" (Ctrl+4 also works, but we click for clarity).
+        var marlinspikeTab = FindTabByName("Marlinspike");
+        Assert.NotNull(marlinspikeTab);
+        marlinspikeTab!.AsTabItem().Select();
+        Thread.Sleep(500);
+
+        // The "Include filename/ResRef" checkbox starts unchecked
+        var filenameCheckbox = FindCheckBoxByName("Include filename/ResRef");
+        Assert.NotNull(filenameCheckbox);
+        var cb = filenameCheckbox!.AsCheckBox();
+        Assert.False(cb.IsChecked ?? false, "Include filename/ResRef checkbox should start unchecked");
+
+        // Toggle ON — drives the SearchFilenameResRef binding, which triggers the
+        // auto-check-all-file-types side-effect in MarlinspikePanelViewModel.
+        cb.IsChecked = true;
+        Thread.Sleep(300);
+
+        // The NSS file-type checkbox (the 18th, added in this feature) should now be checked
+        var nssCheckbox = FindCheckBoxByName("NSS");
+        Assert.NotNull(nssCheckbox);
+        Assert.True(nssCheckbox!.AsCheckBox().IsChecked ?? false,
+            "NSS checkbox should be auto-checked when filename/ResRef mode toggles on");
+    }
+
+    #region Helpers
+
+    private AutomationElement? FindTabByName(string name)
+    {
+        for (int attempt = 0; attempt < 5; attempt++)
+        {
+            var tabs = MainWindow?.FindAllDescendants(cf => cf.ByControlType(ControlType.TabItem));
+            if (tabs != null)
+            {
+                foreach (var tab in tabs)
+                {
+                    if (tab.Name?.Contains(name, StringComparison.OrdinalIgnoreCase) == true)
+                        return tab;
+                }
+            }
+            Thread.Sleep(300);
+        }
+        return null;
+    }
+
+    private AutomationElement? FindCheckBoxByName(string name)
+    {
+        for (int attempt = 0; attempt < 5; attempt++)
+        {
+            var checks = MainWindow?.FindAllDescendants(cf => cf.ByControlType(ControlType.CheckBox));
+            if (checks != null)
+            {
+                foreach (var c in checks)
+                {
+                    if (c.Name?.Contains(name, StringComparison.OrdinalIgnoreCase) == true)
+                        return c;
+                }
+            }
+            Thread.Sleep(300);
+        }
+        return null;
+    }
+
+    #endregion
+}

--- a/Radoub.UI/Radoub.UI.Tests/Radoub.UI.Tests.csproj
+++ b/Radoub.UI/Radoub.UI.Tests/Radoub.UI.Tests.csproj
@@ -30,4 +30,11 @@
     <ProjectReference Include="..\..\Radoub.TestUtilities\Radoub.TestUtilities\Radoub.TestUtilities.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Share the GFF fixture builder with Radoub.Formats.Tests to avoid duplication.
+         (Can't reference the test project directly — xUnit v2 vs v3 conflict.) -->
+    <Compile Include="..\..\Radoub.Formats\Radoub.Formats.Tests\Search\Rename\TestGffBuilder.cs"
+             Link="Services\Search\Shared\TestGffBuilder.cs" />
+  </ItemGroup>
+
 </Project>

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/BatchReplaceServiceTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/BatchReplaceServiceTests.cs
@@ -249,6 +249,43 @@ public class BatchReplaceServiceTests : IDisposable
         Assert.False(preview.AllowResRefReplace);
     }
 
+    [Fact]
+    public async Task ExecuteReplace_WithAllowResRefReplace_RewritesResRefField()
+    {
+        // Write a real UTC with Conversation = "louis_conv" (a ResRef field)
+        var utc = new UtcFile
+        {
+            FirstName = new CExoLocString { LocalizedStrings = new Dictionary<uint, string> { [0] = "Louis" } },
+            Tag = "LOUIS",
+            Conversation = "louis_conv"
+        };
+        var utcPath = WriteUtcFile("louis.utc", utc);
+
+        // Search the file — Conversation field will match since pattern is "louis_conv"
+        var searchService = new ModuleSearchService();
+        var fileResult = searchService.SearchSingleFile(utcPath, new SearchCriteria { Pattern = "louis_conv" });
+
+        // Confirm there's a Conversation match (ResRef field, IsReplaceable=false)
+        Assert.Contains(fileResult.Matches,
+            m => m.Field.Name == "Conversation" && m.Field.FieldType == SearchFieldType.ResRef);
+
+        var preview = _service.PreviewReplace(new[] { fileResult }, "louis", allowResRefReplace: true);
+        Assert.True(preview.AllowResRefReplace);
+
+        // Find the Conversation change in the preview
+        Assert.Contains(preview.Changes, c => c.Match.Field.Name == "Conversation");
+
+        var result = await _service.ExecuteReplaceAsync(preview, "TestModule");
+
+        Assert.True(result.Success);
+        Assert.True(result.ReplacementsMade >= 1);
+
+        // Verify the file on disk now has Conversation = "louis"
+        var rewrittenBytes = await File.ReadAllBytesAsync(utcPath);
+        var rewritten = UtcReader.Read(rewrittenBytes);
+        Assert.Equal("louis", rewritten.Conversation);
+    }
+
     private static SearchMatch MakeMatch(FieldDefinition field, string value) => new()
     {
         Field = field,

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/BatchReplaceServiceTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/BatchReplaceServiceTests.cs
@@ -1,3 +1,4 @@
+using Radoub.Formats.Common;
 using Radoub.Formats.Dlg;
 using Radoub.Formats.Gff;
 using Radoub.Formats.Search;
@@ -200,4 +201,69 @@ public class BatchReplaceServiceTests : IDisposable
         Assert.True(result.Success);
         Assert.Equal(0, result.FilesModified);
     }
+
+    // --- ResRef bypass (allowResRefReplace) ---
+
+    [Fact]
+    public void PreviewReplace_WithAllowResRefReplace_IncludesResRefFields()
+    {
+        // Build a FileSearchResult containing a ResRef-field match with IsReplaceable=false
+        var resRefField = new FieldDefinition
+        {
+            Name = "TemplateResRef",
+            GffPath = "TemplateResRef",
+            FieldType = SearchFieldType.ResRef,
+            Category = SearchFieldCategory.Identity,
+            IsReplaceable = false  // ResRef fields are non-replaceable in normal mode
+        };
+        var match = MakeMatch(resRefField, "louis_roumain");
+        var fileResult = MakeFileResult(Path.Combine(_testDir, "test.utc"), new[] { match });
+
+        var preview = _service.PreviewReplace(
+            new[] { fileResult },
+            replacementText: "bob",
+            allowResRefReplace: true);
+
+        Assert.Single(preview.Changes);
+        Assert.Equal("TemplateResRef", preview.Changes[0].Match.Field.Name);
+        Assert.True(preview.AllowResRefReplace);
+    }
+
+    [Fact]
+    public void PreviewReplace_WithoutAllowResRefReplace_SkipsResRefFields()
+    {
+        var resRefField = new FieldDefinition
+        {
+            Name = "TemplateResRef", GffPath = "TemplateResRef",
+            FieldType = SearchFieldType.ResRef,
+            Category = SearchFieldCategory.Identity,
+            IsReplaceable = false
+        };
+        var match = MakeMatch(resRefField, "louis_roumain");
+        var fileResult = MakeFileResult(Path.Combine(_testDir, "test.utc"), new[] { match });
+
+        // Default (allowResRefReplace omitted, defaults to false)
+        var preview = _service.PreviewReplace(new[] { fileResult }, replacementText: "bob");
+
+        Assert.Empty(preview.Changes);
+        Assert.False(preview.AllowResRefReplace);
+    }
+
+    private static SearchMatch MakeMatch(FieldDefinition field, string value) => new()
+    {
+        Field = field,
+        MatchedText = value,
+        FullFieldValue = value,
+        MatchOffset = 0,
+        MatchLength = value.Length,
+        Location = "test"
+    };
+
+    private static FileSearchResult MakeFileResult(string path, IEnumerable<SearchMatch> matches) => new()
+    {
+        FilePath = path,
+        ResourceType = ResourceTypes.Utc,
+        ToolId = "quartermaster",
+        Matches = matches.ToList()
+    };
 }

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/FilenameSearchProviderTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/FilenameSearchProviderTests.cs
@@ -1,0 +1,41 @@
+using Radoub.Formats.Common;
+using Radoub.Formats.Search;
+using Radoub.UI.Services.Search;
+using Xunit;
+
+namespace Radoub.UI.Tests.Services.Search;
+
+public class FilenameSearchProviderTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public FilenameSearchProviderTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"filename-search-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose() => Directory.Delete(_tempDir, recursive: true);
+
+    private void Touch(string fileName)
+    {
+        File.WriteAllText(Path.Combine(_tempDir, fileName), "stub");
+    }
+
+    [Fact]
+    public void Search_BasicMatch_ReturnsFilenameResult()
+    {
+        Touch("louis_roumain.dlg");
+        Touch("alice.utc");
+        Touch("bob.utc");
+
+        var provider = new FilenameSearchProvider();
+        var criteria = new SearchCriteria { Pattern = "louis", IncludeFilenameResRef = true };
+
+        var results = provider.Search(_tempDir, criteria);
+
+        Assert.Single(results);
+        Assert.Equal("louis_roumain.dlg", results[0].FileName);
+        Assert.Equal(ResourceTypes.Dlg, results[0].ResourceType);
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/FilenameSearchProviderTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/FilenameSearchProviderTests.cs
@@ -97,8 +97,13 @@ public class FilenameSearchProviderTests : IDisposable
     }
 
     [Fact]
-    public void Search_FileTypeFilter_ExcludesUncheckedTypes()
+    public void Search_FileTypeFilter_DoesNotGateFilenameSearch()
     {
+        // Filename search is independent of the 18 file-type content checkboxes.
+        // Those checkboxes gate file-CONTENT searching; filename matches are their
+        // own search domain enabled by SearchFilenameResRef. A user typing "louis"
+        // with only the filename/ResRef checkbox on should get matches across all
+        // file types — that's the surgical workflow.
         Touch("louis.dlg");
         Touch("louis.utc");
         Touch("louis.git");
@@ -108,13 +113,14 @@ public class FilenameSearchProviderTests : IDisposable
         {
             Pattern = "louis",
             IncludeFilenameResRef = true,
-            FileTypeFilter = new[] { ResourceTypes.Dlg }  // ONLY DLG
+            FileTypeFilter = new[] { ResourceTypes.Dlg }  // narrowed content filter
         };
 
         var results = provider.Search(_tempDir, criteria);
 
-        Assert.Single(results);
-        Assert.Equal("louis.dlg", results[0].FileName);
+        // All three filenames match — the file-type filter does NOT constrain
+        // filename search results.
+        Assert.Equal(3, results.Count);
     }
 
     [Fact]

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/FilenameSearchProviderTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/FilenameSearchProviderTests.cs
@@ -38,4 +38,135 @@ public class FilenameSearchProviderTests : IDisposable
         Assert.Equal("louis_roumain.dlg", results[0].FileName);
         Assert.Equal(ResourceTypes.Dlg, results[0].ResourceType);
     }
+
+    [Fact]
+    public void Search_CaseInsensitive_FindsMixedCaseFilenames()
+    {
+        Touch("Louis_Roumain.dlg");
+        Touch("LOUIS_ALT.utc");
+        Touch("alice.dlg");
+
+        var provider = new FilenameSearchProvider();
+        var criteria = new SearchCriteria { Pattern = "LOUIS", IncludeFilenameResRef = true };
+
+        var results = provider.Search(_tempDir, criteria);
+
+        Assert.Equal(2, results.Count);
+    }
+
+    [Fact]
+    public void Search_CaseSensitive_OnlyMatchesExactCase()
+    {
+        Touch("Louis_Roumain.dlg");
+        Touch("louis_alt.utc");
+
+        var provider = new FilenameSearchProvider();
+        var criteria = new SearchCriteria
+        {
+            Pattern = "Louis",
+            CaseSensitive = true,
+            IncludeFilenameResRef = true
+        };
+
+        var results = provider.Search(_tempDir, criteria);
+
+        Assert.Single(results);
+        Assert.Equal("Louis_Roumain.dlg", results[0].FileName);
+    }
+
+    [Fact]
+    public void Search_WholeWord_DoesNotMatchSubstring()
+    {
+        Touch("louis_roumain.dlg");  // contains "louis" as a prefix-with-underscore-after
+        Touch("louis.utc");           // is exactly "louis"
+
+        var provider = new FilenameSearchProvider();
+        var criteria = new SearchCriteria
+        {
+            Pattern = "louis",
+            WholeWord = true,
+            IncludeFilenameResRef = true
+        };
+
+        var results = provider.Search(_tempDir, criteria);
+
+        // \blouis\b: \b treats _ as a word character, so "louis_roumain" has \b "louis" \b false.
+        // Only "louis.utc" (where the whole filename without extension IS "louis") should match.
+        Assert.Single(results);
+        Assert.Equal("louis.utc", results[0].FileName);
+    }
+
+    [Fact]
+    public void Search_FileTypeFilter_ExcludesUncheckedTypes()
+    {
+        Touch("louis.dlg");
+        Touch("louis.utc");
+        Touch("louis.git");
+
+        var provider = new FilenameSearchProvider();
+        var criteria = new SearchCriteria
+        {
+            Pattern = "louis",
+            IncludeFilenameResRef = true,
+            FileTypeFilter = new[] { ResourceTypes.Dlg }  // ONLY DLG
+        };
+
+        var results = provider.Search(_tempDir, criteria);
+
+        Assert.Single(results);
+        Assert.Equal("louis.dlg", results[0].FileName);
+    }
+
+    [Fact]
+    public void Search_ExcludesSubdirectoryFiles()
+    {
+        Touch("louis.dlg");
+        var subDir = Path.Combine(_tempDir, "backup");
+        Directory.CreateDirectory(subDir);
+        File.WriteAllText(Path.Combine(subDir, "louis_old.dlg"), "stub");
+
+        var provider = new FilenameSearchProvider();
+        var criteria = new SearchCriteria { Pattern = "louis", IncludeFilenameResRef = true };
+
+        var results = provider.Search(_tempDir, criteria);
+
+        Assert.Single(results);
+        Assert.Equal("louis.dlg", results[0].FileName);
+    }
+
+    [Fact]
+    public void Search_EmptyDirectory_ReturnsNoResults()
+    {
+        var provider = new FilenameSearchProvider();
+        var criteria = new SearchCriteria { Pattern = "louis", IncludeFilenameResRef = true };
+
+        var results = provider.Search(_tempDir, criteria);
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Search_NonexistentDirectory_ReturnsNoResults()
+    {
+        var provider = new FilenameSearchProvider();
+        var criteria = new SearchCriteria { Pattern = "louis", IncludeFilenameResRef = true };
+
+        var results = provider.Search(Path.Combine(_tempDir, "does-not-exist"), criteria);
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Search_InvalidCriteria_ReturnsNoResults()
+    {
+        Touch("louis.dlg");
+
+        var provider = new FilenameSearchProvider();
+        // Invalid: empty pattern
+        var criteria = new SearchCriteria { Pattern = "", IncludeFilenameResRef = true };
+
+        var results = provider.Search(_tempDir, criteria);
+
+        Assert.Empty(results);
+    }
 }

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/GffReferenceLocationApplierTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/GffReferenceLocationApplierTests.cs
@@ -1,0 +1,101 @@
+using Radoub.Formats.Common;
+using Radoub.Formats.Gff;
+using Radoub.Formats.Search.Rename;
+using Radoub.Formats.Tests.Search.Rename;
+using Radoub.UI.Services.Search;
+using Xunit;
+
+namespace Radoub.UI.Tests.Services.Search;
+
+/// <summary>
+/// Tests for <see cref="GffReferenceLocationApplier"/> — verifies each branch of the
+/// location-string parser correctly updates the GFF tree.
+/// </summary>
+public class GffReferenceLocationApplierTests
+{
+    private readonly GffReferenceLocationApplier _applier = new();
+
+    [Fact]
+    public void Apply_TopLevelField_UpdatesValue()
+    {
+        var gff = TestGffBuilder.MakeUtc(conversation: "louis");
+        var refRow = MakeRef("Conversation", ResRefScopeTier.TypedGffField, "louis");
+
+        Assert.True(_applier.Apply(gff, refRow, "bob"));
+        Assert.Equal("bob", gff.RootStruct.GetField("Conversation")?.Value);
+    }
+
+    [Fact]
+    public void Apply_NestedListItem_UpdatesValue()
+    {
+        var gff = TestGffBuilder.MakeGitWithList("Creature List", "TemplateResRef", "louis", "alice");
+        var refRow = MakeRef("Creature List > Item 0 > TemplateResRef", ResRefScopeTier.TypedGffField, "louis");
+
+        Assert.True(_applier.Apply(gff, refRow, "bob"));
+
+        var list = gff.RootStruct.GetField("Creature List")?.Value as GffList;
+        Assert.NotNull(list);
+        Assert.Equal("bob", list!.Elements[0].GetField("TemplateResRef")?.Value);
+        Assert.Equal("alice", list.Elements[1].GetField("TemplateResRef")?.Value);  // sibling untouched
+    }
+
+    [Fact]
+    public void Apply_DlgEntrySound_UpdatesValue()
+    {
+        var gff = TestGffBuilder.MakeDlgWithSound(entryIndex: 1, sound: "louis_voice");
+        var refRow = MakeRef("Entry 1 > Sound", ResRefScopeTier.TypedGffField, "louis_voice");
+
+        Assert.True(_applier.Apply(gff, refRow, "bob_voice"));
+
+        var entries = gff.RootStruct.GetField("EntryList")?.Value as GffList;
+        Assert.NotNull(entries);
+        Assert.Equal("bob_voice", entries!.Elements[1].GetField("Sound")?.Value);
+    }
+
+    [Fact]
+    public void Apply_DlgActionParam_UpdatesSubstring()
+    {
+        var gff = TestGffBuilder.MakeDlgWithActionParam(
+            entryIndex: 0, key: "target_resref", value: "the louis here");
+        var refRow = new ResRefReference
+        {
+            FilePath = "/m/x.dlg",
+            ResourceType = ResourceTypes.Dlg,
+            Field = null,
+            Location = "Entry 0 > ActionParams[0] (target_resref)",
+            OldValue = "louis",
+            NewValue = "bob",
+            ScopeTier = ResRefScopeTier.DlgScriptParam,
+            MatchOffset = 4,  // offset of "louis" in "the louis here"
+            MatchLength = 5
+        };
+
+        Assert.True(_applier.Apply(gff, refRow, "bob"));
+
+        var entries = gff.RootStruct.GetField("EntryList")?.Value as GffList;
+        Assert.NotNull(entries);
+        var actionParams = entries!.Elements[0].GetField("ActionParams")?.Value as GffList;
+        Assert.NotNull(actionParams);
+        Assert.Equal("the bob here", actionParams!.Elements[0].GetField("Value")?.Value);
+    }
+
+    [Fact]
+    public void Apply_UnparseableLocation_ReturnsFalse()
+    {
+        var gff = TestGffBuilder.MakeUtc(conversation: "louis");
+        var refRow = MakeRef("garbage > non > sense", ResRefScopeTier.TypedGffField, "louis");
+
+        Assert.False(_applier.Apply(gff, refRow, "bob"));
+    }
+
+    private static ResRefReference MakeRef(string location, ResRefScopeTier tier, string oldValue) => new()
+    {
+        FilePath = "/m/test",
+        ResourceType = ResourceTypes.Utc,
+        Field = null,
+        Location = location,
+        OldValue = oldValue,
+        NewValue = string.Empty,
+        ScopeTier = tier
+    };
+}

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/GffReferenceLocationApplierTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/GffReferenceLocationApplierTests.cs
@@ -88,6 +88,22 @@ public class GffReferenceLocationApplierTests
         Assert.False(_applier.Apply(gff, refRow, "bob"));
     }
 
+    [Fact]
+    public void Apply_UtmStorePanel_UpdatesValueByPanelName()
+    {
+        var gff = TestGffBuilder.MakeUtmWithItems("Weapons", "louis_sword", "alice_shield");
+        var refRow = MakeRef("Weapons > Item 0 > InventoryRes", ResRefScopeTier.TypedGffField, "louis_sword");
+
+        Assert.True(_applier.Apply(gff, refRow, "bob_sword"));
+
+        var storeList = gff.RootStruct.GetField("StoreList")?.Value as GffList;
+        Assert.NotNull(storeList);
+        var panel = storeList!.Elements[0];  // first (only) panel
+        var items = panel.GetField("ItemList")?.Value as GffList;
+        Assert.NotNull(items);
+        Assert.Equal("bob_sword", items!.Elements[0].GetField("InventoryRes")?.Value);
+    }
+
     private static ResRefReference MakeRef(string location, ResRefScopeTier tier, string oldValue) => new()
     {
         FilePath = "/m/test",

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/ModuleSearchServiceTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/ModuleSearchServiceTests.cs
@@ -388,6 +388,49 @@ public class ModuleSearchServiceTests : IDisposable
 
     #endregion
 
+    #region IncludeFilenameResRef
+
+    [Fact]
+    public async Task ScanModuleAsync_WithIncludeFilenameResRef_AddsFilenameMatches()
+    {
+        // Create a file whose name matches but whose CONTENT does not
+        WriteDlgFile("louis_roumain.dlg", "Nothing matching here.");
+
+        var service = new ModuleSearchService();
+        var criteria = new SearchCriteria
+        {
+            Pattern = "louis",
+            IncludeFilenameResRef = true
+        };
+
+        var results = await service.ScanModuleAsync(_tempDir, criteria);
+
+        // Should have a result for the filename match even though file content has no "louis"
+        Assert.Contains(results.Files, f =>
+            f.FileName == "louis_roumain.dlg" &&
+            f.Matches.Any(m => m.Field?.Name == "Filename"));
+    }
+
+    [Fact]
+    public async Task ScanModuleAsync_WithoutIncludeFilenameResRef_NoFilenameMatches()
+    {
+        WriteDlgFile("louis_roumain.dlg", "Nothing matching here.");
+
+        var service = new ModuleSearchService();
+        var criteria = new SearchCriteria
+        {
+            Pattern = "louis"
+            // IncludeFilenameResRef defaults to false
+        };
+
+        var results = await service.ScanModuleAsync(_tempDir, criteria);
+
+        // Without the flag, "louis_roumain.dlg" produces no matches because content has no "louis"
+        Assert.DoesNotContain(results.Files, f => f.Matches.Any(m => m.Field?.Name == "Filename"));
+    }
+
+    #endregion
+
     #region Helpers
 
     private static SearchMatch CreateDummyMatch()

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/NssReferenceScannerTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/NssReferenceScannerTests.cs
@@ -41,4 +41,93 @@ public class NssReferenceScannerTests : IDisposable
         Assert.Equal(ResRefScopeTier.NssQuotedString, refs[0].ScopeTier);
         Assert.Equal("louis_roumain", refs[0].OldValue);
     }
+
+    [Fact]
+    public void Scan_BareSubstringMatch_EmitsLowConfidenceRow()
+    {
+        var path = WriteNss("comment.nss",
+            "// Reminder: louis_roumain is the merchant in town\nvoid main() {}\n");
+
+        var scanner = new NssReferenceScanner();
+        var refs = scanner.Scan(path, oldResRef: "louis_roumain");
+
+        Assert.Single(refs);
+        Assert.Equal(ResRefScopeTier.NssBareSubstring, refs[0].ScopeTier);
+    }
+
+    [Fact]
+    public void Scan_BothQuotedAndBare_EmitsBothWithCorrectTiers()
+    {
+        var path = WriteNss("mix.nss",
+            "// louis_roumain comment\nCreateObject(0, \"louis_roumain\", l);\n");
+
+        var scanner = new NssReferenceScanner();
+        var refs = scanner.Scan(path, oldResRef: "louis_roumain");
+
+        Assert.Equal(2, refs.Count);
+        Assert.Contains(refs, r => r.ScopeTier == ResRefScopeTier.NssQuotedString);
+        Assert.Contains(refs, r => r.ScopeTier == ResRefScopeTier.NssBareSubstring);
+    }
+
+    [Fact]
+    public void Scan_BareSubstring_DoesNotDoubleCountQuoted()
+    {
+        // The substring `louis` appears inside `"louis"`. The bare-substring pass
+        // must not report this as a separate low-confidence match — the quoted
+        // pass already covers it.
+        var path = WriteNss("only_quoted.nss",
+            "Object o = GetObjectByTag(\"louis\");\n");
+
+        var scanner = new NssReferenceScanner();
+        var refs = scanner.Scan(path, oldResRef: "louis");
+
+        Assert.Single(refs);
+        Assert.Equal(ResRefScopeTier.NssQuotedString, refs[0].ScopeTier);
+    }
+
+    [Theory]
+    [InlineData("\"Louis_Roumain\"")]
+    [InlineData("\"LOUIS_ROUMAIN\"")]
+    [InlineData("\"louis_roumain\"")]
+    public void Scan_QuotedMatch_IsCaseInsensitive(string scriptSnippet)
+    {
+        var path = WriteNss("mixed.nss", $"void main() {{ string s = {scriptSnippet}; }}\n");
+
+        var scanner = new NssReferenceScanner();
+        var refs = scanner.Scan(path, oldResRef: "louis_roumain");
+
+        Assert.Single(refs);
+        Assert.Equal(ResRefScopeTier.NssQuotedString, refs[0].ScopeTier);
+    }
+
+    [Fact]
+    public void Scan_EmptyFile_ReturnsNoResults()
+    {
+        var path = WriteNss("empty.nss", string.Empty);
+
+        var scanner = new NssReferenceScanner();
+        var refs = scanner.Scan(path, oldResRef: "louis");
+
+        Assert.Empty(refs);
+    }
+
+    [Fact]
+    public void Scan_EmptyPattern_ReturnsNoResults()
+    {
+        var path = WriteNss("script.nss", "void main() { string s = \"louis\"; }\n");
+
+        var scanner = new NssReferenceScanner();
+        var refs = scanner.Scan(path, oldResRef: "");
+
+        Assert.Empty(refs);
+    }
+
+    [Fact]
+    public void Scan_NonexistentFile_ReturnsNoResults()
+    {
+        var scanner = new NssReferenceScanner();
+        var refs = scanner.Scan(Path.Combine(_tempDir, "missing.nss"), oldResRef: "louis");
+
+        Assert.Empty(refs);
+    }
 }

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/NssReferenceScannerTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/NssReferenceScannerTests.cs
@@ -1,0 +1,44 @@
+using Radoub.Formats.Common;
+using Radoub.Formats.Search.Rename;
+using Radoub.UI.Services.Search;
+using Xunit;
+
+namespace Radoub.UI.Tests.Services.Search;
+
+public class NssReferenceScannerTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public NssReferenceScannerTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"nss-scan-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private string WriteNss(string fileName, string source)
+    {
+        var path = Path.Combine(_tempDir, fileName);
+        File.WriteAllText(path, source);
+        return path;
+    }
+
+    [Fact]
+    public void Scan_QuotedMatch_EmitsHighConfidenceRow()
+    {
+        var path = WriteNss("script.nss",
+            "void main() {\n  CreateObject(OBJECT_TYPE_CREATURE, \"louis_roumain\", GetLocation(OBJECT_SELF));\n}\n");
+
+        var scanner = new NssReferenceScanner();
+        var refs = scanner.Scan(path, oldResRef: "louis_roumain");
+
+        Assert.Single(refs);
+        Assert.Equal(ResRefScopeTier.NssQuotedString, refs[0].ScopeTier);
+        Assert.Equal("louis_roumain", refs[0].OldValue);
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/ResRefRenameOrchestratorTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/ResRefRenameOrchestratorTests.cs
@@ -284,6 +284,149 @@ public class ResRefRenameOrchestratorTests : IDisposable
     }
 
     [Fact]
+    public async Task ExecuteAsync_RichModule_RenamesAcrossAllScopeTiers()
+    {
+        var moduleDir = TestModuleFixture.CreateRichModule(_root);
+        var backupDir = Path.Combine(_root, ".backups");
+
+        // Plan A: rename louis_roumain.utc -> louis.utc
+        // References: GIT TemplateResRef + NSS quoted + NSS bare-substring
+        var planLouis = new ResRefRenamePlan
+        {
+            OldName = "louis_roumain",
+            NewName = "louis",
+            ResourceType = ResourceTypes.Utc,
+            Validation = ResRefValidationResult.Ok("louis"),
+            SourceFilePath = Path.Combine(moduleDir, "louis_roumain.utc"),
+            TargetFilePath = Path.Combine(moduleDir, "louis.utc")
+        };
+
+        // 1. TypedGffField — GIT
+        planLouis.References.Add(new ResRefReference
+        {
+            FilePath = Path.Combine(moduleDir, "area01.git"),
+            ResourceType = ResourceTypes.Git,
+            Field = null,
+            Location = "Creature List > Item 0 > TemplateResRef",
+            OldValue = "louis_roumain",
+            NewValue = "louis",
+            ScopeTier = ResRefScopeTier.TypedGffField,
+            IsSelected = true
+        });
+
+        // 2. NssQuotedString
+        var nssPath = Path.Combine(moduleDir, "script1.nss");
+        var nssText = await File.ReadAllTextAsync(nssPath);
+        var quotedOffset = nssText.IndexOf("\"louis_roumain\"", StringComparison.Ordinal) + 1;
+        planLouis.References.Add(new ResRefReference
+        {
+            FilePath = nssPath,
+            ResourceType = ResourceTypes.Nss,
+            Field = null,
+            Location = "Line 2 (quoted)",
+            OldValue = "louis_roumain",
+            NewValue = "louis",
+            ScopeTier = ResRefScopeTier.NssQuotedString,
+            MatchOffset = quotedOffset,
+            MatchLength = "louis_roumain".Length,
+            IsSelected = true
+        });
+
+        // 3. NssBareSubstring — first occurrence is in the line-1 comment
+        var bareOffset = nssText.IndexOf("louis_roumain", StringComparison.Ordinal);
+        planLouis.References.Add(new ResRefReference
+        {
+            FilePath = nssPath,
+            ResourceType = ResourceTypes.Nss,
+            Field = null,
+            Location = "Line 1 (substring - verify)",
+            OldValue = "louis_roumain",
+            NewValue = "louis",
+            ScopeTier = ResRefScopeTier.NssBareSubstring,
+            MatchOffset = bareOffset,
+            MatchLength = "louis_roumain".Length,
+            IsSelected = true
+        });
+
+        // Plan B: louis_sword.uti rename (file doesn't actually exist on disk —
+        // IsSelected = false skips the file rename, so we only test reference updates
+        // via UTM-panel applier and DLG-script-param applier).
+        var planSword = new ResRefRenamePlan
+        {
+            OldName = "louis_sword",
+            NewName = "blade",
+            ResourceType = ResourceTypes.Uti,
+            Validation = ResRefValidationResult.Ok("blade"),
+            SourceFilePath = Path.Combine(moduleDir, "louis_sword.uti"),
+            TargetFilePath = Path.Combine(moduleDir, "blade.uti"),
+            IsSelected = false  // don't try to rename — file doesn't exist
+        };
+
+        // 4. TypedGffField — UTM panel applier branch
+        planSword.References.Add(new ResRefReference
+        {
+            FilePath = Path.Combine(moduleDir, "store01.utm"),
+            ResourceType = ResourceTypes.Utm,
+            Field = null,
+            Location = "Weapons > Item 0 > InventoryRes",
+            OldValue = "louis_sword",
+            NewValue = "blade",
+            ScopeTier = ResRefScopeTier.TypedGffField,
+            IsSelected = true
+        });
+
+        // 5. DlgScriptParam — DLG ActionParams substring
+        planSword.References.Add(new ResRefReference
+        {
+            FilePath = Path.Combine(moduleDir, "louis_dlg.dlg"),
+            ResourceType = ResourceTypes.Dlg,
+            Field = null,
+            Location = "Entry 0 > ActionParams[0] (weapon_resref)",
+            OldValue = "louis_sword",
+            NewValue = "blade",
+            ScopeTier = ResRefScopeTier.DlgScriptParam,
+            MatchOffset = 0,
+            MatchLength = "louis_sword".Length,
+            IsSelected = true
+        });
+
+        var orchestrator = new ResRefRenameOrchestrator(new BackupService(backupDir));
+        var result = await orchestrator.ExecuteAsync(new[] { planLouis, planSword }, "rich-module-test");
+
+        Assert.True(result.Success, $"Execute failed: {result.Error}");
+        Assert.Equal(1, result.RenamedFiles);              // only planLouis renamed (planSword.IsSelected = false)
+        Assert.Equal(5, result.ReferencesUpdated);         // GIT + NSS quoted + NSS bare + UTM + DLG ActionParam
+
+        // 1. File was renamed
+        Assert.True(File.Exists(Path.Combine(moduleDir, "louis.utc")));
+        Assert.False(File.Exists(Path.Combine(moduleDir, "louis_roumain.utc")));
+
+        // 2. TypedGffField — GIT
+        Assert.Equal("louis", GetGitCreatureTemplateResRef(Path.Combine(moduleDir, "area01.git")));
+
+        // 3+4. NSS quoted + bare both rewritten — file no longer contains "louis_roumain"
+        var nssAfter = await File.ReadAllTextAsync(nssPath);
+        Assert.DoesNotContain("louis_roumain", nssAfter);
+        Assert.Contains("\"louis\"", nssAfter);
+
+        // 5. TypedGffField — UTM panel applier branch
+        var utm = GffReader.Read(File.ReadAllBytes(Path.Combine(moduleDir, "store01.utm")));
+        var storeList = utm.RootStruct.GetField("StoreList")?.Value as GffList;
+        Assert.NotNull(storeList);
+        var weaponsItems = storeList!.Elements[0].GetField("ItemList")?.Value as GffList;
+        Assert.NotNull(weaponsItems);
+        Assert.Equal("blade", weaponsItems!.Elements[0].GetField("InventoryRes")?.Value);
+
+        // 6. DlgScriptParam — DLG ActionParams Value substring updated
+        var dlg = GffReader.Read(File.ReadAllBytes(Path.Combine(moduleDir, "louis_dlg.dlg")));
+        var entries = dlg.RootStruct.GetField("EntryList")?.Value as GffList;
+        Assert.NotNull(entries);
+        var actionParams = entries!.Elements[0].GetField("ActionParams")?.Value as GffList;
+        Assert.NotNull(actionParams);
+        Assert.Equal("blade", actionParams!.Elements[0].GetField("Value")?.Value);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_RestoreAfterRename_ProducesByteIdenticalModule()
     {
         var moduleDir = TestModuleFixture.CreateMinimalModule(_root);

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/ResRefRenameOrchestratorTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/ResRefRenameOrchestratorTests.cs
@@ -1,0 +1,78 @@
+using Radoub.Formats.Common;
+using Radoub.Formats.Gff;
+using Radoub.Formats.Search.Rename;
+using Radoub.UI.Services.Search;
+using Xunit;
+
+namespace Radoub.UI.Tests.Services.Search;
+
+public class ResRefRenameOrchestratorTests : IDisposable
+{
+    private readonly string _root;
+
+    public ResRefRenameOrchestratorTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"orch-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+
+    private static ResRefRenamePlan MakeRenamePlan(string moduleDir, string oldName, string newName) => new()
+    {
+        OldName = oldName,
+        NewName = newName,
+        ResourceType = ResourceTypes.Utc,
+        Validation = ResRefValidationResult.Ok(newName),
+        SourceFilePath = Path.Combine(moduleDir, $"{oldName}.utc"),
+        TargetFilePath = Path.Combine(moduleDir, $"{newName}.utc")
+    };
+
+    /// <summary>Read a GIT's first creature TemplateResRef value (test helper).</summary>
+    private static string? GetGitCreatureTemplateResRef(string gitPath)
+    {
+        var git = GffReader.Read(File.ReadAllBytes(gitPath));
+        var list = git.RootStruct.GetField("Creature List")?.Value as GffList;
+        if (list == null || list.Elements.Count == 0) return null;
+        return list.Elements[0].GetField("TemplateResRef")?.Value as string;
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SimpleRename_RenamesFileAndUpdatesReferences()
+    {
+        var moduleDir = TestModuleFixture.CreateMinimalModule(_root);
+        var backupDir = Path.Combine(_root, ".backups");
+
+        // Plan: rename louis_roumain.utc → louis.utc
+        var plan = MakeRenamePlan(moduleDir, "louis_roumain", "louis");
+        plan.References.Add(new ResRefReference
+        {
+            FilePath = Path.Combine(moduleDir, "area01.git"),
+            ResourceType = ResourceTypes.Git,
+            Field = null,
+            Location = "Creature List > Item 0 > TemplateResRef",
+            OldValue = "louis_roumain",
+            NewValue = "louis",
+            ScopeTier = ResRefScopeTier.TypedGffField,
+            IsSelected = true
+        });
+
+        var orchestrator = new ResRefRenameOrchestrator(new BackupService(backupDir));
+        var result = await orchestrator.ExecuteAsync(new[] { plan }, moduleName: "test");
+
+        Assert.True(result.Success, $"Execute failed: {result.Error}");
+        Assert.Equal(1, result.RenamedFiles);
+        Assert.Equal(1, result.ReferencesUpdated);
+
+        // File renamed on disk
+        Assert.False(File.Exists(Path.Combine(moduleDir, "louis_roumain.utc")));
+        Assert.True(File.Exists(Path.Combine(moduleDir, "louis.utc")));
+
+        // GIT reference updated
+        Assert.Equal("louis", GetGitCreatureTemplateResRef(Path.Combine(moduleDir, "area01.git")));
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/ResRefRenameOrchestratorTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/ResRefRenameOrchestratorTests.cs
@@ -1,5 +1,6 @@
 using Radoub.Formats.Common;
 using Radoub.Formats.Gff;
+using Radoub.Formats.Search;
 using Radoub.Formats.Search.Rename;
 using Radoub.UI.Services.Search;
 using Xunit;
@@ -74,5 +75,259 @@ public class ResRefRenameOrchestratorTests : IDisposable
 
         // GIT reference updated
         Assert.Equal("louis", GetGitCreatureTemplateResRef(Path.Combine(moduleDir, "area01.git")));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TopLevelScalarReference_UpdatesField()
+    {
+        var moduleDir = TestModuleFixture.CreateMinimalModule(_root);
+        var backupDir = Path.Combine(_root, ".backups");
+
+        // louis_dlg.dlg → renamed to "louis_v2"
+        // The reference is: louis_roumain.utc's Conversation field points at "louis_dlg"
+        var plan = new ResRefRenamePlan
+        {
+            OldName = "louis_dlg",
+            NewName = "louis_v2",
+            ResourceType = ResourceTypes.Dlg,
+            Validation = ResRefValidationResult.Ok("louis_v2"),
+            SourceFilePath = Path.Combine(moduleDir, "louis_dlg.dlg"),
+            TargetFilePath = Path.Combine(moduleDir, "louis_v2.dlg")
+        };
+        plan.References.Add(new ResRefReference
+        {
+            FilePath = Path.Combine(moduleDir, "louis_roumain.utc"),
+            ResourceType = ResourceTypes.Utc,
+            Field = new FieldDefinition
+            {
+                Name = "Conversation",
+                GffPath = "Conversation",
+                FieldType = SearchFieldType.ResRef,
+                Category = SearchFieldCategory.Metadata
+            },
+            Location = "Conversation",
+            OldValue = "louis_dlg",
+            NewValue = "louis_v2",
+            ScopeTier = ResRefScopeTier.TypedGffField,
+            IsSelected = true
+        });
+
+        var orchestrator = new ResRefRenameOrchestrator(new BackupService(backupDir));
+        var result = await orchestrator.ExecuteAsync(new[] { plan }, "test");
+
+        Assert.True(result.Success, $"Execute failed: {result.Error}");
+
+        var utc = GffReader.Read(File.ReadAllBytes(Path.Combine(moduleDir, "louis_roumain.utc")));
+        Assert.Equal("louis_v2", utc.RootStruct.GetField("Conversation")?.Value as string);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NssReference_RewritesScriptText()
+    {
+        var moduleDir = TestModuleFixture.CreateMinimalModule(_root);
+        var backupDir = Path.Combine(_root, ".backups");
+
+        var nssPath = Path.Combine(moduleDir, "script1.nss");
+        var source = File.ReadAllText(nssPath);
+        var quotedIdx = source.IndexOf("\"louis_roumain\"", StringComparison.Ordinal);
+        Assert.True(quotedIdx >= 0);  // sanity: fixture contains the quoted token
+
+        var plan = MakeRenamePlan(moduleDir, "louis_roumain", "louis");
+        plan.References.Add(new ResRefReference
+        {
+            FilePath = nssPath,
+            ResourceType = ResourceTypes.Nss,
+            Field = null,
+            Location = "Line 2 (quoted)",
+            OldValue = "louis_roumain",
+            NewValue = "louis",
+            ScopeTier = ResRefScopeTier.NssQuotedString,
+            MatchOffset = quotedIdx + 1,  // inside the quotes
+            MatchLength = "louis_roumain".Length,
+            IsSelected = true
+        });
+
+        var orchestrator = new ResRefRenameOrchestrator(new BackupService(backupDir));
+        var result = await orchestrator.ExecuteAsync(new[] { plan }, "test");
+
+        Assert.True(result.Success, $"Execute failed: {result.Error}");
+
+        var nssText = File.ReadAllText(nssPath);
+        Assert.DoesNotContain("louis_roumain", nssText);
+        Assert.Contains("\"louis\"", nssText);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UntickedReference_NotApplied()
+    {
+        var moduleDir = TestModuleFixture.CreateMinimalModule(_root);
+        var backupDir = Path.Combine(_root, ".backups");
+
+        var plan = MakeRenamePlan(moduleDir, "louis_roumain", "louis");
+        plan.References.Add(new ResRefReference
+        {
+            FilePath = Path.Combine(moduleDir, "area01.git"),
+            ResourceType = ResourceTypes.Git,
+            Field = null,
+            Location = "Creature List > Item 0 > TemplateResRef",
+            OldValue = "louis_roumain",
+            NewValue = "louis",
+            ScopeTier = ResRefScopeTier.TypedGffField,
+            IsSelected = false  // user unticked
+        });
+
+        var orchestrator = new ResRefRenameOrchestrator(new BackupService(backupDir));
+        var result = await orchestrator.ExecuteAsync(new[] { plan }, "test");
+
+        Assert.True(result.Success, $"Execute failed: {result.Error}");
+        Assert.Equal(0, result.ReferencesUpdated);
+
+        // GIT still has the OLD value (unticked reference was not applied)
+        Assert.Equal("louis_roumain", GetGitCreatureTemplateResRef(Path.Combine(moduleDir, "area01.git")));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UntickedRenamePlan_FileNotRenamed()
+    {
+        var moduleDir = TestModuleFixture.CreateMinimalModule(_root);
+        var backupDir = Path.Combine(_root, ".backups");
+
+        var plan = MakeRenamePlan(moduleDir, "louis_roumain", "louis");
+        plan.IsSelected = false;  // user unticked the entire rename
+
+        var orchestrator = new ResRefRenameOrchestrator(new BackupService(backupDir));
+        var result = await orchestrator.ExecuteAsync(new[] { plan }, "test");
+
+        Assert.True(result.Success, $"Execute failed: {result.Error}");
+        Assert.Equal(0, result.RenamedFiles);
+        Assert.True(File.Exists(Path.Combine(moduleDir, "louis_roumain.utc")));
+        Assert.False(File.Exists(Path.Combine(moduleDir, "louis.utc")));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FileModifiedBetweenPreviewAndExecute_AbortsWithoutChanges()
+    {
+        var moduleDir = TestModuleFixture.CreateMinimalModule(_root);
+        var backupDir = Path.Combine(_root, ".backups");
+
+        var plan = MakeRenamePlan(moduleDir, "louis_roumain", "louis");
+        plan.References.Add(new ResRefReference
+        {
+            FilePath = Path.Combine(moduleDir, "area01.git"),
+            ResourceType = ResourceTypes.Git,
+            Field = null,
+            Location = "Creature List > Item 0 > TemplateResRef",
+            OldValue = "louis_roumain",
+            NewValue = "louis",
+            ScopeTier = ResRefScopeTier.TypedGffField,
+            IsSelected = true
+        });
+
+        var snapshots = ResRefRenameOrchestrator.CaptureSnapshots(new[]
+        {
+            plan.SourceFilePath,
+            Path.Combine(moduleDir, "area01.git")
+        });
+
+        // Simulate concurrent modification: bump area01.git's mtime forward
+        File.SetLastWriteTimeUtc(Path.Combine(moduleDir, "area01.git"), DateTime.UtcNow.AddSeconds(5));
+
+        var orchestrator = new ResRefRenameOrchestrator(new BackupService(backupDir));
+        var result = await orchestrator.ExecuteAsync(new[] { plan }, "test", snapshots);
+
+        Assert.False(result.Success);
+        Assert.NotNull(result.Error);
+        Assert.Contains("modified between preview and execute", result.Error!);
+
+        // No changes on disk — original file still exists, no rename happened
+        Assert.True(File.Exists(plan.SourceFilePath));
+        Assert.False(File.Exists(plan.TargetFilePath));
+
+        // GIT reference also unchanged
+        Assert.Equal("louis_roumain", GetGitCreatureTemplateResRef(Path.Combine(moduleDir, "area01.git")));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FailureDuringRename_RollsBackChanges()
+    {
+        var moduleDir = TestModuleFixture.CreateMinimalModule(_root);
+        var backupDir = Path.Combine(_root, ".backups");
+
+        // Pre-create the target file so File.Move throws (Windows: target must not exist).
+        var plan = MakeRenamePlan(moduleDir, "louis_roumain", "louis");
+        File.WriteAllText(plan.TargetFilePath, "preexisting");
+
+        plan.References.Add(new ResRefReference
+        {
+            FilePath = Path.Combine(moduleDir, "area01.git"),
+            ResourceType = ResourceTypes.Git,
+            Field = null,
+            Location = "Creature List > Item 0 > TemplateResRef",
+            OldValue = "louis_roumain",
+            NewValue = "louis",
+            ScopeTier = ResRefScopeTier.TypedGffField,
+            IsSelected = true
+        });
+
+        var orchestrator = new ResRefRenameOrchestrator(new BackupService(backupDir));
+        var result = await orchestrator.ExecuteAsync(new[] { plan }, "test");
+
+        Assert.False(result.Success);
+        Assert.True(result.RollbackAttempted);
+        Assert.True(result.RollbackSucceeded, "rollback should succeed cleanly");
+
+        // Original file still exists at old path
+        Assert.True(File.Exists(plan.SourceFilePath));
+
+        // GIT reference reverted to old value (BackupService.RestoreAsync put it back)
+        Assert.Equal("louis_roumain", GetGitCreatureTemplateResRef(Path.Combine(moduleDir, "area01.git")));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RestoreAfterRename_ProducesByteIdenticalModule()
+    {
+        var moduleDir = TestModuleFixture.CreateMinimalModule(_root);
+        var backupDir = Path.Combine(_root, ".backups");
+
+        // Snapshot the per-file bytes before the operation
+        var beforeBytes = Directory.GetFiles(moduleDir)
+            .ToDictionary(p => Path.GetFileName(p), p => File.ReadAllBytes(p));
+
+        var plan = MakeRenamePlan(moduleDir, "louis_roumain", "louis");
+        plan.References.Add(new ResRefReference
+        {
+            FilePath = Path.Combine(moduleDir, "area01.git"),
+            ResourceType = ResourceTypes.Git,
+            Field = null,
+            Location = "Creature List > Item 0 > TemplateResRef",
+            OldValue = "louis_roumain",
+            NewValue = "louis",
+            ScopeTier = ResRefScopeTier.TypedGffField,
+            IsSelected = true
+        });
+
+        var backupService = new BackupService(backupDir);
+        var orchestrator = new ResRefRenameOrchestrator(backupService);
+        var result = await orchestrator.ExecuteAsync(new[] { plan }, "test");
+        Assert.True(result.Success, $"Execute failed: {result.Error}");
+
+        // Confirm the module changed
+        var afterRenameGit = File.ReadAllBytes(Path.Combine(moduleDir, "area01.git"));
+        Assert.NotEqual(beforeBytes["area01.git"], afterRenameGit);
+
+        // Restore via BackupService — it restores file contents but NOT renames.
+        // To round-trip we manually reverse the rename, then restore content.
+        File.Move(plan.TargetFilePath, plan.SourceFilePath);
+
+        var restoreOk = await backupService.RestoreAsync(result.BackupManifest!);
+        Assert.True(restoreOk);
+
+        // Now every file should be byte-identical to its pre-operation state.
+        foreach (var kvp in beforeBytes)
+        {
+            var path = Path.Combine(moduleDir, kvp.Key);
+            Assert.True(File.Exists(path), $"Expected restored file at {path}");
+            Assert.Equal(kvp.Value, File.ReadAllBytes(path));
+        }
     }
 }

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/TestModuleFixture.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/TestModuleFixture.cs
@@ -1,0 +1,93 @@
+using Radoub.Formats.Gff;
+
+namespace Radoub.UI.Tests.Services.Search;
+
+/// <summary>
+/// Builds a minimal real-on-disk module for orchestrator round-trip testing.
+/// Module contains:
+///   - louis_roumain.utc (creature with Conversation = "louis_dlg")
+///   - louis_dlg.dlg     (dialog with no internal references — leaf)
+///   - area01.git        (GIT instance pointing to "louis_roumain" creature)
+///   - area01.are        (area with no script references — minimal)
+///   - script1.nss       (nss source containing "louis_roumain" as a quoted string)
+/// </summary>
+public static class TestModuleFixture
+{
+    public static string CreateMinimalModule(string parentDir)
+    {
+        var moduleDir = Path.Combine(parentDir, $"module-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(moduleDir);
+
+        // 1. louis_roumain.utc — references louis_dlg
+        var utc = MakeUtc(conversation: "louis_dlg");
+        File.WriteAllBytes(Path.Combine(moduleDir, "louis_roumain.utc"), GffWriter.Write(utc));
+
+        // 2. louis_dlg.dlg — minimal valid DLG (no internal refs)
+        var dlg = MakeMinimalDlg();
+        File.WriteAllBytes(Path.Combine(moduleDir, "louis_dlg.dlg"), GffWriter.Write(dlg));
+
+        // 3. area01.git — references louis_roumain via Creature List > TemplateResRef
+        var git = MakeGitWithCreature("louis_roumain");
+        File.WriteAllBytes(Path.Combine(moduleDir, "area01.git"), GffWriter.Write(git));
+
+        // 4. area01.are — minimal valid ARE
+        var are = MakeMinimalAre();
+        File.WriteAllBytes(Path.Combine(moduleDir, "area01.are"), GffWriter.Write(are));
+
+        // 5. script1.nss — text source with "louis_roumain" quoted
+        File.WriteAllText(Path.Combine(moduleDir, "script1.nss"),
+            "void main() {\n    object o = GetObjectByTag(\"louis_roumain\");\n}\n");
+
+        return moduleDir;
+    }
+
+    /// <summary>
+    /// Compute a SHA256 hash over the directory's files (filename + content concatenated,
+    /// in alphabetical order). Used to detect unintended drift across rename/restore cycles.
+    /// </summary>
+    public static string ComputeDirectoryHash(string dir)
+    {
+        using var sha = System.Security.Cryptography.SHA256.Create();
+        var combined = new MemoryStream();
+        foreach (var file in Directory.EnumerateFiles(dir).OrderBy(p => p, StringComparer.Ordinal))
+        {
+            var bytes = File.ReadAllBytes(file);
+            var name = System.Text.Encoding.UTF8.GetBytes(Path.GetFileName(file));
+            combined.Write(name, 0, name.Length);
+            combined.WriteByte(0);
+            combined.Write(bytes, 0, bytes.Length);
+        }
+        combined.Position = 0;
+        return Convert.ToHexStringLower(sha.ComputeHash(combined));
+    }
+
+    // --- Inline builders (kept here to avoid cross-test-project references) ---
+
+    private static GffFile MakeUtc(string conversation)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        GffFieldBuilder.AddCResRefField(root, "Conversation", conversation);
+        return new GffFile { FileType = "UTC ", FileVersion = "V3.2", RootStruct = root };
+    }
+
+    private static GffFile MakeMinimalDlg()
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        return new GffFile { FileType = "DLG ", FileVersion = "V3.2", RootStruct = root };
+    }
+
+    private static GffFile MakeMinimalAre()
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        return new GffFile { FileType = "ARE ", FileVersion = "V3.2", RootStruct = root };
+    }
+
+    private static GffFile MakeGitWithCreature(string templateResRef)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        var instance = new GffStruct { Type = 0 };
+        GffFieldBuilder.AddCResRefField(instance, "TemplateResRef", templateResRef);
+        GffFieldBuilder.AddListField(root, "Creature List", new[] { instance });
+        return new GffFile { FileType = "GIT ", FileVersion = "V3.2", RootStruct = root };
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/TestModuleFixture.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/TestModuleFixture.cs
@@ -1,4 +1,5 @@
 using Radoub.Formats.Gff;
+using Radoub.Formats.Tests.Search.Rename;  // linked-in TestGffBuilder
 
 namespace Radoub.UI.Tests.Services.Search;
 
@@ -89,5 +90,46 @@ public static class TestModuleFixture
         GffFieldBuilder.AddCResRefField(instance, "TemplateResRef", templateResRef);
         GffFieldBuilder.AddListField(root, "Creature List", new[] { instance });
         return new GffFile { FileType = "GIT ", FileVersion = "V3.2", RootStruct = root };
+    }
+
+    /// <summary>
+    /// Build a richer fixture that exercises every ResRef scope tier the orchestrator
+    /// supports: TypedGffField (GIT, UTM panel), DlgScriptParam, NssQuotedString,
+    /// NssBareSubstring. Used by the orchestrator end-to-end test.
+    /// </summary>
+    public static string CreateRichModule(string parentDir)
+    {
+        var moduleDir = Path.Combine(parentDir, $"rich-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(moduleDir);
+
+        // The renamed-file blueprint
+        File.WriteAllBytes(Path.Combine(moduleDir, "louis_roumain.utc"),
+            GffWriter.Write(TestGffBuilder.MakeUtc(conversation: "louis_dlg")));
+
+        // DLG with an ActionParam carrying "louis_sword" (DlgScriptParam tier target)
+        File.WriteAllBytes(Path.Combine(moduleDir, "louis_dlg.dlg"),
+            GffWriter.Write(TestGffBuilder.MakeDlgWithActionParam(
+                entryIndex: 0, key: "weapon_resref", value: "louis_sword")));
+
+        // GIT instance points to louis_roumain (TypedGffField tier via GIT)
+        File.WriteAllBytes(Path.Combine(moduleDir, "area01.git"),
+            GffWriter.Write(TestGffBuilder.MakeGitWithList(
+                "Creature List", "TemplateResRef", "louis_roumain")));
+
+        // Minimal ARE
+        var areRoot = new GffStruct { Type = 0xFFFFFFFF };
+        File.WriteAllBytes(Path.Combine(moduleDir, "area01.are"),
+            GffWriter.Write(new GffFile { FileType = "ARE ", FileVersion = "V3.2", RootStruct = areRoot }));
+
+        // UTM with Weapons panel carrying louis_sword (TypedGffField via UTM panel branch)
+        File.WriteAllBytes(Path.Combine(moduleDir, "store01.utm"),
+            GffWriter.Write(TestGffBuilder.MakeUtmWithItems("Weapons", "louis_sword", "alice_shield")));
+
+        // NSS source with both quoted (high-confidence) and bare-substring (low-confidence) refs
+        File.WriteAllText(Path.Combine(moduleDir, "script1.nss"),
+            "// Reminder: louis_roumain has the merchant key\n" +
+            "void main() { object o = GetObjectByTag(\"louis_roumain\"); }\n");
+
+        return moduleDir;
     }
 }

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/TestModuleFixtureTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/TestModuleFixtureTests.cs
@@ -1,0 +1,49 @@
+using Xunit;
+
+namespace Radoub.UI.Tests.Services.Search;
+
+public class TestModuleFixtureTests : IDisposable
+{
+    private readonly string _root;
+
+    public TestModuleFixtureTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"fixture-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+
+    [Fact]
+    public void CreateMinimalModule_ProducesExpectedFiles()
+    {
+        var dir = TestModuleFixture.CreateMinimalModule(_root);
+        var files = Directory.GetFiles(dir).Select(Path.GetFileName).OrderBy(n => n).ToArray();
+
+        Assert.Contains("louis_roumain.utc", files);
+        Assert.Contains("louis_dlg.dlg", files);
+        Assert.Contains("area01.git", files);
+        Assert.Contains("area01.are", files);
+        Assert.Contains("script1.nss", files);
+    }
+
+    [Fact]
+    public void CreateMinimalModule_BuildsDeterministicGffFiles()
+    {
+        // GffWriter is deterministic (no timestamps/GUIDs, fields written in declaration order)
+        // — building the same module twice produces byte-identical files for each name.
+        var dir1 = TestModuleFixture.CreateMinimalModule(_root);
+        var dir2 = TestModuleFixture.CreateMinimalModule(_root);
+
+        foreach (var file in new[] { "louis_roumain.utc", "louis_dlg.dlg", "area01.git", "area01.are", "script1.nss" })
+        {
+            var bytes1 = File.ReadAllBytes(Path.Combine(dir1, file));
+            var bytes2 = File.ReadAllBytes(Path.Combine(dir2, file));
+            Assert.Equal(bytes1, bytes2);
+        }
+    }
+}

--- a/Radoub.UI/Radoub.UI/Services/Search/BatchReplaceService.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/BatchReplaceService.cs
@@ -27,12 +27,16 @@ public class BatchReplaceService
     /// <summary>
     /// Generate a preview of all changes from search results.
     /// All changes are selected by default.
+    /// When <paramref name="allowResRefReplace"/> is true, ResRef-typed fields
+    /// are also included in the preview even if their FieldDefinition.IsReplaceable
+    /// is false (used by the filename-rename mode — see spec Section 5).
     /// </summary>
     public BatchReplacePreview PreviewReplace(
         IReadOnlyList<FileSearchResult> fileResults,
-        string replacementText)
+        string replacementText,
+        bool allowResRefReplace = false)
     {
-        var preview = new BatchReplacePreview();
+        var preview = new BatchReplacePreview { AllowResRefReplace = allowResRefReplace };
 
         foreach (var fileResult in fileResults)
         {
@@ -44,7 +48,13 @@ public class BatchReplaceService
 
             foreach (var match in fileResult.Matches)
             {
-                if (!match.Field.IsReplaceable) continue;
+                // Original: skip non-replaceable fields.
+                // New: when allowResRefReplace is true, ResRef fields are also included
+                // even if their FieldDefinition.IsReplaceable is false.
+                var isReplaceable = match.Field.IsReplaceable
+                    || (allowResRefReplace && match.Field.FieldType == SearchFieldType.ResRef);
+
+                if (!isReplaceable) continue;
 
                 var change = new PendingChange
                 {

--- a/Radoub.UI/Radoub.UI/Services/Search/BatchReplaceService.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/BatchReplaceService.cs
@@ -126,7 +126,8 @@ public class BatchReplaceService
                 var operations = changes.Select(c => new ReplaceOperation
                 {
                     Match = c.Match,
-                    ReplacementText = c.ReplacementText
+                    ReplacementText = c.ReplacementText,
+                    AllowResRefReplace = preview.AllowResRefReplace
                 }).ToList();
 
                 var results = provider.Replace(gffFile, operations);

--- a/Radoub.UI/Radoub.UI/Services/Search/FilenameSearchProvider.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/FilenameSearchProvider.cs
@@ -52,10 +52,11 @@ public class FilenameSearchProvider
 
             var resourceType = ResourceTypes.FromExtension(ext);
 
-            // Honor file-type filter — unchecked types are skipped per spec scope-respecting rule
-            if (criteria.FileTypeFilter != null && criteria.FileTypeFilter.Count > 0
-                && !criteria.FileTypeFilter.Contains(resourceType))
-                continue;
+            // Filename search is INDEPENDENT of the 18 file-type checkboxes.
+            // Those checkboxes gate file-CONTENT searching; filename matches are
+            // their own search domain enabled by SearchFilenameResRef. This lets
+            // the user search filenames alone (all 18 unchecked) — the surgical
+            // workflow this feature was designed for.
 
             var resRefPortion = Path.GetFileNameWithoutExtension(filePath);
             var match = pattern.Match(resRefPortion);

--- a/Radoub.UI/Radoub.UI/Services/Search/FilenameSearchProvider.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/FilenameSearchProvider.cs
@@ -1,0 +1,85 @@
+using Radoub.Formats.Common;
+using Radoub.Formats.Search;
+
+namespace Radoub.UI.Services.Search;
+
+/// <summary>
+/// Module-scoped search provider that finds files whose ResRef portion
+/// (filename minus extension) matches the search pattern. Unlike per-file
+/// providers (IFileSearchProvider), this scans the module directory directly.
+/// Honors SearchCriteria.FileTypeFilter — files of unchecked types are skipped.
+/// See spec Section 3 + Section 5 (NonPublic/Trebuchet/2026-05-03-resref-rename-design.md).
+/// </summary>
+public class FilenameSearchProvider
+{
+    /// <summary>Same set of searchable extensions ModuleSearchService uses, plus .nss for rename mode.</summary>
+    private static readonly HashSet<string> SearchableExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".dlg", ".utc", ".bic", ".uti", ".utm", ".jrl", ".ifo", ".fac",
+        ".are", ".git", ".utp", ".ute", ".utt", ".utw", ".utd", ".uts", ".itp",
+        ".nss"  // NSS added for filename-rename mode (existing search ignores .nss; rename includes it)
+    };
+
+    /// <summary>Virtual FieldDefinition representing "the file's own name".
+    /// IsReplaceable=false here; the BatchReplaceService bypass widens to ResRef-type fields.</summary>
+    public static readonly FieldDefinition FilenameField = new()
+    {
+        Name = "Filename",
+        GffPath = "<filename>",
+        FieldType = SearchFieldType.ResRef,
+        Category = SearchFieldCategory.Identity,
+        Description = "Module file name (ResRef portion)",
+        IsReplaceable = false  // overridden by allowResRefReplace bypass in BatchReplaceService
+    };
+
+    public IReadOnlyList<FileSearchResult> Search(string moduleDir, SearchCriteria criteria)
+    {
+        if (string.IsNullOrEmpty(moduleDir) || !Directory.Exists(moduleDir))
+            return Array.Empty<FileSearchResult>();
+
+        var validationError = criteria.Validate();
+        if (validationError != null)
+            return Array.Empty<FileSearchResult>();
+
+        var pattern = criteria.ToRegex();
+        var results = new List<FileSearchResult>();
+
+        foreach (var filePath in Directory.EnumerateFiles(moduleDir))
+        {
+            var ext = Path.GetExtension(filePath);
+            if (string.IsNullOrEmpty(ext) || !SearchableExtensions.Contains(ext))
+                continue;
+
+            var resourceType = ResourceTypes.FromExtension(ext);
+
+            // Honor file-type filter — unchecked types are skipped per spec scope-respecting rule
+            if (criteria.FileTypeFilter != null && criteria.FileTypeFilter.Count > 0
+                && !criteria.FileTypeFilter.Contains(resourceType))
+                continue;
+
+            var resRefPortion = Path.GetFileNameWithoutExtension(filePath);
+            var match = pattern.Match(resRefPortion);
+            if (!match.Success) continue;
+
+            var searchMatch = new SearchMatch
+            {
+                Field = FilenameField,
+                MatchedText = match.Value,
+                FullFieldValue = resRefPortion,
+                MatchOffset = match.Index,
+                MatchLength = match.Length,
+                Location = $"<filename: {Path.GetFileName(filePath)}>"
+            };
+
+            results.Add(new FileSearchResult
+            {
+                FilePath = filePath,
+                ResourceType = resourceType,
+                ToolId = ModuleSearchService.GetToolId(resourceType),
+                Matches = new[] { searchMatch }
+            });
+        }
+
+        return results;
+    }
+}

--- a/Radoub.UI/Radoub.UI/Services/Search/GffReferenceLocationApplier.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/GffReferenceLocationApplier.cs
@@ -40,6 +40,20 @@ public class GffReferenceLocationApplier
             return ApplyDlgNode(gff, segments, refRow, newValue);
         }
 
+        // UTM panel pattern: "{PanelName} > Item N > InventoryRes" — panel name is dynamic,
+        // resolved by walking StoreList for a panel whose struct.Type maps back to the same name
+        // via Utm.StorePanels.GetPanelName. Try this BEFORE the generic nested-list branch since
+        // "Weapons", "Armor", etc. are not top-level field names on the root struct.
+        if (segments.Length == 3
+            && segments[1].StartsWith("Item ", StringComparison.Ordinal)
+            && segments[2] == "InventoryRes")
+        {
+            if (ApplyUtmStorePanel(gff, segments[0], segments[1], newValue))
+                return true;
+            // Fall through to generic — UTC/UTP also have ItemList > Item N > InventoryRes,
+            // where segments[0] is the literal top-level field name "ItemList".
+        }
+
         // Generic nested-list pattern: "ListName > Item N > FieldName" or
         // "ListName > Slot N > FieldName" (UTC Equip_ItemList uses "Slot" wording)
         if (segments.Length == 3
@@ -166,4 +180,29 @@ public class GffReferenceLocationApplier
         return true;
     }
 
+    private static bool ApplyUtmStorePanel(
+        GffFile gff, string panelName, string itemSegment, string newValue)
+    {
+        var storeList = gff.RootStruct.GetField("StoreList")?.Value as GffList;
+        if (storeList == null) return false;
+
+        // The scanner derives panelName from struct.Type via Utm.StorePanels.GetPanelName(int).
+        // Walk StoreList looking for the panel whose Type maps back to the same name.
+        var panel = storeList.Elements.FirstOrDefault(p =>
+            string.Equals(
+                Radoub.Formats.Utm.StorePanels.GetPanelName((int)p.Type),
+                panelName,
+                StringComparison.Ordinal));
+        if (panel == null) return false;
+
+        if (!int.TryParse(itemSegment["Item ".Length..], out var idx)) return false;
+
+        var items = panel.GetField("ItemList")?.Value as GffList;
+        if (items == null || idx >= items.Elements.Count) return false;
+
+        var f = items.Elements[idx].GetField("InventoryRes");
+        if (f == null) return false;
+        f.Value = newValue;
+        return true;
+    }
 }

--- a/Radoub.UI/Radoub.UI/Services/Search/GffReferenceLocationApplier.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/GffReferenceLocationApplier.cs
@@ -1,0 +1,169 @@
+using Radoub.Formats.Gff;
+using Radoub.Formats.Search.Rename;
+
+namespace Radoub.UI.Services.Search;
+
+/// <summary>
+/// Applies a value update to a specific GFF reference site, given a Location
+/// string produced by ResRefReferenceScanner. Each scanner location format
+/// (e.g., "Creature List > Item N > TemplateResRef") has a corresponding
+/// applier branch here.
+///
+/// Extracted from ResRefRenameOrchestrator so that adding a new location format
+/// (e.g., UTM store panels, DLG ConditionParams) doesn't bloat the orchestrator.
+/// </summary>
+public class GffReferenceLocationApplier
+{
+    /// <summary>
+    /// Apply <paramref name="newValue"/> to the field identified by <c>refRow.Location</c>
+    /// in the parsed GFF tree. Returns true when the update was applied; false when
+    /// the location string could not be parsed or the target field was missing.
+    /// </summary>
+    public bool Apply(GffFile gff, ResRefReference refRow, string newValue)
+    {
+        var loc = refRow.Location ?? string.Empty;
+
+        // Top-level scalar field: location is just the field name (e.g., "Conversation").
+        // Also handle the case where a registered FieldDefinition supplies the GffPath.
+        if (!loc.Contains('>'))
+            return ApplyTopLevel(gff, refRow, loc, newValue);
+
+        var segments = loc.Split(" > ", StringSplitOptions.TrimEntries);
+
+        // DLG node: "Entry N > Sound" or "Reply N > Sound" or
+        //          "Entry N > ActionParams[P] (key)" or
+        //          "Entry N > RepliesList[L] > ConditionParams[P] (key)" (nested)
+        if ((segments[0].StartsWith("Entry ", StringComparison.Ordinal)
+             || segments[0].StartsWith("Reply ", StringComparison.Ordinal))
+            && segments.Length >= 2)
+        {
+            return ApplyDlgNode(gff, segments, refRow, newValue);
+        }
+
+        // Generic nested-list pattern: "ListName > Item N > FieldName" or
+        // "ListName > Slot N > FieldName" (UTC Equip_ItemList uses "Slot" wording)
+        if (segments.Length == 3
+            && (segments[1].StartsWith("Item ", StringComparison.Ordinal)
+                || segments[1].StartsWith("Slot ", StringComparison.Ordinal)))
+        {
+            return ApplyNestedListItem(gff, segments[0], segments[1], segments[2], newValue);
+        }
+
+        return false;
+    }
+
+    private static bool ApplyTopLevel(GffFile gff, ResRefReference refRow, string loc, string newValue)
+    {
+        // Prefer the registered GffPath when present; otherwise the Location string IS the field name.
+        var fieldName = refRow.Field?.GffPath ?? loc;
+        if (string.IsNullOrEmpty(fieldName)) return false;
+
+        var f = gff.RootStruct.GetField(fieldName);
+        if (f == null) return false;
+        f.Value = newValue;
+        return true;
+    }
+
+    private static bool ApplyNestedListItem(
+        GffFile gff, string listName, string itemSegment, string fieldName, string newValue)
+    {
+        var idxText = itemSegment.StartsWith("Item ", StringComparison.Ordinal)
+            ? itemSegment["Item ".Length..]
+            : itemSegment["Slot ".Length..];
+        if (!int.TryParse(idxText, out var idx)) return false;
+
+        var list = gff.RootStruct.GetField(listName)?.Value as GffList;
+        if (list == null || idx >= list.Elements.Count) return false;
+
+        var f = list.Elements[idx].GetField(fieldName);
+        if (f == null) return false;
+        f.Value = newValue;
+        return true;
+    }
+
+    private static bool ApplyDlgNode(
+        GffFile gff, string[] segments, ResRefReference refRow, string newValue)
+    {
+        // segments[0] is always "Entry N" or "Reply N".
+        var nodeSegment = segments[0];
+        var (listName, idxText) = nodeSegment.StartsWith("Entry ", StringComparison.Ordinal)
+            ? ("EntryList", nodeSegment["Entry ".Length..])
+            : ("ReplyList", nodeSegment["Reply ".Length..]);
+
+        if (!int.TryParse(idxText, out var idx)) return false;
+
+        var nodes = gff.RootStruct.GetField(listName)?.Value as GffList;
+        if (nodes == null || idx >= nodes.Elements.Count) return false;
+
+        var node = nodes.Elements[idx];
+
+        // Simple node field (e.g., "Entry N > Sound")
+        if (segments.Length == 2)
+        {
+            var fieldOrParam = segments[1];
+            if (fieldOrParam.StartsWith("ActionParams[", StringComparison.Ordinal)
+                || fieldOrParam.StartsWith("ConditionParams[", StringComparison.Ordinal))
+            {
+                return ApplyDlgParam(node, fieldOrParam, refRow, newValue);
+            }
+            var f = node.GetField(fieldOrParam);
+            if (f == null) return false;
+            f.Value = newValue;
+            return true;
+        }
+
+        // Nested link form: "Entry N > RepliesList[L] > ConditionParams[P] (key)"
+        // (per scanner's ConditionParams location format)
+        if (segments.Length == 3)
+        {
+            var linkSegment = segments[1];  // "RepliesList[L]" or "EntriesList[L]"
+            var open = linkSegment.IndexOf('[');
+            var close = linkSegment.IndexOf(']');
+            if (open < 0 || close < 0) return false;
+
+            var linkListName = linkSegment[..open];
+            if (!int.TryParse(linkSegment[(open + 1)..close], out var linkIdx)) return false;
+
+            var linkList = node.GetField(linkListName)?.Value as GffList;
+            if (linkList == null || linkIdx >= linkList.Elements.Count) return false;
+
+            var link = linkList.Elements[linkIdx];
+            return ApplyDlgParam(link, segments[2], refRow, newValue);
+        }
+
+        return false;
+    }
+
+    private static bool ApplyDlgParam(
+        GffStruct container, string segment, ResRefReference refRow, string newValue)
+    {
+        // Parse "ActionParams[P] (key)" or "ConditionParams[P] (key)"
+        var openBracket = segment.IndexOf('[');
+        var closeBracket = segment.IndexOf(']');
+        if (openBracket < 0 || closeBracket < 0) return false;
+
+        var paramListName = segment[..openBracket];
+        if (!int.TryParse(segment[(openBracket + 1)..closeBracket], out var paramIdx)) return false;
+
+        var paramList = container.GetField(paramListName)?.Value as GffList;
+        if (paramList == null || paramIdx >= paramList.Elements.Count) return false;
+
+        var valueField = paramList.Elements[paramIdx].GetField("Value");
+        if (valueField?.Value is not string oldFullValue) return false;
+
+        // Substring replace at MatchOffset (per spec: substring match, not whole-equality, for params)
+        if (refRow.MatchOffset < 0 || refRow.MatchOffset + refRow.MatchLength > oldFullValue.Length)
+            return false;
+
+        var actual = oldFullValue.Substring(refRow.MatchOffset, refRow.MatchLength);
+        if (!string.Equals(actual, refRow.OldValue, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        valueField.Value = string.Concat(
+            oldFullValue.AsSpan(0, refRow.MatchOffset),
+            newValue,
+            oldFullValue.AsSpan(refRow.MatchOffset + refRow.MatchLength));
+        return true;
+    }
+
+}

--- a/Radoub.UI/Radoub.UI/Services/Search/Models/BatchReplaceModels.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/Models/BatchReplaceModels.cs
@@ -46,6 +46,13 @@ public class BatchReplacePreview
 
     /// <summary>Number of selected changes</summary>
     public int SelectedChanges => Changes.Count(c => c.IsSelected);
+
+    /// <summary>
+    /// True when this preview was built with allowResRefReplace=true.
+    /// ExecuteReplaceAsync uses this to propagate the bypass to ReplaceOperation
+    /// instances passed into provider.Replace.
+    /// </summary>
+    public bool AllowResRefReplace { get; init; }
 }
 
 /// <summary>

--- a/Radoub.UI/Radoub.UI/Services/Search/Models/ResRefRenameResult.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/Models/ResRefRenameResult.cs
@@ -1,0 +1,47 @@
+namespace Radoub.UI.Services.Search;
+
+/// <summary>
+/// Outcome of a ResRefRenameOrchestrator.ExecuteAsync call.
+/// </summary>
+public class ResRefRenameResult
+{
+    public required bool Success { get; init; }
+
+    /// <summary>Number of files renamed on disk.</summary>
+    public int RenamedFiles { get; init; }
+
+    /// <summary>Number of references rewritten (across all touched files).</summary>
+    public int ReferencesUpdated { get; init; }
+
+    /// <summary>Backup manifest from BackupService — non-null when backup phase succeeded.</summary>
+    public BackupManifest? BackupManifest { get; init; }
+
+    /// <summary>Error message when Success is false. Null when Success is true.</summary>
+    public string? Error { get; init; }
+
+    /// <summary>True when an automatic rollback was attempted after a failure.</summary>
+    public bool RollbackAttempted { get; init; }
+
+    /// <summary>True when rollback completed cleanly (all files restored, all renames reversed).
+    /// False when rollback itself failed — caller should surface the BackupManifest path
+    /// for manual recovery.</summary>
+    public bool RollbackSucceeded { get; init; }
+
+    public static ResRefRenameResult Ok(int renamed, int refsUpdated, BackupManifest manifest) => new()
+    {
+        Success = true,
+        RenamedFiles = renamed,
+        ReferencesUpdated = refsUpdated,
+        BackupManifest = manifest
+    };
+
+    public static ResRefRenameResult Fail(string error, BackupManifest? manifest = null,
+        bool rollbackAttempted = false, bool rollbackSucceeded = false) => new()
+    {
+        Success = false,
+        Error = error,
+        BackupManifest = manifest,
+        RollbackAttempted = rollbackAttempted,
+        RollbackSucceeded = rollbackSucceeded
+    };
+}

--- a/Radoub.UI/Radoub.UI/Services/Search/ModuleSearchService.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/ModuleSearchService.cs
@@ -107,6 +107,41 @@ public class ModuleSearchService
             scanned++;
         }
 
+        // Filename rename mode: add filename matches as an additional pass.
+        // This is module-scoped (one call per module), not per-file.
+        if (criteria.IncludeFilenameResRef)
+        {
+            var filenameProvider = new FilenameSearchProvider();
+            var filenameResults = filenameProvider.Search(modulePath, criteria);
+
+            foreach (var fnResult in filenameResults)
+            {
+                // If a per-file provider already returned a result for this file, merge filename
+                // match into the existing result's Matches list. Otherwise, add as a new result.
+                var existing = results.FirstOrDefault(r => r.FilePath == fnResult.FilePath);
+                if (existing != null)
+                {
+                    var merged = new FileSearchResult
+                    {
+                        FilePath = existing.FilePath,
+                        ResourceType = existing.ResourceType,
+                        ToolId = existing.ToolId,
+                        Matches = existing.Matches.Concat(fnResult.Matches).ToList(),
+                        HadParseError = existing.HadParseError,
+                        ParseError = existing.ParseError
+                    };
+                    var idx = results.IndexOf(existing);
+                    results[idx] = merged;
+                    matchesSoFar += fnResult.MatchCount;
+                }
+                else
+                {
+                    results.Add(fnResult);
+                    matchesSoFar += fnResult.MatchCount;
+                }
+            }
+        }
+
         sw.Stop();
 
         progress?.Report(new ScanProgress

--- a/Radoub.UI/Radoub.UI/Services/Search/ModuleSearchService.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/ModuleSearchService.cs
@@ -248,8 +248,11 @@ public class ModuleSearchService
             if (!SearchableExtensions.Contains(ext))
                 continue;
 
-            // Apply file type filter if specified
-            if (fileTypeFilter != null && fileTypeFilter.Count > 0)
+            // Apply file type filter if specified.
+            // - null   = no filter, all types searched
+            // - empty  = filter to nothing, no file-type search (filename pass may still run)
+            // - non-empty = only these types searched
+            if (fileTypeFilter != null)
             {
                 var resourceType = ResourceTypes.FromExtension(ext);
                 if (!fileTypeFilter.Contains(resourceType))

--- a/Radoub.UI/Radoub.UI/Services/Search/NssReferenceScanner.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/NssReferenceScanner.cs
@@ -1,0 +1,53 @@
+using System.Text.RegularExpressions;
+using Radoub.Formats.Common;
+using Radoub.Formats.Search.Rename;
+
+namespace Radoub.UI.Services.Search;
+
+/// <summary>
+/// Scans .nss script source for ResRef substring matches.
+/// Quoted matches ("target_resref") are high confidence; bare substring matches
+/// (target_resref) are low confidence and visually flagged in the preview.
+/// See spec Section 4 Tier 3.
+/// </summary>
+public class NssReferenceScanner
+{
+    public IReadOnlyList<ResRefReference> Scan(string nssFilePath, string oldResRef)
+    {
+        if (string.IsNullOrEmpty(oldResRef)) return Array.Empty<ResRefReference>();
+        if (!File.Exists(nssFilePath)) return Array.Empty<ResRefReference>();
+
+        var source = File.ReadAllText(nssFilePath);
+        var results = new List<ResRefReference>();
+
+        // Pass 1: quoted matches (high confidence) — pattern: "<oldResRef>"
+        var quotedPattern = $"\"{Regex.Escape(oldResRef)}\"";
+        foreach (Match m in Regex.Matches(source, quotedPattern, RegexOptions.IgnoreCase))
+        {
+            var inner = m.Index + 1;
+            var innerLen = m.Length - 2;
+            results.Add(new ResRefReference
+            {
+                FilePath = nssFilePath,
+                ResourceType = ResourceTypes.Nss,
+                Field = null,
+                Location = $"Line {LineOf(source, m.Index)} (quoted)",
+                OldValue = source.Substring(inner, innerLen),
+                NewValue = string.Empty,
+                ScopeTier = ResRefScopeTier.NssQuotedString,
+                MatchOffset = inner,
+                MatchLength = innerLen
+            });
+        }
+
+        return results;
+    }
+
+    private static int LineOf(string text, int byteIndex)
+    {
+        int line = 1;
+        for (int i = 0; i < byteIndex && i < text.Length; i++)
+            if (text[i] == '\n') line++;
+        return line;
+    }
+}

--- a/Radoub.UI/Radoub.UI/Services/Search/NssReferenceScanner.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/NssReferenceScanner.cs
@@ -19,6 +19,7 @@ public class NssReferenceScanner
 
         var source = File.ReadAllText(nssFilePath);
         var results = new List<ResRefReference>();
+        var quotedRanges = new List<(int Start, int End)>();
 
         // Pass 1: quoted matches (high confidence) — pattern: "<oldResRef>"
         var quotedPattern = $"\"{Regex.Escape(oldResRef)}\"";
@@ -26,6 +27,8 @@ public class NssReferenceScanner
         {
             var inner = m.Index + 1;
             var innerLen = m.Length - 2;
+            quotedRanges.Add((m.Index, m.Index + m.Length));
+
             results.Add(new ResRefReference
             {
                 FilePath = nssFilePath,
@@ -37,6 +40,28 @@ public class NssReferenceScanner
                 ScopeTier = ResRefScopeTier.NssQuotedString,
                 MatchOffset = inner,
                 MatchLength = innerLen
+            });
+        }
+
+        // Pass 2: bare substring matches (low confidence) — skip ranges inside quoted matches
+        var barePattern = Regex.Escape(oldResRef);
+        foreach (Match m in Regex.Matches(source, barePattern, RegexOptions.IgnoreCase))
+        {
+            // Skip if this match falls entirely inside a quoted range
+            if (quotedRanges.Any(r => m.Index >= r.Start && (m.Index + m.Length) <= r.End))
+                continue;
+
+            results.Add(new ResRefReference
+            {
+                FilePath = nssFilePath,
+                ResourceType = ResourceTypes.Nss,
+                Field = null,
+                Location = $"Line {LineOf(source, m.Index)} (substring — verify)",
+                OldValue = source.Substring(m.Index, m.Length),
+                NewValue = string.Empty,
+                ScopeTier = ResRefScopeTier.NssBareSubstring,
+                MatchOffset = m.Index,
+                MatchLength = m.Length
             });
         }
 

--- a/Radoub.UI/Radoub.UI/Services/Search/ResRefRenameOrchestrator.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/ResRefRenameOrchestrator.cs
@@ -13,6 +13,7 @@ public class ResRefRenameOrchestrator
 {
     private readonly BackupService _backupService;
     private readonly SearchProviderFactory _providerFactory;
+    private readonly GffReferenceLocationApplier _locationApplier = new();
 
     public ResRefRenameOrchestrator(BackupService backupService)
         : this(backupService, SearchProviderFactory.CreateDefault())
@@ -99,7 +100,7 @@ public class ResRefRenameOrchestrator
                 var gff = GffReader.Read(File.ReadAllBytes(kvp.Key));
                 foreach (var (refRow, newName) in kvp.Value)
                 {
-                    if (ApplyGffReferenceUpdate(gff, refRow, newName))
+                    if (_locationApplier.Apply(gff, refRow, newName))
                         refsUpdated++;
                 }
                 await WriteAtomicAsync(kvp.Key, GffWriter.Write(gff));
@@ -176,52 +177,6 @@ public class ResRefRenameOrchestrator
                 RollbackSucceeded = rollbackOk
             };
         }
-    }
-
-    /// <summary>
-    /// Apply a single GFF reference update. Returns true if the update was applied,
-    /// false if the location string did not parse to a known location format.
-    /// Currently handles: top-level scalar fields and the "Creature List > Item N > FieldName" GIT pattern.
-    /// Other nested locations (UTC Equip_ItemList, UTM StoreList[], DLG ActionParams, etc.) will be added in Chunk 5.
-    /// </summary>
-    private static bool ApplyGffReferenceUpdate(GffFile gff, ResRefReference refRow, string newValue)
-    {
-        var loc = refRow.Location ?? string.Empty;
-
-        // Pattern: "Creature List > Item N > FieldName"
-        if (loc.StartsWith("Creature List > Item ", StringComparison.Ordinal))
-        {
-            var parts = loc.Split(" > ");
-            if (parts.Length < 3) return false;
-            var idxText = parts[1].Substring("Item ".Length);
-            if (!int.TryParse(idxText, out var itemIdx)) return false;
-            var fieldName = parts[2];
-
-            var listField = gff.RootStruct.GetField("Creature List");
-            if (listField?.Value is GffList list && itemIdx < list.Elements.Count)
-            {
-                var f = list.Elements[itemIdx].GetField(fieldName);
-                if (f != null)
-                {
-                    f.Value = newValue;
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        // Top-level field: use Field.GffPath when present, otherwise the Location string itself.
-        var topFieldName = refRow.Field?.GffPath ?? loc;
-        if (string.IsNullOrEmpty(topFieldName)) return false;
-
-        var topField = gff.RootStruct.GetField(topFieldName);
-        if (topField != null)
-        {
-            topField.Value = newValue;
-            return true;
-        }
-
-        return false;
     }
 
     /// <summary>

--- a/Radoub.UI/Radoub.UI/Services/Search/ResRefRenameOrchestrator.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/ResRefRenameOrchestrator.cs
@@ -1,0 +1,298 @@
+using Radoub.Formats.Gff;
+using Radoub.Formats.Search;
+using Radoub.Formats.Search.Rename;
+
+namespace Radoub.UI.Services.Search;
+
+/// <summary>
+/// Executes a ResRef rename: preflight, backup, references-first writes,
+/// atomic rename, verify, rollback on failure.
+/// See spec Section 7 (NonPublic/Trebuchet/2026-05-03-resref-rename-design.md).
+/// </summary>
+public class ResRefRenameOrchestrator
+{
+    private readonly BackupService _backupService;
+    private readonly SearchProviderFactory _providerFactory;
+
+    public ResRefRenameOrchestrator(BackupService backupService)
+        : this(backupService, SearchProviderFactory.CreateDefault())
+    {
+    }
+
+    public ResRefRenameOrchestrator(BackupService backupService, SearchProviderFactory providerFactory)
+    {
+        _backupService = backupService ?? throw new ArgumentNullException(nameof(backupService));
+        _providerFactory = providerFactory ?? throw new ArgumentNullException(nameof(providerFactory));
+    }
+
+    /// <summary>
+    /// Execute a set of ResRef rename plans on disk.
+    /// Order: preflight (mtime+size) → backup → references first → rename last → verify → rollback on failure.
+    /// </summary>
+    public async Task<ResRefRenameResult> ExecuteAsync(
+        IReadOnlyList<ResRefRenamePlan> plans,
+        string moduleName,
+        IReadOnlyList<FilePreflightSnapshot>? preflightSnapshots = null)
+    {
+        // Phase 1: Preflight (mtime+size check)
+        if (preflightSnapshots != null)
+        {
+            foreach (var snap in preflightSnapshots)
+            {
+                if (!File.Exists(snap.FilePath))
+                    return ResRefRenameResult.Fail($"Preflight failed: {snap.FilePath} no longer exists");
+
+                var info = new FileInfo(snap.FilePath);
+                if (info.LastWriteTimeUtc != snap.LastWriteTimeUtc || info.Length != snap.Length)
+                    return ResRefRenameResult.Fail(
+                        $"Preflight failed: {Path.GetFileName(snap.FilePath)} was modified between preview and execute");
+            }
+        }
+
+        // Determine the work set
+        var renameMap = new List<(string Old, string New)>();
+        var filesToBackup = new HashSet<string>();
+        foreach (var plan in plans.Where(p => p.IsSelected))
+        {
+            filesToBackup.Add(plan.SourceFilePath);
+            foreach (var r in plan.SelectedReferences)
+                filesToBackup.Add(r.FilePath);
+            renameMap.Add((plan.SourceFilePath, plan.TargetFilePath));
+        }
+
+        // Reference-only files (when a plan is unticked but its references are ticked)
+        foreach (var plan in plans.Where(p => !p.IsSelected))
+        {
+            foreach (var r in plan.SelectedReferences)
+                filesToBackup.Add(r.FilePath);
+        }
+
+        // Phase 2: Backup
+        var manifest = await _backupService.BackupFilesAsync(filesToBackup.ToList(), moduleName);
+
+        int refsUpdated = 0;
+        var completedRenames = new List<(string Old, string New)>();
+
+        try
+        {
+            // Phase 3a: GFF reference updates (per file, batched across all plans)
+            // We must collect references across all plans by file, since one file
+            // could carry references to multiple renamed ResRefs.
+            var gffRefsByFile = new Dictionary<string, List<(ResRefReference Ref, string NewName)>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var plan in plans)
+            {
+                foreach (var r in plan.SelectedReferences
+                    .Where(r => r.ScopeTier == ResRefScopeTier.TypedGffField
+                             || r.ScopeTier == ResRefScopeTier.DlgScriptParam))
+                {
+                    if (!gffRefsByFile.TryGetValue(r.FilePath, out var list))
+                    {
+                        list = new List<(ResRefReference, string)>();
+                        gffRefsByFile[r.FilePath] = list;
+                    }
+                    list.Add((r, plan.NewName));
+                }
+            }
+
+            foreach (var kvp in gffRefsByFile)
+            {
+                var gff = GffReader.Read(File.ReadAllBytes(kvp.Key));
+                foreach (var (refRow, newName) in kvp.Value)
+                {
+                    if (ApplyGffReferenceUpdate(gff, refRow, newName))
+                        refsUpdated++;
+                }
+                await WriteAtomicAsync(kvp.Key, GffWriter.Write(gff));
+            }
+
+            // Phase 3b: NSS text replacements (per file, batched across plans)
+            var nssRefsByFile = new Dictionary<string, List<(ResRefReference Ref, string OldName, string NewName)>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var plan in plans)
+            {
+                foreach (var r in plan.SelectedReferences
+                    .Where(r => r.ScopeTier == ResRefScopeTier.NssQuotedString
+                             || r.ScopeTier == ResRefScopeTier.NssBareSubstring))
+                {
+                    if (!nssRefsByFile.TryGetValue(r.FilePath, out var list))
+                    {
+                        list = new List<(ResRefReference, string, string)>();
+                        nssRefsByFile[r.FilePath] = list;
+                    }
+                    list.Add((r, plan.OldName, plan.NewName));
+                }
+            }
+
+            foreach (var kvp in nssRefsByFile)
+            {
+                var applied = await ApplyNssReferenceUpdates(kvp.Key, kvp.Value);
+                refsUpdated += applied;
+            }
+
+            // Phase 3c: Rename files (after references are updated)
+            foreach (var (oldPath, newPath) in renameMap)
+            {
+                File.Move(oldPath, newPath);
+                completedRenames.Add((oldPath, newPath));
+            }
+
+            // Phase 4: Verify
+            foreach (var (oldPath, newPath) in renameMap)
+            {
+                if (!File.Exists(newPath))
+                    throw new IOException($"Verify failed: expected file at {newPath} after rename");
+                if (File.Exists(oldPath))
+                    throw new IOException($"Verify failed: orphan file remains at {oldPath} after rename");
+            }
+
+            return ResRefRenameResult.Ok(renameMap.Count, refsUpdated, manifest);
+        }
+        catch (Exception ex)
+        {
+            // Rollback path: reverse renames first, then restore content from backup.
+            var rollbackOk = true;
+
+            foreach (var (oldPath, newPath) in completedRenames)
+            {
+                try
+                {
+                    if (File.Exists(newPath) && !File.Exists(oldPath))
+                        File.Move(newPath, oldPath);
+                }
+                catch
+                {
+                    rollbackOk = false;
+                }
+            }
+
+            var restoreOk = await _backupService.RestoreAsync(manifest);
+            rollbackOk = rollbackOk && restoreOk;
+
+            return new ResRefRenameResult
+            {
+                Success = false,
+                Error = ex.Message,
+                BackupManifest = manifest,
+                RollbackAttempted = true,
+                RollbackSucceeded = rollbackOk
+            };
+        }
+    }
+
+    /// <summary>
+    /// Apply a single GFF reference update. Returns true if the update was applied,
+    /// false if the location string did not parse to a known location format.
+    /// Currently handles: top-level scalar fields and the "Creature List > Item N > FieldName" GIT pattern.
+    /// Other nested locations (UTC Equip_ItemList, UTM StoreList[], DLG ActionParams, etc.) will be added in Chunk 5.
+    /// </summary>
+    private static bool ApplyGffReferenceUpdate(GffFile gff, ResRefReference refRow, string newValue)
+    {
+        var loc = refRow.Location ?? string.Empty;
+
+        // Pattern: "Creature List > Item N > FieldName"
+        if (loc.StartsWith("Creature List > Item ", StringComparison.Ordinal))
+        {
+            var parts = loc.Split(" > ");
+            if (parts.Length < 3) return false;
+            var idxText = parts[1].Substring("Item ".Length);
+            if (!int.TryParse(idxText, out var itemIdx)) return false;
+            var fieldName = parts[2];
+
+            var listField = gff.RootStruct.GetField("Creature List");
+            if (listField?.Value is GffList list && itemIdx < list.Elements.Count)
+            {
+                var f = list.Elements[itemIdx].GetField(fieldName);
+                if (f != null)
+                {
+                    f.Value = newValue;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // Top-level field: use Field.GffPath when present, otherwise the Location string itself.
+        var topFieldName = refRow.Field?.GffPath ?? loc;
+        if (string.IsNullOrEmpty(topFieldName)) return false;
+
+        var topField = gff.RootStruct.GetField(topFieldName);
+        if (topField != null)
+        {
+            topField.Value = newValue;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Applies NSS reference updates and returns the count of references actually applied.
+    /// Some refs may be skipped if the file content drifted between scan and execute
+    /// (preflight is mtime+size-based, so a same-size edit slips through).
+    /// </summary>
+    private static async Task<int> ApplyNssReferenceUpdates(
+        string nssPath,
+        IReadOnlyList<(ResRefReference Ref, string OldName, string NewName)> refs)
+    {
+        var source = await File.ReadAllTextAsync(nssPath);
+        int applied = 0;
+
+        // Apply replacements in REVERSE OFFSET ORDER so earlier offsets remain valid.
+        var sorted = refs.OrderByDescending(r => r.Ref.MatchOffset).ToList();
+
+        var sb = new System.Text.StringBuilder(source);
+        foreach (var (refRow, oldName, newName) in sorted)
+        {
+            if (refRow.MatchOffset < 0 || refRow.MatchOffset + refRow.MatchLength > sb.Length)
+                continue;
+
+            var actual = sb.ToString(refRow.MatchOffset, refRow.MatchLength);
+            if (!string.Equals(actual, refRow.OldValue, StringComparison.OrdinalIgnoreCase))
+            {
+                // File content drifted (preflight is mtime+size, not byte-identity). Skip this row.
+                continue;
+            }
+
+            sb.Remove(refRow.MatchOffset, refRow.MatchLength);
+            sb.Insert(refRow.MatchOffset, newName);
+            applied++;
+        }
+
+        var tempPath = nssPath + ".tmp";
+        await File.WriteAllTextAsync(tempPath, sb.ToString());
+        File.Move(tempPath, nssPath, overwrite: true);
+        return applied;
+    }
+
+    /// <summary>
+    /// Atomic write via temp-file + rename. Survives mid-write process kill —
+    /// either the original is intact or the new content is fully written and named.
+    /// </summary>
+    private static async Task WriteAtomicAsync(string path, byte[] bytes)
+    {
+        var tempPath = path + ".tmp";
+        await File.WriteAllBytesAsync(tempPath, bytes);
+        File.Move(tempPath, path, overwrite: true);
+    }
+
+    /// <summary>
+    /// Capture file mtime + size for a set of paths.
+    /// Pass to ExecuteAsync as preflightSnapshots to detect concurrent modification.
+    /// </summary>
+    public static IReadOnlyList<FilePreflightSnapshot> CaptureSnapshots(IEnumerable<string> filePaths)
+    {
+        var snapshots = new List<FilePreflightSnapshot>();
+        foreach (var path in filePaths.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            if (!File.Exists(path)) continue;
+            var info = new FileInfo(path);
+            snapshots.Add(new FilePreflightSnapshot(path, info.LastWriteTimeUtc, info.Length));
+        }
+        return snapshots;
+    }
+}
+
+/// <summary>
+/// Snapshot of file metadata captured at preview time. The orchestrator
+/// re-reads metadata at preflight and aborts if either differs.
+/// </summary>
+public record FilePreflightSnapshot(string FilePath, DateTime LastWriteTimeUtc, long Length);

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.33.0-alpha] - 2026-05-03
+**Branch**: `trebuchet/issue-1926` | **PR**: #TBD
+
+### Feat: ResRef replace with file rename — batch rename support (#1926)
+
+- Enable ResRef field replace by renaming referenced files on disk and updating cross-file references
+- Collision detection, 16-char filename validation, and undo/backup support
+
+---
+
 ## [1.32.0-alpha] - 2026-05-01
 **Branch**: `radoub/issue-2159` | **PR**: #2160
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [1.33.0-alpha] - 2026-05-03
-**Branch**: `trebuchet/issue-1926` | **PR**: #TBD
+**Branch**: `trebuchet/issue-1926` | **PR**: #2169
 
 ### Feat: ResRef replace with file rename — batch rename support (#1926)
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -9,10 +9,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [1.33.0-alpha] - 2026-05-03
 **Branch**: `trebuchet/issue-1926` | **PR**: #2169
 
-### Feat: ResRef replace with file rename — batch rename support (#1926)
+### Feat: Marlinspike — Filename/ResRef rename with cross-file reference updates (#1926)
 
-- Enable ResRef field replace by renaming referenced files on disk and updating cross-file references
-- Collision detection, 16-char filename validation, and undo/backup support
+- New "Include filename/ResRef" checkbox in the Marlinspike search panel converts text-replace into a module-wide rename
+- Renames files on disk AND updates every reference across:
+  - Typed GFF fields (UTC.Conversation, UTI scripts, UTM store inventory, UTP/UTD scripts, DLG.Sound, GIT instances, ARE/IFO event scripts, IFO HAK list, etc.)
+  - DLG `ActionParams` and `ConditionParams` value substrings
+  - `.nss` script source — quoted references (high confidence) and bare substrings (flagged "low confidence" — verify)
+- New NSS file-type checkbox (18th) controls whether `.nss` is scanned
+- Scope-respecting: unchecking a file type removes it from both search AND rename — what you see is what gets replaced
+- Scope-narrowing warning panel appears when the user filters file types in rename mode
+- Auto-suffix collision detection (`_2`..`_99`) with user confirmation dialog
+- 16-character ResRef validation, lowercase normalization
+- Backup + automatic rollback on failure via existing `BackupService`
+- Atomic file writes (temp + rename) prevent half-written state on process kill
+- Preflight check (mtime+size) detects concurrent file modification between preview and execute
 
 ---
 

--- a/Trebuchet/Trebuchet.Tests/MarlinspikePanelViewModelTests.cs
+++ b/Trebuchet/Trebuchet.Tests/MarlinspikePanelViewModelTests.cs
@@ -231,6 +231,21 @@ public class MarlinspikePanelViewModelTests
     }
 
     [Fact]
+    public void CanSearch_NoFileTypesButFilenameResRefOn_ReturnsTrue()
+    {
+        // Filename/ResRef mode is a valid standalone search target — user
+        // can search filenames without any GFF file-types selected.
+        var vm = new MarlinspikePanelViewModel();
+        vm.SearchPattern = "louis";
+        vm.SearchFilenameResRef = true;  // auto-toggle would re-check file types, so deselect AFTER
+        vm.DeselectAllFileTypes();
+
+        Assert.False(vm.HasAnyFileTypeSelected);
+        Assert.True(vm.SearchFilenameResRef);
+        Assert.True(vm.CanSearch);
+    }
+
+    [Fact]
     public void HasAnyFileTypeSelected_OneChecked_ReturnsTrue()
     {
         var vm = new MarlinspikePanelViewModel();

--- a/Trebuchet/Trebuchet.Tests/MarlinspikePanelViewModelTests.cs
+++ b/Trebuchet/Trebuchet.Tests/MarlinspikePanelViewModelTests.cs
@@ -388,61 +388,36 @@ public class MarlinspikePanelViewModelTests
     }
 
     [Fact]
-    public void TogglingSearchFilenameResRefOn_SelectsAllFileTypes()
+    public void TogglingSearchFilenameResRefOn_DoesNotAutoSelectFileTypes()
     {
+        // Per surgical-rename design: row selection IS the scope control.
+        // Toggling filename/ResRef must not bounce the file-type checkboxes
+        // the user deliberately set. Initial default state stays "all checked"
+        // (model defaults), but flipping the toggle does not re-check them.
         var vm = new MarlinspikePanelViewModel();
         vm.DeselectAllFileTypes();
         vm.SelectedCategory = "Identity";
 
         vm.SearchFilenameResRef = true;
 
-        Assert.True(vm.IncludeDlg);
-        Assert.True(vm.IncludeUtc);
-        Assert.True(vm.IncludeNss);
-        Assert.Equal("All Fields", vm.SelectedCategory);
+        Assert.False(vm.IncludeDlg);
+        Assert.False(vm.IncludeUtc);
+        Assert.False(vm.IncludeNss);
+        Assert.Equal("Identity", vm.SelectedCategory);  // category not bounced either
     }
 
     [Fact]
     public void TogglingSearchFilenameResRefOff_PreservesFileTypeSelection()
     {
         var vm = new MarlinspikePanelViewModel();
-        vm.SearchFilenameResRef = true;
         vm.IncludeGit = false;
         vm.IncludeIfo = false;
 
+        vm.SearchFilenameResRef = true;
         vm.SearchFilenameResRef = false;
 
         Assert.False(vm.IncludeGit);
         Assert.False(vm.IncludeIfo);
-    }
-
-    [Fact]
-    public void ShowScopeNarrowingWarning_FalseWhenSearchFilenameResRefIsOff()
-    {
-        var vm = new MarlinspikePanelViewModel();
-        vm.SearchFilenameResRef = false;
-        vm.IncludeGit = false;
-
-        Assert.False(vm.ShowScopeNarrowingWarning);
-    }
-
-    [Fact]
-    public void ShowScopeNarrowingWarning_FalseWhenAllFileTypesChecked()
-    {
-        var vm = new MarlinspikePanelViewModel();
-        vm.SearchFilenameResRef = true;
-
-        Assert.False(vm.ShowScopeNarrowingWarning);
-    }
-
-    [Fact]
-    public void ShowScopeNarrowingWarning_TrueWhenScopeNarrowed()
-    {
-        var vm = new MarlinspikePanelViewModel();
-        vm.SearchFilenameResRef = true;
-        vm.IncludeGit = false;
-
-        Assert.True(vm.ShowScopeNarrowingWarning);
     }
 
     [Fact]

--- a/Trebuchet/Trebuchet.Tests/MarlinspikePanelViewModelTests.cs
+++ b/Trebuchet/Trebuchet.Tests/MarlinspikePanelViewModelTests.cs
@@ -346,6 +346,114 @@ public class MarlinspikePanelViewModelTests
         Assert.True(vm.CanSearch);
     }
 
+    // --- Filename/ResRef rename feature (Chunk 4) ---
+
+    [Fact]
+    public void SearchFilenameResRef_DefaultsToFalse()
+    {
+        var vm = new MarlinspikePanelViewModel();
+        Assert.False(vm.SearchFilenameResRef);
+    }
+
+    [Fact]
+    public void IncludeNss_DefaultsToTrue()
+    {
+        var vm = new MarlinspikePanelViewModel();
+        Assert.True(vm.IncludeNss);
+    }
+
+    [Fact]
+    public void HasAnyFileTypeSelected_TrueWhenOnlyNssChecked()
+    {
+        var vm = new MarlinspikePanelViewModel();
+        vm.DeselectAllFileTypes();
+        vm.IncludeNss = true;
+
+        Assert.True(vm.HasAnyFileTypeSelected);
+    }
+
+    [Fact]
+    public void TogglingSearchFilenameResRefOn_SelectsAllFileTypes()
+    {
+        var vm = new MarlinspikePanelViewModel();
+        vm.DeselectAllFileTypes();
+        vm.SelectedCategory = "Identity";
+
+        vm.SearchFilenameResRef = true;
+
+        Assert.True(vm.IncludeDlg);
+        Assert.True(vm.IncludeUtc);
+        Assert.True(vm.IncludeNss);
+        Assert.Equal("All Fields", vm.SelectedCategory);
+    }
+
+    [Fact]
+    public void TogglingSearchFilenameResRefOff_PreservesFileTypeSelection()
+    {
+        var vm = new MarlinspikePanelViewModel();
+        vm.SearchFilenameResRef = true;
+        vm.IncludeGit = false;
+        vm.IncludeIfo = false;
+
+        vm.SearchFilenameResRef = false;
+
+        Assert.False(vm.IncludeGit);
+        Assert.False(vm.IncludeIfo);
+    }
+
+    [Fact]
+    public void ShowScopeNarrowingWarning_FalseWhenSearchFilenameResRefIsOff()
+    {
+        var vm = new MarlinspikePanelViewModel();
+        vm.SearchFilenameResRef = false;
+        vm.IncludeGit = false;
+
+        Assert.False(vm.ShowScopeNarrowingWarning);
+    }
+
+    [Fact]
+    public void ShowScopeNarrowingWarning_FalseWhenAllFileTypesChecked()
+    {
+        var vm = new MarlinspikePanelViewModel();
+        vm.SearchFilenameResRef = true;
+
+        Assert.False(vm.ShowScopeNarrowingWarning);
+    }
+
+    [Fact]
+    public void ShowScopeNarrowingWarning_TrueWhenScopeNarrowed()
+    {
+        var vm = new MarlinspikePanelViewModel();
+        vm.SearchFilenameResRef = true;
+        vm.IncludeGit = false;
+
+        Assert.True(vm.ShowScopeNarrowingWarning);
+    }
+
+    [Fact]
+    public void BuildSearchCriteria_PropagatesIncludeFilenameResRef()
+    {
+        var vm = new MarlinspikePanelViewModel();
+        vm.SearchPattern = "louis";
+        vm.SearchFilenameResRef = true;
+
+        var criteria = vm.BuildSearchCriteria();
+
+        Assert.True(criteria.IncludeFilenameResRef);
+    }
+
+    [Fact]
+    public void BuildSearchCriteria_AllTypesChecked_IncludingNss_NullFileTypeFilter()
+    {
+        var vm = new MarlinspikePanelViewModel();
+        vm.SearchPattern = "test";
+        // All 18 types default to checked, including Nss.
+
+        var criteria = vm.BuildSearchCriteria();
+
+        Assert.Null(criteria.FileTypeFilter);
+    }
+
     private static ModuleSearchResults CreateTestResults()
     {
         var match = new SearchMatch

--- a/Trebuchet/Trebuchet.Tests/RenameDispatchHelpersTests.cs
+++ b/Trebuchet/Trebuchet.Tests/RenameDispatchHelpersTests.cs
@@ -203,6 +203,64 @@ public class RenameDispatchHelpersTests : IDisposable
         Assert.Contains(plan.References, r => r.ResourceType == ResourceTypes.Utc);
     }
 
+    [Fact]
+    public async Task PopulateReferencesAsync_AllowedFilePathsRestrictsToSelection()
+    {
+        // Two files in the module, both referencing "louis"
+        var utcPath = Path.Combine(_tempDir, "test.utc");
+        File.WriteAllBytes(utcPath, GffWriter.Write(MakeUtcWithConversation("louis")));
+
+        var gitPath = Path.Combine(_tempDir, "area.git");
+        File.WriteAllBytes(gitPath, GffWriter.Write(MakeGitWithCreature("louis")));
+
+        var plan = new ResRefRenamePlan
+        {
+            OldName = "louis",
+            NewName = "alice",
+            ResourceType = ResourceTypes.Dlg,
+            Validation = ResRefValidationResult.Ok("alice"),
+            SourceFilePath = "/dummy",
+            TargetFilePath = "/dummy"
+        };
+        var criteria = new SearchCriteria { Pattern = "louis" };
+
+        // Surgical mode: user selected only the UTC; the GIT must be ignored entirely.
+        var allowed = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { utcPath };
+
+        await RenameDispatchHelpers.PopulateReferencesAsync(
+            new[] { plan }, _tempDir, includeNss: false, criteria, allowed);
+
+        Assert.All(plan.References, r => Assert.NotEqual(ResourceTypes.Git, r.ResourceType));
+        Assert.Contains(plan.References, r => r.ResourceType == ResourceTypes.Utc);
+    }
+
+    [Fact]
+    public async Task PopulateReferencesAsync_NullAllowedFilePathsScansEverything()
+    {
+        // Regression: passing null for allowedFilePaths must preserve module-wide behavior.
+        File.WriteAllBytes(Path.Combine(_tempDir, "test.utc"),
+            GffWriter.Write(MakeUtcWithConversation("louis")));
+        File.WriteAllBytes(Path.Combine(_tempDir, "area.git"),
+            GffWriter.Write(MakeGitWithCreature("louis")));
+
+        var plan = new ResRefRenamePlan
+        {
+            OldName = "louis",
+            NewName = "alice",
+            ResourceType = ResourceTypes.Dlg,
+            Validation = ResRefValidationResult.Ok("alice"),
+            SourceFilePath = "/dummy",
+            TargetFilePath = "/dummy"
+        };
+
+        await RenameDispatchHelpers.PopulateReferencesAsync(
+            new[] { plan }, _tempDir, includeNss: false, new SearchCriteria { Pattern = "louis" },
+            allowedFilePaths: null);
+
+        Assert.Contains(plan.References, r => r.ResourceType == ResourceTypes.Utc);
+        Assert.Contains(plan.References, r => r.ResourceType == ResourceTypes.Git);
+    }
+
     // --- Test fixtures ---
 
     private static SearchMatch MakeMatchOn(FieldDefinition field) => new()

--- a/Trebuchet/Trebuchet.Tests/RenameDispatchHelpersTests.cs
+++ b/Trebuchet/Trebuchet.Tests/RenameDispatchHelpersTests.cs
@@ -1,0 +1,235 @@
+using Radoub.Formats.Common;
+using Radoub.Formats.Gff;
+using Radoub.Formats.Search;
+using Radoub.Formats.Search.Rename;
+using Radoub.UI.Services.Search;
+using RadoubLauncher.Services;
+
+namespace Trebuchet.Tests;
+
+/// <summary>
+/// Unit tests for the rename dispatch helpers extracted from MarlinspikePanel.
+/// These cover the branching logic that converts a BatchReplacePreview with
+/// filename matches into ResRefRenamePlans for the orchestrator.
+/// </summary>
+public class RenameDispatchHelpersTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public RenameDispatchHelpersTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"rdh-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    // --- HasFilenameMatches ---
+
+    [Fact]
+    public void HasFilenameMatches_TrueWhenPreviewContainsFilenameField()
+    {
+        var preview = new BatchReplacePreview();
+        preview.Changes.Add(new PendingChange
+        {
+            Match = MakeMatchOn(FilenameSearchProvider.FilenameField),
+            ReplacementText = "x",
+            FilePath = "/m/test.dlg"
+        });
+
+        Assert.True(RenameDispatchHelpers.HasFilenameMatches(preview));
+    }
+
+    [Fact]
+    public void HasFilenameMatches_FalseWhenPreviewHasOnlyContentFields()
+    {
+        var contentField = new FieldDefinition
+        {
+            Name = "Tag",
+            GffPath = "Tag",
+            FieldType = SearchFieldType.Tag,
+            Category = SearchFieldCategory.Identity
+        };
+        var preview = new BatchReplacePreview();
+        preview.Changes.Add(new PendingChange
+        {
+            Match = MakeMatchOn(contentField),
+            ReplacementText = "x",
+            FilePath = "/m/test.utc"
+        });
+
+        Assert.False(RenameDispatchHelpers.HasFilenameMatches(preview));
+    }
+
+    // --- BuildExistingResRefIndex ---
+
+    [Fact]
+    public void BuildExistingResRefIndex_GroupsByExtension()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "louis.dlg"), "x");
+        File.WriteAllText(Path.Combine(_tempDir, "louis.utc"), "x");
+        File.WriteAllText(Path.Combine(_tempDir, "alice.utc"), "x");
+
+        var index = RenameDispatchHelpers.BuildExistingResRefIndex(_tempDir);
+
+        Assert.Contains("louis", index[".dlg"]);
+        Assert.Contains("louis", index[".utc"]);
+        Assert.Contains("alice", index[".utc"]);
+        Assert.Single(index[".dlg"]);
+        Assert.Equal(2, index[".utc"].Count);
+    }
+
+    // --- ApplyReplacement ---
+
+    [Fact]
+    public void ApplyReplacement_ReplacesAtMatchOffset()
+    {
+        var match = new SearchMatch
+        {
+            Field = FilenameSearchProvider.FilenameField,
+            MatchedText = "louis",
+            FullFieldValue = "louis_roumain",
+            MatchOffset = 0,
+            MatchLength = "louis".Length,
+            Location = "test"
+        };
+
+        var result = RenameDispatchHelpers.ApplyReplacement("louis_roumain", match, "alice");
+
+        Assert.Equal("alice_roumain", result);
+    }
+
+    // --- BuildRenamePlansFromPreview ---
+
+    [Fact]
+    public void BuildRenamePlansFromPreview_SkipsInvalidValidations()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "valid_name.dlg"), "x");
+
+        var preview = new BatchReplacePreview();
+        preview.Changes.Add(new PendingChange
+        {
+            Match = new SearchMatch
+            {
+                Field = FilenameSearchProvider.FilenameField,
+                MatchedText = "valid_name",
+                FullFieldValue = "valid_name",
+                MatchOffset = 0,
+                MatchLength = "valid_name".Length,
+                Location = "test"
+            },
+            ReplacementText = "way-too-long-for-aurora-which-fails-16-char-limit",
+            FilePath = Path.Combine(_tempDir, "valid_name.dlg")
+        });
+
+        var plans = RenameDispatchHelpers.BuildRenamePlansFromPreview(
+            preview, _tempDir, new ResRefValidator());
+
+        Assert.Empty(plans);  // validator rejects > 16 chars; plan skipped
+    }
+
+    [Fact]
+    public void BuildRenamePlansFromPreview_BuildsValidPlanForSimpleRename()
+    {
+        // Create the file being renamed and one unrelated file in the directory.
+        File.WriteAllText(Path.Combine(_tempDir, "louis.dlg"), "x");
+        File.WriteAllText(Path.Combine(_tempDir, "alice.utc"), "x");
+
+        var preview = new BatchReplacePreview();
+        preview.Changes.Add(new PendingChange
+        {
+            Match = new SearchMatch
+            {
+                Field = FilenameSearchProvider.FilenameField,
+                MatchedText = "louis",
+                FullFieldValue = "louis",
+                MatchOffset = 0,
+                MatchLength = "louis".Length,
+                Location = "test"
+            },
+            ReplacementText = "bob",
+            FilePath = Path.Combine(_tempDir, "louis.dlg")
+        });
+
+        var plans = RenameDispatchHelpers.BuildRenamePlansFromPreview(
+            preview, _tempDir, new ResRefValidator());
+
+        var plan = Assert.Single(plans);
+        Assert.Equal("louis", plan.OldName);
+        Assert.Equal("bob", plan.NewName);
+        Assert.Equal(ResourceTypes.Dlg, plan.ResourceType);
+        Assert.Equal(Path.Combine(_tempDir, "louis.dlg"), plan.SourceFilePath);
+        Assert.Equal(Path.Combine(_tempDir, "bob.dlg"), plan.TargetFilePath);
+    }
+
+    // --- PopulateReferencesAsync ---
+
+    [Fact]
+    public async Task PopulateReferencesAsync_HonorsFileTypeFilter()
+    {
+        // UTC referencing "louis" via Conversation field (top-level scalar)
+        var utc = MakeUtcWithConversation("louis");
+        File.WriteAllBytes(Path.Combine(_tempDir, "test.utc"), GffWriter.Write(utc));
+
+        // GIT with a Creature List entry referencing "louis"
+        var git = MakeGitWithCreature("louis");
+        File.WriteAllBytes(Path.Combine(_tempDir, "area.git"), GffWriter.Write(git));
+
+        var plan = new ResRefRenamePlan
+        {
+            OldName = "louis",
+            NewName = "alice",
+            ResourceType = ResourceTypes.Dlg,
+            Validation = ResRefValidationResult.Ok("alice"),
+            SourceFilePath = "/dummy",
+            TargetFilePath = "/dummy"
+        };
+
+        // Filter excludes GIT → only UTC references should be picked up
+        var criteria = new SearchCriteria
+        {
+            Pattern = "louis",
+            FileTypeFilter = new[] { ResourceTypes.Utc }
+        };
+
+        await RenameDispatchHelpers.PopulateReferencesAsync(
+            new[] { plan }, _tempDir, includeNss: false, criteria);
+
+        Assert.All(plan.References, r => Assert.NotEqual(ResourceTypes.Git, r.ResourceType));
+        Assert.Contains(plan.References, r => r.ResourceType == ResourceTypes.Utc);
+    }
+
+    // --- Test fixtures ---
+
+    private static SearchMatch MakeMatchOn(FieldDefinition field) => new()
+    {
+        Field = field,
+        MatchedText = "x",
+        FullFieldValue = "x",
+        MatchOffset = 0,
+        MatchLength = 1,
+        Location = "test"
+    };
+
+    /// <summary>Build a minimal UTC GFF with a Conversation ResRef field.</summary>
+    private static GffFile MakeUtcWithConversation(string conversation)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        GffFieldBuilder.AddCResRefField(root, "Conversation", conversation);
+        return new GffFile { FileType = "UTC ", FileVersion = "V3.2", RootStruct = root };
+    }
+
+    /// <summary>Build a minimal GIT GFF with one Creature List entry referencing the given ResRef.</summary>
+    private static GffFile MakeGitWithCreature(string templateResRef)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        var creature = new GffStruct { Type = 0 };
+        GffFieldBuilder.AddCResRefField(creature, "TemplateResRef", templateResRef);
+        GffFieldBuilder.AddListField(root, "Creature List", new[] { creature });
+        return new GffFile { FileType = "GIT ", FileVersion = "V3.2", RootStruct = root };
+    }
+}

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml
@@ -99,14 +99,6 @@
                     </WrapPanel>
                 </StackPanel>
 
-                <!-- Scope-narrowing warning (only visible when filename/ResRef on AND scope narrowed) -->
-                <TextBlock IsVisible="{Binding ShowScopeNarrowingWarning}"
-                           Text="⚠ Unchecked file types are skipped — references there won't be renamed."
-                           TextWrapping="Wrap"
-                           FontSize="{DynamicResource FontSizeSmall}"
-                           Foreground="{DynamicResource ThemeWarning}"
-                           Margin="0,4,0,0"
-                           ToolTip.Tip="References in unchecked file types will not be updated and may break in-game. Compiled .ncs scripts and 2DA references are never scanned. See Marlinspike documentation for details."/>
             </StackPanel>
         </Border>
 

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml
@@ -51,6 +51,9 @@
                     <CheckBox Content="Include StrRef text" Margin="0,0,12,0"
                               IsChecked="{Binding SearchStrRefs}"
                               ToolTip.Tip="Also search TLK-resolved StrRef text (requires game TLK loaded). Off by default — most modules use embedded text."/>
+                    <CheckBox Content="Include filename/ResRef" Margin="0,0,12,0"
+                              IsChecked="{Binding SearchFilenameResRef}"
+                              ToolTip.Tip="When checked, search includes filename matches AND ResRef field matches become replaceable. See Marlinspike documentation for details."/>
                     <TextBlock Text="Fields:" VerticalAlignment="Center" Margin="8,0,4,0"/>
                     <ComboBox x:Name="CategoryCombo" MinWidth="120"
                               ItemsSource="{Binding Categories}"
@@ -91,8 +94,32 @@
                         <CheckBox Content="IFO" IsChecked="{Binding IncludeIfo}" Margin="0,0,8,0" MinWidth="65"/>
                         <CheckBox Content="FAC" IsChecked="{Binding IncludeFac}" Margin="0,0,8,0" MinWidth="65"/>
                         <CheckBox Content="ITP" IsChecked="{Binding IncludeItp}" Margin="0,0,8,0" MinWidth="65"/>
+                        <CheckBox Content="NSS" IsChecked="{Binding IncludeNss}" Margin="0,0,8,0" MinWidth="65"
+                                  ToolTip.Tip="Plain-text scan of .nss script source for ResRef references. Quoted matches are high confidence; bare substring matches are flagged 'verify'."/>
                     </WrapPanel>
                 </StackPanel>
+
+                <!-- Scope-narrowing warning (only visible when filename/ResRef on AND scope narrowed) -->
+                <Border IsVisible="{Binding ShowScopeNarrowingWarning}"
+                        BorderBrush="{DynamicResource ThemeWarning}"
+                        BorderThickness="1" CornerRadius="4" Padding="8" Margin="0,4">
+                    <StackPanel Spacing="4">
+                        <TextBlock FontWeight="SemiBold" TextWrapping="Wrap"
+                                   Foreground="{DynamicResource ThemeWarning}">
+                            ⚠ Some file types are excluded from the rename.
+                        </TextBlock>
+                        <TextBlock TextWrapping="Wrap" FontSize="{DynamicResource FontSizeSmall}">
+                            References to renamed resources will only be updated in the file types you've checked.
+                            If references exist in unchecked types (e.g., a script in .nss, a creature in .git),
+                            they will be left untouched and may break.
+                        </TextBlock>
+                        <TextBlock TextWrapping="Wrap" FontSize="{DynamicResource FontSizeSmall}" FontStyle="Italic">
+                            Common reasons to narrow scope: splitting one NPC into two; renaming only a specific class of resource.
+                            Less obvious risks: collaborative inconsistency from multiple developers; .ncs and 2DA references are
+                            never scanned. Always run a test session of your module after a rename to verify nothing broke.
+                        </TextBlock>
+                    </StackPanel>
+                </Border>
             </StackPanel>
         </Border>
 

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml
@@ -100,26 +100,13 @@
                 </StackPanel>
 
                 <!-- Scope-narrowing warning (only visible when filename/ResRef on AND scope narrowed) -->
-                <Border IsVisible="{Binding ShowScopeNarrowingWarning}"
-                        BorderBrush="{DynamicResource ThemeWarning}"
-                        BorderThickness="1" CornerRadius="4" Padding="8" Margin="0,4">
-                    <StackPanel Spacing="4">
-                        <TextBlock FontWeight="SemiBold" TextWrapping="Wrap"
-                                   Foreground="{DynamicResource ThemeWarning}">
-                            ⚠ Some file types are excluded from the rename.
-                        </TextBlock>
-                        <TextBlock TextWrapping="Wrap" FontSize="{DynamicResource FontSizeSmall}">
-                            References to renamed resources will only be updated in the file types you've checked.
-                            If references exist in unchecked types (e.g., a script in .nss, a creature in .git),
-                            they will be left untouched and may break.
-                        </TextBlock>
-                        <TextBlock TextWrapping="Wrap" FontSize="{DynamicResource FontSizeSmall}" FontStyle="Italic">
-                            Common reasons to narrow scope: splitting one NPC into two; renaming only a specific class of resource.
-                            Less obvious risks: collaborative inconsistency from multiple developers; .ncs and 2DA references are
-                            never scanned. Always run a test session of your module after a rename to verify nothing broke.
-                        </TextBlock>
-                    </StackPanel>
-                </Border>
+                <TextBlock IsVisible="{Binding ShowScopeNarrowingWarning}"
+                           Text="⚠ Unchecked file types are skipped — references there won't be renamed."
+                           TextWrapping="Wrap"
+                           FontSize="{DynamicResource FontSizeSmall}"
+                           Foreground="{DynamicResource ThemeWarning}"
+                           Margin="0,4,0,0"
+                           ToolTip.Tip="References in unchecked file types will not be updated and may break in-game. Compiled .ncs scripts and 2DA references are never scanned. See Marlinspike documentation for details."/>
             </StackPanel>
         </Border>
 
@@ -141,6 +128,7 @@
 
         <!-- Results Tree -->
         <TreeView x:Name="ResultsTree" Grid.Row="2" Margin="4"
+                  SelectionMode="Multiple"
                   DoubleTapped="OnResultDoubleTapped">
             <TreeView.Styles>
                 <Style Selector="TreeViewItem">

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml
@@ -120,7 +120,6 @@
 
         <!-- Results Tree -->
         <TreeView x:Name="ResultsTree" Grid.Row="2" Margin="4"
-                  SelectionMode="Multiple"
                   DoubleTapped="OnResultDoubleTapped">
             <TreeView.Styles>
                 <Style Selector="TreeViewItem">

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
@@ -316,8 +316,18 @@ public partial class MarlinspikePanel : UserControl
         if (selectedFilePaths.Count == 0)
         {
             if (_viewModel != null)
+            {
+                // Diagnostic: surface what the tree is reporting so we can debug
+                // selection-detection failures without a debugger.
+                var rawItem = ResultsTree.SelectedItem;
+                var rawType = rawItem?.GetType().Name ?? "null";
+                var dcType = (rawItem is Avalonia.Controls.TreeViewItem tvi
+                    ? tvi.DataContext?.GetType().Name
+                    : null) ?? "n/a";
                 _viewModel.StatusText =
-                    "Select a row first (click a file, match, or group), then click Replace Selected. Or use Replace All.";
+                    $"Select a row first (click a file, match, or group). " +
+                    $"[debug: SelectedItem={rawType}, DataContext={dcType}]";
+            }
             return;
         }
 

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
@@ -10,6 +10,7 @@ using Avalonia.Interactivity;
 using Radoub.Formats.Common;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Search;
+using Radoub.Formats.Search.Rename;
 using Radoub.Formats.Settings;
 using Radoub.UI.Services;
 using Radoub.UI.Services.Search;
@@ -304,17 +305,17 @@ public partial class MarlinspikePanel : UserControl
         }
     }
 
-    private void OnReplaceAllClick(object? sender, RoutedEventArgs e)
+    private async void OnReplaceAllClick(object? sender, RoutedEventArgs e)
     {
-        OpenReplacePreview(selectAll: true);
+        await OpenReplacePreviewAsync(selectAll: true);
     }
 
-    private void OnReplaceSelectedClick(object? sender, RoutedEventArgs e)
+    private async void OnReplaceSelectedClick(object? sender, RoutedEventArgs e)
     {
-        OpenReplacePreview(selectAll: true);
+        await OpenReplacePreviewAsync(selectAll: true);
     }
 
-    private void OpenReplacePreview(bool selectAll)
+    private async Task OpenReplacePreviewAsync(bool selectAll)
     {
         if (_viewModel == null || _parentWindow == null) return;
 
@@ -332,10 +333,139 @@ public partial class MarlinspikePanel : UserControl
             replaceText,
             allowResRefReplace: _viewModel.SearchFilenameResRef);
 
+        // Dispatch to ResRef rename orchestrator when filename matches present.
+        if (RenameDispatchHelpers.HasFilenameMatches(preview))
+        {
+            await DispatchResRefRenameAsync(preview);
+            return;
+        }
+
         var previewWindow = new ReplacePreviewWindow();
         previewWindow.Initialize(preview, _viewModel.SearchPattern, replaceText, _batchReplaceService);
         previewWindow.ReplacementComplete += OnReplacementComplete;
         previewWindow.Show(_parentWindow);
+    }
+
+    /// <summary>
+    /// Run the ResRef rename pipeline: build plans, populate references, surface
+    /// auto-suffix collision dialogs, and execute via ResRefRenameOrchestrator.
+    /// </summary>
+    private async Task DispatchResRefRenameAsync(BatchReplacePreview preview)
+    {
+        if (_viewModel == null || _parentWindow == null) return;
+
+        var moduleDir = ModulePath.GetWorkingDirectory(RadoubSettings.Instance.CurrentModulePath);
+        if (string.IsNullOrEmpty(moduleDir))
+        {
+            _viewModel.StatusText = "No module loaded — cannot rename.";
+            return;
+        }
+
+        var validator = new ResRefValidator();
+        var plans = RenameDispatchHelpers.BuildRenamePlansFromPreview(preview, moduleDir, validator);
+
+        if (plans.Count == 0)
+        {
+            _viewModel.StatusText = "Rename skipped — no valid filename targets (validator rejected all proposed names).";
+            return;
+        }
+
+        // Surface auto-suffix collision dialogs before proceeding.
+        // Each plan whose validation triggered an auto-suffix must be confirmed.
+        var confirmedPlans = new List<ResRefRenamePlan>();
+        foreach (var plan in plans)
+        {
+            if (!plan.Validation.AutoSuffixApplied)
+            {
+                confirmedPlans.Add(plan);
+                continue;
+            }
+
+            var originalProposed = ComputeOriginalProposedName(preview, plan);
+            var dialog = new AutoSuffixCollisionDialog(originalProposed, plan.NewName, plan.SourceFilePath);
+            await dialog.ShowDialog(_parentWindow);
+
+            switch (dialog.Result)
+            {
+                case AutoSuffixDialogResult.Continue:
+                    confirmedPlans.Add(plan);
+                    break;
+                case AutoSuffixDialogResult.PickAnother:
+                    _viewModel.StatusText = "Rename cancelled — adjust the replacement text and click Replace again to choose a different name.";
+                    return;
+                case AutoSuffixDialogResult.Cancel:
+                default:
+                    _viewModel.StatusText = "Rename cancelled.";
+                    return;
+            }
+        }
+
+        if (confirmedPlans.Count == 0)
+        {
+            _viewModel.StatusText = "Rename cancelled — no plans confirmed.";
+            return;
+        }
+
+        _viewModel.StatusText = "Scanning module for references...";
+
+        try
+        {
+            var criteria = _viewModel.BuildSearchCriteria();
+            await RenameDispatchHelpers.PopulateReferencesAsync(
+                confirmedPlans, moduleDir, _viewModel.IncludeNss, criteria);
+
+            var snapshotPaths = confirmedPlans
+                .SelectMany(p => p.References.Select(r => r.FilePath)
+                    .Concat(new[] { p.SourceFilePath }))
+                .Distinct(StringComparer.OrdinalIgnoreCase);
+            var snapshots = ResRefRenameOrchestrator.CaptureSnapshots(snapshotPaths);
+
+            var moduleName = !string.IsNullOrEmpty(RadoubSettings.Instance.CurrentModulePath)
+                ? Path.GetFileName(RadoubSettings.Instance.CurrentModulePath)
+                : "unknown";
+
+            var orchestrator = new ResRefRenameOrchestrator(new BackupService());
+            var result = await orchestrator.ExecuteAsync(confirmedPlans, moduleName, snapshots);
+
+            if (result.Success)
+            {
+                _viewModel.StatusText =
+                    $"Renamed {result.RenamedFiles} file{(result.RenamedFiles != 1 ? "s" : "")}, " +
+                    $"updated {result.ReferencesUpdated} reference{(result.ReferencesUpdated != 1 ? "s" : "")}. Backup created.";
+                _viewModel.ClearResults();
+                ResultsTree.ItemsSource = null;
+            }
+            else
+            {
+                var rollbackNote = result.RollbackAttempted
+                    ? (result.RollbackSucceeded ? " — rolled back" : " — ROLLBACK FAILED, see backup manifest")
+                    : string.Empty;
+                _viewModel.StatusText = $"Rename failed: {result.Error}{rollbackNote}";
+            }
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.ERROR, $"ResRef rename failed: {ex.Message}");
+            _viewModel.StatusText = $"Rename error: {ex.Message}";
+        }
+    }
+
+    /// <summary>
+    /// Recover the user's original proposed name (before validator auto-suffixing)
+    /// by re-running ApplyReplacement against the matching PendingChange. Used
+    /// to populate the auto-suffix collision dialog text.
+    /// </summary>
+    private static string ComputeOriginalProposedName(BatchReplacePreview preview, ResRefRenamePlan plan)
+    {
+        var change = preview.Changes.FirstOrDefault(c =>
+            string.Equals(c.FilePath, plan.SourceFilePath, StringComparison.OrdinalIgnoreCase) &&
+            c.Match.Field.GffPath == FilenameSearchProvider.FilenameField.GffPath);
+
+        if (change == null) return plan.NewName;
+
+        var oldName = Path.GetFileNameWithoutExtension(plan.SourceFilePath);
+        var raw = RenameDispatchHelpers.ApplyReplacement(oldName, change.Match, change.ReplacementText);
+        return raw.ToLowerInvariant();
     }
 
     private void OnReplacementComplete(object? sender, BatchReplaceResult result)

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
@@ -317,7 +317,7 @@ public partial class MarlinspikePanel : UserControl
         {
             if (_viewModel != null)
                 _viewModel.StatusText =
-                    "Select rows first (click a row, or Ctrl+click for multiple), then click Replace Selected. Or use Replace All.";
+                    "Select a row first (click a file, match, or group), then click Replace Selected. Or use Replace All.";
             return;
         }
 
@@ -325,41 +325,35 @@ public partial class MarlinspikePanel : UserControl
     }
 
     /// <summary>
-    /// Walk the tree's selection and collect the underlying file paths.
-    /// Selecting a file row pulls that file; selecting a match row pulls its parent file;
-    /// selecting a group row pulls every file in the group.
-    /// Handles both single (SelectedItem) and multi (SelectedItems) selection.
+    /// Get file paths for the user's tree selection. Tree is single-select for
+    /// reliability — Avalonia's multi-select on TreeView had inconsistent behavior
+    /// with bound items, so we fall back to single-select. Multi-select can be
+    /// added later via a separate selection model if needed.
+    ///
+    /// Selecting a file row → that file.
+    /// Selecting a match row → its parent file.
+    /// Selecting a group row → every file in the group.
     /// </summary>
     private HashSet<string> GetSelectedFilePaths()
     {
         var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        // Combine plural and singular: Avalonia populates SelectedItem for the
-        // anchor; SelectedItems is the full multi-select set. Either may be the
-        // VM directly or a TreeViewItem wrapper depending on item-container
-        // lookup state — extract VMs via the DataContext if needed.
-        var collected = new List<object?>();
-        if (ResultsTree.SelectedItems != null)
-            collected.AddRange(ResultsTree.SelectedItems.Cast<object?>());
-        if (ResultsTree.SelectedItem != null && !collected.Contains(ResultsTree.SelectedItem))
-            collected.Add(ResultsTree.SelectedItem);
+        // SelectedItem may be the VM directly or wrapped in a TreeViewItem container.
+        var raw = ResultsTree.SelectedItem;
+        var vm = raw is Avalonia.Controls.TreeViewItem tvi ? tvi.DataContext : raw;
 
-        foreach (var raw in collected)
+        switch (vm)
         {
-            var vm = raw is Avalonia.Controls.TreeViewItem tvi ? tvi.DataContext : raw;
-            switch (vm)
-            {
-                case FileResultViewModel file:
-                    paths.Add(file.FilePath);
-                    break;
-                case MatchViewModel match:
-                    paths.Add(match.FilePath);
-                    break;
-                case FileTypeGroupViewModel group:
-                    foreach (var f in group.Files)
-                        paths.Add(f.FilePath);
-                    break;
-            }
+            case FileResultViewModel file:
+                paths.Add(file.FilePath);
+                break;
+            case MatchViewModel match:
+                paths.Add(match.FilePath);
+                break;
+            case FileTypeGroupViewModel group:
+                foreach (var f in group.Files)
+                    paths.Add(f.FilePath);
+                break;
         }
         return paths;
     }

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
@@ -327,7 +327,10 @@ public partial class MarlinspikePanel : UserControl
         if (filesWithMatches.Count == 0) return;
 
         var replaceText = _viewModel.ReplaceText;
-        var preview = _batchReplaceService!.PreviewReplace(filesWithMatches, replaceText);
+        var preview = _batchReplaceService!.PreviewReplace(
+            filesWithMatches,
+            replaceText,
+            allowResRefReplace: _viewModel.SearchFilenameResRef);
 
         var previewWindow = new ReplacePreviewWindow();
         previewWindow.Initialize(preview, _viewModel.SearchPattern, replaceText, _batchReplaceService);

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
@@ -325,18 +325,29 @@ public partial class MarlinspikePanel : UserControl
     }
 
     /// <summary>
-    /// Walk ResultsTree.SelectedItems and collect the underlying file paths.
+    /// Walk the tree's selection and collect the underlying file paths.
     /// Selecting a file row pulls that file; selecting a match row pulls its parent file;
     /// selecting a group row pulls every file in the group.
+    /// Handles both single (SelectedItem) and multi (SelectedItems) selection.
     /// </summary>
     private HashSet<string> GetSelectedFilePaths()
     {
         var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        if (ResultsTree.SelectedItems == null) return paths;
 
-        foreach (var item in ResultsTree.SelectedItems)
+        // Combine plural and singular: Avalonia populates SelectedItem for the
+        // anchor; SelectedItems is the full multi-select set. Either may be the
+        // VM directly or a TreeViewItem wrapper depending on item-container
+        // lookup state — extract VMs via the DataContext if needed.
+        var collected = new List<object?>();
+        if (ResultsTree.SelectedItems != null)
+            collected.AddRange(ResultsTree.SelectedItems.Cast<object?>());
+        if (ResultsTree.SelectedItem != null && !collected.Contains(ResultsTree.SelectedItem))
+            collected.Add(ResultsTree.SelectedItem);
+
+        foreach (var raw in collected)
         {
-            switch (item)
+            var vm = raw is Avalonia.Controls.TreeViewItem tvi ? tvi.DataContext : raw;
+            switch (vm)
             {
                 case FileResultViewModel file:
                     paths.Add(file.FilePath);
@@ -378,9 +389,11 @@ public partial class MarlinspikePanel : UserControl
             allowResRefReplace: _viewModel.SearchFilenameResRef);
 
         // Dispatch to ResRef rename orchestrator when filename matches present.
+        // Pass the user's selection set down so reference updates are surgical —
+        // only files the user explicitly selected get their references rewritten.
         if (RenameDispatchHelpers.HasFilenameMatches(preview))
         {
-            await DispatchResRefRenameAsync(preview);
+            await DispatchResRefRenameAsync(preview, selectionFilter);
             return;
         }
 
@@ -393,8 +406,14 @@ public partial class MarlinspikePanel : UserControl
     /// <summary>
     /// Run the ResRef rename pipeline: build plans, populate references, surface
     /// auto-suffix collision dialogs, and execute via ResRefRenameOrchestrator.
+    ///
+    /// <paramref name="selectionFilter"/>, when non-null, restricts the reference
+    /// scan to only those file paths — the "surgical rename" mode (Path 1 per
+    /// design discussion). When null, references are populated module-wide.
     /// </summary>
-    private async Task DispatchResRefRenameAsync(BatchReplacePreview preview)
+    private async Task DispatchResRefRenameAsync(
+        BatchReplacePreview preview,
+        IReadOnlySet<string>? selectionFilter)
     {
         if (_viewModel == null || _parentWindow == null) return;
 
@@ -450,13 +469,15 @@ public partial class MarlinspikePanel : UserControl
             return;
         }
 
-        _viewModel.StatusText = "Scanning module for references...";
+        _viewModel.StatusText = selectionFilter != null
+            ? $"Scanning {selectionFilter.Count} selected file(s) for references..."
+            : "Scanning module for references...";
 
         try
         {
             var criteria = _viewModel.BuildSearchCriteria();
             await RenameDispatchHelpers.PopulateReferencesAsync(
-                confirmedPlans, moduleDir, _viewModel.IncludeNss, criteria);
+                confirmedPlans, moduleDir, _viewModel.IncludeNss, criteria, selectionFilter);
 
             var snapshotPaths = confirmedPlans
                 .SelectMany(p => p.References.Select(r => r.FilePath)

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
@@ -307,15 +307,53 @@ public partial class MarlinspikePanel : UserControl
 
     private async void OnReplaceAllClick(object? sender, RoutedEventArgs e)
     {
-        await OpenReplacePreviewAsync(selectAll: true);
+        await OpenReplacePreviewAsync(selectionFilter: null);
     }
 
     private async void OnReplaceSelectedClick(object? sender, RoutedEventArgs e)
     {
-        await OpenReplacePreviewAsync(selectAll: true);
+        var selectedFilePaths = GetSelectedFilePaths();
+        if (selectedFilePaths.Count == 0)
+        {
+            if (_viewModel != null)
+                _viewModel.StatusText =
+                    "Select rows first (click a row, or Ctrl+click for multiple), then click Replace Selected. Or use Replace All.";
+            return;
+        }
+
+        await OpenReplacePreviewAsync(selectionFilter: selectedFilePaths);
     }
 
-    private async Task OpenReplacePreviewAsync(bool selectAll)
+    /// <summary>
+    /// Walk ResultsTree.SelectedItems and collect the underlying file paths.
+    /// Selecting a file row pulls that file; selecting a match row pulls its parent file;
+    /// selecting a group row pulls every file in the group.
+    /// </summary>
+    private HashSet<string> GetSelectedFilePaths()
+    {
+        var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (ResultsTree.SelectedItems == null) return paths;
+
+        foreach (var item in ResultsTree.SelectedItems)
+        {
+            switch (item)
+            {
+                case FileResultViewModel file:
+                    paths.Add(file.FilePath);
+                    break;
+                case MatchViewModel match:
+                    paths.Add(match.FilePath);
+                    break;
+                case FileTypeGroupViewModel group:
+                    foreach (var f in group.Files)
+                        paths.Add(f.FilePath);
+                    break;
+            }
+        }
+        return paths;
+    }
+
+    private async Task OpenReplacePreviewAsync(IReadOnlySet<string>? selectionFilter)
     {
         if (_viewModel == null || _parentWindow == null) return;
 
@@ -325,6 +363,12 @@ public partial class MarlinspikePanel : UserControl
         EnsureServices();
 
         var filesWithMatches = lastResults.Files.Where(f => f.MatchCount > 0).ToList();
+        if (selectionFilter != null)
+        {
+            filesWithMatches = filesWithMatches
+                .Where(f => selectionFilter.Contains(f.FilePath))
+                .ToList();
+        }
         if (filesWithMatches.Count == 0) return;
 
         var replaceText = _viewModel.ReplaceText;
@@ -431,9 +475,11 @@ public partial class MarlinspikePanel : UserControl
             {
                 _viewModel.StatusText =
                     $"Renamed {result.RenamedFiles} file{(result.RenamedFiles != 1 ? "s" : "")}, " +
-                    $"updated {result.ReferencesUpdated} reference{(result.ReferencesUpdated != 1 ? "s" : "")}. Backup created.";
-                _viewModel.ClearResults();
-                ResultsTree.ItemsSource = null;
+                    $"updated {result.ReferencesUpdated} reference{(result.ReferencesUpdated != 1 ? "s" : "")}. " +
+                    "Backup created. Re-run search to refresh results.";
+                // Don't clear results tree — leaves the user wondering whether everything
+                // got renamed. Stale entries (renamed files at the old name) will simply
+                // not be found on the next search.
             }
             else
             {

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
@@ -316,18 +316,8 @@ public partial class MarlinspikePanel : UserControl
         if (selectedFilePaths.Count == 0)
         {
             if (_viewModel != null)
-            {
-                // Diagnostic: surface what the tree is reporting so we can debug
-                // selection-detection failures without a debugger.
-                var rawItem = ResultsTree.SelectedItem;
-                var rawType = rawItem?.GetType().Name ?? "null";
-                var dcType = (rawItem is Avalonia.Controls.TreeViewItem tvi
-                    ? tvi.DataContext?.GetType().Name
-                    : null) ?? "n/a";
                 _viewModel.StatusText =
-                    $"Select a row first (click a file, match, or group). " +
-                    $"[debug: SelectedItem={rawType}, DataContext={dcType}]";
-            }
+                    "Select a row first (click a file, match, or group), then click Replace Selected. Or use Replace All.";
             return;
         }
 
@@ -335,34 +325,41 @@ public partial class MarlinspikePanel : UserControl
     }
 
     /// <summary>
-    /// Get file paths for the user's tree selection. Tree is single-select for
-    /// reliability — Avalonia's multi-select on TreeView had inconsistent behavior
-    /// with bound items, so we fall back to single-select. Multi-select can be
-    /// added later via a separate selection model if needed.
+    /// Get file paths for the user's tree selection. The tree is populated
+    /// programmatically with raw TreeViewItem instances that carry their row
+    /// data in the .Tag property (FileSearchResult, MatchInfo, or null for
+    /// group nodes). Inherited DataContext is the panel VM, so we read .Tag
+    /// directly — same pattern OnResultDoubleTapped uses.
     ///
     /// Selecting a file row → that file.
     /// Selecting a match row → its parent file.
-    /// Selecting a group row → every file in the group.
+    /// Selecting a group row → every file under that group.
     /// </summary>
     private HashSet<string> GetSelectedFilePaths()
     {
         var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        // SelectedItem may be the VM directly or wrapped in a TreeViewItem container.
-        var raw = ResultsTree.SelectedItem;
-        var vm = raw is Avalonia.Controls.TreeViewItem tvi ? tvi.DataContext : raw;
+        if (ResultsTree.SelectedItem is not Avalonia.Controls.TreeViewItem item)
+            return paths;
 
-        switch (vm)
+        switch (item.Tag)
         {
-            case FileResultViewModel file:
-                paths.Add(file.FilePath);
+            case MatchInfo matchInfo:
+                paths.Add(matchInfo.FilePath);
                 break;
-            case MatchViewModel match:
-                paths.Add(match.FilePath);
+            case FileSearchResult fileResult:
+                paths.Add(fileResult.FilePath);
                 break;
-            case FileTypeGroupViewModel group:
-                foreach (var f in group.Files)
-                    paths.Add(f.FilePath);
+            default:
+                // Group node (no Tag) — walk its child file-result items.
+                foreach (var child in item.Items)
+                {
+                    if (child is Avalonia.Controls.TreeViewItem childItem
+                        && childItem.Tag is FileSearchResult childFile)
+                    {
+                        paths.Add(childFile.FilePath);
+                    }
+                }
                 break;
         }
         return paths;

--- a/Trebuchet/Trebuchet/Services/RenameDispatchHelpers.cs
+++ b/Trebuchet/Trebuchet/Services/RenameDispatchHelpers.cs
@@ -134,15 +134,22 @@ public static class RenameDispatchHelpers
     }
 
     /// <summary>
-    /// Walk every file in the module directory, parse each one, and append matching
-    /// references to each plan's References list. Honors the user's file-type filter
-    /// (unchecked types are skipped).
+    /// Walk files in the module directory, parse each one, and append matching
+    /// references to each plan's References list.
+    ///
+    /// Honors the user's file-type filter (unchecked types are skipped) AND, when
+    /// <paramref name="allowedFilePaths"/> is non-null, restricts the scan to ONLY
+    /// those paths. This is the "surgical rename" path — reference updates are
+    /// confined to files the user explicitly selected, leaving everything else
+    /// untouched. When <paramref name="allowedFilePaths"/> is null, the scan
+    /// covers every file in <paramref name="moduleDir"/> (legacy module-wide mode).
     /// </summary>
     public static async Task PopulateReferencesAsync(
         IReadOnlyList<ResRefRenamePlan> plans,
         string moduleDir,
         bool includeNss,
-        SearchCriteria criteria)
+        SearchCriteria criteria,
+        IReadOnlySet<string>? allowedFilePaths = null)
     {
         if (plans == null || plans.Count == 0) return;
         if (string.IsNullOrEmpty(moduleDir) || !Directory.Exists(moduleDir)) return;
@@ -154,6 +161,12 @@ public static class RenameDispatchHelpers
 
         foreach (var path in Directory.EnumerateFiles(moduleDir))
         {
+            // Surgical mode: skip any file outside the user's selection set.
+            // The file being renamed itself doesn't carry a self-reference, so
+            // excluding it from the scan is harmless when it's not in the set.
+            if (allowedFilePaths != null && !allowedFilePaths.Contains(path))
+                continue;
+
             var ext = Path.GetExtension(path);
             if (string.IsNullOrEmpty(ext)) continue;
 

--- a/Trebuchet/Trebuchet/Services/RenameDispatchHelpers.cs
+++ b/Trebuchet/Trebuchet/Services/RenameDispatchHelpers.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Radoub.Formats.Common;
+using Radoub.Formats.Gff;
+using Radoub.Formats.Search;
+using Radoub.Formats.Search.Rename;
+using Radoub.UI.Services.Search;
+
+namespace RadoubLauncher.Services;
+
+/// <summary>
+/// Helpers used by MarlinspikePanel to convert a BatchReplacePreview that contains
+/// filename-row matches into a set of ResRefRenamePlan instances ready for
+/// ResRefRenameOrchestrator. Pure logic — extracted from the codebehind so it
+/// can be unit tested. Per spec Section 5 (rename dispatch path).
+/// </summary>
+public static class RenameDispatchHelpers
+{
+    /// <summary>
+    /// True when the preview contains at least one match against the virtual
+    /// filename field (FilenameSearchProvider.FilenameField). Indicates the Replace
+    /// flow must dispatch to ResRefRenameOrchestrator instead of the standard
+    /// BatchReplaceService.ExecuteReplaceAsync path.
+    /// </summary>
+    public static bool HasFilenameMatches(BatchReplacePreview preview)
+    {
+        if (preview == null) return false;
+        return preview.Changes.Any(c => c.Match.Field.GffPath == FilenameSearchProvider.FilenameField.GffPath);
+    }
+
+    /// <summary>
+    /// Build ResRefRenamePlans from filename-row PendingChanges in a preview.
+    /// Skips entries whose validator result is invalid. Caller is responsible
+    /// for surfacing skipped entries to the user (e.g., via status bar).
+    /// </summary>
+    public static IReadOnlyList<ResRefRenamePlan> BuildRenamePlansFromPreview(
+        BatchReplacePreview preview, string moduleDir, ResRefValidator validator)
+    {
+        if (preview == null) return Array.Empty<ResRefRenamePlan>();
+        if (string.IsNullOrEmpty(moduleDir)) return Array.Empty<ResRefRenamePlan>();
+        if (validator == null) throw new ArgumentNullException(nameof(validator));
+
+        var plans = new List<ResRefRenamePlan>();
+        var filenameChanges = preview.Changes
+            .Where(c => c.Match.Field.GffPath == FilenameSearchProvider.FilenameField.GffPath)
+            .ToList();
+
+        if (filenameChanges.Count == 0) return plans;
+
+        var existingResRefsByExt = BuildExistingResRefIndex(moduleDir);
+
+        foreach (var change in filenameChanges)
+        {
+            var oldFilePath = change.FilePath;
+            var oldName = Path.GetFileNameWithoutExtension(oldFilePath);
+            var ext = Path.GetExtension(oldFilePath);
+            if (string.IsNullOrEmpty(ext)) continue;
+
+            var proposedNewName = ApplyReplacement(oldName, change.Match, change.ReplacementText);
+
+            // Existing names in the target extension scope, MINUS the file being renamed
+            // (validator must not flag a no-op rename as a collision).
+            var existingMinusSelf = existingResRefsByExt.TryGetValue(ext, out var set)
+                ? new HashSet<string>(set, StringComparer.OrdinalIgnoreCase)
+                : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            existingMinusSelf.Remove(oldName);
+
+            var validation = validator.Validate(proposedNewName, existingMinusSelf, ext);
+
+            if (!validation.IsValid)
+            {
+                // Skip invalid entries — caller may inspect plans count vs preview filename count
+                // to surface a status message.
+                continue;
+            }
+
+            plans.Add(new ResRefRenamePlan
+            {
+                OldName = oldName,
+                NewName = validation.NormalizedName,
+                ResourceType = ResourceTypes.FromExtension(ext),
+                Validation = validation,
+                SourceFilePath = oldFilePath,
+                TargetFilePath = Path.Combine(
+                    Path.GetDirectoryName(oldFilePath)!,
+                    $"{validation.NormalizedName}{ext}")
+            });
+        }
+
+        return plans;
+    }
+
+    /// <summary>
+    /// Index every file in the module directory by extension. Used as the existing-name
+    /// set for collision detection during validation.
+    /// </summary>
+    public static Dictionary<string, HashSet<string>> BuildExistingResRefIndex(string moduleDir)
+    {
+        var byExt = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrEmpty(moduleDir) || !Directory.Exists(moduleDir))
+            return byExt;
+
+        foreach (var path in Directory.EnumerateFiles(moduleDir))
+        {
+            var ext = Path.GetExtension(path);
+            if (string.IsNullOrEmpty(ext)) continue;
+            var name = Path.GetFileNameWithoutExtension(path);
+            if (!byExt.TryGetValue(ext, out var set))
+                byExt[ext] = set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            set.Add(name);
+        }
+        return byExt;
+    }
+
+    /// <summary>
+    /// Apply a SearchMatch's offset/length-based replacement to a string.
+    /// Used to compute proposed new ResRef names from filename matches.
+    /// </summary>
+    public static string ApplyReplacement(string oldName, SearchMatch match, string replacementText)
+    {
+        if (oldName == null) return string.Empty;
+        if (match == null) return oldName;
+
+        var offset = Math.Clamp(match.MatchOffset, 0, oldName.Length);
+        var length = Math.Clamp(match.MatchLength, 0, oldName.Length - offset);
+
+        return string.Concat(
+            oldName.AsSpan(0, offset),
+            replacementText ?? string.Empty,
+            oldName.AsSpan(offset + length));
+    }
+
+    /// <summary>
+    /// Walk every file in the module directory, parse each one, and append matching
+    /// references to each plan's References list. Honors the user's file-type filter
+    /// (unchecked types are skipped).
+    /// </summary>
+    public static async Task PopulateReferencesAsync(
+        IReadOnlyList<ResRefRenamePlan> plans,
+        string moduleDir,
+        bool includeNss,
+        SearchCriteria criteria)
+    {
+        if (plans == null || plans.Count == 0) return;
+        if (string.IsNullOrEmpty(moduleDir) || !Directory.Exists(moduleDir)) return;
+
+        var refScanner = new ResRefReferenceScanner();
+        var nssScanner = includeNss ? new NssReferenceScanner() : null;
+
+        var fileTypeFilter = criteria?.FileTypeFilter;
+
+        foreach (var path in Directory.EnumerateFiles(moduleDir))
+        {
+            var ext = Path.GetExtension(path);
+            if (string.IsNullOrEmpty(ext)) continue;
+
+            var resourceType = ResourceTypes.FromExtension(ext);
+            if (resourceType == 0) continue;
+
+            // Honor file-type filter — unchecked types skipped (scope-respecting per spec)
+            if (fileTypeFilter != null && fileTypeFilter.Count > 0
+                && !fileTypeFilter.Contains(resourceType))
+                continue;
+
+            if (string.Equals(ext, ".nss", StringComparison.OrdinalIgnoreCase))
+            {
+                if (nssScanner == null) continue;
+                foreach (var plan in plans)
+                {
+                    var refs = nssScanner.Scan(path, plan.OldName);
+                    foreach (var r in refs)
+                        plan.References.Add(CloneReferenceWithNewValue(r, plan.NewName));
+                }
+                // also process plans synchronously; nothing async per file beyond this
+                continue;
+            }
+
+            // GFF-style file: read once, then scan against every plan
+            byte[] bytes;
+            try
+            {
+                bytes = await File.ReadAllBytesAsync(path);
+            }
+            catch
+            {
+                continue;
+            }
+
+            GffFile gff;
+            try
+            {
+                gff = GffReader.Read(bytes);
+            }
+            catch
+            {
+                continue;  // not a parseable GFF; skip
+            }
+
+            foreach (var plan in plans)
+            {
+                var refs = refScanner.Scan(gff, resourceType, plan.OldName, path);
+                foreach (var r in refs)
+                    plan.References.Add(CloneReferenceWithNewValue(r, plan.NewName));
+            }
+        }
+    }
+
+    /// <summary>
+    /// ResRefReference is a class (not record) — duplicate explicit copy so we
+    /// can attach the per-plan NewValue without mutating the scanner's outputs
+    /// across multiple plans. See Chunk 1a Task 1a.16 for the design rationale.
+    /// </summary>
+    private static ResRefReference CloneReferenceWithNewValue(ResRefReference source, string newValue)
+    {
+        return new ResRefReference
+        {
+            FilePath = source.FilePath,
+            ResourceType = source.ResourceType,
+            Field = source.Field,
+            Location = source.Location,
+            OldValue = source.OldValue,
+            NewValue = newValue,
+            ScopeTier = source.ScopeTier,
+            MatchOffset = source.MatchOffset,
+            MatchLength = source.MatchLength,
+            IsSelected = source.IsSelected
+        };
+    }
+}

--- a/Trebuchet/Trebuchet/ViewModels/MarlinspikePanelViewModel.cs
+++ b/Trebuchet/Trebuchet/ViewModels/MarlinspikePanelViewModel.cs
@@ -40,7 +40,7 @@ public partial class MarlinspikePanelViewModel : ObservableObject
     private bool _searchStrRefs;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(ShowScopeNarrowingWarning))]
+    [NotifyPropertyChangedFor(nameof(ShowScopeNarrowingWarning), nameof(CanSearch))]
     private bool _searchFilenameResRef;
 
     [ObservableProperty]
@@ -111,7 +111,10 @@ public partial class MarlinspikePanelViewModel : ObservableObject
         IncludeUtw || IncludeUts || IncludeGit || IncludeAre || IncludeIfo ||
         IncludeFac || IncludeItp || IncludeNss;
 
-    public bool CanSearch => !string.IsNullOrEmpty(SearchPattern) && !IsSearching && HasAnyFileTypeSelected;
+    // Filename/ResRef mode can search filenames even with no GFF file-types selected;
+    // otherwise the user must have at least one file type checked.
+    public bool CanSearch => !string.IsNullOrEmpty(SearchPattern) && !IsSearching
+        && (HasAnyFileTypeSelected || SearchFilenameResRef);
 
     public bool CanReplace => HasResults && !string.IsNullOrEmpty(ReplaceText) && !IsSearching;
 

--- a/Trebuchet/Trebuchet/ViewModels/MarlinspikePanelViewModel.cs
+++ b/Trebuchet/Trebuchet/ViewModels/MarlinspikePanelViewModel.cs
@@ -40,7 +40,7 @@ public partial class MarlinspikePanelViewModel : ObservableObject
     private bool _searchStrRefs;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(ShowScopeNarrowingWarning), nameof(CanSearch))]
+    [NotifyPropertyChangedFor(nameof(CanSearch))]
     private bool _searchFilenameResRef;
 
     [ObservableProperty]
@@ -72,24 +72,24 @@ public partial class MarlinspikePanelViewModel : ObservableObject
 
     // --- File type checkboxes ---
 
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeDlg = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeUtc = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeBic = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeUti = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeUtm = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeJrl = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeUtp = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeUtd = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeUte = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeUtt = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeUtw = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeUts = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeGit = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeAre = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeIfo = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeFac = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeItp = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeNss = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeDlg = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeUtc = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeBic = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeUti = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeUtm = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeJrl = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeUtp = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeUtd = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeUte = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeUtt = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeUtw = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeUts = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeGit = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeAre = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeIfo = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeFac = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeItp = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeNss = true;
 
     // --- Category list ---
 
@@ -118,35 +118,7 @@ public partial class MarlinspikePanelViewModel : ObservableObject
 
     public bool CanReplace => HasResults && !string.IsNullOrEmpty(ReplaceText) && !IsSearching;
 
-    /// <summary>
-    /// Visible only when SearchFilenameResRef is ON and at least one file-type
-    /// checkbox is unchecked — warns the user that references in unchecked file
-    /// types will not be updated. See spec Section 8.
-    /// </summary>
-    public bool ShowScopeNarrowingWarning
-    {
-        get
-        {
-            if (!SearchFilenameResRef) return false;
-            return !(IncludeDlg && IncludeUtc && IncludeBic && IncludeUti && IncludeUtm &&
-                     IncludeJrl && IncludeUtp && IncludeUtd && IncludeUte && IncludeUtt &&
-                     IncludeUtw && IncludeUts && IncludeGit && IncludeAre && IncludeIfo &&
-                     IncludeFac && IncludeItp && IncludeNss);
-        }
-    }
 
-    /// <summary>
-    /// CommunityToolkit.MVVM source-generator partial method: when SearchFilenameResRef
-    /// flips ON, auto-select all file types and reset the category filter. Turning OFF
-    /// preserves whatever the user last set. Per spec Section 8.
-    /// </summary>
-    partial void OnSearchFilenameResRefChanged(bool value)
-    {
-        if (!value) return;
-
-        SelectAllFileTypes();
-        SelectedCategory = "All Fields";
-    }
 
     // --- Methods ---
 

--- a/Trebuchet/Trebuchet/ViewModels/MarlinspikePanelViewModel.cs
+++ b/Trebuchet/Trebuchet/ViewModels/MarlinspikePanelViewModel.cs
@@ -40,6 +40,10 @@ public partial class MarlinspikePanelViewModel : ObservableObject
     private bool _searchStrRefs;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowScopeNarrowingWarning))]
+    private bool _searchFilenameResRef;
+
+    [ObservableProperty]
     private string _selectedCategory = "All Fields";
 
     // --- Search state ---
@@ -68,23 +72,24 @@ public partial class MarlinspikePanelViewModel : ObservableObject
 
     // --- File type checkboxes ---
 
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeDlg = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeUtc = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeBic = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeUti = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeUtm = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeJrl = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeUtp = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeUtd = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeUte = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeUtt = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeUtw = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeUts = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeGit = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeAre = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeIfo = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeFac = true;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected))] private bool _includeItp = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeDlg = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeUtc = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeBic = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeUti = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeUtm = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeJrl = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeUtp = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeUtd = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeUte = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeUtt = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeUtw = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeUts = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeGit = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeAre = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeIfo = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeFac = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeItp = true;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(CanSearch), nameof(HasAnyFileTypeSelected), nameof(ShowScopeNarrowingWarning))] private bool _includeNss = true;
 
     // --- Category list ---
 
@@ -104,11 +109,41 @@ public partial class MarlinspikePanelViewModel : ObservableObject
         IncludeDlg || IncludeUtc || IncludeBic || IncludeUti || IncludeUtm ||
         IncludeJrl || IncludeUtp || IncludeUtd || IncludeUte || IncludeUtt ||
         IncludeUtw || IncludeUts || IncludeGit || IncludeAre || IncludeIfo ||
-        IncludeFac || IncludeItp;
+        IncludeFac || IncludeItp || IncludeNss;
 
     public bool CanSearch => !string.IsNullOrEmpty(SearchPattern) && !IsSearching && HasAnyFileTypeSelected;
 
     public bool CanReplace => HasResults && !string.IsNullOrEmpty(ReplaceText) && !IsSearching;
+
+    /// <summary>
+    /// Visible only when SearchFilenameResRef is ON and at least one file-type
+    /// checkbox is unchecked — warns the user that references in unchecked file
+    /// types will not be updated. See spec Section 8.
+    /// </summary>
+    public bool ShowScopeNarrowingWarning
+    {
+        get
+        {
+            if (!SearchFilenameResRef) return false;
+            return !(IncludeDlg && IncludeUtc && IncludeBic && IncludeUti && IncludeUtm &&
+                     IncludeJrl && IncludeUtp && IncludeUtd && IncludeUte && IncludeUtt &&
+                     IncludeUtw && IncludeUts && IncludeGit && IncludeAre && IncludeIfo &&
+                     IncludeFac && IncludeItp && IncludeNss);
+        }
+    }
+
+    /// <summary>
+    /// CommunityToolkit.MVVM source-generator partial method: when SearchFilenameResRef
+    /// flips ON, auto-select all file types and reset the category filter. Turning OFF
+    /// preserves whatever the user last set. Per spec Section 8.
+    /// </summary>
+    partial void OnSearchFilenameResRefChanged(bool value)
+    {
+        if (!value) return;
+
+        SelectAllFileTypes();
+        SelectedCategory = "All Fields";
+    }
 
     // --- Methods ---
 
@@ -141,7 +176,8 @@ public partial class MarlinspikePanelViewModel : ObservableObject
             SearchStrRefs = SearchStrRefs,
             TlkResolver = TlkResolver,
             CategoryFilter = BuildCategoryFilter(),
-            FileTypeFilter = BuildFileTypeFilter()
+            FileTypeFilter = BuildFileTypeFilter(),
+            IncludeFilenameResRef = SearchFilenameResRef
         };
     }
 
@@ -235,6 +271,7 @@ public partial class MarlinspikePanelViewModel : ObservableObject
         IncludeIfo = true;
         IncludeFac = true;
         IncludeItp = true;
+        IncludeNss = true;
     }
 
     /// <summary>
@@ -259,6 +296,7 @@ public partial class MarlinspikePanelViewModel : ObservableObject
         IncludeIfo = false;
         IncludeFac = false;
         IncludeItp = false;
+        IncludeNss = false;
     }
 
     // --- Private helpers ---
@@ -280,7 +318,7 @@ public partial class MarlinspikePanelViewModel : ObservableObject
         if (IncludeDlg && IncludeUtc && IncludeBic && IncludeUti && IncludeUtm &&
             IncludeJrl && IncludeUtp && IncludeUtd && IncludeUte && IncludeUtt &&
             IncludeUtw && IncludeUts && IncludeGit && IncludeAre && IncludeIfo &&
-            IncludeFac && IncludeItp)
+            IncludeFac && IncludeItp && IncludeNss)
             return null;
 
         var types = new List<ushort>();
@@ -301,6 +339,7 @@ public partial class MarlinspikePanelViewModel : ObservableObject
         if (IncludeIfo) types.Add(ResourceTypes.Ifo);
         if (IncludeFac) types.Add(ResourceTypes.Fac);
         if (IncludeItp) types.Add(ResourceTypes.Itp);
+        if (IncludeNss) types.Add(ResourceTypes.Nss);
         return types;
     }
 

--- a/Trebuchet/Trebuchet/Views/AutoSuffixCollisionDialog.axaml
+++ b/Trebuchet/Trebuchet/Views/AutoSuffixCollisionDialog.axaml
@@ -1,0 +1,46 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="RadoubLauncher.Views.AutoSuffixCollisionDialog"
+        Title="Filename Already Exists"
+        Width="480" Height="220"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        ShowInTaskbar="False">
+
+    <Border Padding="16">
+        <DockPanel>
+            <!-- Buttons -->
+            <StackPanel DockPanel.Dock="Bottom"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        Spacing="8"
+                        Margin="0,12,0,0">
+                <Button Content="Continue"
+                        Click="OnContinueClick"
+                        IsDefault="True"
+                        Padding="20,6"
+                        ToolTip.Tip="Use the auto-suffixed name and proceed with the rename."/>
+                <Button Content="Pick a different name"
+                        Click="OnPickAnotherClick"
+                        Padding="20,6"
+                        ToolTip.Tip="Cancel this rename so you can edit the replacement text and try again."/>
+                <Button Content="Cancel"
+                        Click="OnCancelClick"
+                        IsCancel="True"
+                        Padding="20,6"
+                        ToolTip.Tip="Cancel the entire rename operation."/>
+            </StackPanel>
+
+            <!-- Message -->
+            <StackPanel Spacing="8" VerticalAlignment="Center">
+                <TextBlock x:Name="HeaderText"
+                           FontSize="{DynamicResource FontSizeMedium}"
+                           FontWeight="SemiBold"
+                           TextWrapping="Wrap"/>
+                <TextBlock x:Name="DetailText"
+                           TextWrapping="Wrap"
+                           Opacity="0.85"/>
+            </StackPanel>
+        </DockPanel>
+    </Border>
+</Window>

--- a/Trebuchet/Trebuchet/Views/AutoSuffixCollisionDialog.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/AutoSuffixCollisionDialog.axaml.cs
@@ -1,0 +1,64 @@
+using System.IO;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace RadoubLauncher.Views;
+
+/// <summary>
+/// Result returned by the auto-suffix collision confirmation dialog.
+/// See spec Section 6 (validator returns AutoSuffixApplied=true).
+/// </summary>
+public enum AutoSuffixDialogResult
+{
+    /// <summary>User accepted the auto-suffixed name; proceed with rename.</summary>
+    Continue,
+
+    /// <summary>User wants to pick a different name; abort and ask them to retry.</summary>
+    PickAnother,
+
+    /// <summary>User cancelled the entire rename operation.</summary>
+    Cancel
+}
+
+/// <summary>
+/// Confirmation dialog shown when ResRefValidator auto-suffixes a colliding ResRef
+/// (e.g., "louis" already exists, validator returns "louis_2"). User picks among:
+/// Continue (use suffixed name), Pick a different name (retry), Cancel (abort).
+/// </summary>
+public partial class AutoSuffixCollisionDialog : Window
+{
+    public AutoSuffixDialogResult Result { get; private set; } = AutoSuffixDialogResult.Cancel;
+
+    public AutoSuffixCollisionDialog()
+    {
+        InitializeComponent();
+    }
+
+    public AutoSuffixCollisionDialog(string originalProposedName, string actualName, string sourceFilePath)
+        : this()
+    {
+        var ext = Path.GetExtension(sourceFilePath);
+        HeaderText.Text = $"\"{originalProposedName}{ext}\" already exists.";
+        DetailText.Text =
+            $"To avoid a collision, the file would be renamed to \"{actualName}{ext}\" instead.\n\n" +
+            "Continue with the auto-suffixed name, pick a different name, or cancel?";
+    }
+
+    private void OnContinueClick(object? sender, RoutedEventArgs e)
+    {
+        Result = AutoSuffixDialogResult.Continue;
+        Close();
+    }
+
+    private void OnPickAnotherClick(object? sender, RoutedEventArgs e)
+    {
+        Result = AutoSuffixDialogResult.PickAnother;
+        Close();
+    }
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e)
+    {
+        Result = AutoSuffixDialogResult.Cancel;
+        Close();
+    }
+}

--- a/Trebuchet/Trebuchet/Views/ReplacePreviewWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/ReplacePreviewWindow.axaml.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Radoub.Formats.Logging;
+using Radoub.Formats.Search;
 using Radoub.UI.Services.Search;
 
 namespace RadoubLauncher.Views;
@@ -70,9 +71,17 @@ public partial class ReplacePreviewWindow : Window
 
                 var location = change.Match.Location?.ToString() ?? change.Match.Field.Name;
 
+                // Visual flag for ResRef-typed field rows when running in ResRef-replace mode.
+                // These are rows that would be skipped by the standard replace path but are
+                // visible because allowResRefReplace=true. See spec Section 5.
+                var resRefBadge = preview.AllowResRefReplace
+                    && change.Match.Field.FieldType == SearchFieldType.ResRef
+                    ? "\ud83d\udd17 " // \ud83d\udd17
+                    : string.Empty;
+
                 var matchCheckBox = new CheckBox
                 {
-                    Content = $"[{location}] {change.Match.Field.Name}: \"{oldText}\" \u2192 \"{newText}\"",
+                    Content = $"{resRefBadge}[{location}] {change.Match.Field.Name}: \"{oldText}\" \u2192 \"{newText}\"",
                     IsChecked = true,
                     Tag = change
                 };


### PR DESCRIPTION
## Summary

Adds **Filename/ResRef rename mode** to Marlinspike. New checkbox in the search panel converts text-replace into module-wide resource rename — renames files on disk and updates references across typed GFF fields, DLG script params, and `.nss` script source.

**Surgical scope**: row selection in results tree controls which files get touched. Lets users split one NPC into two while preserving original references where desired (Bucky, not Thanos).

## Highlights

- New "Include filename/ResRef" + NSS (18th file-type) checkboxes
- Per-row selection scopes the rename — references rewritten only in selected files
- Auto-suffix collision detection (`_2`..`_99`) with Continue / Pick-Another / Cancel dialog
- 16-char ResRef validation, lowercase normalization
- Backup + automatic rollback on failure via existing `BackupService`
- Atomic file writes (temp + rename)
- Preflight check (mtime+size) detects concurrent modification

## Architecture

- `Radoub.Formats/Search/Rename/` — pure-logic primitives (validator, scanner, plan, reference, scope-tier)
- `Radoub.UI/Services/Search/` — orchestrator, filename provider, NSS scanner, location applier
- `Trebuchet/` — Marlinspike UI wiring, dispatch helpers, auto-suffix dialog

## Tests

- **2099 passing / 0 failed** across Radoub.Formats.Tests (1233), Radoub.UI.Tests (667), Radoub.Dictionary.Tests (54), Trebuchet.Tests (145)
- **~120 new unit tests** for this feature
- Privacy scan: clean
- Tech debt: no large files (>800 lines)
- CI: ubuntu + windows builds and tests all green

## Manual testing performed

- ✅ Single-row select + Replace Selected (filename + references in selected file only)
- ✅ Group-row select cascades to all files in group
- ✅ Replace All renames every filename match
- ✅ Auto-suffix collision dialog (all 3 buttons)
- ✅ Validator errors surface in status (16-char, invalid chars)
- ✅ `.nss` reference rewrite works (quoted and bare substring)
- ✅ Backup created at `~/Radoub/Backups/{Module}/{Timestamp}/`

## Followups filed (non-blocking)

- #2178 — ITP references not yet renamed
- #2179 — Multi-select via row checkboxes + conflict popup
- #2180 — Optional case-preservation for ResRef rename
- #2181 — Reverse-rename orphan bug when filename contains old name as substring
- #2182 — Validator error wording clarity
- #2183 — `.nss` files report "no editor" — wire default external editor
- #2184 — Auto-suffix dialog too small for large fonts, not resizable

## Related

Closes #1926
Spec: `NonPublic/Trebuchet/2026-05-03-resref-rename-design.md`
Plan: `NonPublic/Trebuchet/2026-05-03-resref-rename-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)