### PR TITLE
[Radoub] Fix + Chore: CP-1252 encoding (#2242) + establish root CHANGELOG (#2203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog - Radoub (Shared Libraries & Cross-Cutting)
+
+All notable changes to Radoub shared libraries (`Radoub.Formats`, `Radoub.UI`, `Radoub.Dictionary`) and cross-cutting repository work that does not belong to a single tool.
+
+Tool-specific changes live in each tool's `CHANGELOG.md` (Parley, Manifest, Quartermaster, Fence, Relique, Trebuchet).
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+
+## [Radoub.Formats 0.2.60-alpha] - 2026-05-26
+**Branch**: `radoub/issue-2242` | **PR**: #2272
+
+### Fix: UTF-8 vs CP-1252 encoding mismatch corrupts accented characters (#2242)
+
+- `GffWriter` (CExoString / CExoLocString), `ErfReader`/`ErfWriter` localized strings, and `TwoDAReader` switched from UTF-8 to Windows-1252 to match NWN1 native encoding (per [neverwinter.nim util.nim](https://github.com/niv/neverwinter.nim/blob/master/neverwinter/util.nim) `toNwnEncoding`/`fromNwnEncoding`). Round-tripping vanilla NWN files with accented characters (é, ü, ß) no longer rewrites bytes incorrectly. Affects German/Polish 2DA builds, French dialog, localized item descriptions. `Encoding.RegisterProvider(CodePagesEncodingProvider.Instance)` hoisted out of per-call hot path in `GffReader` to static ctor.
+
+---
+
+## [Radoub.Formats 0.2.59] - 2026-05-26
+**Branch**: `radoub/issue-2243` | **PR**: #2269
+
+### Fix: Narrow SsfReader bare-catch to format exceptions (#2243)
+
+- `SsfReader` bare `catch (Exception)` at line 73 replaced with specific handlers for `EndOfStreamException`, `InvalidDataException`, and `ArgumentException`. Unexpected exceptions (OOM, etc.) now propagate instead of being silently swallowed behind a WARN log. Null-return contract preserved for format-level corruption.
+
+---
+
+## [Radoub.Formats 0.2.58] - 2026-05-26
+**Branch**: `radoub/issue-2244` | **PR**: #2266
+
+### Fix: Parser hardening — integer overflow, atomic writes, silent truncation (#2244)
+
+- ERF/KEY/BIF: uint arithmetic that wrapped before bounds checks now uses long-promoted comparisons.
+- `ErfWriter.UpdateResource` switched to `File.Replace` (atomic — original survives mid-rename failures).
+- ERF `ResId` preserved instead of silently renumbered to sequential index.
+- GFF: `ReadCExoString` / `CExoLocString` no longer abandon entire string tables on a single oversized entry; bare `catch {}` in `GffFile.GetFieldValue<T>` narrowed and logged.
+- TLK: `CleanResRef` no longer strips mid-string whitespace asymmetric with the writer.
+- Dead UTF-8 fallback removed.
+
+---
+
+## [Radoub.Formats 0.2.57] - 2026-05-25
+**Branch**: `radoub/issue-2241` | **PR**: #2265
+
+### Fix: GFF 64-bit field types silently corrupt on round-trip (#2241)
+
+- DWORD64/INT64/DOUBLE were classified as simple types and read/written as 32-bit, silently zeroing values on save and producing wrong floats on load. Now treated as complex types per Aurora spec — value stored as 8 bytes in `FieldData` section. Affects every tool consuming GFF (UTC, UTI, UTM, BIC, IFO, JRL, DLG).
+
+---
+
+## [Radoub.Formats 0.2.56] - 2026-05-25
+**Branch**: `radoub/issue-2238` | **PR**: #2239
+
+### Fix: Severe memory bloat — idle RSS dropped from multi-GB to ~377 MB (#2238)
+
+- HAK index loading switched to `ErfReader.ReadMetadataOnly` so the resolver no longer buffers entire HAK byte arrays on the Large Object Heap. Eliminates the OOM-kill and hard-reboot risk when running multiple Radoub apps concurrently against large-HAK modules (CEP3 etc.).
+
+---
+
+## Establishing this CHANGELOG (#2203)
+
+Shared-library work (`Radoub.Formats`, `Radoub.UI`, `Radoub.Dictionary`) previously had no logging home — entries were either omitted entirely or duplicated into every tool CHANGELOG. This file is the canonical record for shared-library and cross-cutting changes going forward; per-tool CHANGELOGs continue to cover tool-specific work without duplication.
+
+---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -819,10 +819,11 @@ Follow the same standards as Parley (see `Parley/CLAUDE.md`):
 
 ## CHANGELOG Management
 
-**Per-tool CHANGELOGs only** — no repository-level CHANGELOG. Git history is the detailed archive.
+**Per-tool CHANGELOGs for tool-specific work, plus a root `/CHANGELOG.md` for shared-library and cross-cutting work.** Git history is the detailed archive.
 
 | Location | Contents |
 |----------|----------|
+| `/CHANGELOG.md` (repo root) | `Radoub.Formats`, `Radoub.UI`, `Radoub.Dictionary`, and cross-cutting work that does not belong to a single tool |
 | `Parley/CHANGELOG.md` | Parley highlights |
 | `Manifest/CHANGELOG.md` | Manifest highlights |
 | `Quartermaster/CHANGELOG.md` | Quartermaster highlights |
@@ -830,13 +831,19 @@ Follow the same standards as Parley (see `Parley/CLAUDE.md`):
 | `Relique/CHANGELOG.md` | Relique highlights |
 | `Trebuchet/CHANGELOG.md` | Trebuchet highlights |
 
+**Routing rules**:
+- Pure shared-library change (no immediate tool-facing behavior) → root `/CHANGELOG.md` only
+- Shared-library change with tool-visible impact → root `/CHANGELOG.md` is the canonical entry; tool CHANGELOGs may add a one-liner that links the root entry (no duplication of details)
+- Tool-specific work → tool CHANGELOG only
+- Cross-tool sprint touching multiple tools → each affected tool gets its own one-liner; root `/CHANGELOG.md` only if a shared-library change is also part of the sprint
+
 **Rules**:
 - Highlights only — major features, breaking changes, notable fixes
 - Git history is the detailed archive
-- Cross-tool sprints: each affected tool gets its own one-liner entry
-- No cross-references between CHANGELOGs
+- No cross-references between tool CHANGELOGs (shared-lib changes go in root)
 - Never use `[Unreleased]` — all entries go in versioned sections
 - One entry per feature, not implementation checklists
+- Root `/CHANGELOG.md` versions per shared library (e.g. `[Radoub.Formats 0.2.60-alpha]`) since the shared libraries version independently of tools
 
 ---
 

--- a/Radoub.Formats/Radoub.Formats.Tests/EncodingRoundTripTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/EncodingRoundTripTests.cs
@@ -1,0 +1,225 @@
+using System.Text;
+using Radoub.Formats.Erf;
+using Radoub.Formats.Gff;
+using Radoub.Formats.TwoDA;
+using Xunit;
+
+namespace Radoub.Formats.Tests;
+
+/// <summary>
+/// Round-trip tests for NWN1 native Windows-1252 encoding across GFF, ERF, and 2DA.
+/// Issue #2242 — writers used UTF-8 instead of CP-1252, corrupting accented characters
+/// (é, ü, ß) and breaking in-game string lookup for vanilla NWN files.
+///
+/// Reference: neverwinter.nim util.nim:49 — getNwnEncoding default = "windows-1252".
+/// </summary>
+public class EncodingRoundTripTests
+{
+    static EncodingRoundTripTests()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+    }
+
+    private const string AccentedSample = "café—Mädchen—straße";
+
+    // Pre-computed CP-1252 byte sequence for AccentedSample so the assertion is
+    // independent of the SUT's own encoding choice.
+    //   'café'    = 63 61 66 E9
+    //   '—'       = 97 (CP-1252 em dash)
+    //   'Mädchen' = 4D E4 64 63 68 65 6E
+    //   '—'       = 97
+    //   'straße'  = 73 74 72 61 DF 65
+    private static readonly byte[] AccentedCp1252 = new byte[]
+    {
+        0x63, 0x61, 0x66, 0xE9,
+        0x97,
+        0x4D, 0xE4, 0x64, 0x63, 0x68, 0x65, 0x6E,
+        0x97,
+        0x73, 0x74, 0x72, 0x61, 0xDF, 0x65
+    };
+
+    // -----------------------------------------------------------------
+    // GFF — CExoString
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void GffWriter_CExoString_WritesCp1252Bytes()
+    {
+        var gff = BuildGffWithCExoString("Description", AccentedSample);
+
+        var bytes = GffWriter.Write(gff);
+
+        Assert.Contains(SearchableByteWindow(bytes), w => SequenceEqual(w, AccentedCp1252));
+    }
+
+    [Fact]
+    public void GffRoundTrip_CExoString_PreservesAccentedChars()
+    {
+        var gff = BuildGffWithCExoString("Description", AccentedSample);
+
+        var bytes = GffWriter.Write(gff);
+        var parsed = GffReader.Read(bytes);
+
+        var field = parsed.RootStruct.GetField("Description");
+        Assert.NotNull(field);
+        Assert.Equal(AccentedSample, field.Value);
+    }
+
+    [Fact]
+    public void GffReader_CExoString_ReadsCp1252EncodedBytes()
+    {
+        var gff = BuildGffWithCExoString("Description", AccentedSample);
+        var bytes = GffWriter.Write(gff);
+
+        var parsed = GffReader.Read(bytes);
+
+        Assert.Equal(AccentedSample, parsed.RootStruct.GetField("Description")!.Value);
+    }
+
+    // -----------------------------------------------------------------
+    // GFF — CExoLocString
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void GffWriter_CExoLocString_WritesCp1252Bytes()
+    {
+        var loc = new CExoLocString { StrRef = 0xFFFFFFFFu };
+        loc.LocalizedStrings[0] = AccentedSample;
+        var gff = BuildGffWithCExoLocString("LocName", loc);
+
+        var bytes = GffWriter.Write(gff);
+
+        Assert.Contains(SearchableByteWindow(bytes), w => SequenceEqual(w, AccentedCp1252));
+    }
+
+    [Fact]
+    public void GffRoundTrip_CExoLocString_PreservesAccentedChars()
+    {
+        var loc = new CExoLocString { StrRef = 0xFFFFFFFFu };
+        loc.LocalizedStrings[0] = AccentedSample;
+        var gff = BuildGffWithCExoLocString("LocName", loc);
+
+        var bytes = GffWriter.Write(gff);
+        var parsed = GffReader.Read(bytes);
+
+        var field = parsed.RootStruct.GetField("LocName");
+        Assert.NotNull(field);
+        var parsedLoc = Assert.IsType<CExoLocString>(field.Value);
+        Assert.Equal(AccentedSample, parsedLoc.LocalizedStrings[0]);
+    }
+
+    // -----------------------------------------------------------------
+    // ERF localized strings
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ErfWriter_LocalizedString_WritesCp1252Bytes()
+    {
+        var erf = new ErfFile { FileType = "MOD ", FileVersion = "V1.0" };
+        erf.LocalizedStrings.Add(new ErfLocalizedString { LanguageId = 0, Text = AccentedSample });
+
+        using var ms = new MemoryStream();
+        ErfWriter.Write(erf, ms, new Dictionary<(string, ushort), byte[]>());
+        var bytes = ms.ToArray();
+
+        Assert.Contains(SearchableByteWindow(bytes), w => SequenceEqual(w, AccentedCp1252));
+    }
+
+    [Fact]
+    public void ErfRoundTrip_LocalizedString_PreservesAccentedChars()
+    {
+        var erf = new ErfFile { FileType = "MOD ", FileVersion = "V1.0" };
+        erf.LocalizedStrings.Add(new ErfLocalizedString { LanguageId = 0, Text = AccentedSample });
+
+        using var ms = new MemoryStream();
+        ErfWriter.Write(erf, ms, new Dictionary<(string, ushort), byte[]>());
+        var parsed = ErfReader.Read(ms.ToArray());
+
+        Assert.Single(parsed.LocalizedStrings);
+        Assert.Equal(AccentedSample, parsed.LocalizedStrings[0].Text);
+    }
+
+    // -----------------------------------------------------------------
+    // 2DA
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void TwoDAReader_ReadsCp1252EncodedFile()
+    {
+        // Hand-build a 2DA byte stream in CP-1252.
+        var cp1252 = Encoding.GetEncoding(1252);
+        var content = "2DA V2.0\nLabel Name\n0 Mädchen\n1 straße";
+        var bytes = cp1252.GetBytes(content);
+
+        var twoDA = TwoDAReader.Read(bytes);
+
+        Assert.Equal(2, twoDA.Rows.Count);
+        Assert.Equal("Mädchen", twoDA.Rows[0].Values[0]);
+        Assert.Equal("straße", twoDA.Rows[1].Values[0]);
+    }
+
+    [Fact]
+    public void TwoDAReader_PreservesUtf8WhenBomPresent()
+    {
+        // UTF-8 BOM = EF BB BF. If present, reader treats input as UTF-8 so
+        // hand-edited UTF-8 2DAs (which some community tools produce) still parse.
+        var content = "2DA V2.0\nLabel Name\n0 Mädchen";
+        var utf8WithBom = new List<byte> { 0xEF, 0xBB, 0xBF };
+        utf8WithBom.AddRange(Encoding.UTF8.GetBytes(content));
+
+        var twoDA = TwoDAReader.Read(utf8WithBom.ToArray());
+
+        Assert.Single(twoDA.Rows);
+        Assert.Equal("Mädchen", twoDA.Rows[0].Values[0]);
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    private static GffFile BuildGffWithCExoString(string label, string value)
+    {
+        var gff = new GffFile { FileType = "TST ", FileVersion = "V3.2" };
+        gff.RootStruct.Type = 0xFFFFFFFF;
+        gff.RootStruct.Fields.Add(new GffField
+        {
+            Label = label,
+            Type = GffField.CExoString,
+            Value = value
+        });
+        return gff;
+    }
+
+    private static GffFile BuildGffWithCExoLocString(string label, CExoLocString value)
+    {
+        var gff = new GffFile { FileType = "TST ", FileVersion = "V3.2" };
+        gff.RootStruct.Type = 0xFFFFFFFF;
+        gff.RootStruct.Fields.Add(new GffField
+        {
+            Label = label,
+            Type = GffField.CExoLocString,
+            Value = value
+        });
+        return gff;
+    }
+
+    /// <summary>
+    /// Enumerate sliding byte windows of the target length so we can search the
+    /// full file for the expected CP-1252 sequence regardless of where the
+    /// string field lands inside the FieldData block.
+    /// </summary>
+    private static IEnumerable<ArraySegment<byte>> SearchableByteWindow(byte[] buffer)
+    {
+        int windowLen = AccentedCp1252.Length;
+        for (int i = 0; i + windowLen <= buffer.Length; i++)
+            yield return new ArraySegment<byte>(buffer, i, windowLen);
+    }
+
+    private static bool SequenceEqual(ArraySegment<byte> window, byte[] expected)
+    {
+        if (window.Count != expected.Length) return false;
+        for (int i = 0; i < expected.Length; i++)
+            if (window.Array![window.Offset + i] != expected[i]) return false;
+        return true;
+    }
+}

--- a/Radoub.Formats/Radoub.Formats/Erf/ErfReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Erf/ErfReader.cs
@@ -8,6 +8,14 @@ namespace Radoub.Formats.Erf;
 /// </summary>
 public static class ErfReader
 {
+    private static readonly Encoding NwnEncoding;
+
+    static ErfReader()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        NwnEncoding = Encoding.GetEncoding(1252);
+    }
+
     private const int HeaderSize = 160;
     private const int KeyEntrySize = 24;
     private const int ResourceEntrySize = 8;
@@ -252,7 +260,9 @@ public static class ErfReader
                     return;
                 }
 
-                text = Encoding.UTF8.GetString(buffer, currentOffset, (int)stringSize).TrimEnd('\0');
+                // NWN1 native encoding is Windows-1252 (#2242, matches
+                // neverwinter.nim erf.nim:80 → util.nim getNwnEncoding default).
+                text = NwnEncoding.GetString(buffer, currentOffset, (int)stringSize).TrimEnd('\0');
                 currentOffset += (int)stringSize;
             }
 

--- a/Radoub.Formats/Radoub.Formats/Erf/ErfWriter.cs
+++ b/Radoub.Formats/Radoub.Formats/Erf/ErfWriter.cs
@@ -12,6 +12,14 @@ public static class ErfWriter
     private const int KeyEntrySize = 24;
     private const int ResourceEntrySize = 8;
 
+    private static readonly Encoding NwnEncoding;
+
+    static ErfWriter()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        NwnEncoding = Encoding.GetEncoding(1252);
+    }
+
     /// <summary>
     /// Write an ERF file to disk.
     /// </summary>
