### PR TITLE
[Trebuchet] Sprint: Launcher UX Polish (#2219)

### DIFF
--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.36.0-alpha] - 2026-05-24
+**Branch**: `trebuchet/issue-2219` | **PR**: #TBD
+
+### Sprint: Launcher UX Polish (#2219)
+
+- Refresh cached tool paths from sibling executables on startup — fixes stale paths after in-place Trebuchet update (#2079)
+- Document Windows SmartScreen first-launch workaround in README (#2079)
+- `AutoSuffixCollisionDialog` now auto-sizes to content and is user-resizable — readable at all font-size accessibility settings (#2184)
+
+---
+
 ## [1.35.0-alpha] - 2026-05-24
 **Branch**: `radoub/issue-2218` | **PR**: #2222
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [1.36.0-alpha] - 2026-05-24
-**Branch**: `trebuchet/issue-2219` | **PR**: #TBD
+**Branch**: `trebuchet/issue-2219` | **PR**: #2223
 
 ### Sprint: Launcher UX Polish (#2219)
 

--- a/Trebuchet/README.md
+++ b/Trebuchet/README.md
@@ -21,6 +21,17 @@ See [Known Issues](https://github.com/LordOfMyatar/Radoub/issues?q=is%3Aissue+is
 
 ---
 
+## First-launch SmartScreen warning (Windows)
+
+On first launch after downloading or updating Trebuchet, Windows SmartScreen may show a "Windows protected your PC" warning because the executable is not yet code-signed. To proceed:
+
+1. Click **More info** on the warning dialog.
+2. Click **Run anyway**.
+
+You may see this warning again the first time you launch each sibling tool (Parley, Manifest, Quartermaster, Fence, Relique) from Trebuchet. Code-signing is on the roadmap; see [#2079](https://github.com/LordOfMyatar/Radoub/issues/2079) for status.
+
+---
+
 ## Features
 
 ### Tool Launcher

--- a/Trebuchet/Trebuchet.Tests/ErfImportServiceTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ErfImportServiceTests.cs
@@ -106,7 +106,7 @@ public class ErfImportServiceTests : IDisposable
     {
         var erf = ErfReader.ReadMetadataOnly(_erfPath);
 
-        var result = await _service.ImportResourcesAsync(_erfPath, erf.Resources, _targetDir, overwriteExisting: false);
+        var result = await _service.ImportResourcesAsync(_erfPath, erf.Resources, _targetDir, overwriteExisting: false, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(3, result.ImportedCount);
         Assert.Equal(0, result.OverwrittenCount);
@@ -124,13 +124,13 @@ public class ErfImportServiceTests : IDisposable
         File.WriteAllBytes(Path.Combine(_targetDir, "test_item.uti"), existingContent);
         var erf = ErfReader.ReadMetadataOnly(_erfPath);
 
-        var result = await _service.ImportResourcesAsync(_erfPath, erf.Resources, _targetDir, overwriteExisting: false);
+        var result = await _service.ImportResourcesAsync(_erfPath, erf.Resources, _targetDir, overwriteExisting: false, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(2, result.ImportedCount);
         Assert.Equal(0, result.OverwrittenCount);
         Assert.Equal(1, result.SkippedCount);
         // Verify the existing file was NOT overwritten
-        var actual = await File.ReadAllBytesAsync(Path.Combine(_targetDir, "test_item.uti"));
+        var actual = await File.ReadAllBytesAsync(Path.Combine(_targetDir, "test_item.uti"), TestContext.Current.CancellationToken);
         Assert.Equal(existingContent, actual);
     }
 
@@ -140,20 +140,20 @@ public class ErfImportServiceTests : IDisposable
         File.WriteAllBytes(Path.Combine(_targetDir, "test_item.uti"), new byte[] { 0xFF, 0xFF });
         var erf = ErfReader.ReadMetadataOnly(_erfPath);
 
-        var result = await _service.ImportResourcesAsync(_erfPath, erf.Resources, _targetDir, overwriteExisting: true);
+        var result = await _service.ImportResourcesAsync(_erfPath, erf.Resources, _targetDir, overwriteExisting: true, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(2, result.ImportedCount);
         Assert.Equal(1, result.OverwrittenCount);
         Assert.Equal(3, result.TotalWritten);
         Assert.Equal(0, result.SkippedCount);
-        var actual = await File.ReadAllBytesAsync(Path.Combine(_targetDir, "test_item.uti"));
+        var actual = await File.ReadAllBytesAsync(Path.Combine(_targetDir, "test_item.uti"), TestContext.Current.CancellationToken);
         Assert.NotEqual(new byte[] { 0xFF, 0xFF }, actual);
     }
 
     [Fact]
     public async Task ImportResources_EmptyList_ReturnsZeroCounts()
     {
-        var result = await _service.ImportResourcesAsync(_erfPath, Array.Empty<ErfResourceEntry>(), _targetDir, overwriteExisting: false);
+        var result = await _service.ImportResourcesAsync(_erfPath, Array.Empty<ErfResourceEntry>(), _targetDir, overwriteExisting: false, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(0, result.ImportedCount);
         Assert.Equal(0, result.SkippedCount);
@@ -178,10 +178,10 @@ public class ErfImportServiceTests : IDisposable
         var progressReports = new List<ImportProgress>();
         var progress = new Progress<ImportProgress>(p => progressReports.Add(p));
 
-        await _service.ImportResourcesAsync(_erfPath, erf.Resources, _targetDir, overwriteExisting: false, progress: progress);
+        await _service.ImportResourcesAsync(_erfPath, erf.Resources, _targetDir, overwriteExisting: false, progress: progress, cancellationToken: TestContext.Current.CancellationToken);
 
         // Progress may be reported asynchronously, so allow a small delay
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
         Assert.True(progressReports.Count >= 1);
     }
 
@@ -191,7 +191,7 @@ public class ErfImportServiceTests : IDisposable
         var erf = ErfReader.ReadMetadataOnly(_erfPath);
         var selected = new List<ErfResourceEntry> { erf.Resources[0] }; // Only test_script
 
-        var result = await _service.ImportResourcesAsync(_erfPath, selected, _targetDir, overwriteExisting: false);
+        var result = await _service.ImportResourcesAsync(_erfPath, selected, _targetDir, overwriteExisting: false, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(1, result.ImportedCount);
         Assert.True(File.Exists(Path.Combine(_targetDir, "test_script.ncs")));

--- a/Trebuchet/Trebuchet.Tests/ErfImportViewModelTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ErfImportViewModelTests.cs
@@ -230,7 +230,7 @@ public class ErfImportViewModelTests : IDisposable
     }
 
     [Fact]
-    public async Task CanImport_FalseWhenNotLoaded()
+    public void CanImport_FalseWhenNotLoaded()
     {
         var vm = new ErfImportViewModel(_targetDir);
 

--- a/Trebuchet/Trebuchet.Tests/ToolLauncherSiblingRefreshTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ToolLauncherSiblingRefreshTests.cs
@@ -1,0 +1,171 @@
+using Radoub.Formats.Settings;
+using Radoub.TestUtilities.Helpers;
+using RadoubLauncher.Services;
+
+namespace Trebuchet.Tests;
+
+/// <summary>
+/// Tests for ToolLauncherService.RefreshPathsFromSiblingDirectory (#2079).
+///
+/// When Trebuchet is updated in place, RadoubSettings still holds the old tool
+/// paths from the previous install location. On startup, Trebuchet must
+/// overwrite those cached paths with any sibling executables that live next to
+/// the current Trebuchet binary — otherwise launching a tool fires
+/// File.Exists() against a path that no longer exists.
+/// </summary>
+public class ToolLauncherSiblingRefreshTests : IDisposable
+{
+    private static readonly string ExeExt = OperatingSystem.IsWindows() ? ".exe" : "";
+
+    private readonly string _testDirectory;
+    private readonly string _settingsDirectory;
+
+    public ToolLauncherSiblingRefreshTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), $"TrebuchetSiblingTest_{Guid.NewGuid():N}");
+        _settingsDirectory = Path.Combine(_testDirectory, "settings");
+        Directory.CreateDirectory(_testDirectory);
+        Directory.CreateDirectory(_settingsDirectory);
+
+        // Isolate RadoubSettings so the test doesn't clobber the user's tool paths
+        SingletonTestHelper.ResetSingleton<RadoubSettings>("_instance", "_settingsDirectory");
+        SingletonTestHelper.ConfigureSettingsDirectory("RADOUB_SETTINGS_DIR", _settingsDirectory);
+
+        // Reset ToolLauncherService so each test gets a fresh discovery pass
+        SingletonTestHelper.ResetSingleton<ToolLauncherService>();
+    }
+
+    public void Dispose()
+    {
+        SingletonTestHelper.ResetSingleton<ToolLauncherService>();
+        SingletonTestHelper.ResetSingleton<RadoubSettings>("_instance", "_settingsDirectory");
+        SingletonTestHelper.ConfigureSettingsDirectory("RADOUB_SETTINGS_DIR", null);
+
+        try
+        {
+            if (Directory.Exists(_testDirectory))
+                Directory.Delete(_testDirectory, true);
+        }
+        catch { /* ignore cleanup errors */ }
+    }
+
+    /// <summary>
+    /// Materialize ToolLauncherService.Instance (which runs the production ctor
+    /// — including its own DiscoverTools pass that can write dev-path data into
+    /// RadoubSettings) and then return a clean handle. Tests must arrange stale
+    /// settings AFTER calling this; otherwise the ctor's discovery cascade
+    /// overwrites whatever the test just wrote.
+    /// </summary>
+    private static ToolLauncherService GetInstanceWithCleanSettings()
+    {
+        var instance = ToolLauncherService.Instance;
+        // Wipe anything the ctor's discovery wrote so test arrangements aren't
+        // racing the singleton's own startup writes.
+        var s = RadoubSettings.Instance;
+        s.ParleyPath = "";
+        s.ManifestPath = "";
+        s.QuartermasterPath = "";
+        s.FencePath = "";
+        s.ReliquePath = "";
+        return instance;
+    }
+
+    [Fact]
+    public void RefreshPathsFromSiblingDirectory_OverwritesStaleSetting_WhenSiblingExists()
+    {
+        // Arrange: stale path in settings + a sibling exe at the new location
+        var launcher = GetInstanceWithCleanSettings();
+        var stalePath = Path.Combine(_testDirectory, "old", "Parley" + ExeExt);
+        var siblingPath = Path.Combine(_testDirectory, "Parley" + ExeExt);
+        File.WriteAllBytes(siblingPath, Array.Empty<byte>());
+        RadoubSettings.Instance.ParleyPath = stalePath;
+
+        // Act
+        launcher.RefreshPathsFromSiblingDirectory(_testDirectory);
+
+        // Assert
+        Assert.Equal(siblingPath, RadoubSettings.Instance.ParleyPath);
+    }
+
+    [Fact]
+    public void RefreshPathsFromSiblingDirectory_LeavesSettingAlone_WhenNoSibling()
+    {
+        // Arrange: only the stale setting exists, no sibling exe to overwrite with
+        var launcher = GetInstanceWithCleanSettings();
+        var stalePath = Path.Combine(_testDirectory, "elsewhere", "Manifest" + ExeExt);
+        RadoubSettings.Instance.ManifestPath = stalePath;
+
+        // Act
+        launcher.RefreshPathsFromSiblingDirectory(_testDirectory);
+
+        // Assert
+        Assert.Equal(stalePath, RadoubSettings.Instance.ManifestPath);
+    }
+
+    [Fact]
+    public void RefreshPathsFromSiblingDirectory_HandlesNullDirectory_WithoutThrowing()
+    {
+        // Arrange
+        var launcher = GetInstanceWithCleanSettings();
+        var stalePath = Path.Combine(_testDirectory, "elsewhere", "Quartermaster" + ExeExt);
+        RadoubSettings.Instance.QuartermasterPath = stalePath;
+
+        // Act + Assert: should be a no-op, not an exception
+        var ex = Record.Exception(() => launcher.RefreshPathsFromSiblingDirectory(null));
+        Assert.Null(ex);
+        Assert.Equal(stalePath, RadoubSettings.Instance.QuartermasterPath);
+    }
+
+    [Fact]
+    public void RefreshPathsFromSiblingDirectory_UsesAssemblyName_ForRelique()
+    {
+        // Arrange: Relique's exe is ItemEditor.exe, not Relique.exe (see AssemblyName in ToolLauncherService)
+        var launcher = GetInstanceWithCleanSettings();
+        var stalePath = Path.Combine(_testDirectory, "old", "ItemEditor" + ExeExt);
+        var siblingPath = Path.Combine(_testDirectory, "ItemEditor" + ExeExt);
+        File.WriteAllBytes(siblingPath, Array.Empty<byte>());
+        RadoubSettings.Instance.ReliquePath = stalePath;
+
+        // Act
+        launcher.RefreshPathsFromSiblingDirectory(_testDirectory);
+
+        // Assert
+        Assert.Equal(siblingPath, RadoubSettings.Instance.ReliquePath);
+    }
+
+    [Fact]
+    public void RefreshPathsFromSiblingDirectory_RewritesAllKnownTools_WhenAllSiblingsExist()
+    {
+        // Arrange: every tool has a sibling exe next to Trebuchet
+        var launcher = GetInstanceWithCleanSettings();
+        var parleySibling = Path.Combine(_testDirectory, "Parley" + ExeExt);
+        var manifestSibling = Path.Combine(_testDirectory, "Manifest" + ExeExt);
+        var qmSibling = Path.Combine(_testDirectory, "Quartermaster" + ExeExt);
+        var fenceSibling = Path.Combine(_testDirectory, "Fence" + ExeExt);
+        var reliqueSibling = Path.Combine(_testDirectory, "ItemEditor" + ExeExt);
+
+        foreach (var p in new[] { parleySibling, manifestSibling, qmSibling, fenceSibling, reliqueSibling })
+        {
+            File.WriteAllBytes(p, Array.Empty<byte>());
+        }
+
+        // Pre-populate with stale paths
+        var settings = RadoubSettings.Instance;
+        var oldDir = Path.Combine(_testDirectory, "old");
+        settings.ParleyPath = Path.Combine(oldDir, "Parley" + ExeExt);
+        settings.ManifestPath = Path.Combine(oldDir, "Manifest" + ExeExt);
+        settings.QuartermasterPath = Path.Combine(oldDir, "Quartermaster" + ExeExt);
+        settings.FencePath = Path.Combine(oldDir, "Fence" + ExeExt);
+        settings.ReliquePath = Path.Combine(oldDir, "ItemEditor" + ExeExt);
+
+        // Act
+        launcher.RefreshPathsFromSiblingDirectory(_testDirectory);
+
+        // Assert
+        Assert.Equal(parleySibling, settings.ParleyPath);
+        Assert.Equal(manifestSibling, settings.ManifestPath);
+        Assert.Equal(qmSibling, settings.QuartermasterPath);
+        Assert.Equal(fenceSibling, settings.FencePath);
+        Assert.Equal(reliqueSibling, settings.ReliquePath);
+    }
+}

--- a/Trebuchet/Trebuchet/Services/ToolLauncherService.cs
+++ b/Trebuchet/Trebuchet/Services/ToolLauncherService.cs
@@ -124,7 +124,37 @@ public class ToolLauncherService
             }
         };
 
+        // Repoint cached tool paths to siblings next to Trebuchet.exe before
+        // discovery runs. Fixes stale RadoubSettings entries left over from an
+        // earlier install location after Trebuchet is updated in place (#2079).
+        RefreshPathsFromSiblingDirectory(GetTrebuchetDirectory());
+
         DiscoverTools();
+    }
+
+    /// <summary>
+    /// Overwrite RadoubSettings tool paths with any sibling executable found
+    /// next to <paramref name="trebuchetDir"/>. If no sibling exists for a tool,
+    /// the existing cached path is left untouched and DiscoverTools() falls back
+    /// to its usual cascade (sibling-dir probe, dev path, common install paths).
+    ///
+    /// Null/empty directory is a no-op. Internal so Trebuchet.Tests can drive it
+    /// against a temp directory; not intended for production callers other than
+    /// the singleton constructor.
+    /// </summary>
+    internal void RefreshPathsFromSiblingDirectory(string? trebuchetDir)
+    {
+        if (string.IsNullOrEmpty(trebuchetDir)) return;
+
+        foreach (var tool in _tools)
+        {
+            var assemblyName = tool.AssemblyName ?? tool.Name;
+            var siblingPath = Path.Combine(trebuchetDir, GetExecutableName(assemblyName));
+            if (File.Exists(siblingPath))
+            {
+                CacheToolPath(tool.Name, siblingPath);
+            }
+        }
     }
 
     /// <summary>

--- a/Trebuchet/Trebuchet/Trebuchet.csproj
+++ b/Trebuchet/Trebuchet/Trebuchet.csproj
@@ -17,6 +17,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Trebuchet.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
 

--- a/Trebuchet/Trebuchet/Views/AutoSuffixCollisionDialog.axaml
+++ b/Trebuchet/Trebuchet/Views/AutoSuffixCollisionDialog.axaml
@@ -2,9 +2,11 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="RadoubLauncher.Views.AutoSuffixCollisionDialog"
         Title="Filename Already Exists"
-        Width="480" Height="220"
+        SizeToContent="WidthAndHeight"
+        MinWidth="480"
+        MinHeight="220"
         WindowStartupLocation="CenterOwner"
-        CanResize="False"
+        CanResize="True"
         ShowInTaskbar="False">
 
     <Border Padding="16">


### PR DESCRIPTION
## Summary

Sprint #2219 — Two user-visible Trebuchet pain points: startup friction and dialog accessibility.

### Work Items

- **#2079a** — `ToolLauncherService.RefreshPathsFromSiblingDirectory()` runs in the singleton ctor before `DiscoverTools()`. Any tool whose exe lives next to `Trebuchet.exe` gets its cached `RadoubSettings` path overwritten unconditionally. Fixes stale paths after an in-place update.
- **#2079b** — README "First-launch SmartScreen warning (Windows)" section documents the "More info → Run anyway" flow.
- **#2184** — `AutoSuffixCollisionDialog.axaml`: `SizeToContent="WidthAndHeight"` + `MinWidth/MinHeight="480/220"` + `CanResize="True"`. Drops fixed `Width/Height`. Modal preserved (rename is destructive — CLAUDE.md exception).

### Scoped-in chore

- Cleared 9 xUnit1051 + 1 CS1998 warnings in `ErfImport*Tests`. `Trebuchet.Tests` build is now warning-clean.

## Related Issues

- Closes #2079
- Closes #2184
- Sprint: #2219
- Follow-up filed: #2224 (ReplacePreview shows raw replacement text — surfaced during manual spot-check)

## Pre-Merge Status

| Check | Status |
|-------|--------|
| Privacy scan | ✅ |
| Tech debt scan | ✅ no files >800 lines |
| Theme compatibility | ✅ |
| Trebuchet unit tests | ✅ 169/169 pass |
| FlaUI tests | ⏭️ Skipped (manual spot-check covers AXAML change) |
| CHANGELOG | ✅ versioned, PR linked, no `[Unreleased]` |
| Wiki freshness | ✅ current |
| Release notes draft | ✅ updated |

## Plan

Pre-warmed plan: `NonPublic/Plans/2026-05-24-2219-plan.md`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)