### PR TITLE
[Trebuchet] Sprint: Marlinspike Bug Bash (#2216)

### DIFF
--- a/.claude/scripts/BugBash-Filter.ps1
+++ b/.claude/scripts/BugBash-Filter.ps1
@@ -1,0 +1,93 @@
+<#
+.SYNOPSIS
+    Filter cached issues for bug-bash sprint planning.
+
+.DESCRIPTION
+    Reads .claude/cache/github-data.json and emits bug-tagged issues with
+    age/inactivity, optionally excluding one or more labels (e.g. model-rendering).
+    Also supports a title-keyword exclusion to drop issues that lack a label but
+    clearly belong to the excluded area.
+
+.PARAMETER ExcludeLabels
+    Labels to exclude (comma-separated or array). Default: model-rendering.
+
+.PARAMETER ExcludeTitleRegex
+    Regex of title keywords to exclude. Default catches rendering-by-symptom
+    issues that lack the model-rendering label.
+
+.PARAMETER Tool
+    Optional tool label filter (parley, quartermaster, etc.).
+
+.PARAMETER CacheFile
+    Path to the cache JSON. Defaults to repo cache location.
+
+.PARAMETER AsJson
+    Emit JSON instead of a formatted table.
+
+.EXAMPLE
+    # Default bug-bash filter
+    .\BugBash-Filter.ps1
+
+.EXAMPLE
+    # Strict label-only exclusion
+    .\BugBash-Filter.ps1 -ExcludeTitleRegex ''
+
+.EXAMPLE
+    # Exclude both rendering and accessibility, Trebuchet only
+    .\BugBash-Filter.ps1 -ExcludeLabels model-rendering,accessibility -Tool Trebuchet
+
+.EXAMPLE
+    # Machine-readable
+    .\BugBash-Filter.ps1 -AsJson
+#>
+
+param(
+    [string[]]$ExcludeLabels = @('model-rendering'),
+    [string]$ExcludeTitleRegex = 'render|3D preview|animation playback|floating body|floating fangs|preview has floating|broken/floating',
+    [string]$Tool,
+    [string]$CacheFile,
+    [switch]$AsJson
+)
+
+if (-not $CacheFile) {
+    $CacheFile = Join-Path $PSScriptRoot "..\cache\github-data.json"
+}
+
+if (-not (Test-Path $CacheFile)) {
+    Write-Error "Cache not found: $CacheFile. Run Refresh-GitHubCache.ps1"
+    exit 1
+}
+
+$d = Get-Content $CacheFile | ConvertFrom-Json
+
+$bugs = $d.issues | Where-Object {
+    $names = $_.labels.nodes.name
+    if ($names -notcontains 'bug') { return $false }
+    foreach ($excl in $ExcludeLabels) {
+        if ($names -contains $excl) { return $false }
+    }
+    if ($Tool -and ($names -notcontains $Tool)) { return $false }
+    if ($ExcludeTitleRegex -and $_.title -match $ExcludeTitleRegex) { return $false }
+    return $true
+}
+
+$rows = $bugs | ForEach-Object {
+    $names = $_.labels.nodes.name
+    [PSCustomObject]@{
+        number       = $_.number
+        title        = $_.title
+        ageDays      = [int]((Get-Date) - [datetime]$_.createdAt).TotalDays
+        inactiveDays = [int]((Get-Date) - [datetime]$_.updatedAt).TotalDays
+        labels       = ($names -join ',')
+        assigned     = ($_.assignees.nodes.login -join ',')
+        comments     = $_.comments.totalCount
+    }
+} | Sort-Object ageDays -Descending
+
+if ($AsJson) {
+    $rows | ConvertTo-Json -Depth 4
+} else {
+    "Bug-bash candidates: $($rows.Count)  (excluded labels: $($ExcludeLabels -join ', '); tool: $(if($Tool){$Tool}else{'all'}))"
+    ""
+    $rows | Format-Table -AutoSize -Wrap
+}

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/ItpSearchProviderReplaceTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/ItpSearchProviderReplaceTests.cs
@@ -1,0 +1,221 @@
+using Radoub.Formats.Common;
+using Radoub.Formats.Gff;
+using Radoub.Formats.Search;
+using Xunit;
+
+namespace Radoub.Formats.Tests.Search.Providers;
+
+/// <summary>
+/// Tests for ItpSearchProvider.Replace (#2178 follow-up).
+///
+/// The standard (non-rename) Marlinspike replace path goes through
+/// BatchReplaceService → provider.Replace. ItpSearchProvider.Replace
+/// was previously stubbed out ("ITP palette replace not yet supported"),
+/// causing ITP files to silently skip even when their search matches were
+/// part of the preview.
+/// </summary>
+public class ItpSearchProviderReplaceTests
+{
+    private static readonly FieldDefinition ResRefField = new()
+    {
+        Name = "ResRef",
+        GffPath = "RESREF",
+        FieldType = SearchFieldType.ResRef,
+        Category = SearchFieldCategory.Identity,
+        Description = "Blueprint resource reference",
+        IsReplaceable = false  // requires allowResRefReplace
+    };
+
+    private static readonly FieldDefinition BlueprintNameField = new()
+    {
+        Name = "Name",
+        GffPath = "NAME",
+        FieldType = SearchFieldType.Text,
+        Category = SearchFieldCategory.Content,
+        Description = "Blueprint name"
+    };
+
+    [Fact]
+    public void Replace_FlatItpResRefMatch_UpdatesBlueprintResRef()
+    {
+        var gff = BuildFlatItp(("blackbear", "Black Bear"), ("wolf", "Wolf"));
+        var op = new ReplaceOperation
+        {
+            Match = new SearchMatch
+            {
+                Field = ResRefField,
+                MatchedText = "blackbear",
+                FullFieldValue = "blackbear",
+                MatchOffset = 0,
+                MatchLength = "blackbear".Length,
+                Location = new ItpMatchLocation
+                {
+                    NodeType = ItpNodeType.Blueprint,
+                    DisplayPath = "Bears > Black Bear"
+                }
+            },
+            ReplacementText = "newbear99",
+            AllowResRefReplace = true
+        };
+
+        var provider = new ItpSearchProvider();
+        var results = provider.Replace(gff, new[] { op });
+
+        var result = Assert.Single(results);
+        Assert.True(result.Success, $"Replace skipped: {result.SkipReason}");
+
+        var main = gff.RootStruct.GetField("MAIN")!.Value as GffList;
+        Assert.Equal("newbear99", main!.Elements[0].GetField("RESREF")?.Value);
+        Assert.Equal("wolf", main.Elements[1].GetField("RESREF")?.Value);  // sibling untouched
+    }
+
+    [Fact]
+    public void Replace_NestedItpResRefMatch_UpdatesBlueprintResRef()
+    {
+        // MAIN[0] = category with LIST[ blueprint("blackbear","Black Bear") ]
+        var blueprint = MakeBlueprint("blackbear", "Black Bear");
+        var category = new GffStruct { Type = 1 };
+        GffFieldBuilder.AddByteField(category, "ID", 0);
+        GffFieldBuilder.AddListField(category, "LIST", new[] { blueprint });
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        GffFieldBuilder.AddListField(root, "MAIN", new[] { category });
+        var gff = new GffFile { FileType = "ITP ", FileVersion = "V3.2", RootStruct = root };
+
+        var op = new ReplaceOperation
+        {
+            Match = new SearchMatch
+            {
+                Field = ResRefField,
+                MatchedText = "blackbear",
+                FullFieldValue = "blackbear",
+                MatchOffset = 0,
+                MatchLength = "blackbear".Length,
+                Location = new ItpMatchLocation
+                {
+                    NodeType = ItpNodeType.Blueprint,
+                    DisplayPath = "Bears > Black Bear"
+                }
+            },
+            ReplacementText = "newbear",
+            AllowResRefReplace = true
+        };
+
+        var results = new ItpSearchProvider().Replace(gff, new[] { op });
+
+        Assert.True(results[0].Success);
+        var main = gff.RootStruct.GetField("MAIN")!.Value as GffList;
+        var nestedList = main!.Elements[0].GetField("LIST")!.Value as GffList;
+        Assert.Equal("newbear", nestedList!.Elements[0].GetField("RESREF")?.Value);
+    }
+
+    [Fact]
+    public void Replace_NoMatchingBlueprint_ReturnsSkipped()
+    {
+        var gff = BuildFlatItp(("wolf", "Wolf"));
+        var op = new ReplaceOperation
+        {
+            Match = new SearchMatch
+            {
+                Field = ResRefField,
+                MatchedText = "blackbear",
+                FullFieldValue = "blackbear",
+                MatchOffset = 0,
+                MatchLength = "blackbear".Length,
+                Location = new ItpMatchLocation
+                {
+                    NodeType = ItpNodeType.Blueprint,
+                    DisplayPath = "Bears > Black Bear"
+                }
+            },
+            ReplacementText = "newbear99",
+            AllowResRefReplace = true
+        };
+
+        var results = new ItpSearchProvider().Replace(gff, new[] { op });
+        Assert.False(results[0].Success);
+    }
+
+    [Fact]
+    public void Replace_BlueprintNameField_UpdatesName()
+    {
+        // Name field replace is allowed (no allowResRefReplace required).
+        var gff = BuildFlatItp(("blackbear", "Black Bear"));
+        var op = new ReplaceOperation
+        {
+            Match = new SearchMatch
+            {
+                Field = BlueprintNameField,
+                MatchedText = "Black",
+                FullFieldValue = "Black Bear",
+                MatchOffset = 0,
+                MatchLength = "Black".Length,
+                Location = new ItpMatchLocation
+                {
+                    NodeType = ItpNodeType.Blueprint,
+                    DisplayPath = "Bears > Black Bear"
+                }
+            },
+            ReplacementText = "Grizzly",
+            AllowResRefReplace = false
+        };
+
+        var results = new ItpSearchProvider().Replace(gff, new[] { op });
+
+        Assert.True(results[0].Success);
+        var main = gff.RootStruct.GetField("MAIN")!.Value as GffList;
+        Assert.Equal("Grizzly Bear", main!.Elements[0].GetField("NAME")?.Value);
+        Assert.Equal("blackbear", main.Elements[0].GetField("RESREF")?.Value);  // ResRef unchanged
+    }
+
+    [Fact]
+    public void Replace_SubstringMatchInResRef_UpdatesWithOffsetReplacement()
+    {
+        // ResRef = "blackbear_old", search matches "old" at offset 10.
+        var gff = BuildFlatItp(("blackbear_old", null));
+        var op = new ReplaceOperation
+        {
+            Match = new SearchMatch
+            {
+                Field = ResRefField,
+                MatchedText = "old",
+                FullFieldValue = "blackbear_old",
+                MatchOffset = 10,
+                MatchLength = 3,
+                Location = new ItpMatchLocation
+                {
+                    NodeType = ItpNodeType.Blueprint,
+                    DisplayPath = "Bears > Black Bear Old"
+                }
+            },
+            ReplacementText = "new",
+            AllowResRefReplace = true
+        };
+
+        var results = new ItpSearchProvider().Replace(gff, new[] { op });
+
+        Assert.True(results[0].Success);
+        var main = gff.RootStruct.GetField("MAIN")!.Value as GffList;
+        Assert.Equal("blackbear_new", main!.Elements[0].GetField("RESREF")?.Value);
+    }
+
+    // --- Test fixtures ---
+
+    private static GffStruct MakeBlueprint(string resRef, string? name)
+    {
+        var s = new GffStruct { Type = 0 };
+        GffFieldBuilder.AddCResRefField(s, "RESREF", resRef);
+        if (name != null) GffFieldBuilder.AddCExoStringField(s, "NAME", name);
+        return s;
+    }
+
+    private static GffFile BuildFlatItp(params (string resRef, string? name)[] blueprints)
+    {
+        var nodes = new List<GffStruct>();
+        foreach (var (rr, nm) in blueprints)
+            nodes.Add(MakeBlueprint(rr, nm));
+
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        GffFieldBuilder.AddListField(root, "MAIN", nodes);
+        return new GffFile { FileType = "ITP ", FileVersion = "V3.2", RootStruct = root };
+    }
+}

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ItpRenameTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ItpRenameTests.cs
@@ -1,0 +1,129 @@
+using Radoub.Formats.Common;
+using Radoub.Formats.Gff;
+using Radoub.Formats.Search.Rename;
+using Xunit;
+
+namespace Radoub.Formats.Tests.Search.Rename;
+
+/// <summary>
+/// Tests for ITP (palette) reference scanning and application (#2178).
+///
+/// ITP files are GFF-based trees where leaf "blueprint" structs carry a
+/// RESREF field pointing at a UTC/UTI/etc. file. Renaming a blueprint
+/// must update every palette referencing it.
+/// </summary>
+public class ItpRenameTests
+{
+    // --- Scanner ---
+
+    [Fact]
+    public void Scan_FlatItpWithMatchingBlueprint_FindsReference()
+    {
+        var gff = BuildItp(
+            Blueprint("louis_roumain"),
+            Blueprint("alice_smith"));
+
+        var refs = new ResRefReferenceScanner()
+            .Scan(gff, ResourceTypes.Itp, oldResRef: "louis_roumain", filePath: "/m/itemref.itp");
+
+        Assert.Single(refs);
+        Assert.Equal("louis_roumain", refs[0].OldValue);
+        Assert.Equal(ResourceTypes.Itp, refs[0].ResourceType);
+        Assert.Equal(ResRefScopeTier.TypedGffField, refs[0].ScopeTier);
+    }
+
+    [Fact]
+    public void Scan_NestedItpWithMatchingBlueprintInCategory_FindsReference()
+    {
+        // MAIN > Category(0) > LIST > [ Blueprint("louis_roumain") ]
+        var category = new GffStruct { Type = 1 };
+        GffFieldBuilder.AddByteField(category, "ID", 0);
+        GffFieldBuilder.AddListField(category, "LIST", new[] { MakeBlueprint("louis_roumain") });
+
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        GffFieldBuilder.AddListField(root, "MAIN", new[] { category });
+        var gff = new GffFile { FileType = "ITP ", FileVersion = "V3.2", RootStruct = root };
+
+        var refs = new ResRefReferenceScanner()
+            .Scan(gff, ResourceTypes.Itp, oldResRef: "louis_roumain", filePath: "/m/test.itp");
+
+        Assert.Single(refs);
+        Assert.Equal("louis_roumain", refs[0].OldValue);
+    }
+
+    [Fact]
+    public void Scan_NoMatchingBlueprint_ReturnsEmpty()
+    {
+        var gff = BuildItp(Blueprint("alice_smith"), Blueprint("bob_jones"));
+
+        var refs = new ResRefReferenceScanner()
+            .Scan(gff, ResourceTypes.Itp, oldResRef: "louis_roumain", filePath: "/m/test.itp");
+
+        Assert.Empty(refs);
+    }
+
+    [Fact]
+    public void Scan_MultipleMatches_ReturnsAll()
+    {
+        // Two blueprints with the same RESREF (palette duplicates are possible).
+        var gff = BuildItp(
+            Blueprint("louis_roumain"),
+            Blueprint("louis_roumain"));
+
+        var refs = new ResRefReferenceScanner()
+            .Scan(gff, ResourceTypes.Itp, oldResRef: "louis_roumain", filePath: "/m/test.itp");
+
+        Assert.Equal(2, refs.Count);
+        Assert.All(refs, r => Assert.Equal("louis_roumain", r.OldValue));
+    }
+
+    [Fact]
+    public void Scan_CaseInsensitiveMatch_PreservesOriginalCaseInOldValue()
+    {
+        var gff = BuildItp(Blueprint("Louis_Roumain"));
+
+        var refs = new ResRefReferenceScanner()
+            .Scan(gff, ResourceTypes.Itp, oldResRef: "louis_roumain", filePath: "/m/test.itp");
+
+        Assert.Single(refs);
+        Assert.Equal("Louis_Roumain", refs[0].OldValue);  // preserves original case
+    }
+
+    // --- Round-trip: scan + apply via Radoub.UI applier (tested in Radoub.UI.Tests) ---
+    //
+    // The applier itself lives in Radoub.UI (GffReferenceLocationApplier) so its
+    // round-trip test lives there. Here we only verify the scanner emits a
+    // Location string the applier can recognize.
+
+    [Fact]
+    public void Scan_Reference_HasItpLocationPrefix()
+    {
+        var gff = BuildItp(Blueprint("louis_roumain"));
+
+        var refs = new ResRefReferenceScanner()
+            .Scan(gff, ResourceTypes.Itp, oldResRef: "louis_roumain", filePath: "/m/test.itp");
+
+        Assert.Single(refs);
+        Assert.StartsWith("MAIN", refs[0].Location);
+        Assert.EndsWith("RESREF", refs[0].Location);
+    }
+
+    // --- Test fixtures ---
+
+    private static GffStruct MakeBlueprint(string resRef)
+    {
+        var s = new GffStruct { Type = 0 };
+        GffFieldBuilder.AddCResRefField(s, "RESREF", resRef);
+        return s;
+    }
+
+    private static GffStruct Blueprint(string resRef) => MakeBlueprint(resRef);
+
+    /// <summary>Build a minimal flat ITP: MAIN list contains blueprint structs directly.</summary>
+    private static GffFile BuildItp(params GffStruct[] blueprints)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        GffFieldBuilder.AddListField(root, "MAIN", blueprints);
+        return new GffFile { FileType = "ITP ", FileVersion = "V3.2", RootStruct = root };
+    }
+}

