### PR TITLE
[Radoub] Fix: GFF 64-bit field types (DWORD64/INT64/DOUBLE) silently corrupt on round-trip (#2241)

### DIFF
--- a/Fence/CHANGELOG.md
+++ b/Fence/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.1.34-alpha] - 2026-05-25
-**Branch**: `radoub/issue-2241` | **PR**: #TBD
+**Branch**: `radoub/issue-2241` | **PR**: #2265
 
 ### Fix: GFF 64-bit field types (DWORD64/INT64/DOUBLE) silently corrupt on round-trip (#2241)
 

--- a/Fence/CHANGELOG.md
+++ b/Fence/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.1.34-alpha] - 2026-05-25
+**Branch**: `radoub/issue-2241` | **PR**: #TBD
+
+### Fix: GFF 64-bit field types (DWORD64/INT64/DOUBLE) silently corrupt on round-trip (#2241)
+
+- Shared `Radoub.Formats` fix: DWORD64/INT64/DOUBLE were classified as simple types and read/written as 32-bit, silently zeroing values on save and producing wrong floats on load. Now treated as complex types per Aurora spec — value stored as 8 bytes in FieldData section. Affects every tool consuming GFF (UTC, UTI, UTM, BIC, IFO, JRL, DLG).
+
+---
+
 ## [0.1.33-alpha] - 2026-05-25
 **Branch**: `radoub/issue-2238` | **PR**: #2239
 

--- a/Manifest/CHANGELOG.md
+++ b/Manifest/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.15.7-alpha] - 2026-05-25
-**Branch**: `radoub/issue-2241` | **PR**: #TBD
+**Branch**: `radoub/issue-2241` | **PR**: #2265
 
 ### Fix: GFF 64-bit field types (DWORD64/INT64/DOUBLE) silently corrupt on round-trip (#2241)
 

--- a/Manifest/CHANGELOG.md
+++ b/Manifest/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.15.7-alpha] - 2026-05-25
+**Branch**: `radoub/issue-2241` | **PR**: #TBD
+
+### Fix: GFF 64-bit field types (DWORD64/INT64/DOUBLE) silently corrupt on round-trip (#2241)
+
+- Shared `Radoub.Formats` fix: DWORD64/INT64/DOUBLE were classified as simple types and read/written as 32-bit, silently zeroing values on save and producing wrong floats on load. Now treated as complex types per Aurora spec — value stored as 8 bytes in FieldData section. Affects every tool consuming GFF (UTC, UTI, UTM, BIC, IFO, JRL, DLG).
+
+---
+
 ## [0.15.6-alpha] - 2026-03-24
 **Branch**: `quartermaster/issue-1900` | **PR**: #1969
 

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Parley. One-line highlights per version; full details in 
 
 ---
 
+## [0.1.169-alpha] - 2026-05-25
+**Branch**: `radoub/issue-2241` | **PR**: #TBD
+
+### Fix: GFF 64-bit field types (DWORD64/INT64/DOUBLE) silently corrupt on round-trip (#2241)
+
+- Shared `Radoub.Formats` fix: DWORD64/INT64/DOUBLE were classified as simple types and read/written as 32-bit, silently zeroing values on save and producing wrong floats on load. Now treated as complex types per Aurora spec — value stored as 8 bytes in FieldData section. Affects every tool consuming GFF (UTC, UTI, UTM, BIC, IFO, JRL, DLG).
+
+---
+
 ## [0.1.168-alpha] - 2026-05-24
 **Branch**: `parley/issue-2210` | **PR**: #2214
 

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Parley. One-line highlights per version; full details in 
 ---
 
 ## [0.1.169-alpha] - 2026-05-25
-**Branch**: `radoub/issue-2241` | **PR**: #TBD
+**Branch**: `radoub/issue-2241` | **PR**: #2265
 
 ### Fix: GFF 64-bit field types (DWORD64/INT64/DOUBLE) silently corrupt on round-trip (#2241)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.94-alpha] - 2026-05-25
-**Branch**: `radoub/issue-2241` | **PR**: #TBD
+**Branch**: `radoub/issue-2241` | **PR**: #2265
 
 ### Fix: GFF 64-bit field types (DWORD64/INT64/DOUBLE) silently corrupt on round-trip (#2241)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.94-alpha] - 2026-05-25