@@ -139,7 +147,9 @@ public static class ErfWriter
         using var ms = new MemoryStream();
         foreach (var str in strings)
         {
-            var textBytes = Encoding.UTF8.GetBytes(str.Text);
+            // NWN1 native encoding is Windows-1252 (#2242, matches
+            // neverwinter.nim erf.nim:227-228 → util.nim getNwnEncoding default).
+            var textBytes = NwnEncoding.GetBytes(str.Text);
             ms.Write(BitConverter.GetBytes(str.LanguageId), 0, 4);
             ms.Write(BitConverter.GetBytes((uint)textBytes.Length), 0, 4);
             ms.Write(textBytes, 0, textBytes.Length);

--- a/Radoub.Formats/Radoub.Formats/Gff/GffReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Gff/GffReader.cs
@@ -11,6 +11,14 @@ public static class GffReader
 {
     private const int HeaderSize = 56; // 14 uint32_t fields
 
+    private static readonly Encoding NwnEncoding;
+
+    static GffReader()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        NwnEncoding = Encoding.GetEncoding(1252);
+    }
+
     /// <summary>
     /// Read a GFF file from a file path.
     /// </summary>
@@ -376,21 +384,10 @@ public static class GffReader
 
         ValidateAccess(buffer, offset, (int)length);
 
-        // Try UTF-8 first, fall back to Windows-1252 if invalid
-        try
-        {
-            var result = Encoding.UTF8.GetString(buffer, offset, (int)length);
-            if (!result.Contains('\uFFFD'))
-                return result.TrimEnd('\0');
-        }
-        catch (Exception ex)
-        {
-            UnifiedLogger.LogParser(LogLevel.DEBUG, $"UTF-8 decode failed, falling back to Windows-1252: {ex.Message}");
-        }
-
-        // Fall back to Windows-1252
-        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-        return Encoding.GetEncoding(1252).GetString(buffer, offset, (int)length).TrimEnd('\0');
+        // NWN1 native encoding is Windows-1252 (#2242, matches neverwinter.nim
+        // gff.nim:461 \u2192 util.nim getNwnEncoding default). CP-1252 is a total
+        // encoding (every byte \u2192 a character), so no fallback is needed.
+        return NwnEncoding.GetString(buffer, offset, (int)length).TrimEnd('\0');
     }
 
     private static string ReadCResRef(byte[] buffer, int offset)
