### PR TITLE
[Radoub] Feat: FileBrowserPanelBase Name/Tag sort + search infrastructure (#2198)

### DIFF
--- a/Radoub.UI/Radoub.UI.Tests/BrowserSortLogicTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/BrowserSortLogicTests.cs
@@ -1,0 +1,182 @@
+using Radoub.UI.Controls;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Pure-logic tests for FileBrowserPanelBase sort + search across the three
+/// <see cref="BrowserSortMode"/> values. See #2198 (epic #2186).
+/// </summary>
+public class BrowserSortLogicTests
+{
+    private static List<FileBrowserEntry> SampleEntries() => new()
+    {
+        new() { Name = "mod_b", DisplayLabel = "Beta Sword", Tag = "TAG_BETA", IsFromHak = false, Source = "Module" },
+        new() { Name = "mod_a", DisplayLabel = "Alpha Shield", Tag = "TAG_ALPHA", IsFromHak = false, Source = "Module" },
+        new() { Name = "hak_c", DisplayLabel = "Charlie Ring", Tag = "TAG_CHARLIE", IsFromHak = true, Source = "HAK: cep.hak" },
+        new() { Name = "hak_d", DisplayLabel = null, Tag = null, IsFromHak = true, Source = "HAK: cep.hak" }
+    };
+
+    [Fact]
+    public void SortByResRef_ModuleFirst_ThenAlphabetic()
+    {
+        var result = BrowserSortLogic.FilterAndSort(SampleEntries(), null, BrowserSortMode.ResRef);
+
+        Assert.Equal(new[] { "mod_a", "mod_b", "hak_c", "hak_d" }, result.Select(e => e.Name));
+    }
+
+    [Fact]
+    public void SortByName_ModuleFirst_ThenByDisplayLabel_NullsLast()
+    {
+        var result = BrowserSortLogic.FilterAndSort(SampleEntries(), null, BrowserSortMode.Name);
+
+        // Module tier: Alpha Shield, Beta Sword. HAK tier: Charlie Ring, then null-label hak_d last.
+        Assert.Equal(new[] { "mod_a", "mod_b", "hak_c", "hak_d" }, result.Select(e => e.Name));
+    }
+
+    [Fact]
+    public void SortByTag_ModuleFirst_ThenByTag_NullsLast()
+    {
+        var result = BrowserSortLogic.FilterAndSort(SampleEntries(), null, BrowserSortMode.Tag);
+
+        Assert.Equal(new[] { "mod_a", "mod_b", "hak_c", "hak_d" }, result.Select(e => e.Name));
+    }
+
+    [Fact]
+    public void SearchByResRef_MatchesNameField()
+    {
+        var result = BrowserSortLogic.FilterAndSort(SampleEntries(), "mod_", BrowserSortMode.ResRef);
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, e => Assert.StartsWith("mod_", e.Name));
+    }
+
+    [Fact]
+    public void SearchByName_MatchesDisplayLabel_NotResRef()
+    {
+        // "Sword" appears in DisplayLabel of mod_b ("Beta Sword") but NOT in its ResRef.
+        var result = BrowserSortLogic.FilterAndSort(SampleEntries(), "sword", BrowserSortMode.Name);
+
+        Assert.Single(result);
+        Assert.Equal("mod_b", result[0].Name);
+    }
+
+    [Fact]
+    public void SearchByName_NullDisplayLabel_DoesNotMatchEmptySearch()
+    {
+        var entries = new List<FileBrowserEntry>
+        {
+            new() { Name = "indexed", DisplayLabel = "Hello", Tag = null, IsFromHak = false },
+            new() { Name = "unindexed", DisplayLabel = null, Tag = null, IsFromHak = false }
+        };
+
+        var result = BrowserSortLogic.FilterAndSort(entries, "hello", BrowserSortMode.Name);
+
+        Assert.Single(result);
+        Assert.Equal("indexed", result[0].Name);
+    }
+
+    [Fact]
+    public void SearchByTag_MatchesTagField_NotResRef()
+    {
+        var result = BrowserSortLogic.FilterAndSort(SampleEntries(), "alpha", BrowserSortMode.Tag);
+
+        Assert.Single(result);
+        Assert.Equal("mod_a", result[0].Name);
+        Assert.Equal("TAG_ALPHA", result[0].Tag);
+    }
+
+    [Fact]
+    public void EmptySearch_ReturnsAllEntries()
+    {
+        var result = BrowserSortLogic.FilterAndSort(SampleEntries(), "", BrowserSortMode.ResRef);
+        Assert.Equal(4, result.Count);
+    }
+
+    [Fact]
+    public void WhitespaceSearch_ReturnsAllEntries()
+    {
+        var result = BrowserSortLogic.FilterAndSort(SampleEntries(), "   ", BrowserSortMode.Name);
+        Assert.Equal(4, result.Count);
+    }
+
+    [Fact]
+    public void NullSearch_ReturnsAllEntries()
+    {
+        var result = BrowserSortLogic.FilterAndSort(SampleEntries(), null, BrowserSortMode.Tag);
+        Assert.Equal(4, result.Count);
+    }
+
+    [Fact]
+    public void SearchIsCaseInsensitive_ForAllModes()
+    {
+        Assert.Single(BrowserSortLogic.FilterAndSort(SampleEntries(), "MOD_A", BrowserSortMode.ResRef));
+        Assert.Single(BrowserSortLogic.FilterAndSort(SampleEntries(), "ALPHA SHIELD", BrowserSortMode.Name));
+        Assert.Single(BrowserSortLogic.FilterAndSort(SampleEntries(), "tag_alpha", BrowserSortMode.Tag));
+    }
+
+    [Fact]
+    public void ModuleTierAlwaysFirst_EvenWhenSortedByName()
+    {
+        // HAK entry with display label "AAA" should still sort AFTER module entries
+        // because module-first tier is preserved.
+        var entries = new List<FileBrowserEntry>
+        {
+            new() { Name = "hak_aaa", DisplayLabel = "AAA First Alphabetically", IsFromHak = true },
+            new() { Name = "mod_zzz", DisplayLabel = "ZZZ Last Alphabetically", IsFromHak = false }
+        };
+
+        var result = BrowserSortLogic.FilterAndSort(entries, null, BrowserSortMode.Name);
+
+        Assert.Equal(new[] { "mod_zzz", "hak_aaa" }, result.Select(e => e.Name));
+    }
+
+    [Fact]
+    public void NullDisplayLabel_SortsAfterPopulated_WithinTier()
+    {
+        var entries = new List<FileBrowserEntry>
+        {
+            new() { Name = "first", DisplayLabel = null, IsFromHak = false },
+            new() { Name = "second", DisplayLabel = "Real Name", IsFromHak = false }
+        };
+
+        var result = BrowserSortLogic.FilterAndSort(entries, null, BrowserSortMode.Name);
+
+        Assert.Equal(new[] { "second", "first" }, result.Select(e => e.Name));
+    }
+
+    [Fact]
+    public void NullTag_SortsAfterPopulated_WithinTier()
+    {
+        var entries = new List<FileBrowserEntry>
+        {
+            new() { Name = "first", Tag = null, IsFromHak = false },
+            new() { Name = "second", Tag = "TAG_X", IsFromHak = false }
+        };
+
+        var result = BrowserSortLogic.FilterAndSort(entries, null, BrowserSortMode.Tag);
+
+        Assert.Equal(new[] { "second", "first" }, result.Select(e => e.Name));
+    }
+
+    [Fact]
+    public void EmptyInput_ReturnsEmpty()
+    {
+        var result = BrowserSortLogic.FilterAndSort(new List<FileBrowserEntry>(), "search", BrowserSortMode.Name);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void DefaultEntry_BehavesAsResRefMode()
+    {
+        var entries = new List<FileBrowserEntry>
+        {
+            new() { Name = "zzz", IsFromHak = false },
+            new() { Name = "aaa", IsFromHak = false }
+        };
+
+        var result = BrowserSortLogic.FilterAndSort(entries, null, BrowserSortMode.ResRef);
+
+        Assert.Equal(new[] { "aaa", "zzz" }, result.Select(e => e.Name));
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/ItemBrowserPanelIndexingTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/ItemBrowserPanelIndexingTests.cs
@@ -1,0 +1,98 @@
+using Radoub.UI.Controls;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Tests for ItemBrowserPanel.TryFillFromCache — the pure-logic helper that
+/// hydrates FileBrowserEntry.Tag/DisplayLabel from the shared palette cache
+/// during background indexing (#2186 / #2198).
+/// </summary>
+public class ItemBrowserPanelIndexingTests
+{
+    private static Dictionary<string, SharedPaletteCacheItem> Lookup(
+        params SharedPaletteCacheItem[] items)
+    {
+        var dict = new Dictionary<string, SharedPaletteCacheItem>(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in items)
+            dict.TryAdd(item.ResRef, item);
+        return dict;
+    }
+
+    [Fact]
+    public void TryFillFromCache_PopulatesTagAndDisplayLabel_OnHit()
+    {
+        var entry = new ItemBrowserEntry { Name = "nw_wblsw001" };
+        var lookup = Lookup(new SharedPaletteCacheItem
+        {
+            ResRef = "nw_wblsw001",
+            Tag = "NW_IT_SWORD001",
+            DisplayName = "Short Sword"
+        });
+
+        var hit = ItemBrowserPanel.TryFillFromCache(entry, lookup);
+
+        Assert.True(hit);
+        Assert.Equal("NW_IT_SWORD001", entry.Tag);
+        Assert.Equal("Short Sword", entry.DisplayLabel);
+    }
+
+    [Fact]
+    public void TryFillFromCache_ReturnsFalse_OnMiss()
+    {
+        var entry = new ItemBrowserEntry { Name = "missing_item" };
+        var lookup = Lookup(new SharedPaletteCacheItem
+        {
+            ResRef = "different_item",
+            Tag = "X",
+            DisplayName = "Y"
+        });
+
+        var hit = ItemBrowserPanel.TryFillFromCache(entry, lookup);
+
+        Assert.False(hit);
+        Assert.Null(entry.Tag);
+        Assert.Null(entry.DisplayLabel);
+    }
+
+    [Fact]
+    public void TryFillFromCache_EmptyLookup_ReturnsFalse()
+    {
+        var entry = new ItemBrowserEntry { Name = "anything" };
+        var lookup = new Dictionary<string, SharedPaletteCacheItem>(StringComparer.OrdinalIgnoreCase);
+
+        Assert.False(ItemBrowserPanel.TryFillFromCache(entry, lookup));
+    }
+
+    [Fact]
+    public void TryFillFromCache_CaseInsensitiveLookup()
+    {
+        var entry = new ItemBrowserEntry { Name = "NW_WBLSW001" }; // uppercase
+        var lookup = Lookup(new SharedPaletteCacheItem
+        {
+            ResRef = "nw_wblsw001", // lowercase cache key
+            Tag = "TAG",
+            DisplayName = "Name"
+        });
+
+        Assert.True(ItemBrowserPanel.TryFillFromCache(entry, lookup));
+        Assert.Equal("TAG", entry.Tag);
+    }
+
+    [Fact]
+    public void TryFillFromCache_NullTagOrName_ResolveToEmpty()
+    {
+        var entry = new ItemBrowserEntry { Name = "item" };
+        var lookup = Lookup(new SharedPaletteCacheItem
+        {
+            ResRef = "item",
+            Tag = null!,
+            DisplayName = null!
+        });
+
+        Assert.True(ItemBrowserPanel.TryFillFromCache(entry, lookup));
+        Assert.Equal(string.Empty, entry.Tag);
+        Assert.Equal(string.Empty, entry.DisplayLabel);
+    }
+}

--- a/Radoub.UI/Radoub.UI/Controls/BrowserSortLogic.cs
+++ b/Radoub.UI/Radoub.UI/Controls/BrowserSortLogic.cs
@@ -1,0 +1,69 @@
+namespace Radoub.UI.Controls;
+
+/// <summary>
+/// Pure-logic sort + filter for file browser panels. Extracted as a static
+/// test seam so sort/search behavior can be unit-tested without UI binding.
+/// </summary>
+internal static class BrowserSortLogic
+{
+    /// <summary>
+    /// Apply search filter against the field corresponding to <paramref name="mode"/>,
+    /// then sort module-first followed by the sort field.
+    /// </summary>
+    /// <remarks>
+    /// Search semantics:
+    /// <list type="bullet">
+    /// <item>ResRef → matches <see cref="FileBrowserEntry.Name"/></item>
+    /// <item>Name → matches <see cref="FileBrowserEntry.DisplayLabel"/> (empty if null)</item>
+    /// <item>Tag → matches <see cref="FileBrowserEntry.Tag"/> (empty if null)</item>
+    /// </list>
+    /// Sort semantics: module entries (IsFromHak=false) always come before
+    /// archive entries; within each tier entries are ordered by the active
+    /// sort field. Null DisplayLabel/Tag values sort after non-null ones in
+    /// Name/Tag modes so unindexed entries cluster at the bottom of their tier.
+    /// </remarks>
+    public static List<FileBrowserEntry> FilterAndSort(
+        IEnumerable<FileBrowserEntry> entries,
+        string? searchText,
+        BrowserSortMode mode)
+    {
+        var search = string.IsNullOrWhiteSpace(searchText)
+            ? null
+            : searchText.ToLowerInvariant();
+
+        IEnumerable<FileBrowserEntry> filtered = entries;
+
+        if (search != null)
+        {
+            filtered = mode switch
+            {
+                BrowserSortMode.Name => filtered.Where(e =>
+                    (e.DisplayLabel ?? string.Empty).ToLowerInvariant().Contains(search)),
+                BrowserSortMode.Tag => filtered.Where(e =>
+                    (e.Tag ?? string.Empty).ToLowerInvariant().Contains(search)),
+                _ => filtered.Where(e =>
+                    e.Name.ToLowerInvariant().Contains(search))
+            };
+        }
+
+        return mode switch
+        {
+            BrowserSortMode.Name => filtered
+                .OrderBy(e => e.IsFromHak ? 1 : 0)
+                .ThenBy(e => string.IsNullOrEmpty(e.DisplayLabel) ? 1 : 0)
+                .ThenBy(e => e.DisplayLabel ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            BrowserSortMode.Tag => filtered
+                .OrderBy(e => e.IsFromHak ? 1 : 0)
+                .ThenBy(e => string.IsNullOrEmpty(e.Tag) ? 1 : 0)
+                .ThenBy(e => e.Tag ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            _ => filtered
+                .OrderBy(e => e.IsFromHak ? 1 : 0)
+                .ThenBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
+                .ToList()
+        };
+    }
+}

--- a/Radoub.UI/Radoub.UI/Controls/BrowserSortMode.cs
+++ b/Radoub.UI/Radoub.UI/Controls/BrowserSortMode.cs
@@ -1,0 +1,17 @@
+namespace Radoub.UI.Controls;
+
+/// <summary>
+/// Sort/search mode for file browser panels. The search field queries the
+/// active field — e.g. SortMode=Name → search matches DisplayLabel.
+/// </summary>
+public enum BrowserSortMode
+{
+    /// <summary>Sort and search by ResRef (filename). Default; always available.</summary>
+    ResRef,
+
+    /// <summary>Sort and search by localized display name (FileBrowserEntry.DisplayLabel).</summary>
+    Name,
+
+    /// <summary>Sort and search by script tag (FileBrowserEntry.Tag).</summary>
+    Tag
+}

--- a/Radoub.UI/Radoub.UI/Controls/DialogBrowserPanel.cs
+++ b/Radoub.UI/Radoub.UI/Controls/DialogBrowserPanel.cs
@@ -73,6 +73,12 @@ public class DialogBrowserPanel : FileBrowserPanelBase
     // DLG has no Tag or LocName equivalents — ResRef-only rename.
     protected override bool SupportsTagNameRename() => false;
 
+    // DLG format has no Tag/Name fields — restrict to ResRef sort mode only.
+    protected override IReadOnlyList<BrowserSortMode> SupportedSortModes { get; } = new[]
+    {
+        BrowserSortMode.ResRef
+    };
+
     protected override Task<byte[]?> ExtractArchiveBytesAsync(FileBrowserEntry entry)
     {
         if (!entry.IsFromHak || string.IsNullOrEmpty(entry.HakPath))

--- a/Radoub.UI/Radoub.UI/Controls/FileBrowserPanelBase.axaml
+++ b/Radoub.UI/Radoub.UI/Controls/FileBrowserPanelBase.axaml
@@ -5,22 +5,11 @@
 
     <UserControl.Styles>
         <!-- Selection visibility fix for dark mode -->
-        <Style Selector="ListBoxItem:selected /template/ ContentPresenter">
-            <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
-            <Setter Property="Foreground" Value="White"/>
+        <Style Selector="DataGridRow:selected /template/ Rectangle#BackgroundRectangle">
+            <Setter Property="Fill" Value="{DynamicResource SystemAccentColor}"/>
         </Style>
-        <Style Selector="ListBoxItem:selected:focus /template/ ContentPresenter">
-            <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
-            <Setter Property="Foreground" Value="White"/>
-        </Style>
-        <Style Selector="ListBoxItem:selected:pointerover /template/ ContentPresenter">
-            <Setter Property="Background" Value="{DynamicResource SystemAccentColorDark1}"/>
-            <Setter Property="Foreground" Value="White"/>
-        </Style>
-
-        <!-- Current file highlight -->
-        <Style Selector="ListBoxItem.current-file">
-            <Setter Property="FontWeight" Value="Bold"/>
+        <Style Selector="DataGridRow:selected /template/ Rectangle#PointerOverBackgroundRectangle">
+            <Setter Property="Fill" Value="{DynamicResource SystemAccentColorDark1}"/>
         </Style>
     </UserControl.Styles>
 
@@ -48,22 +37,8 @@
 
         <!-- Search and filters -->
         <StackPanel Grid.Row="1" Margin="8,8,8,4" Spacing="4">
-            <Grid x:Name="SortModeRow"
-                  ColumnDefinitions="Auto,*"
-                  IsVisible="False">
-                <TextBlock Grid.Column="0"
-                           Text="Sort:"
-                           VerticalAlignment="Center"
-                           Margin="0,0,6,0"
-                           FontSize="{DynamicResource FontSizeSmall}"/>
-                <ComboBox Grid.Column="1"
-                          x:Name="SortModeBox"
-                          HorizontalAlignment="Stretch"
-                          SelectionChanged="OnSortModeChanged"/>
-            </Grid>
-
             <TextBox x:Name="SearchBox"
-                     Watermark="Type to filter..."
+                     Watermark="Search by resref..."
                      TextChanged="OnSearchTextChanged"/>
 
             <!-- Tool-specific filter options go here via ContentPresenter -->
@@ -86,29 +61,47 @@
                            FontSize="{DynamicResource FontSizeSmall}"
                            Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
 
-                <!-- File ListBox -->
-                <ListBox Grid.Row="1"
-                         x:Name="FileListBox"
-                         SelectionChanged="OnFileSelected"
-                         DoubleTapped="OnFileDoubleClicked"
-                         ContextRequested="OnFileListContextRequested"
-                         Background="Transparent"
-                         Margin="4,0,4,4">
-                    <ListBox.ContextMenu>
+                <!-- File DataGrid: click column header to sort by that field -->
+                <DataGrid Grid.Row="1"
+                          x:Name="FileGrid"
+                          AutoGenerateColumns="False"
+                          CanUserReorderColumns="False"
+                          CanUserResizeColumns="True"
+                          CanUserSortColumns="True"
+                          IsReadOnly="True"
+                          SelectionMode="Single"
+                          GridLinesVisibility="Horizontal"
+                          HeadersVisibility="Column"
+                          RowHeight="22"
+                          SelectionChanged="OnFileGridSelectionChanged"
+                          DoubleTapped="OnFileGridDoubleTapped"
+                          ContextRequested="OnFileGridContextRequested"
+                          Sorting="OnFileGridSorting"
+                          Background="Transparent"
+                          Margin="4,0,4,4">
+                    <DataGrid.ContextMenu>
                         <ContextMenu x:Name="FileListContextMenu">
                             <MenuItem x:Name="DeleteMenuItem"
                                       Header="Delete"
                                       Click="OnDeleteMenuItemClick"/>
                         </ContextMenu>
-                    </ListBox.ContextMenu>
-                    <ListBox.ItemTemplate>
-                        <DataTemplate>
-                            <TextBlock Text="{Binding DisplayName}"
-                                       TextTrimming="CharacterEllipsis"
-                                       Padding="4,2"/>
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
-                </ListBox>
+                    </DataGrid.ContextMenu>
+                    <DataGrid.Columns>
+                        <!-- Column order MUST match *ColumnIndex constants in code-behind -->
+                        <DataGridTextColumn Header="ResRef"
+                                            Binding="{Binding Name}"
+                                            Width="*"/>
+                        <DataGridTextColumn Header="Name"
+                                            Binding="{Binding DisplayLabel}"
+                                            Width="*"/>
+                        <DataGridTextColumn Header="Tag"
+                                            Binding="{Binding Tag}"
+                                            Width="*"/>
+                        <DataGridTextColumn Header="Source"
+                                            Binding="{Binding Source}"
+                                            Width="Auto"/>
+                    </DataGrid.Columns>
+                </DataGrid>
             </Grid>
         </Border>
 

--- a/Radoub.UI/Radoub.UI/Controls/FileBrowserPanelBase.axaml
+++ b/Radoub.UI/Radoub.UI/Controls/FileBrowserPanelBase.axaml
@@ -48,6 +48,20 @@
 
         <!-- Search and filters -->
         <StackPanel Grid.Row="1" Margin="8,8,8,4" Spacing="4">
+            <Grid x:Name="SortModeRow"
+                  ColumnDefinitions="Auto,*"
+                  IsVisible="False">
+                <TextBlock Grid.Column="0"
+                           Text="Sort:"
+                           VerticalAlignment="Center"
+                           Margin="0,0,6,0"
+                           FontSize="{DynamicResource FontSizeSmall}"/>
+                <ComboBox Grid.Column="1"
+                          x:Name="SortModeBox"
+                          HorizontalAlignment="Stretch"
+                          SelectionChanged="OnSortModeChanged"/>
+            </Grid>
+
             <TextBox x:Name="SearchBox"
                      Watermark="Type to filter..."
                      TextChanged="OnSearchTextChanged"/>

--- a/Radoub.UI/Radoub.UI/Controls/FileBrowserPanelBase.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Controls/FileBrowserPanelBase.axaml.cs
@@ -2,11 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Media;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Radoub.Formats.Erf;
 using Radoub.Formats.Logging;
@@ -26,6 +28,9 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
     private string? _modulePath;
     private string? _currentFilePath;
     private bool _isCollapsed;
+    private BrowserSortMode _sortMode = BrowserSortMode.ResRef;
+    private CancellationTokenSource? _indexingCts;
+    private bool _sortModeBoxInitialized;
 
     /// <summary>
     /// Raised when a file is selected (single-click) or activated (double-click).
@@ -87,6 +92,60 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
         set => SearchBox.Watermark = value;
     }
 
+    /// <summary>
+    /// Sort modes this panel exposes in the SortMode ComboBox. Default is all
+    /// three modes. Override to restrict — e.g., DialogBrowserPanel returns
+    /// [ResRef] because DLG has no Tag/Name fields.
+    /// </summary>
+    protected virtual IReadOnlyList<BrowserSortMode> SupportedSortModes { get; } = new[]
+    {
+        BrowserSortMode.ResRef,
+        BrowserSortMode.Name,
+        BrowserSortMode.Tag
+    };
+
+    /// <summary>
+    /// Current sort/search mode. Setting this re-applies the filter and updates
+    /// the ComboBox selection.
+    /// </summary>
+    public BrowserSortMode SortMode
+    {
+        get => _sortMode;
+        set
+        {
+            if (_sortMode != value)
+            {
+                _sortMode = value;
+                UpdateSearchWatermark();
+                ApplyFilter();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Populate <see cref="FileBrowserEntry.DisplayLabel"/> and
+    /// <see cref="FileBrowserEntry.Tag"/> for the given entries in the background.
+    /// Default no-op. Tools override (Relique/Fence/Quartermaster) to read GFF
+    /// fields and/or pull from <see cref="SharedPaletteCacheService"/>.
+    /// </summary>
+    /// <param name="entries">Entries that still need metadata
+    /// (<see cref="FileBrowserEntry.MetadataLoaded"/> is false). The base loop
+    /// passes only un-indexed entries; the override may skip any it can't handle.</param>
+    /// <param name="cancellationToken">Cancelled on module change or when this
+    /// panel is disposed. Honor it between batches.</param>
+    protected virtual Task IndexMetadataAsync(
+        IReadOnlyList<FileBrowserEntry> entries,
+        CancellationToken cancellationToken)
+        => Task.CompletedTask;
+
+    /// <summary>
+    /// Re-read metadata for a single entry — typically called by the host tool
+    /// after a save so the browser row reflects the new Tag/Name without a full
+    /// reindex. Default no-op.
+    /// </summary>
+    public virtual Task RefreshEntryMetadataAsync(FileBrowserEntry entry)
+        => Task.CompletedTask;
+
     public FileBrowserPanelBase()
     {
         InitializeComponent();
@@ -97,7 +156,11 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
 
         // Lazily add Copy-to-Module menu item once the visual tree is ready so
         // subclass constructors have finished setting FileExtension/SupportsCopyToModule.
-        Loaded += (_, _) => TryAddCopyToModuleMenuItem();
+        Loaded += (_, _) =>
+        {
+            TryAddCopyToModuleMenuItem();
+            InitializeSortModeBox();
+        };
     }
 
     #region IFileBrowserPanel Implementation
@@ -134,6 +197,7 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
             if (_modulePath != value)
             {
                 _modulePath = value;
+                CancelIndexing();
                 _ = RefreshAsync();
             }
         }
@@ -263,6 +327,7 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
                 $"FileBrowserPanel: Loaded {_allEntries.Count} files from {UnifiedLogger.SanitizePath(_modulePath)}");
 
             ApplyFilter();
+            KickoffIndexing();
         }
         catch (Exception ex)
         {
@@ -279,25 +344,11 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
     {
         FileListBox.Items.Clear();
 
-        var searchText = SearchBox?.Text?.ToLowerInvariant() ?? "";
+        // Apply tool-specific filters (checkbox-based) BEFORE the shared sort/search
+        // so custom filters can use any FileBrowserEntry field they need.
+        var customFiltered = ApplyCustomFilters(_allEntries);
 
-        // Start with all entries
-        IEnumerable<FileBrowserEntry> filtered = _allEntries;
-
-        // Apply search filter
-        if (!string.IsNullOrWhiteSpace(searchText))
-        {
-            filtered = filtered.Where(e => e.Name.ToLowerInvariant().Contains(searchText));
-        }
-
-        // Apply tool-specific filters
-        filtered = ApplyCustomFilters(filtered);
-
-        // Sort: module files first, then by name
-        _filteredEntries = filtered
-            .OrderBy(e => e.IsFromHak ? 1 : 0)
-            .ThenBy(e => e.Name)
-            .ToList();
+        _filteredEntries = BrowserSortLogic.FilterAndSort(customFiltered, SearchBox?.Text, _sortMode);
 
         UpdateList();
     }
@@ -474,11 +525,14 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
     /// <summary>
     /// Merge additional entries into the master list (with name-based dedup).
     /// Call after lazy-loading entries (e.g., on checkbox toggle) so they
-    /// become visible to ApplyFilter/ApplyCustomFilters.
+    /// become visible to ApplyFilter/ApplyCustomFilters. Also triggers a
+    /// background indexing pass over any newly added entries.
     /// </summary>
     protected void MergeAdditionalEntries(IEnumerable<FileBrowserEntry> entries)
     {
-        MergeEntries(_allEntries, entries);
+        var materialized = entries.ToList();
+        MergeEntries(_allEntries, materialized);
+        KickoffIndexing();
     }
 
     /// <summary>
@@ -494,6 +548,112 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
                 target.Add(entry);
             }
         }
+    }
+
+    #endregion
+
+    #region Sort Mode + Indexing
+
+    private void InitializeSortModeBox()
+    {
+        if (_sortModeBoxInitialized) return;
+        _sortModeBoxInitialized = true;
+
+        var modes = SupportedSortModes;
+        if (modes == null || modes.Count <= 1)
+        {
+            // Nothing meaningful to choose — hide the row entirely.
+            SortModeRow.IsVisible = false;
+            return;
+        }
+
+        SortModeBox.ItemsSource = modes.Select(SortModeDisplayText).ToList();
+        var currentIndex = modes.ToList().IndexOf(_sortMode);
+        SortModeBox.SelectedIndex = currentIndex >= 0 ? currentIndex : 0;
+        SortModeRow.IsVisible = true;
+
+        UpdateSearchWatermark();
+    }
+
+    private void OnSortModeChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (SortModeBox.SelectedIndex < 0) return;
+        var modes = SupportedSortModes;
+        if (modes == null || SortModeBox.SelectedIndex >= modes.Count) return;
+
+        SortMode = modes[SortModeBox.SelectedIndex];
+    }
+
+    private void UpdateSearchWatermark()
+    {
+        SearchBox.Watermark = _sortMode switch
+        {
+            BrowserSortMode.Name => "Search by name...",
+            BrowserSortMode.Tag => "Search by tag...",
+            _ => "Search by resref..."
+        };
+    }
+
+    private static string SortModeDisplayText(BrowserSortMode mode) => mode switch
+    {
+        BrowserSortMode.Name => "Name",
+        BrowserSortMode.Tag => "Tag",
+        _ => "ResRef"
+    };
+
+    /// <summary>
+    /// Cancel any in-flight indexing task. Called on module change and disposal.
+    /// </summary>
+    private void CancelIndexing()
+    {
+        if (_indexingCts != null)
+        {
+            _indexingCts.Cancel();
+            _indexingCts.Dispose();
+            _indexingCts = null;
+        }
+    }
+
+    /// <summary>
+    /// Start a background indexing pass for any entries that don't yet have
+    /// metadata. Cancels and replaces any in-flight indexing. On completion,
+    /// re-applies the current filter so searches that ran during indexing
+    /// see fresh DisplayLabel/Tag data.
+    /// </summary>
+    private void KickoffIndexing()
+    {
+        CancelIndexing();
+
+        var pending = _allEntries.Where(e => !e.MetadataLoaded).ToList();
+        if (pending.Count == 0) return;
+
+        _indexingCts = new CancellationTokenSource();
+        var token = _indexingCts.Token;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await IndexMetadataAsync(pending, token);
+
+                if (token.IsCancellationRequested) return;
+
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    if (token.IsCancellationRequested) return;
+                    ApplyFilter();
+                });
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected on module change — no logging needed.
+            }
+            catch (Exception ex)
+            {
+                UnifiedLogger.LogApplication(LogLevel.WARN,
+                    $"FileBrowserPanel: Indexing error: {ex.Message}");
+            }
+        }, token);
     }
 
     #endregion