+**Branch**: `radoub/issue-2241` | **PR**: #TBD
+
+### Fix: GFF 64-bit field types (DWORD64/INT64/DOUBLE) silently corrupt on round-trip (#2241)
+
+- Shared `Radoub.Formats` fix: DWORD64/INT64/DOUBLE were classified as simple types and read/written as 32-bit, silently zeroing values on save and producing wrong floats on load. Now treated as complex types per Aurora spec — value stored as 8 bytes in FieldData section. Affects every tool consuming GFF (UTC, UTI, UTM, BIC, IFO, JRL, DLG).
+
+---
+
 ## [0.2.93-alpha] - 2026-05-25
 **Branch**: `radoub/issue-2238` | **PR**: #2239
 

--- a/Radoub.Formats/Radoub.Formats.Tests/Gff64BitRoundTripTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Gff64BitRoundTripTests.cs
@@ -1,0 +1,65 @@
+using Radoub.Formats.Gff;
+using Xunit;
+
+namespace Radoub.Formats.Tests;
+
+/// <summary>
+/// Round-trip tests for GFF 64-bit field types (DWORD64, INT64, DOUBLE).
+/// Issue #2241 — these types are misclassified as simple types and corrupt on round-trip.
+/// </summary>
+public class Gff64BitRoundTripTests
+{
+    private const ulong Dword64Value = 0x123456789ABCDEF0UL;
+    private const long Int64Value = -1234567890123456789L;
+    private const double DoubleValue = 3.141592653589793;
+
+    private static GffFile BuildGffWithField(uint type, string label, object value)
+    {
+        var gff = new GffFile { FileType = "TST ", FileVersion = "V3.2" };
+        gff.RootStruct.Type = 0xFFFFFFFF;
+        gff.RootStruct.Fields.Add(new GffField { Label = label, Type = type, Value = value });
+        return gff;
+    }
+
+    [Fact]
+    public void RoundTrip_Dword64_PreservesFullValue()
+    {
+        var gff = BuildGffWithField(GffField.DWORD64, "Dword64Field", Dword64Value);
+
+        var bytes = GffWriter.Write(gff);
+        var parsed = GffReader.Read(bytes);
+
+        var field = parsed.RootStruct.GetField("Dword64Field");
+        Assert.NotNull(field);
+        Assert.Equal(GffField.DWORD64, field.Type);
+        Assert.Equal(Dword64Value, (ulong)field.Value!);
+    }
+
+    [Fact]
+    public void RoundTrip_Int64_PreservesFullValue()
+    {
+        var gff = BuildGffWithField(GffField.INT64, "Int64Field", Int64Value);
+
+        var bytes = GffWriter.Write(gff);
+        var parsed = GffReader.Read(bytes);
+
+        var field = parsed.RootStruct.GetField("Int64Field");
+        Assert.NotNull(field);
+        Assert.Equal(GffField.INT64, field.Type);
+        Assert.Equal(Int64Value, (long)field.Value!);
+    }
+
+    [Fact]
+    public void RoundTrip_Double_PreservesFullValue()
+    {
+        var gff = BuildGffWithField(GffField.DOUBLE, "DoubleField", DoubleValue);
+
+        var bytes = GffWriter.Write(gff);
+        var parsed = GffReader.Read(bytes);
+
+        var field = parsed.RootStruct.GetField("DoubleField");
+        Assert.NotNull(field);
+        Assert.Equal(GffField.DOUBLE, field.Type);
+        Assert.Equal(DoubleValue, (double)field.Value!);
+    }
+}

--- a/Radoub.Formats/Radoub.Formats/Gff/GffFile.cs
+++ b/Radoub.Formats/Radoub.Formats/Gff/GffFile.cs
@@ -312,19 +312,21 @@ public static class GffFieldTypeExtensions
         return fieldType switch
         {
             GffField.BYTE or GffField.CHAR or GffField.WORD or GffField.SHORT or
-            GffField.DWORD or GffField.INT or GffField.DWORD64 or GffField.INT64 or
-            GffField.FLOAT or GffField.DOUBLE => true,
+            GffField.DWORD or GffField.INT or GffField.FLOAT => true,
             _ => false
         };
     }
 
     /// <summary>
     /// Returns true if the field type uses DataOrDataOffset as an offset.