@@ -444,22 +441,9 @@ public static class GffReader
                 continue;
             }
 
-            // Try UTF-8 first, fall back to Windows-1252
-            string text;
-            try
-            {
-                text = Encoding.UTF8.GetString(buffer, offset, (int)stringLength);
-                if (text.Contains('\uFFFD'))
-                {
-                    Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-                    text = Encoding.GetEncoding(1252).GetString(buffer, offset, (int)stringLength);
-                }
-            }
-            catch
-            {
-                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-                text = Encoding.GetEncoding(1252).GetString(buffer, offset, (int)stringLength);
-            }
+            // NWN1 native encoding is Windows-1252 (#2242, matches
+            // neverwinter.nim gff.nim:452 \u2192 util.nim getNwnEncoding default).
+            var text = NwnEncoding.GetString(buffer, offset, (int)stringLength);
 
             locString.LocalizedStrings[languageId] = text.TrimEnd('\0');
             offset += (int)stringLength;

--- a/Radoub.Formats/Radoub.Formats/Gff/GffWriter.cs
+++ b/Radoub.Formats/Radoub.Formats/Gff/GffWriter.cs
@@ -10,6 +10,14 @@ public static class GffWriter
 {
     private const int HeaderSize = 56;
 
+    private static readonly Encoding NwnEncoding;
+
+    static GffWriter()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        NwnEncoding = Encoding.GetEncoding(1252);
+    }
+
     /// <summary>
     /// Write a GFF file to a file path.
     /// </summary>
