### PR TITLE
[Radoub] Sprint: CI Flake Cleanup (#2218)

### DIFF
--- a/.github/workflows/ci-flake-soak.yml
+++ b/.github/workflows/ci-flake-soak.yml
@@ -1,0 +1,56 @@
+name: CI Flake Soak
+
+# Manual-only workflow. Proves stability of the two test suites previously
+# affected by intermittent CI flakes (#2051 RadoubSettings race, #2212
+# Avalonia MenuItem registry race). Run via "Run workflow" from the Actions
+# tab on any branch; default 10 iterations × 2 operating systems = 20 jobs.
+#
+# fail-fast: false so a single flaky job does not hide the rest of the grid.
+# Retained in the repo post-merge for future flake hunts.
+
+on:
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: 'Iterations per OS (informational; matrix is hard-coded to 10)'
+        required: false
+        default: '10'
+
+jobs:
+  soak:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        iteration: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }} #${{ matrix.iteration }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0  # NBGV needs full history
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '9.0.x'
+
+    - name: Restore Radoub.Formats.Tests
+      run: dotnet restore Radoub.Formats/Radoub.Formats.Tests/Radoub.Formats.Tests.csproj
+
+    - name: Build Radoub.Formats.Tests
+      run: dotnet build Radoub.Formats/Radoub.Formats.Tests/Radoub.Formats.Tests.csproj --configuration Release --no-restore
+
+    - name: Test Radoub.Formats.Tests
+      run: dotnet test Radoub.Formats/Radoub.Formats.Tests/Radoub.Formats.Tests.csproj --configuration Release --no-build --logger "console;verbosity=normal"
+
+    - name: Restore Radoub.UI.Tests
+      run: dotnet restore Radoub.UI/Radoub.UI.Tests/Radoub.UI.Tests.csproj
+
+    - name: Build Radoub.UI.Tests
+      run: dotnet build Radoub.UI/Radoub.UI.Tests/Radoub.UI.Tests.csproj --configuration Release --no-restore
+
+    - name: Test Radoub.UI.Tests
+      run: dotnet test Radoub.UI/Radoub.UI.Tests/Radoub.UI.Tests.csproj --configuration Release --no-build --logger "console;verbosity=normal"

--- a/Radoub.Formats/Radoub.Formats.Tests/AssemblyInfo.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+using Xunit;
+
+// Force every test in this assembly to run sequentially.
+//
+// Radoub.Formats.Tests targets xunit.v3, which schedules test classes in
+// parallel by default. RadoubSettings is a process-global singleton
+// (_instance + _settingsDirectory) bound to the RADOUB_SETTINGS_DIR
+// environment variable. The collection-level [CollectionDefinition(...,
+// DisableParallelization = true)] from #2020 serialized the two annotated
+// classes, but any other test class that transitively touches
+// RadoubSettings.Instance (auto-detect on first call reads the real
+// ~/Radoub directory) raced against the annotated classes.
+//
+// Assembly-level serialization is the only way to guarantee no test
+// class touches the singleton concurrently. Cost: small — the assembly
+// runs in a few seconds.
+//
+// Mirrors the pattern in Radoub.UI.Tests (#2186 / #2212). Resolves #2051.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Radoub.Formats/Radoub.Formats.Tests/RadoubSettingsTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/RadoubSettingsTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Radoub.Formats.Common;
 using Radoub.Formats.Settings;
+using Radoub.Formats.Tests.Settings;
 using Radoub.TestUtilities.Helpers;
 using Xunit;
 
@@ -9,46 +10,49 @@ namespace Radoub.Formats.Tests;
 /// <summary>
 /// Tests for RadoubSettings persistence and cross-process propagation (#1384).
 /// Verifies that settings written by one process (Trebuchet) can be read by another (child tools).
+///
+/// Singleton lifecycle (env var + temp dir + static reset) is owned by
+/// <see cref="RadoubSettingsFixture"/> via the "RadoubSettings" collection.
+/// Tests that need to re-bind the singleton mid-class (simulating a child
+/// process startup) call <see cref="ResetAndConfigure"/>.
 /// </summary>
 [Collection("RadoubSettings")]