--- a/Radoub.Formats/Radoub.Formats/Search/Providers/ItpSearchProvider.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Providers/ItpSearchProvider.cs
@@ -119,21 +119,94 @@ public class ItpSearchProvider : SearchProviderBase, IFileSearchProvider
 
     public IReadOnlyList<ReplaceResult> Replace(GffFile gffFile, IReadOnlyList<ReplaceOperation> operations)
     {
-        // ITP palette files: names are replaceable but ResRefs are not.
-        // For now, delegate to GenericGffSearchProvider for replace operations
-        // since palette editing is rare and the tree structure makes targeted replacement complex.
+        // ITP palette replace (#2178 follow-up): walk the MAIN tree, find every
+        // blueprint struct whose target field (RESREF or NAME) equals the
+        // operation's FullFieldValue, and apply the substring replacement at
+        // MatchOffset/MatchLength.
         if (operations.Count == 0) return Array.Empty<ReplaceResult>();
 
-        return operations.Select(op => new ReplaceResult
+        var mainField = gffFile.RootStruct.GetField("MAIN");
+        if (mainField?.Value is not GffList mainList)
         {
-            Success = false,
-            Field = op.Match.Field,
-            OldValue = op.Match.FullFieldValue,
-            NewValue = op.ReplacementText,
-            Skipped = true,
-            SkipReason = "ITP palette replace not yet supported"
-        }).ToList();
+            return operations.Select(op => MakeSkipped(op, "ITP has no MAIN list")).ToList();
+        }
+
+        var results = new List<ReplaceResult>();
+        foreach (var op in operations)
+        {
+            var fieldName = op.Match.Field.GffPath;  // "RESREF" or "NAME"
+            if (string.IsNullOrEmpty(fieldName))
+            {
+                results.Add(MakeSkipped(op, "Missing field path"));
+                continue;
+            }
+
+            bool isResRefField = op.Match.Field.FieldType == SearchFieldType.ResRef;
+            if (isResRefField && !op.AllowResRefReplace)
+            {
+                results.Add(MakeSkipped(op, "ResRef field requires allowResRefReplace"));
+                continue;
+            }
+
+            int updated = ReplaceInTree(mainList, fieldName, op);
+            if (updated > 0)
+            {
+                results.Add(new ReplaceResult
+                {
+                    Success = true,
+                    Field = op.Match.Field,
+                    OldValue = op.Match.FullFieldValue,
+                    NewValue = ComputeNewValue(op.Match.FullFieldValue, op.Match.MatchOffset, op.Match.MatchLength, op.ReplacementText)
+                });
+            }
+            else
+            {
+                results.Add(MakeSkipped(op, "No matching blueprint node found"));
+            }
+        }
+        return results;
     }