@@ -407,7 +415,9 @@ public static class GffWriter
 
     private static void WriteCExoString(MemoryStream stream, string value)
     {
-        var bytes = Encoding.UTF8.GetBytes(value);
+        // NWN1 native encoding is Windows-1252 (#2242, matches neverwinter.nim
+        // gff.nim:623 → util.nim getNwnEncoding default).
+        var bytes = NwnEncoding.GetBytes(value);
         var lengthBytes = BitConverter.GetBytes((uint)bytes.Length);
         stream.Write(lengthBytes, 0, 4);
         stream.Write(bytes, 0, bytes.Length);
@@ -433,7 +443,7 @@ public static class GffWriter
         var substringsSize = 0;
         foreach (var kvp in locString.LocalizedStrings)
         {
-            substringsSize += 8 + Encoding.UTF8.GetByteCount(kvp.Value); // langId + length + string
+            substringsSize += 8 + NwnEncoding.GetByteCount(kvp.Value); // langId + length + string (CP-1252, #2242)
         }
         // Add size for empty padding entries (8 bytes each: langId + length=0)
         substringsSize += (int)paddingCount * 8;
@@ -455,7 +465,7 @@ public static class GffWriter
             var langIdBytes = BitConverter.GetBytes(kvp.Key);
             stream.Write(langIdBytes, 0, 4);
 
-            var stringBytes = Encoding.UTF8.GetBytes(kvp.Value);
+            var stringBytes = NwnEncoding.GetBytes(kvp.Value); // CP-1252 (#2242)
             var stringLengthBytes = BitConverter.GetBytes((uint)stringBytes.Length);
             stream.Write(stringLengthBytes, 0, 4);
             stream.Write(stringBytes, 0, stringBytes.Length);

--- a/Radoub.Formats/Radoub.Formats/TwoDA/TwoDAReader.cs
+++ b/Radoub.Formats/Radoub.Formats/TwoDA/TwoDAReader.cs
@@ -12,13 +12,21 @@ public static class TwoDAReader
     private const string EmptyCell = "****";
     private const int MaxColumns = 1024;
 
+    private static readonly Encoding NwnEncoding;
+
+    static TwoDAReader()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        NwnEncoding = Encoding.GetEncoding(1252);
+    }
+
     /// <summary>
     /// Read a 2DA file from a file path.
     /// </summary>
     public static TwoDAFile Read(string filePath)
     {
-        var text = File.ReadAllText(filePath, Encoding.UTF8);
-        return Parse(text);
+        var buffer = File.ReadAllBytes(filePath);
+        return Read(buffer);
     }
 
     /// <summary>
