### PR TITLE
[Relique] Sprint: UI/UX Polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,6 +361,7 @@ userDict.AddWord("Waterdeep");
 - [ ] **Add dictionary support** if tool has text editing fields
 - [ ] **`AssemblyName` matches the tool name** in the `.csproj` (e.g. `<AssemblyName>Relique</AssemblyName>` for the Relique tool). `RootNamespace` can differ if a legacy internal name is preferred, but the built binary must ship as `ToolName.exe` / `ToolName` — Trebuchet's sibling discovery (`ToolLauncherService.RefreshPathsFromSiblingDirectory`) walks `ToolInfo.Name`, and the release workflow / cross-tool launchers all assume `Radoub/ToolName.exe`. Mismatch causes silent launch failures + a forced rename later with a settings-path migration (#2080).
 - [ ] **Override `IndexMetadataAsync` + `ReadSourceMetadataAsync`** on the file browser panel if the format has Name and/or Tag fields — see [File Browser Adoption](#file-browser-adoption-filebrowserpanelbase)
+- [ ] **Wire Undo/Redo via shared `UndoRedoManager`** — register Ctrl+Z / Ctrl+Y and route every user-initiated mutation through `IUndoableCommand` so the standard Undo/Redo menu items work from day one (#2231). Do **not** ship disabled Undo/Redo menu stubs — either wire them correctly or omit them.
 
 ### Trebuchet Integration
 
@@ -394,6 +395,7 @@ New tools must integrate with Trebuchet (the Radoub launcher):
 | **TLK Support** | Use shared ITlkService for localized strings | Radoub.UI/Services/ITlkService.cs |
 | **Spell-Check** | Use Radoub.Dictionary for game-facing text | Parley/Manifest patterns |
 | **Token Picker** | Right-click "All Tokens..." must open `Radoub.UI.Views.TokenSelectorWindow` (4 tabs: Standard / Highlight / Custom Tokens / Custom Colors). Route through `TokenInsertionHelper.OpenTokenWindow` — do NOT instantiate the older `TokenInsertionWindow` directly; it lacks the Custom Tokens tab (#2075). | Manifest.PropertyPanel, Relique post-#2075 |
+| **Undo/Redo** | Wire shared `UndoRedoManager` + Ctrl+Z / Ctrl+Y; route mutating actions through `IUndoableCommand`. No disabled "Not yet implemented" menu stubs (#2231). | (TBD — pending epic #2231 reference impl) |
 
 **Resource Browsers** (use shared implementations from Radoub.UI):
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,20 @@ Each tool has its own installation instructions. See individual tool README file
 
 ---
 
+## Getting Started
+
+**Recommended first-launch path**: open your module through **Trebuchet**, then launch the per-resource tool (Parley, Relique, etc.) from there.
+
+Why: Trebuchet sets the active module context so the per-tool browsers populate with HAK / module / base-game resources automatically. Launching a per-tool first (e.g. opening Relique directly) leaves the module unset, so palette lookups fall back to defaults and the file browser only sees the current folder.
+
+1. **Launch Trebuchet** — `dotnet run --project Trebuchet/Trebuchet/Trebuchet.csproj` (or the published binary)
+2. **Open your `.mod`** via Trebuchet's module browser
+3. **Click the per-resource tool tile** (Dialog → Parley, Item → Relique, Creature → Quartermaster, Store → Fence, Journal → Manifest) — Trebuchet hands the active module + (optionally) a resource path to the tool over CLI
+
+Once a module is associated with a tool you can launch that tool directly in subsequent sessions; the most-recently-used module is remembered.
+
+---
+
 ## Development
 
 ### Building

--- a/Radoub.UI/Radoub.UI/Controls/StatusBarControl.axaml
+++ b/Radoub.UI/Radoub.UI/Controls/StatusBarControl.axaml
@@ -65,15 +65,16 @@
                  TextTrimming="CharacterEllipsis"
                  IsVisible="{Binding TertiaryText, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
 
-      <!-- File Path (right, trimmed) -->
+      <!-- File Path (right, leading-ellipsis trim so filename stays visible when path is long) -->
       <TextBlock x:Name="FilePathTextBlock"
                  Grid.Column="5"
                  Text="{Binding FilePath, RelativeSource={RelativeSource AncestorType=UserControl}}"
                  Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                  Margin="20,0,0,0"
                  VerticalAlignment="Center"
-                 TextTrimming="CharacterEllipsis"
-                 MaxWidth="300"
+                 TextTrimming="LeadingCharacterEllipsis"
+                 MaxWidth="500"
+                 ToolTip.Tip="{Binding FilePath, RelativeSource={RelativeSource AncestorType=UserControl}}"
                  IsVisible="{Binding FilePath, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
     </Grid>
   </Border>

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -15,7 +15,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Available Properties tree: preserve expansion state after add (#2227)
 - Property edit: smooth Apply Changes friction (auto-apply or workflow improvement) (#2226)
 - Appearance: filtered Part-number dropdowns matching Aurora's `<value> (Part NNN)` style (#2164)
-- Appearance: move icon chooser from inline grid to modal picker dialog (#1912)
 
 ---
 

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.10.16-alpha] - 2026-05-25
-**Branch**: `relique/issue-2229` | **PR**: #TBD
+**Branch**: `relique/issue-2229` | **PR**: #2230
 
 ### Sprint: Relique UI/UX Polish
 

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.10.16-alpha] - 2026-05-25
+**Branch**: `relique/issue-2229` | **PR**: #TBD
+
+### Sprint: Relique UI/UX Polish
+
+- Main editor UI polish: padding, height caps, field width constraints, Flags/Quantities above Description (#2229)
+- Available Properties tree: preserve expansion state after add (#2227)
+- Property edit: smooth Apply Changes friction (auto-apply or workflow improvement) (#2226)
+- Appearance: filtered Part-number dropdowns matching Aurora's `<value> (Part NNN)` style (#2164)
+- Appearance: move icon chooser from inline grid to modal picker dialog (#1912)
+
+---
+
 ## [0.10.15-alpha] - 2026-05-25
 **Branch**: `relique/issue-2217` | **PR**: #2225
 

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -11,10 +11,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Sprint: Relique UI/UX Polish
 
-- Main editor UI polish: padding, height caps, field width constraints, Flags/Quantities above Description (#2229)
-- Available Properties tree: preserve expansion state after add (#2227)
-- Property edit: smooth Apply Changes friction (auto-apply or workflow improvement) (#2226)
-- Appearance: filtered Part-number dropdowns matching Aurora's `<value> (Part NNN)` style (#2164)
+- Main editor UI polish: padding (16→25px right), field width caps, Name/Tag and ResRef/Cost paired side-by-side, Stack+Charges paired, Flags/Quantities moved above Descriptions, Item Properties soft height cap (#2229)
+- Available Properties tree preserves expansion state across add (#2227)
+- Property edit auto-applies on combo change — `Apply Changes` button retired (#2226)
+- Appearance: filtered Part-number dropdowns for armor (parts_*.2da, ACBONUS-sorted) and composite weapons (MDL scan, sorted ascending). Labels read `Part N — ID NNN`, with `(AC ±X)` on Torso only since only parts_chest contributes to item AC (#2164)
+- Item Statistics panel prepends `Base Armor Class: N` for armor items (sprint feedback, ties to #2164)
+- StatusBar file path now uses leading ellipsis + 500px cap so the filename stays visible when paths are long; tooltip shows full sanitized path (shared `Radoub.UI.StatusBarControl`, affects all tools)
+- Filed during sprint: #2231 (epic: Undo/Redo across all tools — bootstrap checklist updated), #2232 (mannequin idle pose), #2233 (composite weapon parts render misaligned, cross-tool with QM), #2234 (Add vs Add Checked UX rationalization), #2235 (real Cost computation engine)
 
 ---
 

--- a/Relique/Relique.Tests/Services/ArmorPartCatalogServiceTests.cs
+++ b/Relique/Relique.Tests/Services/ArmorPartCatalogServiceTests.cs
@@ -1,0 +1,178 @@
+using ItemEditor.Services;
+using Radoub.TestUtilities.Mocks;
+using System.Linq;
+using Xunit;
+
+namespace ItemEditor.Tests.Services;
+
+public class ArmorPartCatalogServiceTests
+{
+    private static MockGameDataService BuildMockWithParts2DA(string twoDAName, params (int row, string? acBonus)[] rows)
+    {
+        var mock = new MockGameDataService(includeSampleData: false);
+        foreach (var (row, acBonus) in rows)
+        {
+            mock.Set2DAValue(twoDAName, row, "ACBONUS", acBonus ?? "****");
+        }
+        return mock;
+    }
+
+    [Fact]
+    public void GetAvailableParts_FiltersRowsWithEmptyACBONUS()
+    {
+        var mock = BuildMockWithParts2DA("parts_chest",
+            (0, null),   // **** filtered out
+            (1, "0"),
+            (2, null),   // **** filtered out
+            (3, "1"));
+        var svc = new ArmorPartCatalogService(mock);
+
+        var parts = svc.GetAvailableParts("Torso").ToList();
+
+        Assert.Equal(2, parts.Count);
+        Assert.Equal(1, parts[0].RowIndex);
+        Assert.Equal(3, parts[1].RowIndex);
+    }
+
+    [Fact]
+    public void GetAvailableParts_SortsByACBONUSAscThenRowAsc()
+    {
+        var mock = BuildMockWithParts2DA("parts_chest",
+            (0, "2"),
+            (1, "0"),
+            (2, "1"),
+            (3, "0"));
+        var svc = new ArmorPartCatalogService(mock);
+
+        var parts = svc.GetAvailableParts("Torso").Select(p => p.RowIndex).ToList();
+
+        // Expected order: row 1 (ac=0), row 3 (ac=0), row 2 (ac=1), row 0 (ac=2)
+        Assert.Equal(new[] { 1, 3, 2, 0 }, parts);
+    }
+
+    [Fact]
+    public void GetAvailableParts_AssignsSequentialDisplayIndex_StartingAt1()
+    {
+        var mock = BuildMockWithParts2DA("parts_chest",
+            (0, "0"),
+            (1, "1"),
+            (2, "2"));
+        var svc = new ArmorPartCatalogService(mock);
+
+        var parts = svc.GetAvailableParts("Torso").ToList();
+
+        Assert.Equal(1, parts[0].DisplayIndex);
+        Assert.Equal(2, parts[1].DisplayIndex);
+        Assert.Equal(3, parts[2].DisplayIndex);
+    }
+
+    [Theory]
+    [InlineData("Neck", "parts_neck")]
+    [InlineData("Torso", "parts_chest")]
+    [InlineData("Belt", "parts_belt")]
+    [InlineData("Pelvis", "parts_pelvis")]
+    [InlineData("RShoul", "parts_shoulder")]
+    [InlineData("LShoul", "parts_shoulder")]
+    [InlineData("RBicep", "parts_bicep")]
+    [InlineData("LBicep", "parts_bicep")]
+    [InlineData("RFArm", "parts_forearm")]
+    [InlineData("LFArm", "parts_forearm")]
+    [InlineData("RHand", "parts_hand")]
+    [InlineData("LHand", "parts_hand")]
+    [InlineData("RThigh", "parts_legs")]
+    [InlineData("LThigh", "parts_legs")]
+    [InlineData("RShin", "parts_shin")]
+    [InlineData("LShin", "parts_shin")]
+    [InlineData("RFoot", "parts_foot")]
+    [InlineData("LFoot", "parts_foot")]
+    [InlineData("Robe", "parts_robe")]
+    public void ResolveTwoDAName_MapsPartNameToCorrect2DA(string partName, string expected2DA)
+    {
+        Assert.Equal(expected2DA, ArmorPartCatalogService.Resolve2DAName(partName));
+    }
+
+    [Fact]
+    public void ResolveTwoDAName_UnknownPartName_ReturnsNull()
+    {
+        Assert.Null(ArmorPartCatalogService.Resolve2DAName("DoesNotExist"));
+    }
+
+    [Fact]
+    public void GetAvailableParts_UnknownPartName_ReturnsEmpty()
+    {
+        var mock = new MockGameDataService(includeSampleData: false);
+        var svc = new ArmorPartCatalogService(mock);
+
+        Assert.Empty(svc.GetAvailableParts("BogusPart"));
+    }
+
+    [Fact]
+    public void GetAvailableParts_Missing2DA_ReturnsEmpty()
+    {
+        var mock = new MockGameDataService(includeSampleData: false);
+        var svc = new ArmorPartCatalogService(mock);
+
+        Assert.Empty(svc.GetAvailableParts("Torso"));
+    }
+
+    [Fact]
+    public void FormatDisplay_Default_OmitsAcBonus()
+    {
+        // Per engine behavior, only the Torso (parts_chest) ACBONUS contributes to item AC.
+        // Showing (AC +X) on non-Torso slots is misleading. Default format omits it (#2164 v2).
+        var entry = new ArmorPartEntry(RowIndex: 11, DisplayIndex: 1, ACBonus: 0);
+
+        Assert.Equal("Part 1 — ID 11", entry.ToDisplayString());
+    }
+
+    [Fact]
+    public void FormatDisplay_IncludeAc_ShowsAcBonus()
+    {
+        // Torso row opts in: passes includeAcBonus=true so the AC contribution is visible
+        // where it actually matters.
+        var entry = new ArmorPartEntry(RowIndex: 11, DisplayIndex: 1, ACBonus: 2);
+
+        Assert.Equal("Part 1 — ID 11 (AC +2)", entry.ToDisplayString(includeAcBonus: true));
+    }
+
+    [Fact]
+    public void FormatDisplay_IncludeAc_NegativeBonus_ShowsSign()
+    {
+        var entry = new ArmorPartEntry(RowIndex: 5, DisplayIndex: 3, ACBonus: -1);
+
+        Assert.Equal("Part 3 — ID 5 (AC -1)", entry.ToDisplayString(includeAcBonus: true));
+    }
+
+    [Fact]
+    public void FormatDisplay_IncludeAc_FractionalRounds()
+    {
+        var entry = new ArmorPartEntry(RowIndex: 7, DisplayIndex: 2, ACBonus: 0.5);
+
+        Assert.Equal("Part 2 — ID 7 (AC +1)", entry.ToDisplayString(includeAcBonus: true));
+    }
+
+    [Fact]
+    public void FormatDisplay_HandlesThreeDigitRowIndex()
+    {
+        var entry = new ArmorPartEntry(RowIndex: 123, DisplayIndex: 42, ACBonus: 5);
+
+        Assert.Equal("Part 42 — ID 123", entry.ToDisplayString());
+    }
+
+    [Fact]
+    public void GetAvailableParts_NonNumericACBONUS_TreatedAsZero()
+    {
+        // Defensive: malformed 2DA cells shouldn't crash.
+        var mock = BuildMockWithParts2DA("parts_chest",
+            (0, "notanumber"),
+            (1, "0"));
+        var svc = new ArmorPartCatalogService(mock);
+
+        var parts = svc.GetAvailableParts("Torso").ToList();
+
+        Assert.Equal(2, parts.Count);
+        // Both treated as AC=0, sort by row index: row 0 first
+        Assert.Equal(0, parts[0].RowIndex);
+        Assert.Equal(1, parts[1].RowIndex);
+    }
+}

--- a/Relique/Relique.Tests/Services/CompositeWeaponPartCatalogServiceTests.cs
+++ b/Relique/Relique.Tests/Services/CompositeWeaponPartCatalogServiceTests.cs
@@ -1,0 +1,94 @@
+using ItemEditor.Services;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace ItemEditor.Tests.Services;
+
+public class CompositeWeaponPartCatalogServiceTests
+{
+    [Theory]
+    [InlineData("wdbsw_b_011", "wdbsw", "b", 11)]
+    [InlineData("wdbsw_b_021", "wdbsw", "b", 21)]
+    [InlineData("wdbsw_m_031", "wdbsw", "m", 31)]
+    [InlineData("wdbsw_t_001", "wdbsw", "t", 1)]
+    [InlineData("WBLAD_B_011", "wblad", "b", 11)] // case-insensitive
+    public void TryParseCompositeResRef_ExtractsItemClassAndPosition(string resRef, string itemClass, string position, int partNumber)
+    {
+        var ok = CompositeWeaponPartCatalogService.TryParseCompositeResRef(
+            resRef, itemClass, position, out var parsed);
+
+        Assert.True(ok);
+        Assert.Equal(partNumber, parsed);
+    }
+
+    [Theory]
+    [InlineData("wdbsw_b_011", "wblad", "b")] // wrong itemClass
+    [InlineData("wdbsw_x_011", "wdbsw", "b")] // wrong position
+    [InlineData("wdbsw_b_xyz", "wdbsw", "b")] // non-numeric suffix
+    [InlineData("wdbsw_b", "wdbsw", "b")]     // missing suffix
+    [InlineData("", "wdbsw", "b")]            // empty
+    [InlineData("wdbsw_005", "wdbsw", "b")]   // simple (non-composite) naming
+    public void TryParseCompositeResRef_RejectsBadFormats(string resRef, string itemClass, string position)
+    {
+        var ok = CompositeWeaponPartCatalogService.TryParseCompositeResRef(
+            resRef, itemClass, position, out var parsed);
+
+        Assert.False(ok);
+        Assert.Equal(0, parsed);
+    }
+
+    [Fact]
+    public void GetAvailableParts_FiltersByItemClassAndPosition_DeduplicatesAndSorts()
+    {
+        var resources = new[]
+        {
+            "wdbsw_b_021",
+            "wdbsw_b_011",
+            "wdbsw_b_031",
+            "wdbsw_m_011",  // wrong position
+            "wblad_b_011",  // wrong itemClass
+            "wdbsw_b_011",  // duplicate
+        };
+
+        var parts = CompositeWeaponPartCatalogService
+            .ExtractPartNumbers(resources, "wdbsw", "b")
+            .ToList();
+
+        // Expected: 11, 21, 31 (sorted asc, no duplicate)
+        Assert.Equal(new[] { 11, 21, 31 }, parts);
+    }
+
+    [Fact]
+    public void GetAvailableParts_EmptyItemClass_ReturnsEmpty()
+    {
+        var parts = CompositeWeaponPartCatalogService
+            .ExtractPartNumbers(new[] { "wdbsw_b_011" }, "", "b");
+
+        Assert.Empty(parts);
+    }
+
+    [Fact]
+    public void GetAvailableParts_NullItemClass_ReturnsEmpty()
+    {
+        var parts = CompositeWeaponPartCatalogService
+            .ExtractPartNumbers(new[] { "wdbsw_b_011" }, null, "b");
+
+        Assert.Empty(parts);
+    }
+
+    [Fact]
+    public void PositionForPartIndex_MapsPartNumbers()
+    {
+        Assert.Equal("b", CompositeWeaponPartCatalogService.PositionForPartIndex(1));
+        Assert.Equal("m", CompositeWeaponPartCatalogService.PositionForPartIndex(2));
+        Assert.Equal("t", CompositeWeaponPartCatalogService.PositionForPartIndex(3));
+    }
+
+    [Fact]
+    public void PositionForPartIndex_OutOfRange_ReturnsNull()
+    {
+        Assert.Null(CompositeWeaponPartCatalogService.PositionForPartIndex(0));
+        Assert.Null(CompositeWeaponPartCatalogService.PositionForPartIndex(4));
+    }
+}

--- a/Relique/Relique.Tests/Services/EditAutoApplyDeciderTests.cs
+++ b/Relique/Relique.Tests/Services/EditAutoApplyDeciderTests.cs
@@ -1,0 +1,55 @@
+using ItemEditor.Services;
+using Xunit;
+
+namespace ItemEditor.Tests.Services;
+
+public class EditAutoApplyDeciderTests
+{
+    [Fact]
+    public void ShouldAutoApply_ReturnsFalse_WhenNotInEditMode()
+    {
+        var result = EditAutoApplyDecider.ShouldAutoApply(
+            editingPropertyIndex: -1, suppressAutoApply: false);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ShouldAutoApply_ReturnsTrue_WhenInEditModeAndNotSuppressed()
+    {
+        var result = EditAutoApplyDecider.ShouldAutoApply(
+            editingPropertyIndex: 3, suppressAutoApply: false);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldAutoApply_ReturnsFalse_WhenSuppressed()
+    {
+        var result = EditAutoApplyDecider.ShouldAutoApply(
+            editingPropertyIndex: 3, suppressAutoApply: true);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ShouldAutoApply_ReturnsTrue_WhenEditingIndexZero()
+    {
+        // Boundary: index 0 is a valid editing target.
+        var result = EditAutoApplyDecider.ShouldAutoApply(
+            editingPropertyIndex: 0, suppressAutoApply: false);
+
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData(-100, false, false)]
+    [InlineData(-1, false, false)]
+    [InlineData(0, true, false)]
+    [InlineData(5, true, false)]
+    [InlineData(5, false, true)]
+    public void ShouldAutoApply_Matrix(int index, bool suppress, bool expected)
+    {
+        Assert.Equal(expected, EditAutoApplyDecider.ShouldAutoApply(index, suppress));
+    }
+}

--- a/Relique/Relique.Tests/Services/TreeExpansionTrackerTests.cs
+++ b/Relique/Relique.Tests/Services/TreeExpansionTrackerTests.cs
@@ -1,0 +1,69 @@
+using ItemEditor.Services;
+using System.Collections.Generic;
+using Xunit;
+
+namespace ItemEditor.Tests.Services;
+
+public class TreeExpansionTrackerTests
+{
+    [Fact]
+    public void Capture_EmptyState_ReturnsEmptySnapshot()
+    {
+        var snapshot = TreeExpansionTracker.Capture(System.Array.Empty<int>());
+
+        Assert.Empty(snapshot.ExpandedPropertyIndices);
+    }
+
+    [Fact]
+    public void Capture_StoresAllProvidedIndices()
+    {
+        var snapshot = TreeExpansionTracker.Capture(new[] { 1, 7, 42 });
+
+        Assert.Equal(new HashSet<int> { 1, 7, 42 }, snapshot.ExpandedPropertyIndices);
+    }
+
+    [Fact]
+    public void ShouldExpand_ReturnsTrue_WhenIndexInSnapshot()
+    {
+        var snapshot = TreeExpansionTracker.Capture(new[] { 5, 9 });
+
+        Assert.True(snapshot.ShouldExpand(5));
+        Assert.True(snapshot.ShouldExpand(9));
+    }
+
+    [Fact]
+    public void ShouldExpand_ReturnsFalse_WhenIndexNotInSnapshot()
+    {
+        var snapshot = TreeExpansionTracker.Capture(new[] { 5, 9 });
+
+        Assert.False(snapshot.ShouldExpand(1));
+        Assert.False(snapshot.ShouldExpand(100));
+    }
+
+    [Fact]
+    public void Empty_NoIndicesExpand()
+    {
+        var snapshot = TreeExpansionSnapshot.Empty;
+
+        Assert.False(snapshot.ShouldExpand(0));
+        Assert.False(snapshot.ShouldExpand(42));
+    }
+
+    [Fact]
+    public void Capture_DeduplicatesIndices()
+    {
+        var snapshot = TreeExpansionTracker.Capture(new[] { 3, 3, 7, 3 });
+
+        Assert.Equal(2, snapshot.ExpandedPropertyIndices.Count);
+        Assert.Contains(3, snapshot.ExpandedPropertyIndices);
+        Assert.Contains(7, snapshot.ExpandedPropertyIndices);
+    }
+
+    [Fact]
+    public void Capture_FromNull_ReturnsEmpty()
+    {
+        var snapshot = TreeExpansionTracker.Capture(null!);
+
+        Assert.Empty(snapshot.ExpandedPropertyIndices);
+    }
+}

--- a/Relique/Relique/Services/ArmorPartCatalogService.cs
+++ b/Relique/Relique/Services/ArmorPartCatalogService.cs
@@ -1,0 +1,102 @@
+using Radoub.Formats.Services;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace ItemEditor.Services;
+
+/// <summary>
+/// One row of a parts_*.2da filtered to entries the engine will actually render
+/// (ACBONUS != ****). DisplayIndex is the 1-based position in the filtered+sorted
+/// list — Aurora's "Part NNN" label (#2164).
+/// </summary>
+public sealed record ArmorPartEntry(int RowIndex, int DisplayIndex, double ACBonus)
+{
+    /// <summary>
+    /// Default label: "Part N — ID NNN". "Part N" keeps Aurora-style sequential indexing;
+    /// "ID NNN" is the stored byte. AC is omitted because only the Torso slot's ACBONUS
+    /// affects item AC — showing it on Neck/Hand/etc. would mislead (#2164 manual-feedback v2).
+    /// Pass includeAcBonus=true on the Torso row to show "(AC ±X)" where it actually matters.
+    /// </summary>
+    public string ToDisplayString(bool includeAcBonus = false)
+    {
+        if (!includeAcBonus)
+            return $"Part {DisplayIndex} — ID {RowIndex}";
+
+        int acRounded = (int)System.Math.Round(ACBonus, System.MidpointRounding.AwayFromZero);
+        string acSign = acRounded >= 0 ? "+" : "";
+        return $"Part {DisplayIndex} — ID {RowIndex} (AC {acSign}{acRounded})";
+    }
+}
+
+/// <summary>
+/// Reads parts_*.2da tables and returns the engine-valid armor parts for a given
+/// armor slot (Torso, Belt, etc.), filtered and sorted per BioWare wiki Ch4 §4.1.4:
+/// "available parts are sorted in order of increasing ACBONUS as listed in the parts
+/// 2da. If several parts have identical ACBONUS, then they are sorted in order of
+/// increasing row number." (#2164)
+/// </summary>
+public sealed class ArmorPartCatalogService
+{
+    private readonly IGameDataService _gameData;
+
+    private static readonly Dictionary<string, string> PartTo2DA = new(System.StringComparer.Ordinal)
+    {
+        ["Neck"]   = "parts_neck",
+        ["Torso"]  = "parts_chest",
+        ["Belt"]   = "parts_belt",
+        ["Pelvis"] = "parts_pelvis",
+        ["RShoul"] = "parts_shoulder", ["LShoul"] = "parts_shoulder",
+        ["RBicep"] = "parts_bicep",    ["LBicep"] = "parts_bicep",
+        ["RFArm"]  = "parts_forearm",  ["LFArm"]  = "parts_forearm",
+        ["RHand"]  = "parts_hand",     ["LHand"]  = "parts_hand",
+        ["RThigh"] = "parts_legs",     ["LThigh"] = "parts_legs",
+        ["RShin"]  = "parts_shin",     ["LShin"]  = "parts_shin",
+        ["RFoot"]  = "parts_foot",     ["LFoot"]  = "parts_foot",
+        ["Robe"]   = "parts_robe",
+    };
+
+    public ArmorPartCatalogService(IGameDataService gameData)
+    {
+        _gameData = gameData;
+    }
+
+    public static string? Resolve2DAName(string partName)
+        => PartTo2DA.TryGetValue(partName, out var n) ? n : null;
+
+    public IEnumerable<ArmorPartEntry> GetAvailableParts(string partName)
+    {
+        var twoDAName = Resolve2DAName(partName);
+        if (twoDAName == null) yield break;
+
+        var table = _gameData.Get2DA(twoDAName);
+        if (table == null) yield break;
+
+        // Collect (rowIndex, acBonus) for rows where ACBONUS != ****.
+        var rows = new List<(int row, double ac)>();
+        for (int i = 0; i < table.Rows.Count; i++)
+        {
+            var raw = table.GetValue(i, "ACBONUS");
+            // Real 2DA reader normalizes **** to null; mock test fixtures may store literal "****".
+            // Both forms mean "no value" — filter both.
+            if (string.IsNullOrEmpty(raw) || raw == "****") continue;
+
+            double ac = 0;
+            double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out ac);
+            rows.Add((i, ac));
+        }
+
+        // Sort: ACBONUS asc, then row index asc. Per wiki Ch4 §4.1.4.
+        rows.Sort((a, b) =>
+        {
+            int cmp = a.ac.CompareTo(b.ac);
+            return cmp != 0 ? cmp : a.row.CompareTo(b.row);
+        });
+
+        int displayIndex = 1;
+        foreach (var (row, ac) in rows)
+        {
+            yield return new ArmorPartEntry(row, displayIndex++, ac);
+        }
+    }
+}

--- a/Relique/Relique/Services/CompositeWeaponPartCatalogService.cs
+++ b/Relique/Relique/Services/CompositeWeaponPartCatalogService.cs
@@ -1,0 +1,89 @@
+using Radoub.Formats.Common;
+using Radoub.Formats.Services;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace ItemEditor.Services;
+
+/// <summary>
+/// Lists composite-weapon model parts (ModelType 2) by scanning MDL resources whose
+/// ResRef matches <c>&lt;itemClass&gt;_&lt;b|m|t&gt;_NNN</c>. Per the BioWare wiki §4.1.3,
+/// the 3-digit suffix is a shape×color variant so part numbers don't start at 001 — the
+/// dropdown lets the user pick from what actually exists instead of guessing (#2164).
+/// </summary>
+public sealed class CompositeWeaponPartCatalogService
+{
+    private readonly IGameDataService _gameData;
+
+    public CompositeWeaponPartCatalogService(IGameDataService gameData)
+    {
+        _gameData = gameData;
+    }
+
+    /// <summary>Position suffix for ModelPart1/2/3 → b (base) / m (middle) / t (top).</summary>
+    public static string? PositionForPartIndex(int partIndex) => partIndex switch
+    {
+        1 => "b",
+        2 => "m",
+        3 => "t",
+        _ => null,
+    };
+
+    /// <summary>
+    /// Try parse a composite-weapon ResRef matching <c>&lt;itemClass&gt;_&lt;position&gt;_NNN</c>.
+    /// Case-insensitive. Returns false if the prefix doesn't match or the suffix isn't numeric.
+    /// </summary>
+    public static bool TryParseCompositeResRef(string resRef, string itemClass, string position, out int partNumber)
+    {
+        partNumber = 0;
+        if (string.IsNullOrEmpty(resRef) || string.IsNullOrEmpty(itemClass) || string.IsNullOrEmpty(position))
+            return false;
+
+        var expectedPrefix = $"{itemClass}_{position}_";
+        if (!resRef.StartsWith(expectedPrefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var suffix = resRef.Substring(expectedPrefix.Length);
+        if (suffix.Length == 0) return false;
+
+        return int.TryParse(suffix, NumberStyles.Integer, CultureInfo.InvariantCulture, out partNumber);
+    }
+
+    /// <summary>
+    /// Pure helper: filter and dedupe a list of MDL ResRefs to part numbers for a
+    /// specific (itemClass, position) pair. Sorted ascending. Used by GetAvailableParts
+    /// and exposed for unit tests so we don't need a live GameDataService.
+    /// </summary>
+    public static IEnumerable<int> ExtractPartNumbers(IEnumerable<string> resRefs, string? itemClass, string position)
+    {
+        if (string.IsNullOrEmpty(itemClass)) yield break;
+
+        var seen = new HashSet<int>();
+        var collected = new List<int>();
+
+        foreach (var rr in resRefs)
+        {
+            if (TryParseCompositeResRef(rr, itemClass, position, out var n) && seen.Add(n))
+                collected.Add(n);
+        }
+
+        collected.Sort();
+        foreach (var n in collected) yield return n;
+    }
+
+    /// <summary>
+    /// List available part numbers for a composite-weapon slot (ModelPart1/2/3 → b/m/t)
+    /// by scanning all MDL resources via IGameDataService.ListResources.
+    /// Returns empty if itemClass is null/empty or partIndex is out of range.
+    /// </summary>
+    public IEnumerable<int> GetAvailableParts(string? itemClass, int partIndex)
+    {
+        var position = PositionForPartIndex(partIndex);
+        if (position == null) return Enumerable.Empty<int>();
+
+        var allMdl = _gameData.ListResources(ResourceTypes.Mdl).Select(r => r.ResRef);
+        return ExtractPartNumbers(allMdl, itemClass, position);
+    }
+}

--- a/Relique/Relique/Services/EditAutoApplyDecider.cs
+++ b/Relique/Relique/Services/EditAutoApplyDecider.cs
@@ -1,0 +1,16 @@
+namespace ItemEditor.Services;
+
+/// <summary>
+/// Pure decision helper for whether a Subtype/Value/Param ComboBox SelectionChanged
+/// should auto-apply during property editing (#2226). Auto-apply fires when the
+/// user is in edit mode (editingPropertyIndex >= 0) and the change isn't a
+/// programmatic pre-select (suppressAutoApply false).
+/// </summary>
+public static class EditAutoApplyDecider
+{
+    public static bool ShouldAutoApply(int editingPropertyIndex, bool suppressAutoApply)
+    {
+        if (suppressAutoApply) return false;
+        return editingPropertyIndex >= 0;
+    }
+}

--- a/Relique/Relique/Services/TreeExpansionTracker.cs
+++ b/Relique/Relique/Services/TreeExpansionTracker.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ItemEditor.Services;
+
+/// <summary>
+/// Snapshot of which top-level Available Properties tree nodes are expanded,
+/// keyed by PropertyIndex. Used to restore expansion state across a tree
+/// rebuild so the user does not have to re-expand a category after each Add (#2227).
+/// </summary>
+public sealed class TreeExpansionSnapshot
+{
+    public static readonly TreeExpansionSnapshot Empty = new(new HashSet<int>());
+
+    public IReadOnlySet<int> ExpandedPropertyIndices { get; }
+
+    internal TreeExpansionSnapshot(IReadOnlySet<int> expandedPropertyIndices)
+    {
+        ExpandedPropertyIndices = expandedPropertyIndices;
+    }
+
+    public bool ShouldExpand(int propertyIndex) => ExpandedPropertyIndices.Contains(propertyIndex);
+}
+
+public static class TreeExpansionTracker
+{
+    public static TreeExpansionSnapshot Capture(IEnumerable<int> expandedPropertyIndices)
+    {
+        if (expandedPropertyIndices == null)
+            return TreeExpansionSnapshot.Empty;
+
+        var set = new HashSet<int>(expandedPropertyIndices);
+        return new TreeExpansionSnapshot(set);
+    }
+}

--- a/Relique/Relique/Views/MainWindow.EditorPopulation.cs
+++ b/Relique/Relique/Views/MainWindow.EditorPopulation.cs
@@ -1,5 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using Avalonia.Media.Imaging;
 using ItemEditor.ViewModels;
 using Radoub.Formats.Gff;
@@ -235,9 +236,13 @@ public partial class MainWindow
         {
             // Parts 2 & 3 only for Composite (ModelType 2)
             ModelPart2Label.IsVisible = showMultipleParts;
-            ModelPart2UpDown.IsVisible = showMultipleParts;
+            ModelPart2Combo.IsVisible = showMultipleParts;
             ModelPart3Label.IsVisible = showMultipleParts;
-            ModelPart3UpDown.IsVisible = showMultipleParts;
+            ModelPart3Combo.IsVisible = showMultipleParts;
+
+            // Populate composite-weapon dropdowns from MDL scan (#2164). For Simple/Layered
+            // we still wire Part 1 as a free-text byte so the existing numeric workflow works.
+            PopulateModelPartCombos(baseItemIndex, showMultipleParts);
         }
 
         // Colors: show for Layered (1) and Armor (3)
@@ -326,23 +331,15 @@ public partial class MainWindow
             Grid.SetColumn(label, col);
             ArmorPartsGrid.Children.Add(label);
 
-            var upDown = new NumericUpDown
-            {
-                Value = _itemViewModel.GetArmorPart(partName),
-                Minimum = 0,
-                Maximum = 255,
-                FormatString = "N0",
-                Margin = new Thickness(0, 0, 0, 8)
-            };
+            // #2164: Filtered ComboBox of engine-valid parts (sourced from parts_*.2da
+            // where ACBONUS != ****). Editable so HAK / forward-compat parts can still
+            // be typed in. Display matches Aurora: "<rowIndex> (Part <displayIndex>)".
             var capturedPartName = partName;
-            upDown.ValueChanged += (_, args) =>
-            {
-                if (_isLoading || _itemViewModel == null) return;
-                _itemViewModel.SetArmorPart(capturedPartName, (byte)(args.NewValue ?? 0));
-            };
-            Grid.SetRow(upDown, row);
-            Grid.SetColumn(upDown, col + 1);
-            ArmorPartsGrid.Children.Add(upDown);
+            byte currentValue = _itemViewModel.GetArmorPart(partName);
+            var combo = BuildArmorPartComboBox(capturedPartName, currentValue);
+            Grid.SetRow(combo, row);
+            Grid.SetColumn(combo, col + 1);
+            ArmorPartsGrid.Children.Add(combo);
 
             if (i % 2 == 1) row++;
         }
@@ -350,6 +347,181 @@ public partial class MainWindow
         if (ArmorPartNames.Length % 2 == 1) row++;
 
         UpdateArmorClassDisplay();
+    }
+
+    /// <summary>
+    /// Populate the three ModelPart ComboBoxes with the current ViewModel values, and
+    /// (for composite weapons) the catalog of available <itemClass>_b/m/t_NNN.mdl parts.
+    /// Simple/Layered base types only get Part 1; ComboBox stays editable so the user
+    /// can still type a raw byte (#2164).
+    /// </summary>
+    private void PopulateModelPartCombos(int baseItemIndex, bool isComposite)
+    {
+        if (_itemViewModel == null) return;
+
+        string? itemClass = _gameDataService?.Get2DAValue("baseitems", baseItemIndex, "ItemClass");
+        if (string.IsNullOrEmpty(itemClass) || itemClass == "****") itemClass = null;
+
+        WireModelPartCombo(ModelPart1Combo, partIndex: 1, _itemViewModel.ModelPart1,
+            v => _itemViewModel.ModelPart1 = v, isComposite, itemClass);
+
+        if (isComposite)
+        {
+            WireModelPartCombo(ModelPart2Combo, partIndex: 2, _itemViewModel.ModelPart2,
+                v => _itemViewModel.ModelPart2 = v, isComposite: true, itemClass);
+            WireModelPartCombo(ModelPart3Combo, partIndex: 3, _itemViewModel.ModelPart3,
+                v => _itemViewModel.ModelPart3 = v, isComposite: true, itemClass);
+        }
+    }
+
+    /// <summary>
+    /// Wire one ModelPart ComboBox: clear + repopulate from the composite-weapon catalog
+    /// (if applicable), pre-select the current value, and re-attach the SelectionChanged /
+    /// LostFocus handlers that write through to the ViewModel.
+    /// </summary>
+    private void WireModelPartCombo(ComboBox combo, int partIndex, byte currentValue,
+        System.Action<byte> setter, bool isComposite, string? itemClass)
+    {
+        // Detach prior handlers (PopulateEditor can run multiple times per session).
+        if (combo.Tag is System.Collections.Generic.List<System.Delegate> oldHandlers)
+        {
+            // We stored (SelectionChanged, LostFocus) handlers as Delegates so we can remove them
+            // before re-wiring.
+            foreach (var h in oldHandlers)
+            {
+                if (h is System.EventHandler<SelectionChangedEventArgs> sh) combo.SelectionChanged -= sh;
+                else if (h is System.EventHandler<RoutedEventArgs> lh) combo.LostFocus -= lh;
+            }
+        }
+
+        combo.Items.Clear();
+
+        ComboBoxItem? matched = null;
+        if (isComposite && itemClass != null && _compositeWeaponCatalog != null)
+        {
+            int displayIndex = 1;
+            foreach (var partNumber in _compositeWeaponCatalog.GetAvailableParts(itemClass, partIndex))
+            {
+                var item = new ComboBoxItem
+                {
+                    // Match armor-part label scheme: "Part N — ID NNN". Composite weapons
+                    // have no AC bonus, so we omit that field. (#2164 manual-feedback revision)
+                    Content = $"Part {displayIndex} — ID {partNumber}",
+                    Tag = partNumber,
+                };
+                combo.Items.Add(item);
+                if (partNumber == currentValue) matched = item;
+                displayIndex++;
+            }
+        }
+
+        if (matched != null)
+        {
+            combo.SelectedItem = matched;
+        }
+        else
+        {
+            combo.Text = currentValue == 0 ? "0" :
+                (isComposite ? $"{currentValue} (unverified)" : currentValue.ToString());
+        }
+
+        var selectionHandler = new System.EventHandler<SelectionChangedEventArgs>((_, _) =>
+        {
+            if (_isLoading || _itemViewModel == null) return;
+            if (combo.SelectedItem is ComboBoxItem item && item.Tag is int rowIdx)
+            {
+                setter((byte)System.Math.Clamp(rowIdx, 0, 255));
+            }
+        });
+        var lostFocusHandler = new System.EventHandler<RoutedEventArgs>((_, _) =>
+        {
+            if (_isLoading || _itemViewModel == null) return;
+            if (combo.SelectedItem is ComboBoxItem) return;
+            if (byte.TryParse((combo.Text ?? string.Empty).Trim(), out var parsed))
+            {
+                setter(parsed);
+            }
+        });
+
+        combo.SelectionChanged += selectionHandler;
+        combo.LostFocus += lostFocusHandler;
+        combo.Tag = new System.Collections.Generic.List<System.Delegate>
+        {
+            selectionHandler, lostFocusHandler,
+        };
+    }
+
+    /// <summary>
+    /// Build an editable ComboBox for an armor part slot, populated from parts_*.2da
+    /// via ArmorPartCatalogService (#2164). Items are tagged with the stored byte so
+    /// SelectionChanged can write it back to the ViewModel; the .Text fallback handles
+    /// HAK / forward-compat custom entries the user types in.
+    /// </summary>
+    private ComboBox BuildArmorPartComboBox(string partName, byte currentValue)
+    {
+        var combo = new ComboBox
+        {
+            HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Stretch,
+            Margin = new Thickness(0, 0, 0, 8),
+            // Editable: lets advanced users type a custom byte (HAK / unverified parts).
+            // The catalog only knows about base-game parts_*.2da rows.
+            IsEditable = true,
+        };
+
+        ComboBoxItem? matched = null;
+        // Only the Torso (parts_chest) row's ACBONUS affects item AC, per the engine.
+        // Showing (AC ±X) on other slots misleads — keep it on Torso only.
+        bool showAc = partName == "Torso";
+        if (_armorPartCatalog != null)
+        {
+            foreach (var entry in _armorPartCatalog.GetAvailableParts(partName))
+            {
+                var item = new ComboBoxItem
+                {
+                    Content = entry.ToDisplayString(includeAcBonus: showAc),
+                    Tag = entry.RowIndex,
+                };
+                combo.Items.Add(item);
+                if (entry.RowIndex == currentValue) matched = item;
+            }
+        }
+
+        if (matched != null)
+        {
+            combo.SelectedItem = matched;
+        }
+        else
+        {
+            // Current value not in the catalog (custom / HAK / out-of-range). Show the raw
+            // byte with an (unverified) hint so the user knows it didn't come from the 2DA.
+            combo.Text = currentValue == 0 ? "0" : $"{currentValue} (unverified)";
+        }
+
+        combo.SelectionChanged += (_, _) =>
+        {
+            if (_isLoading || _itemViewModel == null) return;
+            if (combo.SelectedItem is ComboBoxItem item && item.Tag is int rowIdx)
+            {
+                _itemViewModel.SetArmorPart(partName, (byte)System.Math.Clamp(rowIdx, 0, 255));
+                UpdateArmorClassDisplay();
+            }
+        };
+
+        // Free-text path: user types a raw byte (HAK / forward-compat). After the labelled
+        // format change, the dropdown text is no longer parseable as a leading byte, so
+        // we only honor a bare numeric entry like "42".
+        combo.LostFocus += (_, _) =>
+        {
+            if (_isLoading || _itemViewModel == null) return;
+            if (combo.SelectedItem is ComboBoxItem) return; // selection handler already wrote it
+            if (byte.TryParse((combo.Text ?? string.Empty).Trim(), out var parsed))
+            {
+                _itemViewModel.SetArmorPart(partName, parsed);
+                UpdateArmorClassDisplay();
+            }
+        };
+
+        return combo;
     }
 
     // --- Icon Preview + Picker ---

--- a/Relique/Relique/Views/MainWindow.ItemProperties.cs
+++ b/Relique/Relique/Views/MainWindow.ItemProperties.cs
@@ -20,6 +20,24 @@ public partial class MainWindow
     {
         PropertySearchBox.TextChanged += OnPropertySearchTextChanged;
         InitializeCategoryFilter();
+
+        // Auto-apply on combo change during edit mode (#2226). Suppressed when
+        // _suppressAutoApply is true (programmatic repopulation / pre-select).
+        SubtypeComboBox.SelectionChanged += OnEditComboSelectionChanged;
+        CostValueComboBox.SelectionChanged += OnEditComboSelectionChanged;
+        ParamValueComboBox.SelectionChanged += OnEditComboSelectionChanged;
+
+        // Apply button is no longer needed in auto-apply mode (#2226). Hidden permanently
+        // — kept in AXAML to avoid breaking the Click wireup, but never shown.
+        ApplyEditButton.IsVisible = false;
+    }
+
+    private void OnEditComboSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (!EditAutoApplyDecider.ShouldAutoApply(_editingPropertyIndex, _suppressAutoApply))
+            return;
+
+        ApplyEditCore(teardownOnSuccess: false);
     }
 
     private void InitializeCategoryFilter()
@@ -301,6 +319,12 @@ public partial class MainWindow
 
     private void UpdatePropertyConfigPanel(PropertyTypeInfo propertyType)
     {
+        // Suppress auto-apply while combos are being cleared/repopulated (#2226).
+        // Each SelectedIndex assignment below fires SelectionChanged; without
+        // suppression, opening an edit would auto-apply a half-built state.
+        _suppressAutoApply = true;
+        try
+        {
         PropertyConfigPanel.IsVisible = true;
         SelectedPropertyName.Text = propertyType.DisplayName;
 
@@ -376,6 +400,11 @@ public partial class MainWindow
             }
             if (ParamValueComboBox.Items.Count > 0)
                 ParamValueComboBox.SelectedIndex = 0;
+        }
+        }
+        finally
+        {
+            _suppressAutoApply = false;
         }
     }
 
@@ -542,19 +571,39 @@ public partial class MainWindow
         _selectedPropertyType = type;
         UpdatePropertyConfigPanel(type);
 
-        // Pre-select current values in dropdowns
-        SelectComboBoxByTag(SubtypeComboBox, prop.Subtype);
-        SelectComboBoxByTag(CostValueComboBox, prop.CostValue);
-        if (prop.Param1 != 0xFF)
-            SelectComboBoxByTag(ParamValueComboBox, prop.Param1Value);
+        // Pre-select current values without firing auto-apply (#2226).
+        _suppressAutoApply = true;
+        try
+        {
+            SelectComboBoxByTag(SubtypeComboBox, prop.Subtype);
+            SelectComboBoxByTag(CostValueComboBox, prop.CostValue);
+            if (prop.Param1 != 0xFF)
+                SelectComboBoxByTag(ParamValueComboBox, prop.Param1Value);
+        }
+        finally
+        {
+            _suppressAutoApply = false;
+        }
 
-        ApplyEditButton.IsVisible = true;
+        // ApplyEditButton stays hidden under auto-apply mode (#2226).
         AddPropertyButton.IsEnabled = false;
 
-        UpdateStatus($"Editing: {type.DisplayName}");
+        UpdateStatus($"Editing: {type.DisplayName} (auto-applies on change)");
     }
 
     private void OnApplyEditClick(object? sender, RoutedEventArgs e)
+    {
+        // Apply button hidden under auto-apply (#2226). Handler kept for AXAML wireup safety.
+        ApplyEditCore(teardownOnSuccess: true);
+    }
+
+    /// <summary>
+    /// Apply current PropertyConfigPanel ComboBox values to the property at _editingPropertyIndex (#2226).
+    /// teardownOnSuccess=true mirrors the old explicit-Apply flow (closes the edit panel, exits edit mode);
+    /// teardownOnSuccess=false is auto-apply mode (keeps panel open so user can keep tweaking).
+    /// Rollback to oldProperty on failure preserves item state for bad combos (#2166 pattern).
+    /// </summary>
+    private void ApplyEditCore(bool teardownOnSuccess)
     {
         if (_currentItem == null || _itemPropertyService == null || _selectedPropertyType == null)
             return;
@@ -575,6 +624,7 @@ public partial class MainWindow
             paramValueIndex = paramIdx;
 
         var oldProperty = _currentItem.Properties[_editingPropertyIndex];
+        var editingIndex = _editingPropertyIndex;
 
         try
         {
@@ -584,20 +634,34 @@ public partial class MainWindow
                 costValueIndex,
                 paramValueIndex);
 
-            _currentItem.Properties[_editingPropertyIndex] = property;
+            _currentItem.Properties[editingIndex] = property;
+
+            // RefreshAssignedProperties calls PopulateAvailableProperties which clears
+            // the assigned list selection. In auto-apply mode we re-select the same
+            // row + restore the edit state so the user can keep tweaking.
             RefreshAssignedProperties();
             MarkDirty();
 
-            _editingPropertyIndex = -1;
-            ApplyEditButton.IsVisible = false;
-            PropertyConfigPanel.IsVisible = false;
-
-            UpdateStatus($"Updated property: {_selectedPropertyType.DisplayName}");
+            if (teardownOnSuccess)
+            {
+                _editingPropertyIndex = -1;
+                ApplyEditButton.IsVisible = false;
+                PropertyConfigPanel.IsVisible = false;
+                UpdateStatus($"Updated property: {_selectedPropertyType.DisplayName}");
+            }
+            else
+            {
+                // Auto-apply: keep edit state intact, re-select the edited row.
+                if (editingIndex < AssignedPropertiesList.Items.Count)
+                    AssignedPropertiesList.SelectedIndex = editingIndex;
+                _editingPropertyIndex = editingIndex;
+                UpdateStatus($"Auto-applied: {_selectedPropertyType.DisplayName}");
+            }
         }
         catch (Exception ex)
         {
             // Roll back to previous value and report — preserves item state on bad combos (#2166).
-            _currentItem.Properties[_editingPropertyIndex] = oldProperty;
+            _currentItem.Properties[editingIndex] = oldProperty;
             UnifiedLogger.LogApplication(LogLevel.ERROR,
                 $"Failed to update {_selectedPropertyType.DisplayName}: {ex.GetType().Name}: {ex.Message}");
             UpdateStatus($"Cannot update {_selectedPropertyType.DisplayName}: {ex.Message}");

--- a/Relique/Relique/Views/MainWindow.ItemProperties.cs
+++ b/Relique/Relique/Views/MainWindow.ItemProperties.cs
@@ -42,6 +42,9 @@ public partial class MainWindow
 
     private void PopulateAvailableProperties(string? searchFilter = null)
     {
+        // Capture expansion state so a refresh after Add doesn't collapse the user's open category (#2227).
+        var expansionSnapshot = CaptureAvailablePropertiesExpansion();
+
         AvailablePropertiesTree.Items.Clear();
         _checkedPropertyIndices.Clear();
         UpdateAddCheckedButton();
@@ -127,12 +130,31 @@ public partial class MainWindow
                 }
             }
 
-            // Auto-expand when a subtype matched the search
-            if (hasMatchingSubtype)
+            // Auto-expand when a subtype matched the search, or when the user had this category
+            // open before the rebuild (#2227).
+            if (hasMatchingSubtype || expansionSnapshot.ShouldExpand(type.PropertyIndex))
                 node.IsExpanded = true;
 
             AvailablePropertiesTree.Items.Add(node);
         }
+    }
+
+    /// <summary>
+    /// Snapshot which top-level Available Properties tree nodes are currently expanded,
+    /// keyed by PropertyIndex. Caller restores via TreeExpansionSnapshot.ShouldExpand
+    /// during the rebuild loop (#2227).
+    /// </summary>
+    private TreeExpansionSnapshot CaptureAvailablePropertiesExpansion()
+    {
+        var expanded = new List<int>();
+        foreach (var obj in AvailablePropertiesTree.Items)
+        {
+            if (obj is TreeViewItem tvi && tvi.IsExpanded && tvi.Tag is PropertyTypeInfo pti)
+            {
+                expanded.Add(pti.PropertyIndex);
+            }
+        }
+        return TreeExpansionTracker.Capture(expanded);
     }
 
     private void UpdateAddCheckedButton()

--- a/Relique/Relique/Views/MainWindow.ItemProperties.cs
+++ b/Relique/Relique/Views/MainWindow.ItemProperties.cs
@@ -819,7 +819,40 @@ public partial class MainWindow
         }
 
         var stats = _itemStatisticsService.GenerateStatistics(_currentItem.Properties);
+
+        // For armor items, prepend the base AC derived from parts_chest[Torso].ACBONUS
+        // so the Item Statistics panel shows the AC that comes from the armor itself,
+        // separate from any AC Bonus item-properties listed below (#2164 followup).
+        var baseAc = ResolveBaseArmorAc();
+        if (baseAc != null)
+        {
+            stats = string.IsNullOrEmpty(stats)
+                ? $"Base Armor Class: {baseAc}"
+                : $"Base Armor Class: {baseAc}{System.Environment.NewLine}{stats}";
+        }
+
         ItemStatisticsText.Text = stats;
         ItemStatisticsPanel.IsVisible = true;
+    }
+
+    /// <summary>
+    /// Look up the base AC from parts_chest.ACBONUS at the row indicated by
+    /// ArmorPart_Torso. Returns null if not an armor item, no game data, or AC unset.
+    /// Mirrors UpdateArmorClassDisplay's logic but returns a value instead of mutating UI.
+    /// </summary>
+    private string? ResolveBaseArmorAc()
+    {
+        if (_itemViewModel == null || _gameDataService == null || !_gameDataService.IsConfigured)
+            return null;
+
+        // Only armor (ModelType 3) has Torso parts → base AC.
+        var typeInfo = _baseItemTypes?.FirstOrDefault(t => t.BaseItemIndex == _itemViewModel.BaseItem);
+        if (typeInfo == null || !typeInfo.HasArmorParts) return null;
+
+        var torsoPart = _itemViewModel.GetArmorPart("Torso");
+        var acBonus = _gameDataService.Get2DAValue("parts_chest", torsoPart, "ACBONUS");
+
+        if (string.IsNullOrEmpty(acBonus) || acBonus == "****") return null;
+        return acBonus;
     }
 }

--- a/Relique/Relique/Views/MainWindow.Lifecycle.cs
+++ b/Relique/Relique/Views/MainWindow.Lifecycle.cs
@@ -107,6 +107,8 @@ public partial class MainWindow
             _itemStatisticsService = itemStatisticsService;
             _itemIconService = itemIconService;
             _paletteColorService = paletteColorService;
+            _armorPartCatalog = new ArmorPartCatalogService(gameDataService); // #2164
+            _compositeWeaponCatalog = new CompositeWeaponPartCatalogService(gameDataService); // #2164
 
             // UI updates must happen on UI thread
             LoadPaletteCategories(paletteCategories);

--- a/Relique/Relique/Views/MainWindow.axaml
+++ b/Relique/Relique/Views/MainWindow.axaml
@@ -133,12 +133,17 @@
                         </Border>
 
                         <ScrollViewer Grid.Row="1" x:Name="EditorContent">
-                        <StackPanel Margin="16" Spacing="16">
+                        <!-- 25px right padding to keep content clear of the scroll bar (#2229) -->
+                        <StackPanel Margin="16,16,25,16" Spacing="16">
 
                             <!-- Basic Properties -->
                             <TextBlock Text="Basic Properties" FontSize="{DynamicResource FontSizeLarge}" FontWeight="SemiBold" Margin="0,0,0,4"/>
 
-                            <Grid ColumnDefinitions="120,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+                            <!-- 2-column layout: pair logically related fields side-by-side and cap field
+                                 widths per Aurora limits so they don't sprawl across the panel (#2229).
+                                 Aurora hard limits: Tag = 32 chars, ResRef = 16 chars, Cost = uint32 (10 digits). -->
+                            <Grid ColumnDefinitions="100,Auto,24,100,Auto"
+                                  RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto"
                                   Margin="0,0,0,8">
                                 <Grid.Styles>
                                     <Style Selector="TextBlock.label">
@@ -150,35 +155,60 @@
                                     </Style>
                                 </Grid.Styles>
 
-                                <!-- Name -->
+                                <!-- Row 0: Name (wider) | Tag -->
                                 <TextBlock Grid.Row="0" Grid.Column="0" Text="Name" Classes="label"/>
                                 <controls:SpellCheckTextBox Grid.Row="0" Grid.Column="1"
                                          x:Name="NameTextBox"
                                          Text="{Binding Name, Mode=TwoWay}"
+                                         Width="300"
+                                         HorizontalAlignment="Left"
                                          Watermark="Item name"/>
-
-                                <!-- Tag -->
-                                <TextBlock Grid.Row="1" Grid.Column="0" Text="Tag" Classes="label"/>
-                                <TextBox Grid.Row="1" Grid.Column="1"
+                                <TextBlock Grid.Row="0" Grid.Column="3" Text="Tag" Classes="label"/>
+                                <TextBox Grid.Row="0" Grid.Column="4"
                                          x:Name="TagTextBox"
                                          Text="{Binding Tag, Mode=TwoWay}"
                                          MaxLength="32"
+                                         Width="260"
+                                         HorizontalAlignment="Left"
                                          Watermark="Item tag (max 32 chars)"/>
 
-                                <!-- ResRef (synced from filename, read-only) -->
-                                <TextBlock Grid.Row="2" Grid.Column="0" Text="ResRef" Classes="label"/>
-                                <TextBox Grid.Row="2" Grid.Column="1"
+                                <!-- Row 1: ResRef | Cost -->
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="ResRef" Classes="label"/>
+                                <TextBox Grid.Row="1" Grid.Column="1"
                                          x:Name="ResRefTextBox"
                                          Text="{Binding ResRef, Mode=OneWay}"
                                          IsReadOnly="True"
                                          MaxLength="16"
+                                         Width="160"
+                                         HorizontalAlignment="Left"
                                          Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                          ToolTip.Tip="Resource reference (auto-set from filename). Use Save As to change."
                                          Watermark="(set from filename)"/>
+                                <TextBlock Grid.Row="1" Grid.Column="3" Text="Cost" Classes="label"/>
+                                <StackPanel Grid.Row="1" Grid.Column="4" Orientation="Horizontal" Margin="0,0,0,8">
+                                    <!-- Cost is calculated by the engine from base AC + iprp_*.Cost rows; making
+                                         it editable is misleading since it gets recomputed on load. Show as
+                                         read-only display; AddCost is the user-adjustable adjustment.
+                                         Real computation engine tracked in #2235. -->
+                                    <TextBox x:Name="CostDisplay"
+                                             Text="{Binding Cost, Mode=OneWay}"
+                                             IsReadOnly="True"
+                                             Width="140"
+                                             Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                             ToolTip.Tip="Calculated base cost (engine-derived). Edit Additional to adjust the final price."
+                                             Watermark="(calculated)"/>
+                                    <TextBlock Text="Additional" VerticalAlignment="Center" Margin="10,0,8,0"/>
+                                    <NumericUpDown x:Name="AddCostUpDown"
+                                                   Value="{Binding AddCost, Mode=TwoWay}"
+                                                   Minimum="0" Maximum="999999999"
+                                                   FormatString="N0"
+                                                   Width="140"
+                                                   Watermark="Additional"/>
+                                </StackPanel>
 
-                                <!-- Base Item Type -->
-                                <TextBlock Grid.Row="3" Grid.Column="0" Text="Base Type" Classes="label"/>
-                                <Grid Grid.Row="3" Grid.Column="1" ColumnDefinitions="*,Auto" Margin="0,0,0,8">
+                                <!-- Row 2: Base Type (full width spanning columns 1-4) -->
+                                <TextBlock Grid.Row="2" Grid.Column="0" Text="Base Type" Classes="label"/>
+                                <Grid Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="4" ColumnDefinitions="*,Auto" Margin="0,0,0,8">
                                     <TextBox Grid.Column="0"
                                              x:Name="BaseItemTypeTextBox"
                                              IsReadOnly="True"
@@ -192,35 +222,17 @@
                                             Click="OnBrowseBaseItemTypeClick"/>
                                 </Grid>
 
-                                <!-- Cost -->
-                                <TextBlock Grid.Row="4" Grid.Column="0" Text="Cost" Classes="label"/>
-                                <Grid Grid.Row="4" Grid.Column="1" ColumnDefinitions="*,16,Auto,*" Margin="0,0,0,8">
-                                    <NumericUpDown Grid.Column="0"
-                                                   x:Name="CostUpDown"
-                                                   Value="{Binding Cost, Mode=TwoWay}"
-                                                   Minimum="0" Maximum="999999999"
-                                                   FormatString="N0"
-                                                   Watermark="Base cost"/>
-                                    <TextBlock Grid.Column="2" Text="Additional" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                                    <NumericUpDown Grid.Column="3"
-                                                   x:Name="AddCostUpDown"
-                                                   Value="{Binding AddCost, Mode=TwoWay}"
-                                                   Minimum="0" Maximum="999999999"
-                                                   FormatString="N0"
-                                                   Watermark="Additional cost"/>
-                                </Grid>
-
-                                <!-- Palette Category -->
-                                <TextBlock Grid.Row="5" Grid.Column="0" Text="Category" Classes="label"/>
-                                <ComboBox Grid.Row="5" Grid.Column="1"
+                                <!-- Row 3: Palette Category (full width) -->
+                                <TextBlock Grid.Row="3" Grid.Column="0" Text="Category" Classes="label"/>
+                                <ComboBox Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="4"
                                           x:Name="PaletteCategoryComboBox"
                                           HorizontalAlignment="Stretch"
                                           Margin="0,0,0,8"
                                           SelectionChanged="OnPaletteCategorySelectionChanged"/>
 
-                                <!-- Item Type Description (read-only from 2DA) -->
-                                <TextBlock Grid.Row="6" Grid.Column="0" Text="Type Info" Classes="label"/>
-                                <TextBox Grid.Row="6" Grid.Column="1"
+                                <!-- Row 4: Item Type Description (full width readonly) -->
+                                <TextBlock Grid.Row="4" Grid.Column="0" Text="Type Info" Classes="label"/>
+                                <TextBox Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="4"
                                          x:Name="BaseItemDescriptionText"
                                          IsReadOnly="True"
                                          AcceptsReturn="True"
@@ -230,6 +242,61 @@
                                          Watermark="(no description available)"
                                          Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
                             </Grid>
+
+                            <!-- Flags & Quantities — moved above Descriptions so Description stays the
+                                 tall bottom element with reclaimed horizontal space (#2229). -->
+                            <TextBlock Text="Flags and Quantities" FontSize="{DynamicResource FontSizeLarge}" FontWeight="SemiBold" Margin="0,0,0,4"/>
+
+                            <Grid ColumnDefinitions="120,*" RowDefinitions="Auto,Auto"
+                                  Margin="0,0,0,8">
+                                <!-- Flags row -->
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="Flags"
+                                           VerticalAlignment="Center" Margin="0,0,8,8"/>
+                                <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal" Spacing="16" Margin="0,0,0,8">
+                                    <CheckBox x:Name="PlotCheckBox"
+                                              Content="Plot"
+                                              IsChecked="{Binding Plot, Mode=TwoWay}"
+                                              ToolTip.Tip="Cannot be dropped or sold"/>
+                                    <CheckBox x:Name="CursedCheckBox"
+                                              Content="Cursed"
+                                              IsChecked="{Binding Cursed, Mode=TwoWay}"
+                                              ToolTip.Tip="Cannot be unequipped"/>
+                                    <CheckBox x:Name="StolenCheckBox"
+                                              Content="Stolen"
+                                              IsChecked="{Binding Stolen, Mode=TwoWay}"
+                                              ToolTip.Tip="Marked as stolen"/>
+                                    <CheckBox x:Name="IdentifiedCheckBox"
+                                              Content="Identified"
+                                              IsChecked="{Binding Identified, Mode=TwoWay}"
+                                              ToolTip.Tip="Already identified (no lore check needed)"/>
+                                    <CheckBox x:Name="DropableCheckBox"
+                                              Content="Droppable"
+                                              IsChecked="{Binding Dropable, Mode=TwoWay}"
+                                              ToolTip.Tip="Item can be dropped from inventory"/>
+                                </StackPanel>
+
+                                <!-- Stack Size + Charges side-by-side (#2229 user feedback) -->
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="Stack Size"
+                                           x:Name="StackSizeLabel"
+                                           VerticalAlignment="Center" Margin="0,0,8,8"/>
+                                <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal" Margin="0,0,0,8">
+                                    <NumericUpDown x:Name="StackSizeUpDown"
+                                                   Value="{Binding StackSize, Mode=TwoWay}"
+                                                   Minimum="1" Maximum="65535"
+                                                   FormatString="N0"
+                                                   Width="140"/>
+                                    <TextBlock Text="Charges"
+                                               x:Name="ChargesLabel"
+                                               VerticalAlignment="Center" Margin="20,0,8,0"/>
+                                    <NumericUpDown x:Name="ChargesUpDown"
+                                                   Value="{Binding Charges, Mode=TwoWay}"
+                                                   Minimum="0" Maximum="255"
+                                                   FormatString="N0"
+                                                   Width="140"/>
+                                </StackPanel>
+                            </Grid>
+
+                            <Separator/>
 
                             <!-- Descriptions (side-by-side) -->
                             <TextBlock Text="Descriptions" FontSize="{DynamicResource FontSizeLarge}" FontWeight="SemiBold" Margin="0,0,0,4"/>
@@ -275,66 +342,6 @@
                                         MaxHeight="200"
                                         Watermark="Identified description"/>
                                 </StackPanel>
-                            </Grid>
-
-                            <Separator/>
-
-                            <!-- Flags & Quantities -->
-                            <TextBlock Text="Flags and Quantities" FontSize="{DynamicResource FontSizeLarge}" FontWeight="SemiBold" Margin="0,0,0,4"/>
-
-                            <Grid ColumnDefinitions="120,*" RowDefinitions="Auto,Auto,Auto"
-                                  Margin="0,0,0,8">
-                                <!-- Flags row -->
-                                <TextBlock Grid.Row="0" Grid.Column="0" Text="Flags"
-                                           VerticalAlignment="Center" Margin="0,0,8,8"/>
-                                <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal" Spacing="16" Margin="0,0,0,8">
-                                    <CheckBox x:Name="PlotCheckBox"
-                                              Content="Plot"
-                                              IsChecked="{Binding Plot, Mode=TwoWay}"
-                                              ToolTip.Tip="Cannot be dropped or sold"/>
-                                    <CheckBox x:Name="CursedCheckBox"
-                                              Content="Cursed"
-                                              IsChecked="{Binding Cursed, Mode=TwoWay}"
-                                              ToolTip.Tip="Cannot be unequipped"/>
-                                    <CheckBox x:Name="StolenCheckBox"
-                                              Content="Stolen"
-                                              IsChecked="{Binding Stolen, Mode=TwoWay}"
-                                              ToolTip.Tip="Marked as stolen"/>
-                                    <CheckBox x:Name="IdentifiedCheckBox"
-                                              Content="Identified"
-                                              IsChecked="{Binding Identified, Mode=TwoWay}"
-                                              ToolTip.Tip="Already identified (no lore check needed)"/>
-                                    <CheckBox x:Name="DropableCheckBox"
-                                              Content="Droppable"
-                                              IsChecked="{Binding Dropable, Mode=TwoWay}"
-                                              ToolTip.Tip="Item can be dropped from inventory"/>
-                                </StackPanel>
-
-                                <!-- Stack Size -->
-                                <TextBlock Grid.Row="1" Grid.Column="0" Text="Stack Size"
-                                           x:Name="StackSizeLabel"
-                                           VerticalAlignment="Center" Margin="0,0,8,8"/>
-                                <NumericUpDown Grid.Row="1" Grid.Column="1"
-                                               x:Name="StackSizeUpDown"
-                                               Value="{Binding StackSize, Mode=TwoWay}"
-                                               Minimum="1" Maximum="65535"
-                                               FormatString="N0"
-                                               HorizontalAlignment="Left"
-                                               Width="150"
-                                               Margin="0,0,0,8"/>
-
-                                <!-- Charges -->
-                                <TextBlock Grid.Row="2" Grid.Column="0" Text="Charges"
-                                           x:Name="ChargesLabel"
-                                           VerticalAlignment="Center" Margin="0,0,8,8"/>
-                                <NumericUpDown Grid.Row="2" Grid.Column="1"
-                                               x:Name="ChargesUpDown"
-                                               Value="{Binding Charges, Mode=TwoWay}"
-                                               Minimum="0" Maximum="255"
-                                               FormatString="N0"
-                                               HorizontalAlignment="Left"
-                                               Width="150"
-                                               Margin="0,0,0,8"/>
                             </Grid>
 
                             <!-- Appearance (collapsible, conditional on base item type) -->
@@ -586,7 +593,9 @@
                             <!-- Item Properties Editor -->
                             <TextBlock Text="Item Properties" FontSize="{DynamicResource FontSizeLarge}" FontWeight="SemiBold" Margin="0,0,0,4"/>
 
-                            <Grid ColumnDefinitions="*,Auto,*" RowDefinitions="Auto,*" MinHeight="300" Margin="0,0,0,8">
+                            <!-- Soft height cap so Item Properties doesn't push everything below it off-screen.
+                                 Internal lists scroll within their borders (#2229). -->
+                            <Grid ColumnDefinitions="*,Auto,*" RowDefinitions="Auto,*" MinHeight="300" MaxHeight="500" Margin="0,0,0,8">
                                 <!-- Left: Available Properties header -->
                                 <DockPanel Grid.Column="0" Grid.Row="0" Margin="0,0,0,4">
                                     <TextBlock Text="Available Properties"

--- a/Relique/Relique/Views/MainWindow.axaml
+++ b/Relique/Relique/Views/MainWindow.axaml
@@ -366,41 +366,38 @@
                                         </StackPanel>
                                     </StackPanel>
 
-                                    <!-- Model Parts (ModelType 0/1/2) -->
+                                    <!-- Model Parts (ModelType 0/1/2). For composite weapons (ModelType 2)
+                                         the ComboBoxes are populated from a scan of <itemClass>_b/m/t_*.mdl
+                                         resources (#2164). For simple/layered the ComboBox is empty but
+                                         remains editable so the existing numeric workflow still works. -->
                                     <StackPanel x:Name="ModelPartsPanel" IsVisible="False">
                                         <TextBlock Text="Model Parts" FontWeight="SemiBold" Margin="0,0,0,4"/>
                                         <Grid ColumnDefinitions="120,*" RowDefinitions="Auto,Auto,Auto" Margin="0,0,0,8">
                                             <TextBlock Grid.Row="0" Grid.Column="0" Text="Part 1"
                                                        VerticalAlignment="Center" Margin="0,0,8,8"/>
-                                            <NumericUpDown Grid.Row="0" Grid.Column="1"
-                                                           x:Name="ModelPart1UpDown"
-                                                           Value="{Binding ModelPart1, Mode=TwoWay}"
-                                                           Minimum="0" Maximum="255"
-                                                           FormatString="N0"
-                                                           HorizontalAlignment="Left" Width="150"
-                                                           Margin="0,0,0,8"/>
+                                            <ComboBox Grid.Row="0" Grid.Column="1"
+                                                      x:Name="ModelPart1Combo"
+                                                      IsEditable="True"
+                                                      HorizontalAlignment="Left" MinWidth="200"
+                                                      Margin="0,0,0,8"/>
 
                                             <TextBlock Grid.Row="1" Grid.Column="0" Text="Part 2"
                                                        x:Name="ModelPart2Label"
                                                        VerticalAlignment="Center" Margin="0,0,8,8"/>
-                                            <NumericUpDown Grid.Row="1" Grid.Column="1"
-                                                           x:Name="ModelPart2UpDown"
-                                                           Value="{Binding ModelPart2, Mode=TwoWay}"
-                                                           Minimum="0" Maximum="255"
-                                                           FormatString="N0"
-                                                           HorizontalAlignment="Left" Width="150"
-                                                           Margin="0,0,0,8"/>
+                                            <ComboBox Grid.Row="1" Grid.Column="1"
+                                                      x:Name="ModelPart2Combo"
+                                                      IsEditable="True"
+                                                      HorizontalAlignment="Left" MinWidth="200"
+                                                      Margin="0,0,0,8"/>
 
                                             <TextBlock Grid.Row="2" Grid.Column="0" Text="Part 3"
                                                        x:Name="ModelPart3Label"
                                                        VerticalAlignment="Center" Margin="0,0,8,8"/>
-                                            <NumericUpDown Grid.Row="2" Grid.Column="1"
-                                                           x:Name="ModelPart3UpDown"
-                                                           Value="{Binding ModelPart3, Mode=TwoWay}"
-                                                           Minimum="0" Maximum="255"
-                                                           FormatString="N0"
-                                                           HorizontalAlignment="Left" Width="150"
-                                                           Margin="0,0,0,8"/>
+                                            <ComboBox Grid.Row="2" Grid.Column="1"
+                                                      x:Name="ModelPart3Combo"
+                                                      IsEditable="True"
+                                                      HorizontalAlignment="Left" MinWidth="200"
+                                                      Margin="0,0,0,8"/>
                                         </Grid>
                                     </StackPanel>
 

--- a/Relique/Relique/Views/MainWindow.axaml.cs
+++ b/Relique/Relique/Views/MainWindow.axaml.cs
@@ -34,6 +34,8 @@ public partial class MainWindow : Window, INotifyPropertyChanged
     private readonly HashSet<int> _checkedPropertyIndices = new();
     private readonly ObservableCollection<VariableViewModel> _variables = new();
     private ItemIconService? _itemIconService;
+    private ArmorPartCatalogService? _armorPartCatalog; // #2164
+    private CompositeWeaponPartCatalogService? _compositeWeaponCatalog; // #2164
     private PaletteColorService? _paletteColorService;
     private SpellCheckTextBox? _nameTextBox;
     private SpellCheckTextBox? _descriptionTextBox;

--- a/Relique/Relique/Views/MainWindow.axaml.cs
+++ b/Relique/Relique/Views/MainWindow.axaml.cs
@@ -30,6 +30,7 @@ public partial class MainWindow : Window, INotifyPropertyChanged
     private ItemStatisticsService? _itemStatisticsService;
     private PropertyTypeInfo? _selectedPropertyType;
     private int _editingPropertyIndex = -1; // -1 = add mode, >= 0 = editing that index
+    private bool _suppressAutoApply; // true while combos are being repopulated programmatically (#2226)
     private readonly HashSet<int> _checkedPropertyIndices = new();
     private readonly ObservableCollection<VariableViewModel> _variables = new();
     private ItemIconService? _itemIconService;


### PR DESCRIPTION
## Summary

Relique sprint bundling 4 UI/UX issues + 1 user-requested addition + 1 shared StatusBar tweak.

## Shipped

- **#2227** — Available Properties tree preserves expansion across add. Pure-static `TreeExpansionTracker` snapshot/restore.
- **#2226** — Property edit auto-applies on combo change; `Apply Changes` button retired. Pure-static `EditAutoApplyDecider` seam. Trade-off: no Undo in Relique → epic #2231 + bootstrap requirement filed.
- **#2164** — Filtered Part-number dropdowns for armor (parts_*.2da, ACBONUS-sorted) and composite weapons (MDL scan). Labels `Part N — ID NNN`, AC on Torso only. Editable for HAK/forward-compat.
- **#2229** — Main editor layout: 25px right padding, Name+Tag side-by-side, ResRef+Cost side-by-side (Cost read-only — engine recomputes), Stack+Charges paired, Flags above Description, Item Properties soft height cap 500px.

## Extras

- Item Statistics panel prepends `Base Armor Class: N` for armor (sprint feedback)
- Shared `Radoub.UI.StatusBarControl`: leading ellipsis + 500px cap so filename stays visible; tooltip shows full path (affects all 6 tools)
- Repo README adds Getting Started recommending Trebuchet-first launch
- Bootstrap checklist + UI Uniformity table updated to require Undo/Redo wiring for new tools (#2231)
- Wiki draft staged at `Radoub.wiki/NonPublic/wiki-draft-Relique-first-launch.md`

## Out of Sprint

- #1912 closed as completed by #1911 (icon picker already modal)

## Followups Filed

- #2231 — Epic: Undo/Redo plumbing across all tools (cross-tool)
- #2232 — Mannequin idle pose (armor preview UX)
- #2233 — Composite weapon parts render misaligned (cross-tool with QM)
- #2234 — Add vs Add Checked UX rationalization
- #2235 — Real Cost computation engine (armor.2da + sum(iprp_*.Cost))

## Tests

- 45 new unit tests across 4 new pure-static services
- 375/375 Relique unit pass
- 2436/2436 across affected projects (Radoub.Formats, Radoub.UI, Radoub.Dictionary, Relique)
- Manual smoke verified across all 6 tools (status bar render in each)

## Related Issues

- Closes #2229
- Closes #2227
- Closes #2226
- Closes #2164

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)