### PR TITLE
[Radoub] Sprint: Dependabot Dependency Updates (#2189)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,11 @@ Desktop.ini
 ~$*
 nul
 
+# Root-level build/test logs (dev-local only)
+/build.log
+/test.log
+/flaui*.log
+
 # Python
 __pycache__/
 *.py[cod]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,13 +5,13 @@
 
   <ItemGroup>
     <!-- Avalonia UI Framework -->
-    <PackageVersion Include="Avalonia" Version="11.3.13" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.13" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.13" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.13" />
+    <PackageVersion Include="Avalonia" Version="11.3.16" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.3.16" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.16" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.16" />
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.3.13" />
-    <PackageVersion Include="Avalonia.Skia" Version="11.3.13" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.13" />
+    <PackageVersion Include="Avalonia.Skia" Version="11.3.16" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.16" />
 
     <!-- SkiaSharp -->
     <PackageVersion Include="SkiaSharp" Version="3.119.2" />
@@ -25,8 +25,8 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
 
     <!-- DI / Logging -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 
     <!-- Audio -->
     <PackageVersion Include="NAudio" Version="2.3.0" />
@@ -34,7 +34,7 @@
 
     <!-- Graphics / Rendering -->
     <PackageVersion Include="Pfim" Version="0.11.4" />
-    <PackageVersion Include="Silk.NET.OpenGL" Version="2.22.0" />
+    <PackageVersion Include="Silk.NET.OpenGL" Version="2.23.0" />
     <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="11.3.9.5" />
 
     <!-- Spell-checking -->
@@ -47,7 +47,7 @@
     <PackageVersion Include="AvaloniaGraphControl" Version="0.7.0" />
 
     <!-- Testing -->
-    <PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.13" />
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.16" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />


### PR DESCRIPTION
## Summary

Consolidates 7 of 8 open dependabot PRs into a single sprint.

| Package | From | To | Risk |
|---------|------|----|----|
| Avalonia (+ Skia, Themes.Fluent, Fonts.Inter, Diagnostics, Desktop, Headless.XUnit) | 11.3.13 | 11.3.16 | Low (patch) |
| Microsoft.Extensions.DependencyInjection | 10.0.5 | 10.0.8 | Low (patch) |
| Microsoft.Extensions.Logging | 10.0.5 | 10.0.8 | Low (patch) |
| Silk.NET.OpenGL | 2.22.0 | 2.23.0 | Low (minor) |

**Consolidates**: #2189, #2190, #2191, #2192, #2194, #2195, #2197

**Skipped**: #2193 (Svg.Controls.Skia.Avalonia 11.3.9.5 -> 12.0.0.11) — requires Avalonia 12 (major). Per user instruction.

**Note**: `Avalonia.Controls.DataGrid` kept at 11.3.13 — no 11.3.16 release on NuGet. Compatible since DataGrid 11.3.13 requires Avalonia >= 11.3.13.

## Test Results

- **Build**: ✅ 0 errors, 20 warnings (all pre-existing xUnit1051/CS1998 in test files, not dep-related)
- **Unit tests**: ✅ **4,676 passed, 0 failed, 1 skipped**
  - Radoub.Dictionary.Tests: 54/54
  - Radoub.Formats.Tests: 1,231/1,232 (1 pre-existing skip)
  - Radoub.UI.Tests: 688/688
  - Parley.Tests: 814/814
  - Manifest.Tests: 104/104
  - Quartermaster.Tests: 1,195/1,195
  - Fence.Tests: 138/138
  - Relique.Tests: 307/307
  - Trebuchet.Tests: 145/145
- **FlaUI integration**: 74 passed, 17 skipped, 1 flake (`CreaturePicker_LoadsCreaturesFromTestModule` — passed on retry; FlaUI focus issue, not dep-related)

## Risk Assessment

All low-risk patch/minor bumps. No breaking changes. Avalonia 11.3.13 → 11.3.16 is a 3-patch jump on the same minor line.

## Checklist

- [x] Build passes
- [x] Unit tests pass (4,676/4,676)
- [x] FlaUI integration verified (flake confirmed flake on retry)
- [x] Skipped Avalonia 12 major (#2193)
- [ ] Close superseded dependabot PRs after merge

## Post-Merge Cleanup

```
gh pr close 2189 --comment "Superseded by #<this-pr>"
gh pr close 2190 --comment "Superseded by #<this-pr>"
gh pr close 2191 --comment "Superseded by #<this-pr>"
gh pr close 2192 --comment "Superseded by #<this-pr>"
gh pr close 2194 --comment "Superseded by #<this-pr>"
gh pr close 2195 --comment "Superseded by #<this-pr>"
gh pr close 2197 --comment "Superseded by #<this-pr>"
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)