+
+    private static int ReplaceInTree(GffList list, string fieldName, ReplaceOperation op)
+    {
+        int updated = 0;
+        foreach (var node in list.Elements)
+        {
+            var f = node.GetField(fieldName);
+            if (f?.Value is string current
+                && string.Equals(current, op.Match.FullFieldValue, StringComparison.Ordinal))
+            {
+                f.Value = ComputeNewValue(current, op.Match.MatchOffset, op.Match.MatchLength, op.ReplacementText);
+                updated++;
+            }
+
+            // Recurse into nested LIST
+            var childList = node.GetField("LIST")?.Value as GffList;
+            if (childList != null)
+                updated += ReplaceInTree(childList, fieldName, op);
+        }
+        return updated;
+    }
+
+    private static string ComputeNewValue(string original, int offset, int length, string replacement)
+    {
+        if (offset < 0 || offset > original.Length) return original;
+        if (length < 0 || offset + length > original.Length) return original;
+        return string.Concat(
+            original.AsSpan(0, offset),
+            replacement,
+            original.AsSpan(offset + length));
+    }
+
+    private static ReplaceResult MakeSkipped(ReplaceOperation op, string reason) => new()
+    {
+        Success = false,
+        Field = op.Match.Field,
+        OldValue = op.Match.FullFieldValue,
+        NewValue = op.ReplacementText,
+        Skipped = true,
+        SkipReason = reason
+    };
 }
 
 /// <summary>

--- a/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefReferenceScanner.cs
@@ -57,7 +57,70 @@ public class ResRefReferenceScanner
         if (resourceType == ResourceTypes.Ifo)
             ScanIfoHakList(gffFile, oldResRef, filePath, results);
 
+        if (resourceType == ResourceTypes.Itp)
+            ScanItpPaletteTree(gffFile, oldResRef, filePath, results);
+
         return results;
+    }
+
+    private static readonly FieldDefinition ItpResRefField = new()
+    {
+        Name = "Palette ResRef",
+        GffPath = "RESREF",
+        FieldType = SearchFieldType.ResRef,
+        Category = SearchFieldCategory.Identity,
+        Description = "Palette blueprint ResRef",
+        IsReplaceable = false
+    };
+
+    /// <summary>
+    /// ITP palettes are GFF trees rooted at a "MAIN" list. Nodes are either
+    /// branches/categories (containing a child "LIST") or blueprint leaves
+    /// (carrying a "RESREF" field). #2178 fix: walk the tree and emit a
+    /// reference for every blueprint whose RESREF matches.
+    ///
+    /// Location format: "MAIN > {indexPath} > RESREF" where indexPath is a
+    /// slash-separated sequence of zero-based indices from the MAIN list
+    /// down through nested LIST lists. The applier mirrors this walk.
+    /// </summary>
+    private void ScanItpPaletteTree(
+        GffFile gff, string oldResRef, string filePath, List<ResRefReference> results)
+    {
+        var mainField = gff.RootStruct.GetField("MAIN");
+        if (mainField?.Value is not GffList mainList) return;
+
+        for (int i = 0; i < mainList.Elements.Count; i++)
+            ScanItpNode(mainList.Elements[i], oldResRef, filePath, $"{i}", results);
+    }
+
+    private void ScanItpNode(
+        GffStruct node, string oldResRef, string filePath, string indexPath,
+        List<ResRefReference> results)
+    {
+        var resRefField = node.GetField("RESREF");
+        if (resRefField?.Value is string resRef
+            && string.Equals(resRef, oldResRef, StringComparison.OrdinalIgnoreCase))
+        {
+            results.Add(new ResRefReference
+            {
+                FilePath = filePath,
+                ResourceType = ResourceTypes.Itp,
+                Field = ItpResRefField,
+                Location = $"MAIN > {indexPath} > RESREF",
+                OldValue = resRef,
+                NewValue = string.Empty,
+                ScopeTier = ResRefScopeTier.TypedGffField
+            });
+        }
+
+        // Recurse into LIST children if present (categories/branches).
+        var listField = node.GetField("LIST");
+        if (listField?.Value is GffList children)
+        {
+            for (int i = 0; i < children.Elements.Count; i++)
+                ScanItpNode(children.Elements[i], oldResRef, filePath,
+                    $"{indexPath}/{i}", results);
+        }
     }
 
     private static readonly FieldDefinition ModHakField = new()

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/FileVerifyWithRetryTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/FileVerifyWithRetryTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Radoub.UI.Services.Search;
+using Xunit;
+
+namespace Radoub.UI.Tests.Services.Search;
+
+/// <summary>
+/// Unit tests for <see cref="FileVerifyWithRetry"/> — proves the retry
+/// semantics around the post-rename file-existence verify (#2181).
+/// Uses injected probe + sleep delegates so no real I/O or wall-clock sleeps.
+/// </summary>
+public class FileVerifyWithRetryTests
+{
+    [Fact]
+    public async Task WaitForAsync_ImmediateMatch_SkipsSleep()
+    {
+        var sleepCount = 0;
+        Func<int, Task> sleep = _ => { sleepCount++; return Task.CompletedTask; };
+
+        var result = await FileVerifyWithRetry.WaitForAsync(
+            probe: () => true,
+            desired: true,
+            maxAttempts: 4,
+            delayMs: 50,
+            sleep: sleep);
+
+        Assert.True(result);
+        Assert.Equal(0, sleepCount);
+    }
+
+    [Fact]
+    public async Task WaitForAsync_NeverMatches_ReturnsFalseAfterMaxAttempts()
+    {
+        var probeCount = 0;
+        var sleepCount = 0;
+        Func<int, Task> sleep = _ => { sleepCount++; return Task.CompletedTask; };
+
+        var result = await FileVerifyWithRetry.WaitForAsync(
+            probe: () => { probeCount++; return false; },
+            desired: true,
+            maxAttempts: 4,
+            delayMs: 50,
+            sleep: sleep);
+
+        Assert.False(result);
+        Assert.Equal(4, probeCount);
+        Assert.Equal(3, sleepCount);  // sleeps BETWEEN attempts, not after last
+    }
+
+    [Fact]
+    public async Task WaitForAsync_MatchesOnSecondAttempt_SleepsOnce()
+    {
+        var probeResults = new Queue<bool>(new[] { false, true });
+        var sleepCount = 0;
+        Func<int, Task> sleep = _ => { sleepCount++; return Task.CompletedTask; };
+
+        var result = await FileVerifyWithRetry.WaitForAsync(
+            probe: () => probeResults.Dequeue(),
+            desired: true,
+            maxAttempts: 4,
+            delayMs: 50,
+            sleep: sleep);
+
+        Assert.True(result);
+        Assert.Equal(1, sleepCount);
+    }
+
+    [Fact]
+    public async Task WaitForAsync_DesiredFalse_PollsForFalse()
+    {
+        // Verifies the desired parameter works in both directions (used for
+        // both WaitForGoneAsync and WaitForExistsAsync).
+        var probeResults = new Queue<bool>(new[] { true, true, false });
+        var sleepCount = 0;
+        Func<int, Task> sleep = _ => { sleepCount++; return Task.CompletedTask; };
+
+        var result = await FileVerifyWithRetry.WaitForAsync(
+            probe: () => probeResults.Dequeue(),
+            desired: false,
+            maxAttempts: 4,
+            delayMs: 50,
+            sleep: sleep);
+
+        Assert.True(result);
+        Assert.Equal(2, sleepCount);
+    }
+
+    [Fact]
+    public async Task WaitForAsync_MaxAttemptsZero_StillProbesOnce()
+    {
+        var probeCount = 0;
+        var result = await FileVerifyWithRetry.WaitForAsync(
+            probe: () => { probeCount++; return true; },
+            desired: true,
+            maxAttempts: 0,
+            delayMs: 50,
+            sleep: _ => Task.CompletedTask);
+
+        // Implementation clamps maxAttempts to >= 1.
+        Assert.True(result);
+        Assert.Equal(1, probeCount);
+    }
+
+    [Fact]
+    public async Task WaitForGoneAsync_FileAlreadyGone_ReturnsTrueWithoutSleep()
+    {
+        var sleepCount = 0;
+        var result = await FileVerifyWithRetry.WaitForGoneAsync(
+            "/definitely/does/not/exist/anywhere.tmp",
+            maxAttempts: 4,
+            delayMs: 50,
+            sleep: _ => { sleepCount++; return Task.CompletedTask; });
+
+        Assert.True(result);
+        Assert.Equal(0, sleepCount);
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/GffReferenceLocationApplierTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/GffReferenceLocationApplierTests.cs
@@ -104,6 +104,74 @@ public class GffReferenceLocationApplierTests
         Assert.Equal("bob_sword", items!.Elements[0].GetField("InventoryRes")?.Value);
     }
 
+    // --- ITP palette (#2178) ---
+
+    [Fact]
+    public void Apply_ItpFlatBlueprint_UpdatesResRef()
+    {
+        var gff = MakeFlatItp("louis_roumain", "alice_smith");
+        var refRow = MakeRef("MAIN > 0 > RESREF", ResRefScopeTier.TypedGffField, "louis_roumain");
+
+        Assert.True(_applier.Apply(gff, refRow, "bob"));
+
+        var main = gff.RootStruct.GetField("MAIN")?.Value as GffList;
+        Assert.NotNull(main);
+        Assert.Equal("bob", main!.Elements[0].GetField("RESREF")?.Value);
+        Assert.Equal("alice_smith", main.Elements[1].GetField("RESREF")?.Value);  // sibling untouched
+    }
+
+    [Fact]
+    public void Apply_ItpNestedBlueprint_UpdatesResRefByIndexPath()
+    {
+        // MAIN[0] = category with LIST[ blueprint "louis_roumain", blueprint "carol" ]
+        var blueprint0 = MakeBlueprintStruct("louis_roumain");
+        var blueprint1 = MakeBlueprintStruct("carol");
+
+        var category = new GffStruct { Type = 1 };
+        GffFieldBuilder.AddByteField(category, "ID", 0);
+        GffFieldBuilder.AddListField(category, "LIST", new[] { blueprint0, blueprint1 });
+
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        GffFieldBuilder.AddListField(root, "MAIN", new[] { category });
+        var gff = new GffFile { FileType = "ITP ", FileVersion = "V3.2", RootStruct = root };
+
+        var refRow = MakeRef("MAIN > 0/0 > RESREF", ResRefScopeTier.TypedGffField, "louis_roumain");
+
+        Assert.True(_applier.Apply(gff, refRow, "bob"));
+
+        var main = gff.RootStruct.GetField("MAIN")?.Value as GffList;
+        var nestedList = main!.Elements[0].GetField("LIST")?.Value as GffList;
+        Assert.Equal("bob", nestedList!.Elements[0].GetField("RESREF")?.Value);
+        Assert.Equal("carol", nestedList.Elements[1].GetField("RESREF")?.Value);  // sibling untouched
+    }
+
+    [Fact]
+    public void Apply_ItpInvalidIndexPath_ReturnsFalse()
+    {
+        var gff = MakeFlatItp("louis_roumain");
+        var refRow = MakeRef("MAIN > 99 > RESREF", ResRefScopeTier.TypedGffField, "louis_roumain");
+
+        Assert.False(_applier.Apply(gff, refRow, "bob"));
+    }
+
+    private static GffStruct MakeBlueprintStruct(string resRef)
+    {
+        var s = new GffStruct { Type = 0 };
+        GffFieldBuilder.AddCResRefField(s, "RESREF", resRef);
+        return s;
+    }
+
+    private static GffFile MakeFlatItp(params string[] resRefs)
+    {
+        var blueprints = new List<GffStruct>();
+        foreach (var rr in resRefs)
+            blueprints.Add(MakeBlueprintStruct(rr));
+
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        GffFieldBuilder.AddListField(root, "MAIN", blueprints);
+        return new GffFile { FileType = "ITP ", FileVersion = "V3.2", RootStruct = root };
+    }
+
     private static ResRefReference MakeRef(string location, ResRefScopeTier tier, string oldValue) => new()
     {
         FilePath = "/m/test",

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/ResRefRenameOrchestratorTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/ResRefRenameOrchestratorTests.cs
@@ -473,4 +473,107 @@ public class ResRefRenameOrchestratorTests : IDisposable
             Assert.Equal(kvp.Value, File.ReadAllBytes(path));
         }
     }
