### PR TITLE
[Radoub] Sprint: Dependabot patch bumps + dependabot.yml coverage (#2170)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,14 @@
 # Dependabot configuration for Radoub toolset
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+#
+# Central package management (Directory.Packages.props) is in use, but Dependabot
+# still walks each project directory to discover PackageReference items. One
+# update block per project keeps PRs scoped + labeled per tool.
 
 version: 2
 updates:
-  # NuGet packages for Parley
+  # ---- Tools ----
+
   - package-ecosystem: "nuget"
     directory: "/Parley"
     schedule:
@@ -11,8 +16,68 @@ updates:
     labels:
       - "dependencies"
       - "parley"
+    ignore:
+      # Avalonia 12.x has too many breaking changes for now — stay on 11.x.
+      - dependency-name: "Avalonia*"
+        update-types: ["version-update:semver-major"]
 
-  # NuGet packages for Radoub.Formats shared library
+  - package-ecosystem: "nuget"
+    directory: "/Manifest"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "manifest"
+    ignore:
+      - dependency-name: "Avalonia*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "nuget"
+    directory: "/Quartermaster"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "quartermaster"
+    ignore:
+      - dependency-name: "Avalonia*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "nuget"
+    directory: "/Fence"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "fence"
+    ignore:
+      - dependency-name: "Avalonia*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "nuget"
+    directory: "/Relique"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "relique"
+    ignore:
+      - dependency-name: "Avalonia*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "nuget"
+    directory: "/Trebuchet"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "trebuchet"
+    ignore:
+      - dependency-name: "Avalonia*"
+        update-types: ["version-update:semver-major"]
+
+  # ---- Shared libraries ----
+
   - package-ecosystem: "nuget"
     directory: "/Radoub.Formats"
     schedule:
@@ -21,7 +86,44 @@ updates:
       - "dependencies"
       - "radoub"
 
-  # GitHub Actions workflows
+  - package-ecosystem: "nuget"
+    directory: "/Radoub.UI"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "radoub"
+    ignore:
+      - dependency-name: "Avalonia*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "nuget"
+    directory: "/Radoub.Dictionary"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "radoub"
+
+  - package-ecosystem: "nuget"
+    directory: "/Radoub.TestUtilities"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "radoub"
+
+  - package-ecosystem: "nuget"
+    directory: "/Radoub.IntegrationTests"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "radoub"
+      - "tests"
+
+  # ---- CI ----
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
 
     <!-- MVVM -->
-    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.1" />
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
 
     <!-- Serialization -->
     <PackageVersion Include="System.Text.Json" Version="10.0.5" />
@@ -48,11 +48,11 @@
 
     <!-- Testing -->
     <PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.13" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
 
     <!-- Integration Testing -->
     <PackageVersion Include="FlaUI.Core" Version="5.0.0" />


### PR DESCRIPTION
## Summary

Consolidates open dependabot PRs into a single sprint branch and fixes long-standing dependabot.yml coverage gap.

### Dependency bumps applied

| Package | From | To | Risk | Source PR |
|---------|------|----|------|-----------|
| Microsoft.NET.Test.Sdk | 18.4.0 | 18.5.1 | Low (patch) | #2170 |
| CommunityToolkit.Mvvm | 8.4.1 | 8.4.2 | Low (patch) | #2176 |
| coverlet.collector | 10.0.0 | 10.0.1 | Low (patch) | #2177 |

### Dependency bumps skipped

Avalonia 11.3.13 -> 12.0.2 (#2172, #2173, #2174, #2175) — too many breaking changes to absorb right now. `.github/dependabot.yml` now ignores `Avalonia*` major bumps so these stop being re-proposed every week. When/if we tackle the Avalonia 12 migration it will be its own dedicated sprint.

### dependabot.yml coverage fix

Previous config scanned only **2 of 11** projects (Parley + Radoub.Formats). Now scans every tool and shared library:

**Tools** (with `Avalonia*` major-version ignore):
- Parley, Manifest, Quartermaster, Fence, Relique, Trebuchet

**Shared libraries**:
- Radoub.Formats, Radoub.UI (with Avalonia ignore), Radoub.Dictionary, Radoub.TestUtilities, Radoub.IntegrationTests

GitHub Actions block unchanged.

## Test Results

- Build: 0 errors, 10 warnings (all pre-existing xUnit1051 nags in `Trebuchet.Tests/ErfImportServiceTests.cs`)
- Unit tests: **4681 passed, 0 failed, 1 skipped** across 9 test projects
- Integration tests (FlaUI): not run (per repo policy — UI test suite requires explicit user opt-in)

## Checklist

- [x] Build passes
- [x] Unit tests pass
- [x] dependabot.yml covers all projects
- [x] Avalonia 12 major-bump ignore added
- [ ] Close superseded dependabot PRs after merge: #2170, #2172, #2173, #2174, #2175, #2176, #2177

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)