--- a/Radoub.UI/Radoub.UI/Controls/FileBrowserPanelBase.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Controls/FileBrowserPanelBase.axaml.cs
@@ -30,7 +30,15 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
     private bool _isCollapsed;
     private BrowserSortMode _sortMode = BrowserSortMode.ResRef;
     private CancellationTokenSource? _indexingCts;
-    private bool _sortModeBoxInitialized;
+
+    // DataGrid column indices (must match AXAML column order)
+    private const int ResRefColumnIndex = 0;
+    private const int NameColumnIndex = 1;
+    private const int TagColumnIndex = 2;
+
+    private DataGridColumn ResRefColumn => FileGrid.Columns[ResRefColumnIndex];
+    private DataGridColumn NameColumn => FileGrid.Columns[NameColumnIndex];
+    private DataGridColumn TagColumn => FileGrid.Columns[TagColumnIndex];
 
     /// <summary>
     /// Raised when a file is selected (single-click) or activated (double-click).
@@ -106,7 +114,8 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
 
     /// <summary>
     /// Current sort/search mode. Setting this re-applies the filter and updates
-    /// the ComboBox selection.
+    /// the search-box watermark. Usually changed indirectly by clicking a
+    /// DataGrid column header.
     /// </summary>
     public BrowserSortMode SortMode
     {
@@ -159,7 +168,7 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
         Loaded += (_, _) =>
         {
             TryAddCopyToModuleMenuItem();
-            InitializeSortModeBox();
+            InitializeSortColumns();
         };
     }
 