+
+    // --- #2181: Reverse rename when filename contains old name as substring ---
+
+    [Fact]
+    public async Task ExecuteAsync_ReverseRenameWithSelfReference_DoesNotFailVerify()
+    {
+        // #2181 reproduction. The original report:
+        //   1. lompqj_qu.nss exists; rename to lompqj_qu1.nss → succeeds
+        //   2. Reverse rename lompqj_qu1.nss back to lompqj_qu.nss → fails verify
+        //      "orphan file remains at .../lompqj_qu1.nss after rename"
+        //
+        // The .nss content references its own filename as a bare substring.
+
+        var moduleDir = Path.Combine(_root, "lns_dlg");
+        Directory.CreateDirectory(moduleDir);
+        var backupDir = Path.Combine(_root, ".backups");
+
+        // Start state: file is already named lompqj_qu1.nss (mid-reverse-rename scenario).
+        var startPath = Path.Combine(moduleDir, "lompqj_qu1.nss");
+        var targetPath = Path.Combine(moduleDir, "lompqj_qu.nss");
+        var nssBody =
+            "// lompqj_qu1 script\n" +
+            "void main()\n" +
+            "{\n" +
+            "    // self-reference: lompqj_qu1\n" +
+            "    ExecuteScript(\"lompqj_qu1\", OBJECT_SELF);\n" +
+            "}\n";
+        await File.WriteAllTextAsync(startPath, nssBody);
+
+        // Plan: rename lompqj_qu1 → lompqj_qu, with bare-substring + quoted refs in self.
+        var plan = new ResRefRenamePlan
+        {
+            OldName = "lompqj_qu1",
+            NewName = "lompqj_qu",
+            ResourceType = ResourceTypes.Nss,
+            Validation = ResRefValidationResult.Ok("lompqj_qu"),
+            SourceFilePath = startPath,
+            TargetFilePath = targetPath
+        };
+
+        // Self-reference: the .nss file being renamed has bare substring + quoted
+        // matches for "lompqj_qu1" in its own content. These will be rewritten by
+        // Phase 3b, then Phase 3c renames the file.
+        var bareMatch1 = nssBody.IndexOf("lompqj_qu1", StringComparison.Ordinal);  // header comment
+        var bareMatch2 = nssBody.IndexOf("lompqj_qu1", bareMatch1 + 1, StringComparison.Ordinal);  // self-reference comment
+        var quotedInner = nssBody.IndexOf("\"lompqj_qu1\"", StringComparison.Ordinal) + 1;
+
+        plan.References.Add(new ResRefReference
+        {
+            FilePath = startPath,
+            ResourceType = ResourceTypes.Nss,
+            Field = null,
+            Location = "Line 1 (substring — verify)",
+            OldValue = "lompqj_qu1",
+            NewValue = "lompqj_qu",
+            ScopeTier = ResRefScopeTier.NssBareSubstring,
+            MatchOffset = bareMatch1,
+            MatchLength = "lompqj_qu1".Length,
+            IsSelected = true
+        });
+        plan.References.Add(new ResRefReference
+        {
+            FilePath = startPath,
+            ResourceType = ResourceTypes.Nss,
+            Field = null,
+            Location = "Line 4 (substring — verify)",
+            OldValue = "lompqj_qu1",
+            NewValue = "lompqj_qu",
+            ScopeTier = ResRefScopeTier.NssBareSubstring,
+            MatchOffset = bareMatch2,
+            MatchLength = "lompqj_qu1".Length,
+            IsSelected = true
+        });
+        plan.References.Add(new ResRefReference
+        {
+            FilePath = startPath,
+            ResourceType = ResourceTypes.Nss,
+            Field = null,
+            Location = "Line 5 (quoted)",
+            OldValue = "lompqj_qu1",
+            NewValue = "lompqj_qu",
+            ScopeTier = ResRefScopeTier.NssQuotedString,
+            MatchOffset = quotedInner,
+            MatchLength = "lompqj_qu1".Length,
+            IsSelected = true
+        });
+
+        var orchestrator = new ResRefRenameOrchestrator(new BackupService(backupDir));
+        var result = await orchestrator.ExecuteAsync(new[] { plan }, "test");
+
+        Assert.True(result.Success, $"Reverse rename failed: {result.Error}");
+        Assert.False(File.Exists(startPath), "old path still exists after reverse rename");
+        Assert.True(File.Exists(targetPath), "new path missing after reverse rename");
+
+        // Content has been rewritten — no more old name.
+        var content = await File.ReadAllTextAsync(targetPath);
+        Assert.DoesNotContain("lompqj_qu1", content);
+        Assert.Contains("lompqj_qu", content);
+
+        // No .tmp residue left behind anywhere.
+        var tmpResidue = Directory.GetFiles(moduleDir, "*.tmp");
+        Assert.Empty(tmpResidue);
+    }
 }