@@ -26,17 +34,27 @@ public static class TwoDAReader
     /// </summary>
     public static TwoDAFile Read(Stream stream)
     {
-        using var reader = new StreamReader(stream, Encoding.UTF8);
-        var text = reader.ReadToEnd();
-        return Parse(text);
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        return Read(ms.ToArray());
     }
 
     /// <summary>
-    /// Read a 2DA file from a byte buffer.
+    /// Read a 2DA file from a byte buffer. NWN1 2DAs are Windows-1252 (#2242,
+    /// matches neverwinter.nim twoda.nim:118). A UTF-8 BOM (EF BB BF) opts the
+    /// reader into UTF-8 to keep hand-edited / tool-exported UTF-8 2DAs working.
     /// </summary>
     public static TwoDAFile Read(byte[] buffer)
     {
-        var text = Encoding.UTF8.GetString(buffer);
+        string text;
+        if (buffer.Length >= 3 && buffer[0] == 0xEF && buffer[1] == 0xBB && buffer[2] == 0xBF)
+        {
+            text = Encoding.UTF8.GetString(buffer, 3, buffer.Length - 3);
+        }
+        else
+        {
+            text = NwnEncoding.GetString(buffer);
+        }
         return Parse(text);
     }
 


### PR DESCRIPTION
## Summary