@@ -342,8 +351,6 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
 
     private void ApplyFilter()
     {
-        FileListBox.Items.Clear();
-
         // Apply tool-specific filters (checkbox-based) BEFORE the shared sort/search
         // so custom filters can use any FileBrowserEntry field they need.
         var customFiltered = ApplyCustomFilters(_allEntries);
@@ -355,12 +362,11 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
 
     private void UpdateList()
     {
-        FileListBox.Items.Clear();
-
-        foreach (var entry in _filteredEntries)
-        {
-            FileListBox.Items.Add(entry);
-        }
+        // Re-assign ItemsSource so the DataGrid rebinds. Setting to a new
+        // List<> instance forces a full refresh (we don't use ObservableCollection
+        // because the list is fully rebuilt on every filter/sort change anyway).
+        FileGrid.ItemsSource = null;
+        FileGrid.ItemsSource = _filteredEntries;
 
         // Update count
         var moduleCount = _filteredEntries.Count(e => !e.IsFromHak);
@@ -380,7 +386,7 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
     {
         if (string.IsNullOrEmpty(_currentFilePath))
         {
-            FileListBox.SelectedItem = null;
+            FileGrid.SelectedItem = null;
             return;
         }
 
@@ -398,8 +404,8 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
 
         if (entry != null)
         {
-            FileListBox.SelectedItem = entry;
-            FileListBox.ScrollIntoView(entry);
+            FileGrid.SelectedItem = entry;
+            FileGrid.ScrollIntoView(entry, null);
         }
     }
 
@@ -450,17 +456,17 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
         ApplyFilter();
     }
 
-    private void OnFileSelected(object? sender, SelectionChangedEventArgs e)
+    private void OnFileGridSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
-        if (FileListBox.SelectedItem is FileBrowserEntry entry)
+        if (FileGrid.SelectedItem is FileBrowserEntry entry)
         {
             FileSelected?.Invoke(this, new FileSelectedEventArgs(entry, isDoubleClick: false));
         }
     }
 