--- a/Radoub.UI/Radoub.UI/Services/Search/FileVerifyWithRetry.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/FileVerifyWithRetry.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Radoub.UI.Services.Search;
+
+/// <summary>
+/// Retry helpers for file-existence verification after rename operations (#2181).
+///
+/// On Windows, <see cref="File.Move(string, string)"/> can return successfully
+/// while the directory cache, antivirus scanner, or NTFS USN journal briefly
+/// keeps the old path visible to subsequent <see cref="File.Exists(string)"/>
+/// calls — especially when the rename targets a path that is a substring of
+/// the source filename (e.g. `lompqj_qu1.nss` → `lompqj_qu.nss`). The orphan
+/// "remains" only for a few milliseconds; a short retry window resolves the
+/// race without masking real failures.
+///
+/// The helpers are pure (delegate-injected probe + delay) so the retry
+/// semantics can be unit-tested without sleeping the test process.
+/// </summary>
+public static class FileVerifyWithRetry
+{
+    /// <summary>Default: 3 retries, 50 ms apart (~150 ms worst case).</summary>
+    public const int DefaultMaxAttempts = 4;  // initial + 3 retries
+    public const int DefaultDelayMs = 50;
+
+    /// <summary>
+    /// Polls until <paramref name="probe"/> returns the <paramref name="desired"/>
+    /// value or <paramref name="maxAttempts"/> is exhausted. Returns true if the
+    /// probe ever reported the desired value, false if it never did.
+    /// </summary>
+    public static async Task<bool> WaitForAsync(
+        Func<bool> probe,
+        bool desired,
+        int maxAttempts = DefaultMaxAttempts,
+        int delayMs = DefaultDelayMs,
+        Func<int, Task>? sleep = null)
+    {
+        if (probe == null) throw new ArgumentNullException(nameof(probe));
+        if (maxAttempts < 1) maxAttempts = 1;
+
+        sleep ??= ms => Task.Delay(ms);
+
+        for (int attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            if (probe() == desired) return true;
+            if (attempt < maxAttempts - 1) await sleep(delayMs);
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Wait until <paramref name="path"/> no longer exists on disk. Returns true
+    /// if the path disappears within the retry window, false otherwise.
+    /// </summary>
+    public static Task<bool> WaitForGoneAsync(
+        string path,
+        int maxAttempts = DefaultMaxAttempts,
+        int delayMs = DefaultDelayMs,
+        Func<int, Task>? sleep = null)
+        => WaitForAsync(() => !File.Exists(path), desired: true, maxAttempts, delayMs, sleep);
+
+    /// <summary>
+    /// Wait until <paramref name="path"/> exists on disk. Returns true if the
+    /// path appears within the retry window, false otherwise.
+    /// </summary>
+    public static Task<bool> WaitForExistsAsync(
+        string path,
+        int maxAttempts = DefaultMaxAttempts,
+        int delayMs = DefaultDelayMs,
+        Func<int, Task>? sleep = null)
+        => WaitForAsync(() => File.Exists(path), desired: true, maxAttempts, delayMs, sleep);
+}

--- a/Radoub.UI/Radoub.UI/Services/Search/GffReferenceLocationApplier.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/GffReferenceLocationApplier.cs
@@ -30,6 +30,14 @@ public class GffReferenceLocationApplier
 
         var segments = loc.Split(" > ", StringSplitOptions.TrimEntries);
 
+        // ITP palette tree: "MAIN > {indexPath} > RESREF" where indexPath is a
+        // slash-separated sequence of zero-based indices walking the MAIN list
+        // and any nested LIST lists. See ResRefReferenceScanner.ScanItpPaletteTree (#2178).
+        if (segments.Length == 3 && segments[0] == "MAIN" && segments[2] == "RESREF")
+        {
+            return ApplyItpPaletteNode(gff, segments[1], newValue);
+        }
+
         // DLG node: "Entry N > Sound" or "Reply N > Sound" or
         //          "Entry N > ActionParams[P] (key)" or
         //          "Entry N > RepliesList[L] > ConditionParams[P] (key)" (nested)
@@ -177,6 +185,40 @@ public class GffReferenceLocationApplier
             oldFullValue.AsSpan(0, refRow.MatchOffset),
             newValue,
             oldFullValue.AsSpan(refRow.MatchOffset + refRow.MatchLength));
+        return true;
+    }
+
+    /// <summary>
+    /// Apply a RESREF update to a node inside the ITP palette tree (#2178).
+    /// <paramref name="indexPath"/> is the slash-separated index sequence
+    /// emitted by ResRefReferenceScanner.ScanItpPaletteTree, e.g. "0/2/1".
+    /// </summary>
+    private static bool ApplyItpPaletteNode(GffFile gff, string indexPath, string newValue)
+    {
+        if (string.IsNullOrEmpty(indexPath)) return false;
+
+        var indices = indexPath.Split('/');
+        if (indices.Length == 0) return false;
+
+        var mainList = gff.RootStruct.GetField("MAIN")?.Value as GffList;
+        if (mainList == null) return false;
+        if (!int.TryParse(indices[0], out var topIdx)) return false;
+        if (topIdx < 0 || topIdx >= mainList.Elements.Count) return false;
+
+        var node = mainList.Elements[topIdx];
+
+        for (int depth = 1; depth < indices.Length; depth++)
+        {
+            var listField = node.GetField("LIST")?.Value as GffList;
+            if (listField == null) return false;
+            if (!int.TryParse(indices[depth], out var childIdx)) return false;
+            if (childIdx < 0 || childIdx >= listField.Elements.Count) return false;
+            node = listField.Elements[childIdx];
+        }
+
+        var resRefField = node.GetField("RESREF");
+        if (resRefField == null) return false;
+        resRefField.Value = newValue;
         return true;
     }
 

--- a/Radoub.UI/Radoub.UI/Services/Search/ResRefRenameOrchestrator.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/ResRefRenameOrchestrator.cs
@@ -129,19 +129,32 @@ public class ResRefRenameOrchestrator
                 refsUpdated += applied;
             }
 
-            // Phase 3c: Rename files (after references are updated)
+            // Phase 3c: Rename files (after references are updated). Clear any
+            // stale .tmp residue from Phase 3a/3b atomic writes before the move
+            // so an AV scanner that briefly grabbed the .tmp can't masquerade as
+            // an orphan after the rename (#2181).
             foreach (var (oldPath, newPath) in renameMap)
             {
+                var oldTmp = oldPath + ".tmp";
+                if (File.Exists(oldTmp))
+                {
+                    try { File.Delete(oldTmp); } catch { /* best-effort */ }
+                }
                 File.Move(oldPath, newPath);
                 completedRenames.Add((oldPath, newPath));
             }
 
