### PR TITLE
[Quartermaster] Feat: Adopt FileBrowserPanelBase Name/Tag sort + search (#2201)

### DIFF
--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.92-alpha] - 2026-05-24
+**Branch**: `quartermaster/issue-2201` | **PR**: #TBD
+
+### Feat: Adopt FileBrowserPanelBase Name/Tag sort + search (#2201)
+
+Sprint 4 of #2186. `CreatureBrowserPanel` now supports Name and Tag sort/search via the FileBrowserPanelBase infrastructure landed in Sprint 1 (#2198), mirroring the Relique (#2199) and Fence (#2200) adoptions.
+
+- HAK/BIF creatures indexed instantly from persistent palette cache (`~/Radoub/Cache/CreaturePalette/`)
+- Module + vault creatures indexed lazily via background GFF read
+- Saving a UTC/BIC refreshes its browser row Tag/Name without full reindex
+- BIC files share the UTC indexing path (same GFF schema)
+
+---
+
 ## [0.2.91-alpha] - 2026-05-01
 **Branch**: `radoub/issue-2159` | **PR**: #2160
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.92-alpha] - 2026-05-24
-**Branch**: `quartermaster/issue-2201` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2201` | **PR**: #2213
 
 ### Feat: Adopt FileBrowserPanelBase Name/Tag sort + search (#2201)
 

--- a/Quartermaster/Quartermaster/Views/MainWindow.FileOps.cs
+++ b/Quartermaster/Quartermaster/Views/MainWindow.FileOps.cs
@@ -539,6 +539,11 @@ public partial class MainWindow
             ShowProgress(false);
             UpdateStatus($"Saved: {Path.GetFileName(_currentFilePath)}");
 
+            // Refresh browser row Tag/Name without full reindex (#2201).
+            // Fire-and-forget — save flow does not block on UI refresh.
+            var creatureBrowserPanel = this.FindControl<CreatureBrowserPanel>("CreatureBrowserPanel");
+            _ = Radoub.UI.Controls.BrowserSaveNotifier.NotifyAsync(creatureBrowserPanel, _currentFilePath);
+
             UnifiedLogger.LogCreature(LogLevel.INFO, $"Saved creature: {UnifiedLogger.SanitizePath(_currentFilePath)}");
         }
         catch (Exception ex)

--- a/Quartermaster/Quartermaster/Views/MainWindow.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/MainWindow.axaml.cs
@@ -52,6 +52,13 @@ public partial class MainWindow : Window, INotifyPropertyChanged
     private AudioService? _audioService;
     private bool _servicesInitialized;
 
+    // Per-resource UTC palette cache for creature browser Name/Tag indexing (#2201).
+    // Subdirectory keeps it isolated from the UTI ItemPalette and UTM StorePalette caches.
+    private readonly ISharedPaletteCacheService _creaturePaletteCache =
+        new SharedPaletteCacheService(Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            "Radoub", "Cache", "CreaturePalette"));
+
     // Service accessors with null guards - throw clear error instead of NullReferenceException
     private IGameDataService GameData => _gameDataService ?? throw new InvalidOperationException("GameDataService not initialized - services must be initialized before use");
     private CreatureDisplayService DisplayService => _creatureDisplayService ?? throw new InvalidOperationException("CreatureDisplayService not initialized");
@@ -246,10 +253,12 @@ public partial class MainWindow : Window, INotifyPropertyChanged
         InventoryPanelContent.DeleteFromBackpackRequested += OnDeleteFromBackpackRequested;
 
         // Provide GameDataService to creature browser for BIF scanning (#1133)
+        // and shared palette cache for Name/Tag indexing (#2201).
         var creatureBrowserPanel = this.FindControl<CreatureBrowserPanel>("CreatureBrowserPanel");
         if (creatureBrowserPanel != null)
         {
             creatureBrowserPanel.GameDataService = _gameDataService;
+            creatureBrowserPanel.PaletteCache = _creaturePaletteCache;
         }
     }
 

--- a/Radoub.UI/Radoub.UI.Tests/AssemblyInfo.cs
+++ b/Radoub.UI/Radoub.UI.Tests/AssemblyInfo.cs
@@ -1,0 +1,14 @@
+using Xunit;
+
+// Force every test in this assembly to run sequentially. A subset of tests
+// (ItemBrowserPanelBifTests.GameDataService_IsSettableAndReadable) instantiates
+// Avalonia controls (ItemBrowserPanel -> FileBrowserPanelBase.InitializeComponent),
+// which touches the process-global Avalonia.AvaloniaPropertyRegistry. When xUnit
+// runs test classes in parallel, two classes instantiating Avalonia controls on
+// different threads race on that registry and throw
+// "An item with the same key has already been added. Key: Avalonia.Controls.MenuItem"
+// (surfaced on PR #2213 / Sprint 4 of #2186).
+//
+// Mirrors the Radoub.IntegrationTests pattern (#1526). Cheap — full assembly
+// runs in ~7s.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Radoub.UI/Radoub.UI.Tests/CreatureBrowserPanelCachePopulatorTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/CreatureBrowserPanelCachePopulatorTests.cs
@@ -1,3 +1,4 @@
+using Radoub.Formats.Bic;
 using Radoub.Formats.Utc;
 using Radoub.UI.Controls;
 using Radoub.UI.Services;
@@ -93,5 +94,26 @@ public class CreatureBrowserPanelCachePopulatorTests
             sourceLocation: "HAK: broken.hak");
 
         Assert.Null(item);
+    }
+
+    [Fact]
+    public void BuildPaletteItemFromUtc_AcceptsBicBytes_ExtractsFirstAndLastName()
+    {
+        // BIC and UTC share Tag/FirstName/LastName at the root struct, but
+        // BIC has FileType "BIC " — UtcReader would reject this. Verify the
+        // GFF-direct read path works for player-character bytes.
+        var bic = new BicFile { Tag = "PLAYER_TAG" };
+        bic.FirstName.SetString(0, "Aragorn");
+        bic.LastName.SetString(0, "Elessar");
+        var bytes = BicWriter.Write(bic);
+
+        var item = CreatureBrowserPanel.BuildPaletteItemFromUtc(
+            bytes,
+            resRef: "hero",
+            sourceLocation: "LocalVault");
+
+        Assert.NotNull(item);
+        Assert.Equal("PLAYER_TAG", item!.Tag);
+        Assert.Equal("Aragorn Elessar", item.DisplayName);
     }
 }

--- a/Radoub.UI/Radoub.UI.Tests/CreatureBrowserPanelCachePopulatorTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/CreatureBrowserPanelCachePopulatorTests.cs
@@ -1,0 +1,97 @@
+using Radoub.Formats.Utc;
+using Radoub.UI.Controls;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Tests for CreatureBrowserPanel.BuildPaletteItemFromUtc — the pure-logic
+/// helper that produces a SharedPaletteCacheItem from a UTC byte buffer,
+/// used by the HAK/BIF eager populator (#2186 Sprint 4 / #2201).
+/// </summary>
+public class CreatureBrowserPanelCachePopulatorTests
+{
+    private static byte[] BuildUtc(string resRef, string tag, string firstName, string lastName)
+    {
+        var utc = new UtcFile
+        {
+            TemplateResRef = resRef,
+            Tag = tag
+        };
+        utc.FirstName.SetString(0, firstName);
+        utc.LastName.SetString(0, lastName);
+        return UtcWriter.Write(utc);
+    }
+
+    [Fact]
+    public void BuildPaletteItemFromUtc_PopulatesResRefTagAndFullName()
+    {
+        var bytes = BuildUtc("nw_orc01", "NW_ORC_GRUNT", "Orog", "Stoneskull");
+
+        var item = CreatureBrowserPanel.BuildPaletteItemFromUtc(
+            bytes,
+            resRef: "nw_orc01",
+            sourceLocation: "HAK: my_module.hak");
+
+        Assert.NotNull(item);
+        Assert.Equal("nw_orc01", item!.ResRef);
+        Assert.Equal("NW_ORC_GRUNT", item.Tag);
+        Assert.Equal("Orog Stoneskull", item.DisplayName);
+        Assert.Equal("HAK: my_module.hak", item.SourceLocation);
+    }
+
+    [Fact]
+    public void BuildPaletteItemFromUtc_EmptyLastName_DisplayNameIsFirstNameOnly()
+    {
+        var bytes = BuildUtc("nw_villager", "TAG", "Bartholomew", string.Empty);
+
+        var item = CreatureBrowserPanel.BuildPaletteItemFromUtc(
+            bytes,
+            resRef: "nw_villager",
+            sourceLocation: "Base Game");
+
+        Assert.NotNull(item);
+        Assert.Equal("Bartholomew", item!.DisplayName);
+    }
+
+    [Fact]
+    public void BuildPaletteItemFromUtc_EmptyFirstName_DisplayNameIsLastNameOnly()
+    {
+        var bytes = BuildUtc("nw_lord", "TAG", string.Empty, "Greyhawk");
+
+        var item = CreatureBrowserPanel.BuildPaletteItemFromUtc(
+            bytes,
+            resRef: "nw_lord",
+            sourceLocation: "Base Game");
+
+        Assert.NotNull(item);
+        Assert.Equal("Greyhawk", item!.DisplayName);
+    }
+
+    [Fact]
+    public void BuildPaletteItemFromUtc_BothNamesEmpty_DisplayNameIsEmpty()
+    {
+        var bytes = BuildUtc("nw_anon", string.Empty, string.Empty, string.Empty);
+
+        var item = CreatureBrowserPanel.BuildPaletteItemFromUtc(
+            bytes,
+            resRef: "nw_anon",
+            sourceLocation: "HAK: anon.hak");
+
+        Assert.NotNull(item);
+        Assert.Equal(string.Empty, item!.DisplayName);
+        Assert.Equal(string.Empty, item.Tag);
+    }
+
+    [Fact]
+    public void BuildPaletteItemFromUtc_CorruptBytes_ReturnsNull()
+    {
+        var item = CreatureBrowserPanel.BuildPaletteItemFromUtc(
+            new byte[] { 0xFF, 0xFF, 0xFF, 0xFF },
+            resRef: "broken",
+            sourceLocation: "HAK: broken.hak");
+
+        Assert.Null(item);
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/CreatureBrowserPanelIndexingTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/CreatureBrowserPanelIndexingTests.cs
@@ -1,0 +1,98 @@
+using Radoub.UI.Controls;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Tests for CreatureBrowserPanel.TryFillFromCache — the pure-logic helper
+/// that hydrates FileBrowserEntry.Tag/DisplayLabel from the shared palette
+/// cache during background indexing (#2186 Sprint 4 / #2201).
+/// </summary>
+public class CreatureBrowserPanelIndexingTests
+{
+    private static Dictionary<string, SharedPaletteCacheItem> Lookup(
+        params SharedPaletteCacheItem[] items)
+    {
+        var dict = new Dictionary<string, SharedPaletteCacheItem>(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in items)
+            dict.TryAdd(item.ResRef, item);
+        return dict;
+    }
+
+    [Fact]
+    public void TryFillFromCache_PopulatesTagAndDisplayLabel_OnHit()
+    {
+        var entry = new CreatureBrowserEntry { Name = "nw_orc01" };
+        var lookup = Lookup(new SharedPaletteCacheItem
+        {
+            ResRef = "nw_orc01",
+            Tag = "NW_ORC_GRUNT",
+            DisplayName = "Orog Stoneskull"
+        });
+
+        var hit = CreatureBrowserPanel.TryFillFromCache(entry, lookup);
+
+        Assert.True(hit);
+        Assert.Equal("NW_ORC_GRUNT", entry.Tag);
+        Assert.Equal("Orog Stoneskull", entry.DisplayLabel);
+    }
+
+    [Fact]
+    public void TryFillFromCache_ReturnsFalse_OnMiss()
+    {
+        var entry = new CreatureBrowserEntry { Name = "missing_creature" };
+        var lookup = Lookup(new SharedPaletteCacheItem
+        {
+            ResRef = "different_creature",
+            Tag = "X",
+            DisplayName = "Y"
+        });
+
+        var hit = CreatureBrowserPanel.TryFillFromCache(entry, lookup);
+
+        Assert.False(hit);
+        Assert.Null(entry.Tag);
+        Assert.Null(entry.DisplayLabel);
+    }
+
+    [Fact]
+    public void TryFillFromCache_EmptyLookup_ReturnsFalse()
+    {
+        var entry = new CreatureBrowserEntry { Name = "anything" };
+        var lookup = new Dictionary<string, SharedPaletteCacheItem>(StringComparer.OrdinalIgnoreCase);
+
+        Assert.False(CreatureBrowserPanel.TryFillFromCache(entry, lookup));
+    }
+
+    [Fact]
+    public void TryFillFromCache_CaseInsensitiveLookup()
+    {
+        var entry = new CreatureBrowserEntry { Name = "NW_ORC01" }; // uppercase
+        var lookup = Lookup(new SharedPaletteCacheItem
+        {
+            ResRef = "nw_orc01", // lowercase cache key
+            Tag = "TAG",
+            DisplayName = "Name"
+        });
+
+        Assert.True(CreatureBrowserPanel.TryFillFromCache(entry, lookup));
+        Assert.Equal("TAG", entry.Tag);
+    }
+
+    [Fact]
+    public void TryFillFromCache_NullTagOrName_ResolveToEmpty()
+    {
+        var entry = new CreatureBrowserEntry { Name = "creature" };
+        var lookup = Lookup(new SharedPaletteCacheItem
+        {
+            ResRef = "creature",
+            Tag = null!,
+            DisplayName = null!
+        });
+
+        Assert.True(CreatureBrowserPanel.TryFillFromCache(entry, lookup));
+        Assert.Equal(string.Empty, entry.Tag);
+        Assert.Equal(string.Empty, entry.DisplayLabel);
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/CreatureBrowserPanelRefreshTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/CreatureBrowserPanelRefreshTests.cs
@@ -1,0 +1,143 @@
+using System.IO;
+using Radoub.Formats.Utc;
+using Radoub.UI.Controls;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Tests for CreatureBrowserPanel.RefreshEntryFromDiskAsync — the save-flow
+/// hook that re-reads Tag/DisplayLabel from a UTC on disk after the host tool
+/// (Quartermaster) overwrites it (#2186 Sprint 4 / #2201).
+/// </summary>
+public class CreatureBrowserPanelRefreshTests
+{
+    private static byte[] BuildUtc(string resRef, string tag, string firstName, string lastName)
+    {
+        var utc = new UtcFile
+        {
+            TemplateResRef = resRef,
+            Tag = tag
+        };
+        utc.FirstName.SetString(0, firstName);
+        utc.LastName.SetString(0, lastName);
+        return UtcWriter.Write(utc);
+    }
+
+    [Fact]
+    public async Task RefreshEntryFromDiskAsync_RereadsUpdatedTagAndName()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(tempFile, BuildUtc("orc01", "OLD_TAG", "Orog", "Stoneskull"));
+            var entry = new CreatureBrowserEntry
+            {
+                Name = "orc01",
+                FilePath = tempFile,
+                Tag = "OLD_TAG",
+                DisplayLabel = "Orog Stoneskull",
+                MetadataLoaded = true
+            };
+
+            File.WriteAllBytes(tempFile, BuildUtc("orc01", "NEW_TAG", "Grommash", "Hellscream"));
+
+            await CreatureBrowserPanel.RefreshEntryFromDiskAsync(entry);
+
+            Assert.Equal("NEW_TAG", entry.Tag);
+            Assert.Equal("Grommash Hellscream", entry.DisplayLabel);
+            Assert.True(entry.MetadataLoaded);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task RefreshEntryFromDiskAsync_FirstNameOnly_DisplayLabelTrimmed()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(tempFile, BuildUtc("villager", "TAG", "Bartholomew", string.Empty));
+            var entry = new CreatureBrowserEntry
+            {
+                Name = "villager",
+                FilePath = tempFile
+            };
+
+            await CreatureBrowserPanel.RefreshEntryFromDiskAsync(entry);
+
+            Assert.Equal("Bartholomew", entry.DisplayLabel);
+            Assert.True(entry.MetadataLoaded);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task RefreshEntryFromDiskAsync_NullFilePath_NoOp()
+    {
+        var entry = new CreatureBrowserEntry
+        {
+            Name = "hak_creature",
+            FilePath = null,
+            Tag = "FROM_CACHE",
+            DisplayLabel = "From Cache",
+            MetadataLoaded = true
+        };
+
+        await CreatureBrowserPanel.RefreshEntryFromDiskAsync(entry);
+
+        Assert.Equal("FROM_CACHE", entry.Tag);
+        Assert.Equal("From Cache", entry.DisplayLabel);
+    }
+
+    [Fact]
+    public async Task RefreshEntryFromDiskAsync_MissingFile_NoOp()
+    {
+        var entry = new CreatureBrowserEntry
+        {
+            Name = "ghost",
+            FilePath = @"C:\nonexistent\ghost.utc",
+            Tag = "PRIOR_TAG",
+            DisplayLabel = "Prior Name",
+            MetadataLoaded = true
+        };
+
+        await CreatureBrowserPanel.RefreshEntryFromDiskAsync(entry);
+
+        Assert.Equal("PRIOR_TAG", entry.Tag);
+        Assert.Equal("Prior Name", entry.DisplayLabel);
+    }
+
+    [Fact]
+    public async Task RefreshEntryFromDiskAsync_CorruptFile_EntryUnchanged()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(tempFile, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF });
+            var entry = new CreatureBrowserEntry
+            {
+                Name = "corrupt",
+                FilePath = tempFile,
+                Tag = "PRIOR_TAG",
+                DisplayLabel = "Prior Name",
+                MetadataLoaded = true
+            };
+
+            await CreatureBrowserPanel.RefreshEntryFromDiskAsync(entry);
+
+            Assert.Equal("PRIOR_TAG", entry.Tag);
+            Assert.Equal("Prior Name", entry.DisplayLabel);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/CreatureBrowserPanelRefreshTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/CreatureBrowserPanelRefreshTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using Radoub.Formats.Bic;
 using Radoub.Formats.Utc;
 using Radoub.UI.Controls;
 using Xunit;
@@ -112,6 +113,39 @@ public class CreatureBrowserPanelRefreshTests
 
         Assert.Equal("PRIOR_TAG", entry.Tag);
         Assert.Equal("Prior Name", entry.DisplayLabel);
+    }
+
+    [Fact]
+    public async Task RefreshEntryFromDiskAsync_BicFile_ReadsFirstAndLastName()
+    {
+        // Vault rows are BIC files. BIC has FileType "BIC " — UtcReader
+        // would reject it. Verify the GFF-direct path picks up Tag and the
+        // FirstName/LastName CExoLocStrings.
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var bic = new BicFile { Tag = "PLAYER_TAG" };
+            bic.FirstName.SetString(0, "Aragorn");
+            bic.LastName.SetString(0, "Elessar");
+            File.WriteAllBytes(tempFile, BicWriter.Write(bic));
+
+            var entry = new CreatureBrowserEntry
+            {
+                Name = "hero",
+                FilePath = tempFile,
+                IsBic = true
+            };
+
+            await CreatureBrowserPanel.RefreshEntryFromDiskAsync(entry);
+
+            Assert.Equal("PLAYER_TAG", entry.Tag);
+            Assert.Equal("Aragorn Elessar", entry.DisplayLabel);
+            Assert.True(entry.MetadataLoaded);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
     }
 
     [Fact]

--- a/Radoub.UI/Radoub.UI/Controls/CreatureBrowserPanel.cs
+++ b/Radoub.UI/Radoub.UI/Controls/CreatureBrowserPanel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -61,7 +62,7 @@ internal class CreatureHakCacheEntry
 /// Creature browser panel for embedding in Quartermaster's main window.
 /// Provides .utc/.bic file list from module, vaults, and HAKs.
 /// </summary>
-public class CreatureBrowserPanel : FileBrowserPanelBase
+public class CreatureBrowserPanel : FileBrowserPanelBase, IBrowserRowRefresher
 {
     private readonly IScriptBrowserContext? _context;
     private readonly CheckBox _showModuleCheck;
@@ -212,6 +213,251 @@ public class CreatureBrowserPanel : FileBrowserPanelBase
                 $"CreatureBrowserPanel.ReadSourceMetadataAsync: {ex.Message}");
             return Task.FromResult((string.Empty, string.Empty));
         }
+    }
+
+    /// <summary>
+    /// Optional shared UTC palette cache. When provided, BIF/HAK entries pull
+    /// Tag/DisplayLabel from the cache (zero disk I/O) before falling back to
+    /// GFF extraction. Module + vault entries always read GFF directly.
+    /// Callers should construct a <see cref="SharedPaletteCacheService"/>
+    /// pointing at a UTC-specific subdirectory (e.g. ~/Radoub/Cache/CreaturePalette/)
+    /// so it does not collide with the UTI/UTM caches.
+    /// </summary>
+    public ISharedPaletteCacheService? PaletteCache { get; set; }
+
+    /// <summary>
+    /// Background pass: populate Tag + DisplayLabel on every entry that does
+    /// not yet have metadata. Yields every 50 entries to keep the UI thread
+    /// responsive. Honors <paramref name="cancellationToken"/> between batches.
+    /// </summary>
+    protected override async Task IndexMetadataAsync(
+        IReadOnlyList<FileBrowserEntry> entries,
+        CancellationToken cancellationToken)
+    {
+        var paletteLookup = BuildPaletteLookup();
+        int processed = 0;
+
+        foreach (var entry in entries)
+        {
+            if (cancellationToken.IsCancellationRequested) return;
+            if (entry.MetadataLoaded) { processed++; continue; }
+
+            try
+            {
+                if (TryFillFromCache(entry, paletteLookup))
+                {
+                    entry.MetadataLoaded = true;
+                }
+                else
+                {
+                    var bytes = await ReadEntryBytesAsync(entry, cancellationToken);
+                    if (bytes != null)
+                    {
+                        var (tag, name) = await ReadSourceMetadataAsync(bytes);
+                        entry.Tag = tag;
+                        entry.DisplayLabel = name;
+                    }
+                    entry.MetadataLoaded = true;
+                }
+            }
+            catch (Exception ex)
+            {
+                UnifiedLogger.LogApplication(LogLevel.WARN,
+                    $"CreatureBrowserPanel.IndexMetadataAsync({entry.Name}): {ex.Message}");
+                entry.MetadataLoaded = true; // don't retry forever
+            }
+
+            processed++;
+            if (processed % 50 == 0)
+            {
+                await Task.Yield();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Build a ResRef → cache-item lookup from the active palette cache. Returns
+    /// an empty dictionary when no cache is wired or the cache is empty.
+    /// </summary>
+    private Dictionary<string, SharedPaletteCacheItem> BuildPaletteLookup()
+    {
+        if (PaletteCache == null) return new Dictionary<string, SharedPaletteCacheItem>();
+
+        var items = PaletteCache.GetAggregatedCache();
+        if (items == null || items.Count == 0)
+            return new Dictionary<string, SharedPaletteCacheItem>();
+
+        var dict = new Dictionary<string, SharedPaletteCacheItem>(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in items)
+        {
+            dict.TryAdd(item.ResRef, item);
+        }
+        return dict;
+    }
+
+    /// <summary>
+    /// Pure-logic test seam: try to populate Tag + DisplayLabel from a cache
+    /// lookup. Returns true on hit, false on miss. Lookup is keyed by ResRef
+    /// (case-insensitive — caller responsible for using OrdinalIgnoreCase).
+    /// </summary>
+    internal static bool TryFillFromCache(
+        FileBrowserEntry entry,
+        Dictionary<string, SharedPaletteCacheItem> lookup)
+    {
+        if (lookup.Count == 0) return false;
+        if (!lookup.TryGetValue(entry.Name, out var item)) return false;
+
+        entry.Tag = item.Tag ?? string.Empty;
+        entry.DisplayLabel = item.DisplayName ?? string.Empty;
+        return true;
+    }
+
+    private async Task<byte[]?> ReadEntryBytesAsync(
+        FileBrowserEntry entry,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrEmpty(entry.FilePath) && File.Exists(entry.FilePath))
+        {
+            return await File.ReadAllBytesAsync(entry.FilePath, cancellationToken);
+        }
+
+        // HAK/BIF/archive entry — synchronous extraction wrapped in Task.Run
+        return await Task.Run(() => ExtractCreatureArchiveBytes(entry, GameDataService), cancellationToken);
+    }
+
+    /// <summary>
+    /// Route an archive-sourced CreatureBrowserEntry to the correct extraction path
+    /// (BIF via GameDataService, HAK via shared ExtractFromHak helper). Returns
+    /// null when the entry is not archive-sourced or required dependencies are missing.
+    /// </summary>
+    private static byte[]? ExtractCreatureArchiveBytes(FileBrowserEntry entry, IGameDataService? gameDataService)
+    {
+        if (entry is not CreatureBrowserEntry creatureEntry) return null;
+
+        if (creatureEntry.IsFromBif)
+        {
+            if (gameDataService is { IsConfigured: true })
+                return gameDataService.FindResource(creatureEntry.Name, ResourceTypes.Utc);
+            return null;
+        }
+
+        if (creatureEntry.IsFromHak && !string.IsNullOrEmpty(creatureEntry.HakPath))
+            return ExtractFromHak(creatureEntry.HakPath, creatureEntry.Name, ResourceTypes.Utc);
+
+        return null;
+    }
+
+    /// <summary>
+    /// Re-read metadata for a single entry — called by the host tool after a
+    /// save so the browser row reflects the new Tag/Name without a full reindex.
+    /// </summary>
+    public override async Task RefreshEntryMetadataAsync(FileBrowserEntry entry)
+    {
+        try
+        {
+            var bytes = await ReadEntryBytesAsync(entry, CancellationToken.None);
+            if (bytes == null) return;
+            var (tag, name) = await ReadSourceMetadataAsync(bytes);
+            entry.Tag = tag;
+            entry.DisplayLabel = name;
+            entry.MetadataLoaded = true;
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"CreatureBrowserPanel.RefreshEntryMetadataAsync({entry.Name}): {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// <see cref="IBrowserRowRefresher"/> implementation. Host tools should
+    /// depend on the interface (via <see cref="BrowserSaveNotifier"/>) rather
+    /// than calling the static method directly, so the post-save wire-up is
+    /// testable with a fake refresher.
+    /// </summary>
+    public Task RefreshRowAsync(string filePath)
+    {
+        var entry = FindEntryByFilePath(filePath);
+        return entry == null ? Task.CompletedTask : RefreshEntryFromDiskAsync(entry);
+    }
+
+    /// <summary>
+    /// Pure-logic helper: parse a UTC byte blob into a <see cref="SharedPaletteCacheItem"/>
+    /// for cache persistence. Returns null on parse failure so the populator can
+    /// skip corrupt entries without aborting an entire HAK scan. DisplayName uses
+    /// the canonical "{FirstName} {LastName}".Trim() formatting (matches
+    /// CreatureDisplayService.GetCreatureFullName).
+    /// </summary>
+    public static SharedPaletteCacheItem? BuildPaletteItemFromUtc(
+        byte[] bytes,
+        string resRef,
+        string sourceLocation)
+    {
+        try
+        {
+            var utc = Radoub.Formats.Utc.UtcReader.Read(bytes);
+            var firstName = utc.FirstName.GetDefault() ?? string.Empty;
+            var lastName = utc.LastName.GetDefault() ?? string.Empty;
+            var fullName = string.IsNullOrEmpty(lastName) ? firstName : $"{firstName} {lastName}".Trim();
+            return new SharedPaletteCacheItem
+            {
+                ResRef = resRef,
+                Tag = utc.Tag ?? string.Empty,
+                DisplayName = fullName,
+                SourceLocation = sourceLocation
+            };
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"CreatureBrowserPanel.BuildPaletteItemFromUtc({resRef}): {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Save-flow hook for module + vault entries: re-read Tag + DisplayLabel
+    /// from the on-disk UTC/BIC bytes. Pure-static so host tools (Quartermaster)
+    /// can call without holding a CreatureBrowserPanel reference, and so the
+    /// round-trip is unit-testable without Avalonia (#2201).
+    ///
+    /// No-op for entries without a FilePath (HAK/BIF rows are cache-driven).
+    /// On read or parse failure the entry is left untouched.
+    /// </summary>
+    public static async Task RefreshEntryFromDiskAsync(FileBrowserEntry entry)
+    {
+        if (string.IsNullOrEmpty(entry.FilePath)) return;
+        if (!File.Exists(entry.FilePath)) return;
+
+        try
+        {
+            var bytes = await File.ReadAllBytesAsync(entry.FilePath);
+            var utc = Radoub.Formats.Utc.UtcReader.Read(bytes);
+            var firstName = utc.FirstName.GetDefault() ?? string.Empty;
+            var lastName = utc.LastName.GetDefault() ?? string.Empty;
+            entry.Tag = utc.Tag ?? string.Empty;
+            entry.DisplayLabel = string.IsNullOrEmpty(lastName)
+                ? firstName
+                : $"{firstName} {lastName}".Trim();
+            entry.MetadataLoaded = true;
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"CreatureBrowserPanel.RefreshEntryFromDiskAsync({entry.Name}): {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// True when the persistent palette cache for this HAK is missing or stale —
+    /// the populator should extract+parse the UTCs and write the cache. False
+    /// when no PaletteCache is wired or the existing cache is fresh.
+    /// </summary>
+    private bool ShouldPopulatePaletteCacheForHak(string hakPath, DateTime lastModified)
+    {
+        if (PaletteCache == null) return false;
+        if (PaletteCache.HasValidSourceCache("hak", hakPath)) return false;
+        return true;
     }
 
     protected override Task<byte[]> ApplyCopyCustomizationsAsync(byte[] sourceBytes, CopyToModuleResult result)
@@ -580,6 +826,11 @@ public class CreatureBrowserPanel : FileBrowserPanelBase
                 Creatures = new List<CreatureBrowserEntry>()
             };
 
+            // Persistent palette cache: populate Tag/DisplayName for instant
+            // sort/search on subsequent panel loads (#2201).
+            var populate = ShouldPopulatePaletteCacheForHak(hakPath, lastModified);
+            var paletteItems = populate ? new List<SharedPaletteCacheItem>() : null;
+
             foreach (var resource in utcResources)
             {
                 var creatureEntry = new CreatureBrowserEntry
@@ -593,6 +844,16 @@ public class CreatureBrowserPanel : FileBrowserPanelBase
 
                 newCacheEntry.Creatures.Add(creatureEntry);
 
+                if (populate && paletteItems != null)
+                {
+                    var bytes = ExtractFromHak(hakPath, resource.ResRef, ResourceTypes.Utc);
+                    if (bytes != null)
+                    {
+                        var item = BuildPaletteItemFromUtc(bytes, resource.ResRef, $"HAK: {hakFileName}");
+                        if (item != null) paletteItems.Add(item);
+                    }
+                }
+
                 // Skip if already have this creature
                 if (_hakEntries.Any(c => c.Name.Equals(resource.ResRef, StringComparison.OrdinalIgnoreCase)))
                     continue;
@@ -601,6 +862,15 @@ public class CreatureBrowserPanel : FileBrowserPanelBase
             }
 
             _hakCache[hakPath] = newCacheEntry;
+
+            if (populate && paletteItems != null && PaletteCache != null)
+            {
+                _ = PaletteCache.SaveSourceCacheAsync(
+                    "hak",
+                    paletteItems,
+                    validationPath: hakPath,
+                    sourceModified: lastModified);
+            }
 
             UnifiedLogger.LogApplication(LogLevel.DEBUG,
                 $"CreatureBrowserPanel: Cached {utcResources.Count} creatures from {hakFileName}");
@@ -626,11 +896,18 @@ public class CreatureBrowserPanel : FileBrowserPanelBase
             var sw = System.Diagnostics.Stopwatch.StartNew();
             ShowLoading("Scanning base game creatures...");
 
+            // Capture GameDataService into local for closure use inside Task.Run
+            var gameDataService = GameDataService;
+            var populate = PaletteCache != null && !PaletteCache.HasValidSourceCache("bif");
+            List<SharedPaletteCacheItem>? paletteItems = null;
+
             await Task.Run(() =>
             {
-                var resources = GameDataService.ListResources(ResourceTypes.Utc)
+                var resources = gameDataService.ListResources(ResourceTypes.Utc)
                     .Where(r => r.Source == GameResourceSource.Bif)
                     .ToList();
+
+                if (populate) paletteItems = new List<SharedPaletteCacheItem>();
 
                 foreach (var resource in resources)
                 {
@@ -642,11 +919,26 @@ public class CreatureBrowserPanel : FileBrowserPanelBase
                         IsFromBif = true,
                         IsBic = false
                     });
+
+                    if (populate && paletteItems != null)
+                    {
+                        var bytes = gameDataService.FindResource(resource.ResRef, ResourceTypes.Utc);
+                        if (bytes != null)
+                        {
+                            var item = BuildPaletteItemFromUtc(bytes, resource.ResRef, "Base Game");
+                            if (item != null) paletteItems.Add(item);
+                        }
+                    }
                 }
 
                 UnifiedLogger.LogApplication(LogLevel.INFO,
                     $"[TIMING] CreatureBrowserPanel: BIF scan — {_bifEntries.Count} creatures in {sw.ElapsedMilliseconds}ms (KEY cache lookup)");
             });
+
+            if (populate && paletteItems != null && PaletteCache != null)
+            {
+                _ = PaletteCache.SaveSourceCacheAsync("bif", paletteItems);
+            }
 
             _bifEntries = _bifEntries.OrderBy(e => e.Name).ToList();
             _bifCreaturesLoaded = true;

--- a/Radoub.UI/Radoub.UI/Controls/CreatureBrowserPanel.cs
+++ b/Radoub.UI/Radoub.UI/Controls/CreatureBrowserPanel.cs
@@ -8,6 +8,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Radoub.Formats.Common;
 using Radoub.Formats.Erf;
+using Radoub.Formats.Gff;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Resolver;
 using Radoub.Formats.Services;
@@ -201,11 +202,8 @@ public class CreatureBrowserPanel : FileBrowserPanelBase, IBrowserRowRefresher
     {
         try
         {
-            var utc = Radoub.Formats.Utc.UtcReader.Read(bytes);
-            var firstName = utc.FirstName.GetDefault() ?? string.Empty;
-            var lastName = utc.LastName.GetDefault() ?? string.Empty;
-            var fullName = string.IsNullOrEmpty(lastName) ? firstName : $"{firstName} {lastName}".Trim();
-            return Task.FromResult((utc.Tag ?? string.Empty, fullName));
+            var (tag, name) = ReadCreatureMetadataFromGff(bytes);
+            return Task.FromResult((tag, name));
         }
         catch (Exception ex)
         {
@@ -213,6 +211,32 @@ public class CreatureBrowserPanel : FileBrowserPanelBase, IBrowserRowRefresher
                 $"CreatureBrowserPanel.ReadSourceMetadataAsync: {ex.Message}");
             return Task.FromResult((string.Empty, string.Empty));
         }
+    }
+
+    /// <summary>
+    /// Pull Tag + FirstName/LastName from a UTC- or BIC-formatted GFF byte
+    /// buffer. Bypasses UtcReader/BicReader file-type validation so a single
+    /// path handles both resource types — they share Tag, FirstName, and
+    /// LastName field names at the root struct.
+    /// </summary>
+    private static (string tag, string name) ReadCreatureMetadataFromGff(byte[] bytes)
+    {
+        var gff = GffReader.Read(bytes);
+        var root = gff.RootStruct;
+        var tag = root.GetFieldValue<string>("Tag", string.Empty) ?? string.Empty;
+
+        var firstNameField = root.GetField("FirstName");
+        var firstName = firstNameField?.Value is CExoLocString fn
+            ? fn.GetDefault() ?? string.Empty
+            : string.Empty;
+
+        var lastNameField = root.GetField("LastName");
+        var lastName = lastNameField?.Value is CExoLocString ln
+            ? ln.GetDefault() ?? string.Empty
+            : string.Empty;
+
+        var fullName = string.IsNullOrEmpty(lastName) ? firstName : $"{firstName} {lastName}".Trim();
+        return (tag, fullName);
     }
 
     /// <summary>
@@ -382,11 +406,13 @@ public class CreatureBrowserPanel : FileBrowserPanelBase, IBrowserRowRefresher
     }
 
     /// <summary>
-    /// Pure-logic helper: parse a UTC byte blob into a <see cref="SharedPaletteCacheItem"/>
-    /// for cache persistence. Returns null on parse failure so the populator can
-    /// skip corrupt entries without aborting an entire HAK scan. DisplayName uses
-    /// the canonical "{FirstName} {LastName}".Trim() formatting (matches
-    /// CreatureDisplayService.GetCreatureFullName).
+    /// Pure-logic helper: parse a UTC or BIC byte blob into a
+    /// <see cref="SharedPaletteCacheItem"/> for cache persistence. Returns null
+    /// on parse failure so the populator can skip corrupt entries without
+    /// aborting an entire HAK scan. DisplayName uses the canonical
+    /// "{FirstName} {LastName}".Trim() formatting (matches
+    /// CreatureDisplayService.GetCreatureFullName). BIC and UTC share Tag,
+    /// FirstName, and LastName fields, so a single helper handles both.
     /// </summary>
     public static SharedPaletteCacheItem? BuildPaletteItemFromUtc(
         byte[] bytes,
@@ -395,14 +421,11 @@ public class CreatureBrowserPanel : FileBrowserPanelBase, IBrowserRowRefresher
     {
         try
         {
-            var utc = Radoub.Formats.Utc.UtcReader.Read(bytes);
-            var firstName = utc.FirstName.GetDefault() ?? string.Empty;
-            var lastName = utc.LastName.GetDefault() ?? string.Empty;
-            var fullName = string.IsNullOrEmpty(lastName) ? firstName : $"{firstName} {lastName}".Trim();
+            var (tag, fullName) = ReadCreatureMetadataFromGff(bytes);
             return new SharedPaletteCacheItem
             {
                 ResRef = resRef,
-                Tag = utc.Tag ?? string.Empty,
+                Tag = tag,
                 DisplayName = fullName,
                 SourceLocation = sourceLocation
             };
@@ -419,7 +442,8 @@ public class CreatureBrowserPanel : FileBrowserPanelBase, IBrowserRowRefresher
     /// Save-flow hook for module + vault entries: re-read Tag + DisplayLabel
     /// from the on-disk UTC/BIC bytes. Pure-static so host tools (Quartermaster)
     /// can call without holding a CreatureBrowserPanel reference, and so the
-    /// round-trip is unit-testable without Avalonia (#2201).
+    /// round-trip is unit-testable without Avalonia (#2201). Handles both UTC
+    /// and BIC formats — they share Tag/FirstName/LastName field layout.
     ///
     /// No-op for entries without a FilePath (HAK/BIF rows are cache-driven).
     /// On read or parse failure the entry is left untouched.
@@ -432,13 +456,9 @@ public class CreatureBrowserPanel : FileBrowserPanelBase, IBrowserRowRefresher
         try
         {
             var bytes = await File.ReadAllBytesAsync(entry.FilePath);
-            var utc = Radoub.Formats.Utc.UtcReader.Read(bytes);
-            var firstName = utc.FirstName.GetDefault() ?? string.Empty;
-            var lastName = utc.LastName.GetDefault() ?? string.Empty;
-            entry.Tag = utc.Tag ?? string.Empty;
-            entry.DisplayLabel = string.IsNullOrEmpty(lastName)
-                ? firstName
-                : $"{firstName} {lastName}".Trim();
+            var (tag, fullName) = ReadCreatureMetadataFromGff(bytes);
+            entry.Tag = tag;
+            entry.DisplayLabel = fullName;
             entry.MetadataLoaded = true;
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary

Sprint 4 of #2186. `CreatureBrowserPanel` adopts the FileBrowserPanelBase Name/Tag sort + search infrastructure landed in Sprint 1 (#2198), mirroring Relique (#2199) and Fence (#2200).

- HAK/BIF creatures pull metadata instantly from `~/Radoub/Cache/CreaturePalette/` (per-resource cache, isolated from ItemPalette/StorePalette)
- Module + vault (LocalVault/ServerVault/DmVault) creatures index lazily via background GFF read
- Saving a UTC/BIC refreshes its browser row Tag/Name via `BrowserSaveNotifier` — no full reindex
- BIC indexing: single GFF-direct read path handles both UTC and BIC at the browser layer (UtcReader/BicReader file-type validation would otherwise reject BIC bytes in the UTC path)

## Related Issues

- Closes #2201
- Relates to #2186 (epic)

## Pre-Merge Checklist

| Check | Status |
|-------|--------|
| Privacy scan | ✅ PASS — no hardcoded paths |
| Tech debt | ⚠️ Warning: CreatureBrowserPanel.cs 921 lines (>800, <1000 — no tracking issue required) |
| Unit tests | ✅ 3218 passed (Radoub.Formats 1233, Radoub.UI 736, Radoub.Dictionary 54, Quartermaster 1195) |
| UI tests (FlaUI) | ✅ 11 passed / 9 skipped — initial run had 1 flaky failure on `Quartermaster_LaunchAndCoreUI` (cold-start `GetMainWindow null` matching #1526 retry-once pattern), re-ran isolated and passed cleanly |
| CHANGELOG | ✅ 0.2.92-alpha with PR #2213, today's date |
| [Unreleased] sections | ✅ Empty across all changelogs |
| Wiki freshness | ✅ Quartermaster pages within 30-day window |
| Release notes | ✅ Updated NonPublic/release-notes.md |

## Manual Spot-Checks (recommended pre-merge)

- [ ] Sort creatures by Name shows FirstName + LastName
- [ ] Sort by Tag, search "merchant" matches by tag not filename
- [ ] Base Game checkbox: first scan creates `bif.json` cache; subsequent module open instant
- [ ] HAK checkbox: creates `hak_<name>.json`; subsequent loads instant
- [ ] LocalVault BIC rows show character name (FirstName LastName) once indexed
- [ ] ServerVault row Name shows `"resref (PlayerName)"`; sort by Name uses BIC's FirstName/LastName
- [ ] Edit UTC FirstName + Ctrl+S → browser row updates in place
- [ ] Column header click toggles asc/desc

🤖 Generated with [Claude Code](https://claude.com/claude-code)