-    private void OnFileDoubleClicked(object? sender, RoutedEventArgs e)
+    private void OnFileGridDoubleTapped(object? sender, RoutedEventArgs e)
     {
-        if (FileListBox.SelectedItem is FileBrowserEntry entry)
+        if (FileGrid.SelectedItem is FileBrowserEntry entry)
         {
             FileSelected?.Invoke(this, new FileSelectedEventArgs(entry, isDoubleClick: true));
         }
@@ -468,28 +474,42 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
 
     /// <summary>
     /// Right-click should select the row under the pointer before the context menu
-    /// opens. Avalonia's ListBox doesn't do this by default — without it, the
-    /// context-menu Opening handlers see SelectedItem == null when the user
-    /// right-clicks an unselected row, and Copy-to-Module never appears (#2106).
+    /// opens (#2106 — fixes Copy-to-Module visibility on right-click). We walk up
+    /// the visual tree from the click source to the DataGridRow and select its
+    /// DataContext so context-menu Opening handlers see a non-null SelectedItem.
     /// </summary>
-    /// <summary>
-    /// ContextRequested fires before the context menu opens, giving us the source
-    /// element under the pointer. We walk up the visual tree to the ListBoxItem
-    /// and select its DataContext, so context-menu Opening handlers see a non-null
-    /// SelectedItem (#2106 — fixes Copy-to-Module visibility on right-click).
-    /// </summary>
-    private void OnFileListContextRequested(object? sender, Avalonia.Controls.ContextRequestedEventArgs e)
+    private void OnFileGridContextRequested(object? sender, Avalonia.Controls.ContextRequestedEventArgs e)
     {
         var source = e.Source as Avalonia.Visual;
-        while (source != null && source is not ListBoxItem)
+        while (source != null && source is not DataGridRow)
         {
             source = source.GetVisualParent();
         }
 
-        if (source is ListBoxItem lbi && lbi.DataContext is FileBrowserEntry entry)
+        if (source is DataGridRow row && row.DataContext is FileBrowserEntry entry)
         {
-            FileListBox.SelectedItem = entry;
+            FileGrid.SelectedItem = entry;
         }
+    }
+
+    /// <summary>
+    /// Intercept DataGrid column-header sorts: translate the clicked column into
+    /// a <see cref="BrowserSortMode"/>, set <see cref="SortMode"/> (which re-applies
+    /// the filter), and cancel the built-in sort so module-first tier is preserved.
+    /// </summary>
+    private void OnFileGridSorting(object? sender, DataGridColumnEventArgs e)
+    {
+        BrowserSortMode? requested = null;
+        if (ReferenceEquals(e.Column, ResRefColumn)) requested = BrowserSortMode.ResRef;
+        else if (ReferenceEquals(e.Column, NameColumn)) requested = BrowserSortMode.Name;
+        else if (ReferenceEquals(e.Column, TagColumn)) requested = BrowserSortMode.Tag;
+
+        if (requested == null) return;
+
+        // Suppress DataGrid's built-in sort (it would override our module-first tier).
+        e.Handled = true;
+
+        SortMode = requested.Value;
     }
 
     private void OnCollapseClick(object? sender, RoutedEventArgs e)
@@ -500,7 +520,7 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
     private void OnContextMenuOpening(object? sender, System.ComponentModel.CancelEventArgs e)
     {
         // Only enable Delete for module files (not HAK/vault resources)
-        var hasSelection = FileListBox.SelectedItem is FileBrowserEntry entry
+        var hasSelection = FileGrid.SelectedItem is FileBrowserEntry entry
             && !entry.IsFromHak
             && !string.IsNullOrEmpty(entry.FilePath);
         DeleteMenuItem.IsEnabled = hasSelection;
@@ -508,7 +528,7 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
 
     private void OnDeleteMenuItemClick(object? sender, RoutedEventArgs e)
     {
-        if (FileListBox.SelectedItem is FileBrowserEntry entry && !entry.IsFromHak && !string.IsNullOrEmpty(entry.FilePath))
+        if (FileGrid.SelectedItem is FileBrowserEntry entry && !entry.IsFromHak && !string.IsNullOrEmpty(entry.FilePath))
         {
             FileDeleteRequested?.Invoke(this, new FileDeleteRequestedEventArgs(entry));
         }
@@ -554,34 +574,20 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
 
     #region Sort Mode + Indexing
 
-    private void InitializeSortModeBox()
+    /// <summary>
+    /// Apply the panel's <see cref="SupportedSortModes"/> to the DataGrid columns:
+    /// hide unsupported columns (e.g., Parley DLG hides Name/Tag), and update
+    /// the search-box watermark to match the current SortMode.
+    /// </summary>
+    private void InitializeSortColumns()
     {
-        if (_sortModeBoxInitialized) return;
-        _sortModeBoxInitialized = true;
+        var modes = SupportedSortModes ?? new[] { BrowserSortMode.ResRef };
+        var modeSet = new HashSet<BrowserSortMode>(modes);
 
-        var modes = SupportedSortModes;
-        if (modes == null || modes.Count <= 1)
-        {
-            // Nothing meaningful to choose — hide the row entirely.
-            SortModeRow.IsVisible = false;
-            return;
-        }
-
-        SortModeBox.ItemsSource = modes.Select(SortModeDisplayText).ToList();
-        var currentIndex = modes.ToList().IndexOf(_sortMode);
-        SortModeBox.SelectedIndex = currentIndex >= 0 ? currentIndex : 0;
-        SortModeRow.IsVisible = true;
+        NameColumn.IsVisible = modeSet.Contains(BrowserSortMode.Name);
+        TagColumn.IsVisible = modeSet.Contains(BrowserSortMode.Tag);
 
         UpdateSearchWatermark();
-    }
-
-    private void OnSortModeChanged(object? sender, SelectionChangedEventArgs e)
-    {
-        if (SortModeBox.SelectedIndex < 0) return;
-        var modes = SupportedSortModes;
-        if (modes == null || SortModeBox.SelectedIndex >= modes.Count) return;
-
-        SortMode = modes[SortModeBox.SelectedIndex];
     }
 
     private void UpdateSearchWatermark()
@@ -593,13 +599,6 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
             _ => "Search by resref..."
         };
     }
-
-    private static string SortModeDisplayText(BrowserSortMode mode) => mode switch
-    {
-        BrowserSortMode.Name => "Name",
-        BrowserSortMode.Tag => "Tag",
-        _ => "ResRef"
-    };
 
     /// <summary>
     /// Cancel any in-flight indexing task. Called on module change and disposal.
@@ -729,7 +728,7 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
         _copyToModuleMenuItem = new MenuItem { Header = "Copy to Module" };
         _copyToModuleMenuItem.Click += async (_, _) =>
         {
-            if (FileListBox.SelectedItem is FileBrowserEntry entry)
+            if (FileGrid.SelectedItem is FileBrowserEntry entry)
                 await CopyArchiveEntryToModuleAsync(entry);
         };
 
@@ -744,7 +743,7 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
     {
         if (_copyToModuleMenuItem == null) return;
 
-        var entry = FileListBox.SelectedItem as FileBrowserEntry;
+        var entry = FileGrid.SelectedItem as FileBrowserEntry;
         var isArchive = entry != null && IsArchiveEntry(entry);
         _copyToModuleMenuItem.IsVisible = isArchive && !string.IsNullOrEmpty(ModulePath);
     }

--- a/Radoub.UI/Radoub.UI/Controls/IFileBrowserPanel.cs
+++ b/Radoub.UI/Radoub.UI/Controls/IFileBrowserPanel.cs
@@ -58,6 +58,25 @@ public class FileBrowserEntry
     public string? HakPath { get; set; }
 
     /// <summary>
+    /// Localized in-game name (e.g., UTI.LocalizedName, UTM.LocName, UTC.FirstName+LastName).
+    /// Null until the panel's IndexMetadataAsync hook populates it. Used by
+    /// <see cref="BrowserSortMode.Name"/> sort/search.
+    /// </summary>
+    public string? DisplayLabel { get; set; }
+
+    /// <summary>
+    /// Script tag (e.g., UTI.Tag). Null until IndexMetadataAsync populates.
+    /// Used by <see cref="BrowserSortMode.Tag"/> sort/search.
+    /// </summary>
+    public string? Tag { get; set; }
+
+    /// <summary>
+    /// True once DisplayLabel/Tag have been populated (or attempted) for this entry.
+    /// Lets the panel skip re-indexing entries that already have metadata.
+    /// </summary>
+    public bool MetadataLoaded { get; set; }
+
+    /// <summary>
     /// Display name shown in the list. Override for custom formatting.
     /// </summary>
     public virtual string DisplayName => IsFromHak ? $"{Name} ({Source})" : Name;

--- a/Radoub.UI/Radoub.UI/Controls/ItemBrowserPanel.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ItemBrowserPanel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Radoub.Formats.Common;
@@ -167,6 +168,138 @@ public class ItemBrowserPanel : FileBrowserPanelBase
 
     protected override Task<byte[]> ApplyCopyCustomizationsAsync(byte[] sourceBytes, CopyToModuleResult result)
         => Task.FromResult(ApplyUtiCopyCustomizations(sourceBytes, result));
+
+    /// <summary>
+    /// Optional shared UTI palette cache. When provided, BIF/HAK entries pull
+    /// Tag/DisplayLabel from the cache (zero disk I/O) before falling back to
+    /// extraction. Module entries always read GFF directly.
+    /// </summary>
+    public ISharedPaletteCacheService? PaletteCache { get; set; }
+
+    /// <summary>
+    /// Background pass: populate Tag + DisplayLabel on every entry that does
+    /// not yet have metadata. Yields every 50 entries to keep the UI thread
+    /// responsive. Honors <paramref name="cancellationToken"/> between batches.
+    /// </summary>
+    protected override async Task IndexMetadataAsync(
+        IReadOnlyList<FileBrowserEntry> entries,
+        CancellationToken cancellationToken)
+    {
+        var paletteLookup = BuildPaletteLookup();
+        int processed = 0;
+
+        foreach (var entry in entries)
+        {
+            if (cancellationToken.IsCancellationRequested) return;
+            if (entry.MetadataLoaded) { processed++; continue; }
+
+            try
+            {
+                if (TryFillFromCache(entry, paletteLookup))
+                {
+                    entry.MetadataLoaded = true;
+                }
+                else
+                {
+                    var bytes = await ReadEntryBytesAsync(entry, cancellationToken);
+                    if (bytes != null)
+                    {
+                        var (tag, name) = await ReadSourceMetadataAsync(bytes);
+                        entry.Tag = tag;
+                        entry.DisplayLabel = name;
+                    }
+                    entry.MetadataLoaded = true;
+                }
+            }
+            catch (Exception ex)
+            {
+                UnifiedLogger.LogApplication(LogLevel.WARN,
+                    $"ItemBrowserPanel.IndexMetadataAsync({entry.Name}): {ex.Message}");
+                entry.MetadataLoaded = true; // don't retry forever
+            }
+
+            processed++;
+            if (processed % 50 == 0)
+            {
+                await Task.Yield();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Build a ResRef → cache-item lookup from the active palette cache. Returns
+    /// an empty dictionary when no cache is wired or the cache is empty.
+    /// </summary>
+    private Dictionary<string, SharedPaletteCacheItem> BuildPaletteLookup()
+    {
+        if (PaletteCache == null) return new Dictionary<string, SharedPaletteCacheItem>();
+
+        var items = PaletteCache.GetAggregatedCache();
+        if (items == null || items.Count == 0)
+            return new Dictionary<string, SharedPaletteCacheItem>();
+
+        var dict = new Dictionary<string, SharedPaletteCacheItem>(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in items)
+        {
+            // First-write-wins matches the lookup order used elsewhere
+            // (Module > Override > HAK > BIF takes priority via insertion order).
+            dict.TryAdd(item.ResRef, item);
+        }
+        return dict;
+    }
+
+    /// <summary>
+    /// Pure-logic test seam: try to populate Tag + DisplayLabel from a cache
+    /// lookup. Returns true on hit, false on miss. Lookup is keyed by ResRef
+    /// (case-insensitive — caller responsible for using OrdinalIgnoreCase).
+    /// </summary>
+    internal static bool TryFillFromCache(
+        FileBrowserEntry entry,
+        Dictionary<string, SharedPaletteCacheItem> lookup)
+    {
+        if (lookup.Count == 0) return false;
+        if (!lookup.TryGetValue(entry.Name, out var item)) return false;
+
+        entry.Tag = item.Tag ?? string.Empty;
+        entry.DisplayLabel = item.DisplayName ?? string.Empty;
+        return true;
+    }
+
+    private async Task<byte[]?> ReadEntryBytesAsync(
+        FileBrowserEntry entry,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrEmpty(entry.FilePath) && File.Exists(entry.FilePath))
+        {
+            return await File.ReadAllBytesAsync(entry.FilePath, cancellationToken);
+        }
+
+        // HAK/BIF/archive entry — synchronous extraction wrapped in Task.Run
+        return await Task.Run(() => ExtractItemArchiveBytes(entry, GameDataService), cancellationToken);
+    }
+
+    /// <summary>
+    /// Reset metadata so the next indexing pass re-reads Tag + DisplayLabel for
+    /// the given entry. Called by tools after a save so the browser row updates
+    /// without a full reindex.
+    /// </summary>
+    public override async Task RefreshEntryMetadataAsync(FileBrowserEntry entry)
+    {
+        try
+        {
+            var bytes = await ReadEntryBytesAsync(entry, CancellationToken.None);
+            if (bytes == null) return;
+            var (tag, name) = await ReadSourceMetadataAsync(bytes);
+            entry.Tag = tag;
+            entry.DisplayLabel = name;
+            entry.MetadataLoaded = true;
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"ItemBrowserPanel.RefreshEntryMetadataAsync({entry.Name}): {ex.Message}");
+        }
+    }
 
     /// <summary>
     /// Rewrite a UTI byte blob with the user's new TemplateResRef/Tag/LocalizedName.

--- a/Relique/Relique/Views/MainWindow.Lifecycle.cs
+++ b/Relique/Relique/Views/MainWindow.Lifecycle.cs
@@ -170,6 +170,11 @@ public partial class MainWindow
         // Wire GameDataService for "Base Game" (BIF) item scanning (#2106)
         ItemBrowserPanel.GameDataService = _gameDataService;
 
+        // Wire shared UTI palette cache for Tag/Name indexing (#2186 / #2198).
+        // BIF + HAK entries pull from cache (warmed by Trebuchet) so first-time
+        // indexing is instant; cache miss falls back to per-file GFF read.
+        ItemBrowserPanel.PaletteCache = new SharedPaletteCacheService();
+
         // Set initial module path from RadoubSettings (set by Trebuchet)
         var moduleDir = GetModuleWorkingDirectory(RadoubSettings.Instance.CurrentModulePath);
         if (!string.IsNullOrEmpty(moduleDir))


### PR DESCRIPTION
## Summary

Sprint 1 of epic #2186 🎯 (user-reported by Toblerone on Discord 2026-05-22). Foundation work in `Radoub.UI` to enable Name/Tag sort + search across all file browser panels. Also wires Relique's `ItemBrowserPanel` end-to-end so the feature is verifiable.

### What this PR adds

**Shared (Radoub.UI)**:
- `BrowserSortMode` enum (`ResRef | Name | Tag`) in `Radoub.UI.Controls`
- New fields on `FileBrowserEntry`: `DisplayLabel`, `Tag`, `MetadataLoaded`
- `BrowserSortLogic.FilterAndSort` pure-logic static helper (test seam)
- **DataGrid replaces ListBox** in `FileBrowserPanelBase`: 4 columns (ResRef / Name / Tag / Source). Click a column header to sort by that field — each sort field is its own visible column so users can see the data they're sorting on.
- `Sorting` event intercepted to map clicked column → `BrowserSortMode` and cancel built-in DataGrid sort (preserves module-first tier)
- New virtual hooks: `IndexMetadataAsync(entries, ct)`, `RefreshEntryMetadataAsync(entry)`, `SupportedSortModes`
- `SupportedSortModes` controls column visibility — Parley `DialogBrowserPanel` hides Name + Tag columns (DLG has no equivalents)
- Background prefetch wiring with per-module `CancellationTokenSource`
- 16 unit tests on `BrowserSortLogic` (sort/filter logic)

**Relique (`ItemBrowserPanel`)** — rolled in from Sprint 2 (#2199) for end-to-end verification:
- `IndexMetadataAsync` override: reads GFF bytes (file or archive), calls existing `ReadSourceMetadataAsync`, yields every 50 entries, honors cancellation
- `PaletteCache` property: when set, indexing first tries `SharedPaletteCacheService` (zero disk I/O for warmed BIF/HAK items)
- `RefreshEntryMetadataAsync` override for single-entry save-flow refresh
- Relique MainWindow wires `PaletteCache` to the panel
- 5 unit tests on `TryFillFromCache` (cache-lookup logic)

### Deferred

- **`SharedPaletteCacheService` generalization** (UTI → UTI/UTC/UTM discriminator) moved to whichever of Sprint 3 (#2200, Fence) or Sprint 4 (#2201, QM) lands first
- **Relique save-flow integration** (call `RefreshEntryMetadataAsync` after UTI save) — remaining Sprint 2 (#2199) scope; thin polish PR
- Round-trip tests with real sample UTI files — current tests cover logic seams only

### Out of scope (v1 decisions)

- No status bar progress UI (background indexing silent)
- No persisted sort mode across sessions
- No TLK lookup for base game StrRef-only Name (fall back to ResRef)
- No DataGrid column-width persistence (revisit if user requests)

## Related Issues

- Closes #2198
- Part of epic #2186 🎯 (user-reported)
- Advances #2199 (Sprint 2 Relique) — partial completion; comment posted
- Still blocks #2200 (Fence) and #2201 (Quartermaster)

## Research

`NonPublic/Radoub/Research/2186-name-tag-search.md`

## Pre-merge results

| Check | Status |
|-------|--------|
| Privacy scan | ✅ No hardcoded paths |
| Tech debt | ✅ No files >800 lines |
| Theme scan | ⚠️ 22 pre-existing warnings (none introduced) |
| Solution build | ✅ 0 errors |
| Radoub.UI.Tests | ✅ **688 passed** (was 683 + 5 new indexing tests) |
| Relique.Tests | ✅ 307 passed |
| Fence.Tests | ✅ 138 passed |
| Quartermaster.Tests | ✅ 1195 passed |
| Parley.Tests | ✅ 838 passed |
| FlaUI | ⏭️ Skipped — logic covered by unit tests |
| CHANGELOG | ✅ No `[Unreleased]` sections |

## Manual spot-checks (for reviewer)

- [ ] Launch Relique → browser shows DataGrid with ResRef / Name / Tag / Source columns; **Name + Tag values populate** for module items after brief background pass
- [ ] Click "Name" column header → rows re-sort by display name; module entries before HAK
- [ ] Click "Tag" column header → rows re-sort by script tag
- [ ] Toggle HAK / BIF checkboxes → those entries also get Name/Tag indexed
- [ ] Launch Fence → DataGrid renders but Name/Tag columns empty (Sprint 3 work)
- [ ] Launch Quartermaster → DataGrid renders but Name/Tag columns empty (Sprint 4 work)
- [ ] Launch Parley → DLG browser hides Name + Tag columns (ResRef + Source only)
- [ ] Search box watermark changes per active sort column
- [ ] Double-click row → opens file (unchanged); right-click → Copy-to-Module visible for HAK rows (unchanged)

## Checklist

- [x] BrowserSortMode enum + FileBrowserEntry fields
- [x] BrowserSortLogic static helper with 16 unit tests
- [x] DataGrid replaces ListBox with sortable column headers
- [x] Virtual hooks: IndexMetadataAsync, RefreshEntryMetadataAsync, SupportedSortModes
- [x] Background prefetch + CancellationTokenSource per module
- [x] DialogBrowserPanel restricted to ResRef-only (Name/Tag columns hidden)
- [x] Selection / double-tap / context-request / Copy-to-Module / Delete rebound to DataGrid
- [x] **Relique ItemBrowserPanel IndexMetadataAsync override** (end-to-end verification)
- [x] **5 unit tests on TryFillFromCache cache-lookup logic**
- [x] Relique MainWindow wires PaletteCache
- [x] /pre-merge clean (5375 unit tests pass across 9 projects)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)