+    /// DWORD64/INT64/DOUBLE are 8-byte values stored in FieldData (lower 32 bits of value
+    /// won't fit in DataOrDataOffset), per Aurora GFF spec / neverwinter.nim gff.nim:147.
     /// </summary>
     public static bool IsComplexType(this uint fieldType)
     {
         return fieldType switch
         {
+            GffField.DWORD64 or GffField.INT64 or GffField.DOUBLE or
             GffField.CExoString or GffField.CResRef or GffField.CExoLocString or
             GffField.VOID or GffField.Struct or GffField.List => true,
             _ => false

--- a/Radoub.Formats/Radoub.Formats/Gff/GffReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Gff/GffReader.cs
@@ -335,10 +335,7 @@ public static class GffReader
                 GffField.SHORT => (object)(short)(field.DataOrDataOffset & 0xFFFF),
                 GffField.DWORD => (object)field.DataOrDataOffset,
                 GffField.INT => (object)(int)field.DataOrDataOffset,
-                GffField.DWORD64 => (object)(ulong)field.DataOrDataOffset,
-                GffField.INT64 => (object)(long)field.DataOrDataOffset,
                 GffField.FLOAT => (object)BitConverter.Int32BitsToSingle((int)field.DataOrDataOffset),
-                GffField.DOUBLE => (object)BitConverter.Int64BitsToDouble((long)field.DataOrDataOffset),
                 _ => (object)field.DataOrDataOffset
             };
         }
@@ -349,6 +346,10 @@ public static class GffReader
 
             return field.Type switch
             {
+                // 64-bit types: 8 bytes stored in FieldData (Aurora spec / neverwinter.nim gff.nim:147)
+                GffField.DWORD64 => ReadDword64(buffer, dataOffset),
+                GffField.INT64 => ReadInt64(buffer, dataOffset),
+                GffField.DOUBLE => ReadDouble(buffer, dataOffset),
                 GffField.CExoString => ReadCExoString(buffer, dataOffset),
                 GffField.CResRef => ReadCResRef(buffer, dataOffset),
                 GffField.CExoLocString => ReadCExoLocString(buffer, dataOffset),
@@ -507,6 +508,24 @@ public static class GffReader
         var result = BitConverter.ToUInt32(buffer, offset);
         offset += 4;
         return result;
+    }
+
+    private static ulong ReadDword64(byte[] buffer, int offset)
+    {
+        ValidateAccess(buffer, offset, 8);
+        return BitConverter.ToUInt64(buffer, offset);
+    }
+
+    private static long ReadInt64(byte[] buffer, int offset)
+    {
+        ValidateAccess(buffer, offset, 8);
+        return BitConverter.ToInt64(buffer, offset);
+    }
+
+    private static double ReadDouble(byte[] buffer, int offset)
+    {
+        ValidateAccess(buffer, offset, 8);
+        return BitConverter.ToDouble(buffer, offset);
     }
 
     private static void ValidateAccess(byte[] buffer, int offset, int length)

--- a/Radoub.Formats/Radoub.Formats/Gff/GffWriter.cs
+++ b/Radoub.Formats/Radoub.Formats/Gff/GffWriter.cs
@@ -355,6 +355,28 @@ public static class GffWriter
         // Note: Struct and List are handled directly in WriteFieldData, not here
         switch (field.Type)
         {
+            // 64-bit types: 8 bytes appended to FieldData (Aurora spec / neverwinter.nim gff.nim:147)
+            case GffField.DWORD64:
+                {
+                    var value = field.Value is ulong u ? u : 0UL;
+                    fieldData.Write(BitConverter.GetBytes(value), 0, 8);
+                }
+                break;
+
+            case GffField.INT64:
+                {
+                    var value = field.Value is long s ? s : 0L;
+                    fieldData.Write(BitConverter.GetBytes(value), 0, 8);
+                }
+                break;
+
+            case GffField.DOUBLE:
+                {
+                    var value = field.Value is double d ? d : 0.0;
+                    fieldData.Write(BitConverter.GetBytes(value), 0, 8);
+                }
+                break;
+
             case GffField.CExoString:
                 WriteCExoString(fieldData, field.Value as string ?? string.Empty);
                 break;

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.10.18-alpha] - 2026-05-25
-**Branch**: `radoub/issue-2241` | **PR**: #TBD
+**Branch**: `radoub/issue-2241` | **PR**: #2265
 
 ### Fix: GFF 64-bit field types (DWORD64/INT64/DOUBLE) silently corrupt on round-trip (#2241)
 

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.10.18-alpha] - 2026-05-25
+**Branch**: `radoub/issue-2241` | **PR**: #TBD
+
+### Fix: GFF 64-bit field types (DWORD64/INT64/DOUBLE) silently corrupt on round-trip (#2241)
+
+- Shared `Radoub.Formats` fix: DWORD64/INT64/DOUBLE were classified as simple types and read/written as 32-bit, silently zeroing values on save and producing wrong floats on load. Now treated as complex types per Aurora spec — value stored as 8 bytes in FieldData section. Affects every tool consuming GFF (UTC, UTI, UTM, BIC, IFO, JRL, DLG).
+
+---
+
 ## [0.10.17-alpha] - 2026-05-25
 **Branch**: `radoub/issue-2238` | **PR**: #2239
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [1.36.1-alpha] - 2026-05-25
-**Branch**: `radoub/issue-2241` | **PR**: #TBD
+**Branch**: `radoub/issue-2241` | **PR**: #2265
 
 ### Fix: GFF 64-bit field types (DWORD64/INT64/DOUBLE) silently corrupt on round-trip (#2241)
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.36.1-alpha] - 2026-05-25
+**Branch**: `radoub/issue-2241` | **PR**: #TBD
+
+### Fix: GFF 64-bit field types (DWORD64/INT64/DOUBLE) silently corrupt on round-trip (#2241)
+
+- Shared `Radoub.Formats` fix: DWORD64/INT64/DOUBLE were classified as simple types and read/written as 32-bit, silently zeroing values on save and producing wrong floats on load. Now treated as complex types per Aurora spec — value stored as 8 bytes in FieldData section. Affects IFO `Expansion_Pack` extensions and every tool consuming GFF.
+
+---
+
 ## [1.36.0-alpha] - 2026-05-24
 **Branch**: `trebuchet/issue-2219` | **PR**: #2223
 