Two related items bundled because the encoding fix is itself a shared-library change and is the first entry that uses the new root CHANGELOG.

### Fix: UTF-8 vs CP-1252 encoding (#2242)

NWN1 file formats use Windows-1252 natively, but `GffWriter`, `ErfWriter`, `ErfReader`, and `TwoDAReader` used UTF-8. Round-tripping any vanilla NWN file with accented characters (é, ü, ß) rewrites bytes incorrectly and breaks in-game string lookup. Affects German/Polish 2DA builds, French dialog, localized item descriptions, plus all GFF-based formats (DLG, UTI, UTC, UTM, JRL, BIC, IFO) and ERF descriptions.

The GFF reader's old UTF-8-first / CP-1252-fallback path was masking the writer bug for Radoub's own output — symmetric UTF-8↔UTF-8 round-trips passed locally while vanilla files corrupted on save.

Scope:
- `GffWriter.WriteCExoString` + `WriteCExoLocString` → CP-1252
- `GffReader.ReadCExoString` + `ReadCExoLocString` → pure CP-1252 (drop UTF-8-first fallback; CP-1252 is a total encoding so no fallback needed, matches neverwinter.nim `gff.nim:452/461`)
- `ErfReader` / `ErfWriter` localized strings → CP-1252
- `TwoDAReader` → CP-1252 native; UTF-8 BOM (`EF BB BF`) opts into UTF-8 so hand-edited / tool-exported UTF-8 2DAs still parse
- `Encoding.RegisterProvider(CodePagesEncodingProvider.Instance)` hoisted into static ctor on each affected class (mirrors existing `TlkReader` / `TlkWriter` pattern)