-            // Phase 4: Verify
+            // Phase 4: Verify — with a short retry window. Windows can briefly
+            // report stale File.Exists results after File.Move when the
+            // directory cache / AV scanner / NTFS USN journal is settling
+            // (#2181: reverse rename "lompqj_qu1.nss" → "lompqj_qu.nss" failed
+            // intermittently because the orphan check fired before the OS had
+            // released the old path).
             foreach (var (oldPath, newPath) in renameMap)
             {
-                if (!File.Exists(newPath))
+                if (!await FileVerifyWithRetry.WaitForExistsAsync(newPath))
                     throw new IOException($"Verify failed: expected file at {newPath} after rename");
-                if (File.Exists(oldPath))
+                if (!await FileVerifyWithRetry.WaitForGoneAsync(oldPath))
                     throw new IOException($"Verify failed: orphan file remains at {oldPath} after rename");
             }
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [1.34.0-alpha] - 2026-05-24
-**Branch**: `trebuchet/issue-2216` | **PR**: #TBD
+**Branch**: `trebuchet/issue-2216` | **PR**: #2221
 
 ### Sprint: Marlinspike Bug Bash (#2216)
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.34.0-alpha] - 2026-05-24
+**Branch**: `trebuchet/issue-2216` | **PR**: #TBD
+
+### Sprint: Marlinspike Bug Bash (#2216)
+
+- Fix Marlinspike search index staleness after ERF import or external file changes (#2072)
+- Extend ResRef rename to update `.itp` palette references (#2178)
+- Fix reverse rename `'orphan file remains'` when filename contains old name as substring (#2181)
+- Wire default external editor for `.nss` files (#2183)
+
+---
+
 ## [1.33.0-alpha] - 2026-05-03
 **Branch**: `trebuchet/issue-1926` | **PR**: #2169
 

--- a/Trebuchet/Trebuchet.Tests/RenameDispatchHelpersTests.cs
+++ b/Trebuchet/Trebuchet.Tests/RenameDispatchHelpersTests.cs
@@ -261,6 +261,147 @@ public class RenameDispatchHelpersTests : IDisposable
         Assert.Contains(plan.References, r => r.ResourceType == ResourceTypes.Git);
     }
 
+    // --- BuildResidualPreview (#2178 follow-up) ---
+    //
+    // When the dispatch path runs rename for filename rows, non-filename content
+    // rows in the same preview (e.g. ITP Name field matches) must still be
+    // processed by the standard replace path. BuildResidualPreview produces a
+    // preview containing only those non-filename rows, with file paths remapped
+    // to post-rename targets when the source was renamed.
+
+    [Fact]
+    public void BuildResidualPreview_StripsFilenameRows()
+    {
+        var filenameChange = new PendingChange
+        {
+            Match = MakeMatchOn(FilenameSearchProvider.FilenameField),
+            ReplacementText = "lewie",
+            FilePath = "/m/louis.utc"
+        };
+        var nameField = new FieldDefinition
+        {
+            Name = "Name", GffPath = "NAME",
+            FieldType = SearchFieldType.Text,
+            Category = SearchFieldCategory.Content
+        };
+        var contentChange = new PendingChange
+        {
+            Match = MakeMatchOn(nameField),
+            ReplacementText = "Lewie",
+            FilePath = "/m/palette.itp"
+        };
+
+        var preview = new BatchReplacePreview { AllowResRefReplace = true };
+        preview.Changes.Add(filenameChange);
+        preview.Changes.Add(contentChange);
+
+        var residual = RenameDispatchHelpers.BuildResidualPreview(
+            preview, renameMap: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+        Assert.Single(residual.Changes);
+        Assert.Same(contentChange.Match.Field, residual.Changes[0].Match.Field);
+        Assert.Equal("/m/palette.itp", residual.Changes[0].FilePath);
+        Assert.True(residual.AllowResRefReplace);
+    }
+
+    [Fact]
+    public void BuildResidualPreview_RemapsFilePathsForRenamedFiles()
+    {
+        // A non-filename change on a file that's about to be renamed must
+        // refer to the post-rename target path.
+        var resRefField = new FieldDefinition
+        {
+            Name = "ResRef", GffPath = "RESREF",
+            FieldType = SearchFieldType.ResRef,
+            Category = SearchFieldCategory.Identity,
+            IsReplaceable = false
+        };
+        var change = new PendingChange
+        {
+            Match = MakeMatchOn(resRefField),
+            ReplacementText = "lewie",
+            FilePath = "/m/louis.utc"
+        };
+        var preview = new BatchReplacePreview { AllowResRefReplace = true };
+        preview.Changes.Add(change);
+
+        var renameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["/m/louis.utc"] = "/m/lewie.utc"
+        };
+
+        var residual = RenameDispatchHelpers.BuildResidualPreview(preview, renameMap);
+
+        Assert.Single(residual.Changes);
+        Assert.Equal("/m/lewie.utc", residual.Changes[0].FilePath);
+    }
+
+    [Fact]
+    public void BuildResidualPreview_PreservesAllowResRefReplaceFlag()
+    {
+        var preview = new BatchReplacePreview { AllowResRefReplace = true };
+        var residual = RenameDispatchHelpers.BuildResidualPreview(
+            preview, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+        Assert.True(residual.AllowResRefReplace);
+
+        var preview2 = new BatchReplacePreview { AllowResRefReplace = false };
+        var residual2 = RenameDispatchHelpers.BuildResidualPreview(
+            preview2, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+        Assert.False(residual2.AllowResRefReplace);
+    }
+
+    [Fact]
+    public void BuildResidualPreview_EmptyWhenAllRowsAreFilenameMatches()
+    {
+        var preview = new BatchReplacePreview();
+        preview.Changes.Add(new PendingChange
+        {
+            Match = MakeMatchOn(FilenameSearchProvider.FilenameField),
+            ReplacementText = "lewie",
+            FilePath = "/m/louis.utc"
+        });
+
+        var residual = RenameDispatchHelpers.BuildResidualPreview(
+            preview, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+        Assert.Empty(residual.Changes);
+    }
+
+    [Fact]
+    public void BuildResidualPreview_PreservesIsSelectedState()
+    {
+        var nameField = new FieldDefinition
+        {
+            Name = "Name", GffPath = "NAME",
+            FieldType = SearchFieldType.Text,
+            Category = SearchFieldCategory.Content
+        };
+        var selectedChange = new PendingChange
+        {
+            Match = MakeMatchOn(nameField),
+            ReplacementText = "x",
+            FilePath = "/m/a.itp",
+            IsSelected = true
+        };
+        var unselectedChange = new PendingChange
+        {
+            Match = MakeMatchOn(nameField),
+            ReplacementText = "x",
+            FilePath = "/m/b.itp",
+            IsSelected = false
+        };
+        var preview = new BatchReplacePreview();
+        preview.Changes.Add(selectedChange);
+        preview.Changes.Add(unselectedChange);
+
+        var residual = RenameDispatchHelpers.BuildResidualPreview(
+            preview, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+        Assert.Equal(2, residual.Changes.Count);
+        Assert.Contains(residual.Changes, c => c.FilePath == "/m/a.itp" && c.IsSelected);
+        Assert.Contains(residual.Changes, c => c.FilePath == "/m/b.itp" && !c.IsSelected);
+    }
+
     // --- Test fixtures ---
 
     private static SearchMatch MakeMatchOn(FieldDefinition field) => new()

--- a/Trebuchet/Trebuchet.Tests/ResultDispatcherTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ResultDispatcherTests.cs
@@ -1,0 +1,152 @@
+using System.Collections.Generic;
+using Radoub.Formats.Common;
+using RadoubLauncher.Services;
+
+namespace Trebuchet.Tests;
+
+/// <summary>
+/// Unit tests for ResultDispatcher.Plan — pure decision logic that maps a
+/// Marlinspike result row (file path + resource type) to a DispatchAction.
+///
+/// Covers the fallback chain for #2183: tool launch → configured external editor
+/// → OS default handler → final no-file/file-missing terminals.
+/// </summary>
+public class ResultDispatcherTests
+{
+    private static readonly IReadOnlyDictionary<ushort, string> DefaultToolMap = new Dictionary<ushort, string>
+    {
+        [ResourceTypes.Dlg] = "Parley",
+        [ResourceTypes.Utc] = "Quartermaster",
+        [ResourceTypes.Uti] = "Relique",
+    };
+
+    [Fact]
+    public void Plan_NullOrEmptyFilePath_ReturnsNoFile()
+    {
+        var plan = ResultDispatcher.Plan(
+            filePath: null,
+            resourceType: ResourceTypes.Nss,
+            resourceToolMap: DefaultToolMap,
+            codeEditorPath: null,
+            fileExists: _ => true);
+
+        Assert.Equal(DispatchAction.NoFile, plan.Action);
+    }
+
+    [Fact]
+    public void Plan_FileDoesNotExist_ReturnsFileMissing()
+    {
+        var plan = ResultDispatcher.Plan(
+            filePath: "/tmp/ghost.nss",
+            resourceType: ResourceTypes.Nss,
+            resourceToolMap: DefaultToolMap,
+            codeEditorPath: null,
+            fileExists: _ => false);
+
+        Assert.Equal(DispatchAction.FileMissing, plan.Action);
+        Assert.Equal("/tmp/ghost.nss", plan.FilePath);
+    }
+
+    [Fact]
+    public void Plan_KnownResourceType_DispatchesToTool()
+    {
+        var plan = ResultDispatcher.Plan(
+            filePath: "/m/test.dlg",
+            resourceType: ResourceTypes.Dlg,
+            resourceToolMap: DefaultToolMap,
+            codeEditorPath: null,
+            fileExists: _ => true);
+
+        Assert.Equal(DispatchAction.ToolLaunch, plan.Action);
+        Assert.Equal("Parley", plan.ToolName);
+        Assert.Equal("/m/test.dlg", plan.FilePath);
+    }
+
+    [Fact]
+    public void Plan_NssWithConfiguredEditor_DispatchesToExternalEditor()
+    {
+        var plan = ResultDispatcher.Plan(
+            filePath: "/m/script.nss",
+            resourceType: ResourceTypes.Nss,
+            resourceToolMap: DefaultToolMap,
+            codeEditorPath: "C:/tools/code.exe",
+            fileExists: path => path == "/m/script.nss" || path == "C:/tools/code.exe");
+
+        Assert.Equal(DispatchAction.ExternalEditor, plan.Action);
+        Assert.Equal("C:/tools/code.exe", plan.EditorPath);
+        Assert.Equal("/m/script.nss", plan.FilePath);
+    }
+
+    [Fact]
+    public void Plan_NssWithoutEditor_FallsBackToOsDefault()
+    {
+        var plan = ResultDispatcher.Plan(
+            filePath: "/m/script.nss",
+            resourceType: ResourceTypes.Nss,
+            resourceToolMap: DefaultToolMap,
+            codeEditorPath: null,
+            fileExists: _ => true);
+
+        Assert.Equal(DispatchAction.OsDefault, plan.Action);
+        Assert.Equal("/m/script.nss", plan.FilePath);
+    }
+
+    [Fact]
+    public void Plan_NssWithEmptyEditorPath_FallsBackToOsDefault()
+    {
+        var plan = ResultDispatcher.Plan(
+            filePath: "/m/script.nss",
+            resourceType: ResourceTypes.Nss,
+            resourceToolMap: DefaultToolMap,
+            codeEditorPath: "",
+            fileExists: _ => true);
+
+        Assert.Equal(DispatchAction.OsDefault, plan.Action);
+    }
+
+    [Fact]
+    public void Plan_EditorPathConfiguredButFileMissing_FallsBackToOsDefault()
+    {
+        // Editor path set but the configured editor exe no longer exists on disk —
+        // don't try to spawn it; fall back to OS default handler.
+        var plan = ResultDispatcher.Plan(
+            filePath: "/m/script.nss",
+            resourceType: ResourceTypes.Nss,
+            resourceToolMap: DefaultToolMap,
+            codeEditorPath: "C:/tools/missing.exe",
+            fileExists: path => path == "/m/script.nss");
+
+        Assert.Equal(DispatchAction.OsDefault, plan.Action);
+    }
+
+    [Fact]
+    public void Plan_UnknownResourceTypeAnyExtension_UsesEditorFallback()
+    {
+        // ResourceType 0 (unknown), but file exists — should fall through to
+        // ExternalEditor (if configured) or OsDefault. .ncs is a plausible case.
+        var plan = ResultDispatcher.Plan(
+            filePath: "/m/script.ncs",
+            resourceType: 0,
+            resourceToolMap: DefaultToolMap,
+            codeEditorPath: "C:/tools/code.exe",
+            fileExists: _ => true);
+
+        Assert.Equal(DispatchAction.ExternalEditor, plan.Action);
+        Assert.Equal("C:/tools/code.exe", plan.EditorPath);
+    }
+
+    [Fact]
+    public void Plan_ToolLaunchTakesPrecedenceOverEditor()
+    {
+        // Even if CodeEditorPath is configured, a known resource type goes to its tool.
+        var plan = ResultDispatcher.Plan(
+            filePath: "/m/test.utc",
+            resourceType: ResourceTypes.Utc,
+            resourceToolMap: DefaultToolMap,
+            codeEditorPath: "C:/tools/code.exe",
+            fileExists: _ => true);
+
+        Assert.Equal(DispatchAction.ToolLaunch, plan.Action);
+        Assert.Equal("Quartermaster", plan.ToolName);
+    }
+}

--- a/Trebuchet/Trebuchet.Tests/SearchIndexStalenessTests.cs
+++ b/Trebuchet/Trebuchet.Tests/SearchIndexStalenessTests.cs
@@ -1,0 +1,58 @@
+using System;
+using RadoubLauncher.Services;
+
+namespace Trebuchet.Tests;
+
+/// <summary>
+/// Unit tests for SearchIndexStaleness — pure decision logic that decides
+/// whether the cached Marlinspike search/item-resolution services should be
+/// invalidated based on the module working directory's last-write time.
+///
+/// Covers #2072: search index never refreshes after ERF import / external
+/// file changes.
+/// </summary>
+public class SearchIndexStalenessTests
+{
+    [Fact]
+    public void IsStale_NoPriorIndex_ReturnsTrue()
+    {
+        // Never indexed before — must build the index now.
+        Assert.True(SearchIndexStaleness.IsStale(
+            currentMtime: new DateTime(2026, 5, 24, 12, 0, 0, DateTimeKind.Utc),
+            lastIndexedMtime: null));
+    }
+
+    [Fact]
+    public void IsStale_DirectoryMtimeUnchanged_ReturnsFalse()
+    {
+        var t = new DateTime(2026, 5, 24, 12, 0, 0, DateTimeKind.Utc);
+        Assert.False(SearchIndexStaleness.IsStale(currentMtime: t, lastIndexedMtime: t));
+    }
+
+    [Fact]
+    public void IsStale_DirectoryMtimeNewer_ReturnsTrue()
+    {
+        var t0 = new DateTime(2026, 5, 24, 12, 0, 0, DateTimeKind.Utc);
+        var t1 = t0.AddSeconds(5);
+        Assert.True(SearchIndexStaleness.IsStale(currentMtime: t1, lastIndexedMtime: t0));
+    }
+
+    [Fact]
+    public void IsStale_DirectoryMtimeOlder_ReturnsFalse()
+    {
+        // Pathological — directory mtime went backward (clock skew, file restore).
+        // Don't invalidate; the existing index is at least as fresh.
+        var t0 = new DateTime(2026, 5, 24, 12, 0, 0, DateTimeKind.Utc);
+        var t1 = t0.AddSeconds(-5);
+        Assert.False(SearchIndexStaleness.IsStale(currentMtime: t1, lastIndexedMtime: t0));
+    }
+
+    [Fact]
+    public void IsStale_CurrentMtimeNull_ReturnsTrue()
+    {
+        // Directory disappeared between indexing and check — force re-init.
+        Assert.True(SearchIndexStaleness.IsStale(
+            currentMtime: null,
+            lastIndexedMtime: new DateTime(2026, 5, 24, 12, 0, 0, DateTimeKind.Utc)));
+    }
+}

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
@@ -31,6 +31,8 @@ public partial class MarlinspikePanel : UserControl
     private ItemResolutionService? _itemResolutionService;
     private TlkService? _tlkService;
     private CancellationTokenSource? _searchCts;
+    private DateTime? _indexedModuleDirMtime;
+    private string? _indexedModuleDirPath;
 
     /// <summary>Maps resource types to Trebuchet tool names for launch dispatch.</summary>
     private static readonly Dictionary<ushort, string> ResourceTypeToToolName = new()
@@ -79,19 +81,64 @@ public partial class MarlinspikePanel : UserControl
 
     private void EnsureServices()
     {
+        var modulePath = ModulePath.GetWorkingDirectory(RadoubSettings.Instance.CurrentModulePath);
+
+        // #2072 — invalidate cached services if the module working directory's
+        // mtime moved (ERF import wrote new files, external editor saved, etc.)
+        // or if the working directory itself changed.
+        if (_searchService != null)
+        {
+            var currentMtime = GetDirectoryMtime(modulePath);
+            var pathChanged = !string.Equals(_indexedModuleDirPath, modulePath, StringComparison.OrdinalIgnoreCase);
+            if (pathChanged || SearchIndexStaleness.IsStale(currentMtime, _indexedModuleDirMtime))
+            {
+                _itemResolutionService = null;
+                _searchService = null;
+            }
+        }
+
         if (_searchService == null)
         {
             var gameDataService = _mainViewModel?.ModuleEditorViewModel?.GameDataService;
             _itemResolutionService = new ItemResolutionService(gameDataService);
-            var modulePath = ModulePath.GetWorkingDirectory(RadoubSettings.Instance.CurrentModulePath);
             if (!string.IsNullOrEmpty(modulePath))
                 _itemResolutionService.SetModuleDirectory(modulePath);
 
             _searchService = new ModuleSearchService(
                 resRef => _itemResolutionService?.ResolveItem(resRef)?.DisplayName);
+
+            _indexedModuleDirPath = modulePath;
+            _indexedModuleDirMtime = GetDirectoryMtime(modulePath);
         }
         _batchReplaceService ??= new BatchReplaceService(new BackupService());
         EnsureTlkResolver();
+    }
+
+    private static DateTime? GetDirectoryMtime(string? path)
+    {
+        if (string.IsNullOrEmpty(path)) return null;
+        try
+        {
+            var di = new DirectoryInfo(path);
+            return di.Exists ? di.LastWriteTimeUtc : (DateTime?)null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Public invalidation hook (#2072) — called by callers that know the
+    /// working directory contents just changed (e.g. ErfImportWindow on
+    /// successful import). Forces the next search to rebuild the index.
+    /// </summary>
+    public void InvalidateSearchIndex()
+    {
+        _itemResolutionService = null;
+        _searchService = null;
+        _indexedModuleDirMtime = null;
+        _indexedModuleDirPath = null;
     }
 
     private void EnsureTlkResolver()
@@ -620,6 +667,8 @@ public partial class MarlinspikePanel : UserControl
     {
         _itemResolutionService = null;
         _searchService = null;
+        _indexedModuleDirMtime = null;
+        _indexedModuleDirPath = null;
         _viewModel?.ClearResults();
         ResultsTree.ItemsSource = null;
         DurationText.Text = "";

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
@@ -290,18 +290,79 @@ public partial class MarlinspikePanel : UserControl
             resourceType = fileResult.ResourceType;
         }
 
-        if (string.IsNullOrEmpty(filePath) || !File.Exists(filePath))
-            return;
+        var plan = ResultDispatcher.Plan(
+            filePath,
+            resourceType,
+            ResourceTypeToToolName,
+            SettingsService.Instance.CodeEditorPath,
+            File.Exists);
 
-        if (ResourceTypeToToolName.TryGetValue(resourceType, out var toolName))
+        ExecuteDispatchPlan(plan);
+    }
+
+    private void ExecuteDispatchPlan(DispatchPlan plan)
+    {
+        switch (plan.Action)
         {
-            var launched = ToolLauncherService.Instance.LaunchTool(toolName, $"--file \"{filePath}\"");
-            if (!launched && _viewModel != null)
-                _viewModel.StatusText = $"Could not launch {toolName} for: {Path.GetFileName(filePath)}";
+            case DispatchAction.NoFile:
+            case DispatchAction.FileMissing:
+                return;
+
+            case DispatchAction.ToolLaunch:
+                var launched = ToolLauncherService.Instance.LaunchTool(
+                    plan.ToolName!, $"--file \"{plan.FilePath}\"");
+                if (!launched && _viewModel != null)
+                    _viewModel.StatusText =
+                        $"Could not launch {plan.ToolName} for: {Path.GetFileName(plan.FilePath)}";
+                return;
+
+            case DispatchAction.ExternalEditor:
+                StartExternalEditor(plan.EditorPath!, plan.FilePath!);
+                return;
+
+            case DispatchAction.OsDefault:
+                StartOsDefault(plan.FilePath!);
+                return;
         }
-        else if (_viewModel != null)
+    }
+
+    private void StartExternalEditor(string editorPath, string filePath)
+    {
+        try
         {
-            _viewModel.StatusText = $"No editor for .{Path.GetExtension(filePath).TrimStart('.')} files";
+            var startInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = editorPath,
+                Arguments = $"\"{filePath}\"",
+                UseShellExecute = false
+            };
+            System.Diagnostics.Process.Start(startInfo)?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"External editor launch failed for {Path.GetFileName(filePath)}: {ex.Message}");
+            StartOsDefault(filePath);
+        }
+    }
+
+    private void StartOsDefault(string filePath)
+    {
+        try
+        {
+            var startInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = filePath,
+                UseShellExecute = true
+            };
+            System.Diagnostics.Process.Start(startInfo)?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"OS default handler failed for {Path.GetFileName(filePath)}: {ex.Message}");
+            if (_viewModel != null)
+                _viewModel.StatusText = $"No editor for {Path.GetFileName(filePath)}";
         }
     }
 

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
@@ -603,9 +603,28 @@ public partial class MarlinspikePanel : UserControl
 
             if (result.Success)
             {
+                // Process any non-filename content matches that were in the same preview
+                // but weren't consumed by the rename (e.g. ITP Name field replaces).
+                // Without this, the user has to click Replace All twice to clean up
+                // residual content rows.
+                var renameMap = confirmedPlans.ToDictionary(
+                    p => p.SourceFilePath,
+                    p => p.TargetFilePath,
+                    StringComparer.OrdinalIgnoreCase);
+                var residualPreview = RenameDispatchHelpers.BuildResidualPreview(preview, renameMap);
+
+                int residualReplacements = 0;
+                if (residualPreview.Changes.Count > 0)
+                {
+                    var residualResult = await _batchReplaceService!.ExecuteReplaceAsync(
+                        residualPreview, moduleName);
+                    residualReplacements = residualResult.ReplacementsMade;
+                }
+
+                var totalRefs = result.ReferencesUpdated + residualReplacements;
                 _viewModel.StatusText =
                     $"Renamed {result.RenamedFiles} file{(result.RenamedFiles != 1 ? "s" : "")}, " +
-                    $"updated {result.ReferencesUpdated} reference{(result.ReferencesUpdated != 1 ? "s" : "")}. " +
+                    $"updated {totalRefs} reference{(totalRefs != 1 ? "s" : "")}. " +
                     "Backup created. Re-run search to refresh results.";
                 // Don't clear results tree — leaves the user wondering whether everything
                 // got renamed. Stale entries (renamed files at the old name) will simply

--- a/Trebuchet/Trebuchet/Services/RenameDispatchHelpers.cs
+++ b/Trebuchet/Trebuchet/Services/RenameDispatchHelpers.cs
@@ -222,6 +222,51 @@ public static class RenameDispatchHelpers
     }
 
     /// <summary>
+    /// Build a residual preview containing only the non-filename rows from the
+    /// original preview. Used by the rename dispatch flow so that content matches
+    /// (e.g. ITP Name field) that weren't consumed by the rename are still
+    /// processed by the standard replace path afterward.
+    ///
+    /// <paramref name="renameMap"/> maps source file paths to their post-rename
+    /// targets, used to remap any residual change whose FilePath refers to a file
+    /// that was just renamed. Rows whose FilePath is not in the map are passed
+    /// through unchanged.
+    ///
+    /// Preserves <see cref="BatchReplacePreview.AllowResRefReplace"/> and per-row
+    /// <see cref="PendingChange.IsSelected"/> state. Does not include FileGroups
+    /// (BatchReplaceService.ExecuteReplaceAsync iterates Changes, not FileGroups).
+    /// </summary>
+    public static BatchReplacePreview BuildResidualPreview(
+        BatchReplacePreview preview,
+        IReadOnlyDictionary<string, string> renameMap)
+    {
+        var residual = new BatchReplacePreview
+        {
+            AllowResRefReplace = preview?.AllowResRefReplace ?? false
+        };
+        if (preview == null) return residual;
+
+        foreach (var change in preview.Changes)
+        {
+            if (change.Match.Field.GffPath == FilenameSearchProvider.FilenameField.GffPath)
+                continue;  // filename rows are handled by the rename path
+
+            var newPath = renameMap != null && renameMap.TryGetValue(change.FilePath, out var mapped)
+                ? mapped
+                : change.FilePath;
+
+            residual.Changes.Add(new PendingChange
+            {
+                Match = change.Match,
+                ReplacementText = change.ReplacementText,
+                FilePath = newPath,
+                IsSelected = change.IsSelected
+            });
+        }
+        return residual;
+    }
+
+    /// <summary>
     /// ResRefReference is a class (not record) — duplicate explicit copy so we
     /// can attach the per-plan NewValue without mutating the scanner's outputs
     /// across multiple plans. See Chunk 1a Task 1a.16 for the design rationale.

--- a/Trebuchet/Trebuchet/Services/ResultDispatcher.cs
+++ b/Trebuchet/Trebuchet/Services/ResultDispatcher.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+
+namespace RadoubLauncher.Services;
+
+/// <summary>
+/// Action chosen by <see cref="ResultDispatcher.Plan"/> for a Marlinspike result
+/// double-click. The caller performs the side effect; this enum + record stays
+/// pure so the decision tree is fully unit-testable.
+/// </summary>
+public enum DispatchAction
+{
+    NoFile,
+    FileMissing,
+    ToolLaunch,
+    ExternalEditor,
+    OsDefault
+}
+
+public record DispatchPlan(
+    DispatchAction Action,
+    string? ToolName,
+    string? EditorPath,
+    string? FilePath);
+
+/// <summary>
+/// Pure decision logic for Marlinspike result dispatch (#2183).
+///
+/// Priority:
+/// 1. <c>NoFile</c> — no path supplied
+/// 2. <c>FileMissing</c> — path supplied but not on disk
+/// 3. <c>ToolLaunch</c> — resource type maps to a Radoub tool
+/// 4. <c>ExternalEditor</c> — <paramref name="codeEditorPath"/> set and exists
+/// 5. <c>OsDefault</c> — fall back to OS shell handler
+/// </summary>
+public static class ResultDispatcher
+{
+    public static DispatchPlan Plan(
+        string? filePath,
+        ushort resourceType,
+        IReadOnlyDictionary<ushort, string> resourceToolMap,
+        string? codeEditorPath,
+        Func<string, bool> fileExists)
+    {
+        if (string.IsNullOrEmpty(filePath))
+            return new DispatchPlan(DispatchAction.NoFile, null, null, null);
+
+        if (!fileExists(filePath))
+            return new DispatchPlan(DispatchAction.FileMissing, null, null, filePath);
+
+        if (resourceToolMap.TryGetValue(resourceType, out var toolName))
+            return new DispatchPlan(DispatchAction.ToolLaunch, toolName, null, filePath);
+
+        if (!string.IsNullOrEmpty(codeEditorPath) && fileExists(codeEditorPath))
+            return new DispatchPlan(DispatchAction.ExternalEditor, null, codeEditorPath, filePath);
+
+        return new DispatchPlan(DispatchAction.OsDefault, null, null, filePath);
+    }
+}

--- a/Trebuchet/Trebuchet/Services/SearchIndexStaleness.cs
+++ b/Trebuchet/Trebuchet/Services/SearchIndexStaleness.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace RadoubLauncher.Services;
+
+/// <summary>
+/// Pure staleness check for Marlinspike's cached search/item-resolution
+/// services (#2072). The panel records the module working-directory's
+/// last-write time at the moment it builds its services; on each search,
+/// it compares the current mtime against that snapshot and rebuilds the
+/// services if the directory changed.
+///
+/// Catches:
+///   - ERF imports (write new files into the working directory)
+///   - External edits / file additions / deletions
+///   - File restores that bump mtime forward
+///
+/// Does NOT catch:
+///   - In-place edits that don't bump the *directory* mtime (e.g. a file
+///     overwritten with the same name). The HAK / palette cache layer
+///     handles that separately.
+/// </summary>
+public static class SearchIndexStaleness
+{
+    /// <summary>
+    /// Returns true if the index needs to be rebuilt.
+    /// </summary>
+    /// <param name="currentMtime">
+    /// Current last-write time of the module working directory, or null if
+    /// the directory no longer exists / cannot be stat'd.
+    /// </param>
+    /// <param name="lastIndexedMtime">
+    /// The directory's last-write time at the moment the cached services
+    /// were created, or null if no index has been built yet.
+    /// </param>
+    public static bool IsStale(DateTime? currentMtime, DateTime? lastIndexedMtime)
+    {
+        if (lastIndexedMtime == null) return true;
+        if (currentMtime == null) return true;
+        return currentMtime.Value > lastIndexedMtime.Value;
+    }
+}

--- a/Trebuchet/Trebuchet/Views/ErfImportWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/ErfImportWindow.axaml.cs
@@ -12,6 +12,13 @@ public partial class ErfImportWindow : Window
 {
     private ErfImportViewModel? _viewModel;
 
+    /// <summary>
+    /// Raised when an import completes with at least one file imported and
+    /// no errors. Subscribers (e.g. MarlinspikePanel) use this to invalidate
+    /// caches that depend on module working-directory contents (#2072).
+    /// </summary>
+    public event EventHandler? ImportSucceeded;
+
     public ErfImportWindow()
     {
         InitializeComponent();
@@ -57,7 +64,8 @@ public partial class ErfImportWindow : Window
         var result = await _viewModel.ImportAsync();
         if (result != null && result.ErrorCount == 0 && result.ImportedCount > 0)
         {
-            // Auto-close on successful import with no errors
+            // Successful import — notify subscribers so dependent caches refresh.
+            ImportSucceeded?.Invoke(this, EventArgs.Empty);
         }
     }
 

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
@@ -308,6 +308,14 @@ public partial class MainWindow : Window
 
         var window = new ErfImportWindow();
         window.Initialize(modulePath);
+        window.ImportSucceeded += (_, _) =>
+        {
+            // #2072 — module working directory contents just changed; invalidate
+            // Marlinspike's cached search/item-resolution services so the next
+            // search picks up the imported files.
+            var panel = this.FindControl<Controls.MarlinspikePanel>("MarlinspikePanel");
+            panel?.InvalidateSearchIndex();
+        };
         window.Show(this);
     }
 


### PR DESCRIPTION
## Summary

Sprint draining all open Marlinspike-tagged bugs.

## Work Items

- [x] #2072 — Search index stale after ERF import or file changes
- [x] #2178 — ITP references not renamed during ResRef rename
- [x] #2181 — Reverse rename fails 'orphan file remains' when filename contains old name as substring
- [x] #2183 — `.nss` files report 'no editor' — wire default external editor

## Related Issues

- Closes #2216
- Closes #2072
- Closes #2178
- Closes #2181
- Closes #2183

## Test Results

| Project | Result |
|---------|--------|
| Radoub.Formats.Tests | 1239/1240 pass (1 pre-existing skip) |
| Radoub.UI.Tests | 746/746 pass |
| Trebuchet.Tests | 159/159 pass |
| Radoub.sln build | 0 errors, 1 pre-existing warning (Fence) |

New tests added: 21 (9 ResultDispatcher + 5 SearchIndexStaleness + 6 ITP scanner/applier + 6 FileVerifyWithRetry + 1 reverse-rename orchestrator).

## Manual Spot-Checks

Verify in running app before merge:

- [x] **#2183** — Marlinspike: double-click a `.nss` result row → opens in configured CodeEditorPath (set in Trebuchet Settings) if set; otherwise OS default handler. Empty CodeEditorPath should still open something (Notepad on Windows) instead of "No editor for .nss files".
- [x] **#2072** — Marlinspike: run a search, then ERF-import a new resource; re-run the same search → newly imported files appear in results without restarting Trebuchet.
- [x] **#2072** — Marlinspike: run a search, edit a file externally (touch mtime); re-run the same search → freshly indexed.
- [x] **#2178** — Marlinspike: search for a ResRef present in a `.itp` palette, replace + check "Include filename/ResRef" → confirm the `.itp` palette entry's RESREF is updated (open the .itp in a GFF viewer or rescan).
- [x] **#2181** — Marlinspike: rename `foo.nss` → `foo1.nss`, then reverse-rename `foo1.nss` → `foo.nss` (ensure the .nss content references its own name). Both directions should succeed without "orphan file remains".

## Checklist

- [x] Implementation complete
- [x] Tests added/updated (21 new tests)
- [x] CHANGELOG updated with date and PR number
- [x] Manual spot-checks above

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)