-public class RadoubSettingsTests : IDisposable
+public class RadoubSettingsTests
 {
-    private readonly string _testDirectory;
+    private readonly RadoubSettingsFixture _fixture;
     private readonly string _fakeTlkPath;
     private readonly string _fakeModulePath;
 
-    public RadoubSettingsTests()
+    public RadoubSettingsTests(RadoubSettingsFixture fixture)
     {
-        _testDirectory = Path.Combine(Path.GetTempPath(), $"RadoubSettingsTest_{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_testDirectory);
+        _fixture = fixture;
+        _fakeTlkPath = Path.Combine(_fixture.TestDirectory, "tlk", "custom.tlk");
+        _fakeModulePath = Path.Combine(_fixture.TestDirectory, "modules", "mymodule");
 
-        // Build privacy-safe test paths under temp
-        _fakeTlkPath = Path.Combine(_testDirectory, "tlk", "custom.tlk");
-        _fakeModulePath = Path.Combine(_testDirectory, "modules", "mymodule");
-
+        // The fixture is shared across the class, so prior tests may have written
+        // RadoubSettings.json into the same temp directory. Delete the persisted
+        // file at the start of each test so each fact gets the same "fresh process"
+        // semantics the original per-test temp-dir design provided. ResetAndConfigure
+        // (called mid-test by some facts) intentionally does NOT delete the file —
+        // those facts depend on file contents surviving a singleton reset.
+        var persistedFile = Path.Combine(_fixture.TestDirectory, "RadoubSettings.json");
+        if (File.Exists(persistedFile))
+        {
+            try { File.Delete(persistedFile); }
+            catch { /* best-effort */ }
+        }
         ResetAndConfigure();
     }
 
-    public void Dispose()
-    {
-        SingletonTestHelper.ResetSingleton<RadoubSettings>("_instance", "_settingsDirectory");
-        SingletonTestHelper.ConfigureSettingsDirectory("RADOUB_SETTINGS_DIR", null);
-
-        try
-        {
-            if (Directory.Exists(_testDirectory))
-                Directory.Delete(_testDirectory, true);
-        }
-        catch { /* Ignore cleanup errors */ }
-    }
-
     /// <summary>
-    /// Reset the RadoubSettings singleton and configure it to use the test directory.
+    /// Reset the RadoubSettings singleton and rebind the env var to the fixture's
+    /// test directory. Does NOT delete the persisted JSON file — tests that simulate
+    /// a child-process restart need the file contents to survive the singleton reset.
     /// </summary>
     private void ResetAndConfigure()
     {
         SingletonTestHelper.ResetSingleton<RadoubSettings>("_instance", "_settingsDirectory");
-        SingletonTestHelper.ConfigureSettingsDirectory("RADOUB_SETTINGS_DIR", _testDirectory);
+        SingletonTestHelper.ConfigureSettingsDirectory("RADOUB_SETTINGS_DIR", _fixture.TestDirectory);
     }
 
     [Fact]
@@ -58,7 +62,7 @@ public class RadoubSettingsTests : IDisposable
         settings.CustomTlkPath = _fakeTlkPath;
 
         // Verify the JSON file was written
-        var filePath = Path.Combine(_testDirectory, "RadoubSettings.json");
+        var filePath = Path.Combine(_fixture.TestDirectory, "RadoubSettings.json");
         Assert.True(File.Exists(filePath));
 
         var json = File.ReadAllText(filePath);
@@ -71,7 +75,7 @@ public class RadoubSettingsTests : IDisposable
         var settings = RadoubSettings.Instance;
         settings.CurrentModulePath = _fakeModulePath;
 
-        var filePath = Path.Combine(_testDirectory, "RadoubSettings.json");
+        var filePath = Path.Combine(_fixture.TestDirectory, "RadoubSettings.json");
         Assert.True(File.Exists(filePath));
 
         var json = File.ReadAllText(filePath);
@@ -81,10 +85,10 @@ public class RadoubSettingsTests : IDisposable
     [Fact]
     public void ReloadSettings_ReadsUpdatedValues()
     {
-        var originalTlk = Path.Combine(_testDirectory, "original", "path.tlk");
-        var originalModule = Path.Combine(_testDirectory, "original", "module");
-        var updatedTlk = Path.Combine(_testDirectory, "updated", "custom.tlk");
-        var updatedModule = Path.Combine(_testDirectory, "updated", "module");
+        var originalTlk = Path.Combine(_fixture.TestDirectory, "original", "path.tlk");
+        var originalModule = Path.Combine(_fixture.TestDirectory, "original", "module");
+        var updatedTlk = Path.Combine(_fixture.TestDirectory, "updated", "custom.tlk");
+        var updatedModule = Path.Combine(_fixture.TestDirectory, "updated", "module");
 
         var settings = RadoubSettings.Instance;
         settings.CustomTlkPath = originalTlk;
@@ -96,7 +100,7 @@ public class RadoubSettingsTests : IDisposable
         // Simulate another process writing updated values to the settings file.
         // Must use ContractPath since that's how RadoubSettings persists paths -
         // on Windows, temp paths are under user profile and get contracted to ~/...
-        var filePath = Path.Combine(_testDirectory, "RadoubSettings.json");
+        var filePath = Path.Combine(_fixture.TestDirectory, "RadoubSettings.json");
         var updatedData = new Dictionary<string, string>
         {
             ["CustomTlkPath"] = PathHelper.ContractPath(updatedTlk),
@@ -139,7 +143,7 @@ public class RadoubSettingsTests : IDisposable
         settings1.CustomTlkPath = fullPath;
 
         // The file should contain contracted path (~)
-        var filePath = Path.Combine(_testDirectory, "RadoubSettings.json");
+        var filePath = Path.Combine(_fixture.TestDirectory, "RadoubSettings.json");
         var json = File.ReadAllText(filePath);
         Assert.Contains("~", json);
 
@@ -168,7 +172,7 @@ public class RadoubSettingsTests : IDisposable
     public void LoadSettings_HandlesCorruptJson()
     {
         // Write corrupt JSON
-        var filePath = Path.Combine(_testDirectory, "RadoubSettings.json");
+        var filePath = Path.Combine(_fixture.TestDirectory, "RadoubSettings.json");
         File.WriteAllText(filePath, "{ this is not valid json }}}");
 
         // Should not throw, just use defaults

--- a/Radoub.Formats/Radoub.Formats.Tests/Settings/BackupRetentionDaysTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Settings/BackupRetentionDaysTests.cs
@@ -6,6 +6,13 @@ namespace Radoub.Formats.Tests.Settings;
 [Collection("RadoubSettings")]
 public class BackupRetentionDaysTests
 {
+    private readonly RadoubSettingsFixture _fixture;
+
+    public BackupRetentionDaysTests(RadoubSettingsFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
     [Theory]
     [InlineData(0, 1)]    // Below minimum, clamps to 1
     [InlineData(-5, 1)]   // Negative, clamps to 1
@@ -16,6 +23,10 @@ public class BackupRetentionDaysTests
     [InlineData(365, 90)] // Way above maximum, clamps to 90
     public void BackupRetentionDays_ClampsToRange(int input, int expected)
     {
+        // Fixture binds the singleton to a fresh temp directory; touch keeps the
+        // unused-variable analyzer quiet without changing semantics.
+        _ = _fixture;
+
         var settings = RadoubSettings.Instance;
         var original = settings.BackupRetentionDays;
         try

--- a/Radoub.Formats/Radoub.Formats.Tests/Settings/RadoubSettingsFixture.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Settings/RadoubSettingsFixture.cs
@@ -1,0 +1,64 @@
+using Radoub.Formats.Settings;
+using Radoub.TestUtilities.Helpers;
+
+namespace Radoub.Formats.Tests.Settings;
+
+/// <summary>
+/// Collection fixture that owns the lifecycle of the process-global state
+/// surrounding <see cref="RadoubSettings"/>: a per-fixture temp directory,
+/// the <c>RADOUB_SETTINGS_DIR</c> environment variable, and the singleton's
+/// static <c>_instance</c> + <c>_settingsDirectory</c> fields.
+///
+/// Constructor:
+///   1. Generates a unique temp directory under <see cref="Path.GetTempPath"/>.
+///   2. Sets <c>RADOUB_SETTINGS_DIR</c> to that directory so the next
+///      <see cref="RadoubSettings.Instance"/> access binds to it.
+///   3. Resets the singleton's static fields via reflection so subsequent
+///      <c>Instance</c> access constructs a fresh instance.
+///
+/// <see cref="Dispose"/>:
+///   1. Resets the singleton again so the next test class starts clean.
+///   2. Clears the <c>RADOUB_SETTINGS_DIR</c> env var so no stale value
+///      leaks into the parent process or follow-up test runs.
+///   3. Deletes the temp directory (swallows IO errors — best-effort).
+///
+/// Wired into <c>[CollectionDefinition("RadoubSettings", DisableParallelization = true)]</c>
+/// in TestCollections.cs. Resolves #2051.
+/// </summary>
+public class RadoubSettingsFixture : IDisposable
+{
+    public string TestDirectory { get; }
+
+    public RadoubSettingsFixture()
+    {
+        TestDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"RadoubSettingsFixture_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(TestDirectory);
+
+        SingletonTestHelper.ConfigureSettingsDirectory("RADOUB_SETTINGS_DIR", TestDirectory);
+        SingletonTestHelper.ResetSingleton<RadoubSettings>("_instance", "_settingsDirectory");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            SingletonTestHelper.ResetSingleton<RadoubSettings>("_instance", "_settingsDirectory");
+            SingletonTestHelper.ConfigureSettingsDirectory("RADOUB_SETTINGS_DIR", null);
+        }
+        finally
+        {
+            try
+            {
+                if (Directory.Exists(TestDirectory))
+                    Directory.Delete(TestDirectory, recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup — swallow IO errors so test crashes
+                // during cleanup do not mask the real failure.
+            }
+        }
+    }
+}

--- a/Radoub.Formats/Radoub.Formats.Tests/Settings/RadoubSettingsFixtureTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Settings/RadoubSettingsFixtureTests.cs
@@ -1,0 +1,100 @@
+using Radoub.Formats.Settings;
+using Radoub.Formats.Tests.Settings;
+using Xunit;
+
+namespace Radoub.Formats.Tests.Settings;
+
+/// <summary>
+/// Tests for <see cref="RadoubSettingsFixture"/> — the fixture itself, not the singleton.
+/// Verifies the lifecycle contract that downstream singleton-touching tests rely on:
+/// env var set on construction, env var cleared on disposal, temp directory present,
+/// temp directory deleted, singleton instance reset.
+/// </summary>
+public class RadoubSettingsFixtureTests
+{
+    [Fact]
+    public void Construction_SetsEnvironmentVariable()
+    {
+        using var fixture = new RadoubSettingsFixture();
+
+        var envValue = Environment.GetEnvironmentVariable("RADOUB_SETTINGS_DIR");
+        Assert.Equal(fixture.TestDirectory, envValue);
+    }
+
+    [Fact]
+    public void Construction_CreatesTestDirectory()
+    {
+        using var fixture = new RadoubSettingsFixture();
+
+        Assert.True(Directory.Exists(fixture.TestDirectory));
+    }
+
+    [Fact]
+    public void Construction_TestDirectoryIsUnderTempPath()
+    {
+        using var fixture = new RadoubSettingsFixture();
+
+        Assert.StartsWith(Path.GetTempPath(), fixture.TestDirectory);
+    }
+
+    [Fact]
+    public void Dispose_ClearsEnvironmentVariable()
+    {
+        var fixture = new RadoubSettingsFixture();
+        fixture.Dispose();
+
+        var envValue = Environment.GetEnvironmentVariable("RADOUB_SETTINGS_DIR");
+        Assert.True(string.IsNullOrEmpty(envValue));
+    }
+
+    [Fact]
+    public void Dispose_DeletesTestDirectory()
+    {
+        var fixture = new RadoubSettingsFixture();
+        var dir = fixture.TestDirectory;
+        Assert.True(Directory.Exists(dir));
+
+        fixture.Dispose();
+
+        Assert.False(Directory.Exists(dir));
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow_WhenTestDirectoryAlreadyDeleted()
+    {
+        var fixture = new RadoubSettingsFixture();
+        Directory.Delete(fixture.TestDirectory, recursive: true);
+
+        // Should not throw — fixture must swallow IO errors during cleanup
+        fixture.Dispose();
+    }
+
+    [Fact]
+    public void Construction_AfterPriorInstance_GetsFreshDirectory()
+    {
+        string firstDir;
+        using (var first = new RadoubSettingsFixture())
+        {
+            firstDir = first.TestDirectory;
+        }
+
+        using var second = new RadoubSettingsFixture();
+        Assert.NotEqual(firstDir, second.TestDirectory);
+    }
+
+    [Fact]
+    public void Construction_ResetsRadoubSettingsSingleton()
+    {
+        // Touch singleton in first fixture's environment
+        using (var first = new RadoubSettingsFixture())
+        {
+            var instance = RadoubSettings.Instance;
+            instance.CustomTlkPath = Path.Combine(first.TestDirectory, "tlk", "first.tlk");
+        }
+
+        // Second fixture must give us a fresh singleton (no leaked state from first)
+        using var second = new RadoubSettingsFixture();
+        var fresh = RadoubSettings.Instance;
+        Assert.Equal("", fresh.CustomTlkPath);
+    }
+}

--- a/Radoub.Formats/Radoub.Formats.Tests/TestCollections.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/TestCollections.cs
@@ -1,16 +1,25 @@
+using Radoub.Formats.Tests.Settings;
 using Xunit;
 
 namespace Radoub.Formats.Tests;
 
 /// <summary>
 /// Collection that serializes RadoubSettings singleton tests so the static
-/// `_instance` and `_settingsDirectory` fields are not raced across parallel
-/// test classes (#1526 / #2051). Both `RadoubSettingsTests` and the nested
-/// `Settings/RadoubSettingsTests` carry [Collection("RadoubSettings")];
-/// declaring DisableParallelization here serializes them as a unit while
-/// pure-fast tests in this project keep running in parallel.
+/// `_instance` and `_settingsDirectory` fields plus the `RADOUB_SETTINGS_DIR`
+/// environment variable are not raced across parallel test classes
+/// (#1526 / #2051).
+///
+/// Implements <see cref="ICollectionFixture{TFixture}"/> for
+/// <see cref="RadoubSettingsFixture"/> so test classes carrying
+/// `[Collection("RadoubSettings")]` receive a per-collection fixture that
+/// owns the env var + temp directory + singleton reset lifecycle.
+///
+/// Assembly-level serialization in AssemblyInfo.cs provides the outer
+/// guarantee that no class outside this collection races against the
+/// singleton; the collection fixture provides the inner guarantee that
+/// state is reset before each class inside the collection.
 /// </summary>
 [CollectionDefinition("RadoubSettings", DisableParallelization = true)]
-public class RadoubSettingsCollection
+public class RadoubSettingsCollection : ICollectionFixture<RadoubSettingsFixture>
 {
 }

--- a/Radoub.UI/Radoub.UI.Tests/AssemblyInfo.cs
+++ b/Radoub.UI/Radoub.UI.Tests/AssemblyInfo.cs
@@ -1,14 +1,37 @@
+using Avalonia.Headless;
+using Radoub.UI.Tests.Fixtures;
 using Xunit;
 
-// Force every test in this assembly to run sequentially. A subset of tests
-// (ItemBrowserPanelBifTests.GameDataService_IsSettableAndReadable) instantiates
-// Avalonia controls (ItemBrowserPanel -> FileBrowserPanelBase.InitializeComponent),
-// which touches the process-global Avalonia.AvaloniaPropertyRegistry. When xUnit
-// runs test classes in parallel, two classes instantiating Avalonia controls on
-// different threads race on that registry and throw
-// "An item with the same key has already been added. Key: Avalonia.Controls.MenuItem"
-// (surfaced on PR #2213 / Sprint 4 of #2186).
+// Wire the Avalonia headless test application. The Avalonia.Headless.XUnit
+// test framework discovers this attribute and runs every test in this
+// assembly on the Avalonia dispatcher thread, which:
+//   1. Allows tests to construct Avalonia controls without "Call from invalid
+//      thread" InvalidOperationException.
+//   2. Seeds the process-global AvaloniaPropertyRegistry from a single known
+//      thread, eliminating the cross-thread race that caused #2212.
+// AvaloniaTestApp.BuildAvaloniaApp() configures a minimal FluentTheme +
+// headless platform app for binding.
+[assembly: AvaloniaTestApplication(typeof(AvaloniaTestApp))]
+
+// Force every test in this assembly to run sequentially.
 //
-// Mirrors the Radoub.IntegrationTests pattern (#1526). Cheap — full assembly
-// runs in ~7s.
+// History:
+//   - #2186 (Sprint 4): assembly-level serial added because a subset of tests
+//     instantiated Avalonia controls (ItemBrowserPanel ->
+//     FileBrowserPanelBase.InitializeComponent), touching the process-global
+//     Avalonia.AvaloniaPropertyRegistry. Parallel test classes raced on registry
+//     init and threw "An item with the same key has already been added. Key:
+//     Avalonia.Controls.MenuItem". Serial execution prevented test-thread races.
+//   - #2212: the same error returned on ubuntu-latest CI even with parallel
+//     execution disabled. Root cause: AvaloniaPropertyRegistry init is also not
+//     thread-safe against background framework threads (JIT, finalizer). Fix:
+//     [AvaloniaTestApplication] seeds the registry via a headless AppBuilder on
+//     the dispatcher thread before any test runs, and routes test execution
+//     through that thread so Avalonia control construction is always
+//     dispatcher-safe.
+//
+// This attribute is retained as defense-in-depth: a future developer who adds
+// a parallel-running test class that constructs Avalonia controls outside the
+// dispatcher path will see a slow test, not a flaky one. Wall-time cost is
+// small — full assembly runs in ~7s.
 [assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Radoub.UI/Radoub.UI.Tests/Fixtures/AvaloniaTestApp.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Fixtures/AvaloniaTestApp.cs
@@ -1,0 +1,28 @@
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Themes.Fluent;
+
+namespace Radoub.UI.Tests.Fixtures;
+
+/// <summary>
+/// Minimal <see cref="Application"/> subclass for headless test runs.
+/// Referenced by the assembly-level
+/// <c>[AvaloniaTestApplication(typeof(AvaloniaTestApp))]</c> attribute in
+/// AssemblyInfo.cs. The Avalonia.Headless.XUnit test framework looks up
+/// <see cref="BuildAvaloniaApp"/> via reflection to construct the headless
+/// application before any test runs.
+/// </summary>
+public class AvaloniaTestApp : Application
+{
+    public override void Initialize()
+    {
+        Styles.Add(new FluentTheme());
+    }
+
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<AvaloniaTestApp>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions
+            {
+                UseHeadlessDrawing = true
+            });
+}

--- a/Radoub.UI/Radoub.UI.Tests/Radoub.UI.Tests.csproj
+++ b/Radoub.UI/Radoub.UI.Tests/Radoub.UI.Tests.csproj
@@ -23,6 +23,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <!-- Seeds AvaloniaPropertyRegistry via headless app for tests that
+         instantiate Avalonia controls. Fixes #2212 ubuntu CI race. -->
+    <PackageReference Include="Avalonia.Headless.XUnit" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.35.0-alpha] - 2026-05-24
+**Branch**: `radoub/issue-2218` | **PR**: #TBD
+
+### Sprint: CI Flake Cleanup (#2218)
+
+- Eliminate `RadoubSettings` singleton race causing intermittent test failures (#2051)
+- Fix Avalonia `MenuItem` registry race on ubuntu-latest CI (#2212)
+- Add manual `ci-flake-soak` workflow for future stability verification
+
+---
+
 ## [1.34.0-alpha] - 2026-05-24
 **Branch**: `trebuchet/issue-2216` | **PR**: #2221
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [1.35.0-alpha] - 2026-05-24
-**Branch**: `radoub/issue-2218` | **PR**: #TBD
+**Branch**: `radoub/issue-2218` | **PR**: #2222
 
 ### Sprint: CI Flake Cleanup (#2218)
 


### PR DESCRIPTION
## Summary

Eliminate two flaky tests undermining confidence in CI green checks. Root-cause fixes only — no `[Fact(Skip)]`, no `[Retry]`, no rerun band-aids.

## Work Items

- [ ] #2051 — `RadoubSettingsTests.CustomTlkPath_PersistsToFile` flaky after #2020
- [ ] #2212 — `TokenContextMenuTests.BuildTokenSubmenu_HasGenderCategory` flaky on ubuntu-latest CI

## Plan

See `NonPublic/Plans/2026-05-24-2218-plan.md`. Spec reviewed twice, approved.

**#2051 fix**: assembly-level `[CollectionBehavior(DisableTestParallelization=true)]` for `Radoub.Formats.Tests` + `RadoubSettingsFixture` (ICollectionFixture) owns env var + temp dir + singleton reset lifecycle + rename misnamed `Settings/RadoubSettingsTests.cs` → `Settings/BackupRetentionDaysTests.cs`.

**#2212 fix**: `Avalonia.Headless.XUnit` (already pinned in `Directory.Packages.props`) + `AvaloniaHeadlessFixture` seeds `AvaloniaPropertyRegistry` via `AppBuilder.Configure<App>().UseHeadless().SetupWithoutStarting()` once per assembly + `[Collection("AvaloniaHeadless")]` on confirmed Avalonia-touching test classes.

**Verification**: new `.github/workflows/ci-flake-soak.yml` runs 2 OS × 10 iterations on `workflow_dispatch`.

## Related Issues

- Closes #2218
- Closes #2051
- Closes #2212

## Checklist

- [ ] #2051 implementation complete
- [ ] #2212 implementation complete
- [ ] CI flake soak workflow added
- [ ] Tests added/updated
- [ ] CHANGELOG updated with date and PR number
- [ ] Soak workflow 20/20 green on PR

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)