### PR TITLE
[Parley] Fix: DialogBrowserPanel shows no entries after Name/Tag sort infrastructure (#2210)

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Parley. One-line highlights per version; full details in 
 
 ---
 
+## [0.1.168-alpha] - 2026-05-24
+**Branch**: `parley/issue-2210` | **PR**: #TBD
+
+### Fix: DialogBrowserPanel shows no entries after Name/Tag sort infrastructure (#2210)
+
+- Regression from #2198 — Parley dialog browser was empty after FileBrowserPanelBase Name/Tag adoption
+- Restores `.dlg` listing while preserving ResRef-only sort for DLG (no Tag/LocName)
+
+---
+
 ## [0.1.167-alpha] - 2026-05-01
 **Branch**: `radoub/issue-2159` | **PR**: #2160
 

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Parley. One-line highlights per version; full details in 
 ---
 
 ## [0.1.168-alpha] - 2026-05-24
-**Branch**: `parley/issue-2210` | **PR**: #TBD
+**Branch**: `parley/issue-2210` | **PR**: #2214
 
 ### Fix: DialogBrowserPanel shows no entries after Name/Tag sort infrastructure (#2210)
 

--- a/Parley/Parley.Tests/AppStylesIncludeTests.cs
+++ b/Parley/Parley.Tests/AppStylesIncludeTests.cs
@@ -1,0 +1,46 @@
+using System.IO;
+using Xunit;
+
+namespace Parley.Tests;
+
+/// <summary>
+/// Regression test for #2210: Parley's App.axaml must include the Avalonia
+/// DataGrid theme so DialogBrowserPanel renders its rows.
+///
+/// FileBrowserPanelBase switched from ListBox to DataGrid in #2198. Without
+/// the explicit DataGrid theme StyleInclude, Avalonia's DataGrid measures
+/// zero-width/zero-height — the browser pane appears completely empty even
+/// though entries are loaded into the underlying list.
+///
+/// This test reads App.axaml from disk because XAML resource registration is
+/// the bug surface — runtime mocking of StyleInclude is more brittle than a
+/// simple content assertion.
+/// </summary>
+public class AppStylesIncludeTests
+{
+    [Fact]
+    public void AppAxaml_IncludesAvaloniaDataGridTheme()
+    {
+        var appAxamlPath = FindAppAxaml();
+        var content = File.ReadAllText(appAxamlPath);
+
+        Assert.Contains(
+            "avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml",
+            content);
+    }
+
+    private static string FindAppAxaml()
+    {
+        // Walk up from the test binary directory to the repo root, then descend
+        // to Parley/Parley/App.axaml. Avoids brittle ".." path math.
+        var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir.FullName, "Parley", "Parley", "App.axaml");
+            if (File.Exists(candidate))
+                return candidate;
+            dir = dir.Parent;
+        }
+        throw new FileNotFoundException("Parley/Parley/App.axaml not found from any ancestor of the test working directory.");
+    }
+}

--- a/Parley/Parley/App.axaml
+++ b/Parley/Parley/App.axaml
@@ -13,6 +13,10 @@
 
     <Application.Styles>
         <FluentTheme />
+        <!-- DataGrid requires explicit style inclusion (#2210)
+             Used by FileBrowserPanelBase since #2198. Without this include the
+             DialogBrowserPanel DataGrid renders blank (no rows, no headers). -->
+        <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
         <!-- Shared UI styles from Radoub.UI (#823, #1089) -->
         <StyleInclude Source="avares://Radoub.UI/Styles/FocusStyles.axaml"/>
         <StyleInclude Source="avares://Radoub.UI/Styles/ButtonStyles.axaml"/>
@@ -68,6 +72,11 @@
         </Style>
 
         <Style Selector="ListBox">
+            <Setter Property="FontSize" Value="{DynamicResource GlobalFontSize}"/>
+            <Setter Property="FontFamily" Value="{DynamicResource GlobalFontFamily}"/>
+        </Style>
+
+        <Style Selector="DataGrid">
             <Setter Property="FontSize" Value="{DynamicResource GlobalFontSize}"/>
             <Setter Property="FontFamily" Value="{DynamicResource GlobalFontFamily}"/>
         </Style>


### PR DESCRIPTION
## Summary

Fix regression introduced in #2198 (FileBrowserPanelBase ListBox → DataGrid refactor). Parley's `App.axaml` was missing the `avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml` StyleInclude that the other Radoub tools (Fence, Relique, Quartermaster, Trebuchet) already had. Without the theme, Avalonia's DataGrid rendered no headers and no rows — so the DialogBrowserPanel appeared completely empty even though `_filteredEntries` was populated with 70 entries.

## Root Cause

`FileBrowserPanelBase` switched ListBox → DataGrid in #2198 but the dependency on `Avalonia.Controls.DataGrid/Themes/Fluent.xaml` was not propagated to Parley's `App.axaml`. The fix adds the missing `StyleInclude` plus a `DataGrid` font Style for consistency with the existing per-control font convention.

Manifest also uses the shared UI but does not (yet) embed any DataGrid, so no fix needed there. Verified Fence, Relique, Quartermaster, Trebuchet all already have the include.

## Changes

- `Parley/Parley/App.axaml` — Add DataGrid theme StyleInclude + DataGrid font Style
- `Parley/Parley.Tests/AppStylesIncludeTests.cs` — Regression test asserting `App.axaml` contains the StyleInclude (verified fails when StyleInclude is removed)

## Related Issues

- Closes #2210
- Relates to epic #2186
- Regression from #2198 (Sprint 1)
- Surfaced by #2200 (Sprint 3 pre-merge spot-check)

## Manual Verification

Opened `LNS_DLG` module (70 `.dlg` files) with `--file party.dlg`:
- Browser shows the full sorted ResRef + Source list
- ResRef-only sort mode preserved (DLG has no Tag/LocName)
- "Show HAK" checkbox + search box unchanged
- Column headers ("ResRef", "Source") visible
- HAK toggle still works

## Tests

- Parley.Tests: 839/839 ✅
- Radoub.UI.Tests: 740/740 ✅
- FlaUI smoke (Parley `Category=Smoke`): 1/1 ✅
- Privacy scan: PASS
- Tech debt: PASS (no files >800 lines in this PR)

## Checklist

- [x] Root cause identified
- [x] Fix implemented
- [x] Regression test added in `Parley.Tests`
- [x] Manual verification: Parley dialog browser shows all `.dlg` files from module
- [x] Manual verification: HAK toggle still works
- [x] Manual verification: ResRef sort still works
- [x] CHANGELOG updated with date and PR number

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)