### PR DESCRIPTION
## Summary

Critical fix for `Radoub.Formats` GFF reader/writer. DWORD64, INT64, and DOUBLE were misclassified as simple types and read/written as 32-bit values — silently zeroing on save and producing wrong floats on load. Affects every Radoub tool consuming GFF (UTC, UTI, UTM, BIC, IFO, JRL, DLG).

## Changes

**Reclassification** (`Gff/GffFile.cs`)
- `IsSimpleType`: remove DWORD64/INT64/DOUBLE from simple-type set
- `IsComplexType`: add them alongside CExoString / CResRef / CExoLocString / VOID / Struct / List

**Reader** (`Gff/GffReader.cs`)
- Route 64-bit types through complex branch
- New `ReadDword64` / `ReadInt64` / `ReadDouble` helpers — 8-byte read at `header.FieldDataOffset + field.DataOrDataOffset`

**Writer** (`Gff/GffWriter.cs`)
- `WriteComplexValue` appends 8 bytes to FieldData for each 64-bit type
- Offset auto-stored via existing `WriteFieldData` complex-type path (`field.DataOrDataOffset = (uint)fieldData.Position`)

## Test plan

- [x] TDD red phase: failing round-trip test for DWORD64 / INT64 / DOUBLE (commit `86a8f8f7`)
- [x] Static analysis confirmed all 3 findings (issue body)
- [x] Runtime reproduction confirmed: write→read silently produces `0` for all 3 types pre-fix
- [x] Fix applied (commit `23713ae3`)
- [x] Round-trip tests pass: `Gff64BitRoundTripTests` 3/3
- [x] Radoub.Formats full suite: 1269 passed, 0 failed, 1 skipped
- [x] Radoub.UI suite: 746 passed, 0 failed
- [x] Radoub.Dictionary suite: 54 passed, 0 failed
- [x] Parley unit suite: 839 passed, 0 failed
- [x] Manifest unit suite: 104 passed, 0 failed
- [x] Quartermaster unit suite: 1195 passed, 0 failed
- [x] Fence unit suite: 138 passed, 0 failed
- [x] Relique unit suite: 375 passed, 0 failed
- [x] Trebuchet unit suite: 169 passed, 0 failed
- [x] Privacy scan: PASS
- [x] Tech debt scan: PASS (no >800-line files in diff)
- [x] CHANGELOG updated across all 6 affected tools with PR number

**Grand total**: 4889 / 4889 tests passing across shared libraries and tool suites.

## Manual verification (recommended)

Automated tests cover synthetic round-trip. Real-world spot-checks below would strengthen confidence — none are blockers since the fix is byte-format-correct per Aurora spec / neverwinter.nim, but they exercise actual game files:

- IFO `Expansion_Pack` field: open module.ifo in Trebuchet, save without changes, diff bytes — DWORD64 must survive.
- BIC `BirthdayTimestamp` (and other DOUBLE/INT64 timestamps): open `.bic` in Quartermaster, save, diff bytes.
- Custom-content UTI/UTC with DOUBLE properties (CEP/PRC): round-trip and confirm value unchanged.
- Cross-check with neverwinter.nim's `nwn_gff` tool: dump pre/post round-trip and diff canonical text output.

## Related Issues

Closes #2241

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)