Reference: [neverwinter.nim `util.nim:49`](https://github.com/niv/neverwinter.nim/blob/master/neverwinter/util.nim) — `getNwnEncoding` default = `windows-1252`.

### Chore: Establish root /CHANGELOG.md (#2203)

Shared-library work (`Radoub.Formats`, `Radoub.UI`, `Radoub.Dictionary`) previously had no logging home — entries were either omitted or duplicated into every tool CHANGELOG. Adds `/CHANGELOG.md` at repo root, backfilled with recent shared-lib entries (#2238, #2241, #2243, #2244), and rewrites the root `CLAUDE.md` "CHANGELOG Management" section with routing rules.

## Related Issues

- Closes #2242
- Closes #2203
- Follow-up filed: #2273 (non-CP1252 NWN locales — Polish CP-1250, Russian CP-1251, CJK)
- Source review for #2242: `NonPublic/Radoub/Reviews/2026-05-25/radoub-formats.md`

## Verification

Targeted test run via `run-tests.ps1 -Tool Radoub -UnitOnly -TechDebt`:

| Suite | Pass | Fail |
|---|---|---|
| Radoub.Formats.Tests | 1295 | 0 |
| Radoub.UI.Tests | 746 | 0 |
| Radoub.Dictionary.Tests | 54 | 0 |
| **Total (shared lib)** | **2095** | **0** |

Plus full downstream regression on consumer suites (run separately during implementation):

| Suite | Pass | Fail |
|---|---|---|
| Parley.Tests | 839 | 0 |
| Manifest.Tests | 104 | 0 |
| Quartermaster.Tests | 1195 | 0 |
| Fence.Tests | 138 | 0 |
| Relique.Tests | 375 | 0 |
| Trebuchet.Tests | 169 | 0 |

Privacy scan: clean. Tech debt scan: no files >800 lines touched.

Theme-warnings (16 reported by `run-tests.ps1`): all pre-existing in files outside this PR's diff.

## Checklist

- [x] Failing tests written first (`EncodingRoundTripTests.cs`, 9 cases — writer byte parity + round-trip + 2DA BOM)
- [x] Pre-computed CP-1252 byte sequence for `café—Mädchen—straße` asserted against writer output (independent of SUT encoding choice)
- [x] Writer encoding changes applied (GFF + ERF + 2DA)
- [x] `Encoding.RegisterProvider` hoisted to static ctor in all 5 affected classes
- [x] Root `/CHANGELOG.md` created with backfilled entries
- [x] Root `CLAUDE.md` CHANGELOG Management section updated with routing rules
- [x] Targeted unit tests pass (2095 / 0)
- [x] Downstream consumer suites pass (2820 / 0)
- [x] Privacy + tech debt scans clean

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)