### PR TITLE
[Trebuchet] Fix: ERF import path traversal — unsanitized ResRef in Path.Combine (#2245)

### DIFF
--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.36.3-alpha] - 2026-05-26
+**Branch**: `trebuchet/issue-2245` | **PR**: #TBD
+
+### Fix: ERF import path traversal — unsanitized ResRef in Path.Combine (#2245)
+
+---
+
 ## [1.36.2-alpha] - 2026-05-26
 **Branch**: `radoub/issue-2244` | **PR**: #2266
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [1.36.3-alpha] - 2026-05-26
-**Branch**: `trebuchet/issue-2245` | **PR**: #TBD
+**Branch**: `trebuchet/issue-2245` | **PR**: #2274
 
 ### Fix: ERF import path traversal — unsanitized ResRef in Path.Combine (#2245)
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fix: ERF import path traversal — unsanitized ResRef in Path.Combine (#2245)
 
+- Crafted ERF/HAK with traversal sequences in ResRef could write outside the import target; now validated against Aurora ResRef regex with a Path.GetFullPath containment fallback.
+
 ---
 
 ## [1.36.2-alpha] - 2026-05-26

--- a/Trebuchet/Trebuchet.Tests/ErfImportServiceTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ErfImportServiceTests.cs
@@ -200,4 +200,112 @@ public class ErfImportServiceTests : IDisposable
     }
 
     #endregion
+
+    #region Path Traversal (#2245)
+
+    // Security: a crafted ERF/HAK with traversal sequences in ResRef
+    // (e.g. "../../tmp/pwned") must not be allowed to write outside targetDirectory.
+    // ErfReader reads ResRef as raw ASCII without filtering "/", "\", or "..".
+    // Path.Combine alone does NOT reject absolute or traversal segments.
+
+    [Theory]
+    [InlineData("../pwned")]
+    [InlineData("..\\pwned")]
+    [InlineData("../../pwned")]
+    [InlineData("..\\..\\pwned")]
+    [InlineData("foo/bar")]
+    [InlineData("foo\\bar")]
+    public void DetectConflicts_MaliciousResRef_DoesNotEscape(string maliciousResRef)
+    {
+        var entries = new List<ErfResourceEntry>
+        {
+            new() { ResRef = maliciousResRef, ResourceType = ResourceTypes.Uti, ResId = 0, Offset = 0, Size = 4 }
+        };
+
+        // Plant a decoy file at the would-be-escaped location so a naive
+        // Path.Combine would report a conflict. Validated impl must NOT.
+        var escapedPath = Path.GetFullPath(Path.Combine(_targetDir, maliciousResRef + ".uti"));
+        Directory.CreateDirectory(Path.GetDirectoryName(escapedPath)!);
+        File.WriteAllBytes(escapedPath, new byte[] { 0xAA });
+
+        var conflicts = _service.DetectConflicts(entries, _targetDir);
+
+        Assert.Empty(conflicts);
+    }
+
+    [Theory]
+    [InlineData("../pwned")]
+    [InlineData("..\\pwned")]
+    [InlineData("../../../../tmp/pwned")]
+    [InlineData("foo/bar")]
+    public async Task ImportResources_MaliciousResRef_DoesNotWriteOutsideTarget(string maliciousResRef)
+    {
+        var sourceErf = ErfReader.ReadMetadataOnly(_erfPath);
+        var realEntry = sourceErf.Resources[0];
+
+        // Inject malicious ResRef while keeping valid Offset/Size so
+        // ExtractResource reads real bytes (worst-case scenario).
+        var entries = new List<ErfResourceEntry>
+        {
+            new()
+            {
+                ResRef = maliciousResRef,
+                ResourceType = realEntry.ResourceType,
+                ResId = realEntry.ResId,
+                Offset = realEntry.Offset,
+                Size = realEntry.Size
+            }
+        };
+
+        var escapedPath = Path.GetFullPath(Path.Combine(_targetDir, maliciousResRef + ResourceTypes.GetExtension(realEntry.ResourceType)));
+        var escapedExistedBefore = File.Exists(escapedPath);
+        var escapedSizeBefore = escapedExistedBefore ? new FileInfo(escapedPath).Length : -1L;
+
+        var result = await _service.ImportResourcesAsync(_erfPath, entries, _targetDir, overwriteExisting: true, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Either skipped via validation or errored — must NOT count as imported.
+        Assert.Equal(0, result.ImportedCount);
+        Assert.Equal(0, result.OverwrittenCount);
+
+        // No file written outside targetDirectory.
+        if (escapedExistedBefore)
+        {
+            Assert.Equal(escapedSizeBefore, new FileInfo(escapedPath).Length);
+        }
+        else
+        {
+            Assert.False(File.Exists(escapedPath), $"File leaked outside target: {escapedPath}");
+        }
+    }
+
+    [Theory]
+    [InlineData("valid_name")]
+    [InlineData("test_item")]
+    [InlineData("a")]
+    [InlineData("abcdefghij012345")] // 16 chars — Aurora ResRef max
+    [InlineData("name_with-dash")]
+    public async Task ImportResources_LegitimateResRef_StillWorks(string legitResRef)
+    {
+        var sourceErf = ErfReader.ReadMetadataOnly(_erfPath);
+        var realEntry = sourceErf.Resources[0];
+
+        var entries = new List<ErfResourceEntry>
+        {
+            new()
+            {
+                ResRef = legitResRef,
+                ResourceType = realEntry.ResourceType,
+                ResId = realEntry.ResId,
+                Offset = realEntry.Offset,
+                Size = realEntry.Size
+            }
+        };
+
+        var result = await _service.ImportResourcesAsync(_erfPath, entries, _targetDir, overwriteExisting: false, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, result.ImportedCount);
+        Assert.True(File.Exists(Path.Combine(_targetDir, legitResRef + ResourceTypes.GetExtension(realEntry.ResourceType))));
+    }
+
+    #endregion
 }

--- a/Trebuchet/Trebuchet/Services/ErfImportService.cs
+++ b/Trebuchet/Trebuchet/Services/ErfImportService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Radoub.Formats.Common;
@@ -11,18 +12,32 @@ namespace RadoubLauncher.Services;
 
 public class ErfImportService
 {
+    // Aurora ResRef: 1-16 chars, alphanumeric + underscore + hyphen.
+    // Rejects path separators, "..", drive letters, NUL — anything a crafted
+    // ERF could use to escape targetDirectory via Path.Combine (#2245).
+    private static readonly Regex ValidResRef = new(@"^[a-zA-Z0-9_\-]{1,16}$", RegexOptions.Compiled);
+
     /// <summary>
     /// Detect which resources already exist in the target directory.
+    /// Entries with invalid ResRefs are skipped silently (cannot conflict — won't be imported).
     /// </summary>
     public HashSet<string> DetectConflicts(IReadOnlyList<ErfResourceEntry> entries, string targetDirectory)
     {
         var conflicts = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var targetFullPath = Path.GetFullPath(targetDirectory);
 
         foreach (var entry in entries)
         {
+            if (!IsResRefSafe(entry.ResRef))
+                continue;
+
             var extension = ResourceTypes.GetExtension(entry.ResourceType);
-            var filePath = Path.Combine(targetDirectory, entry.ResRef + extension);
-            if (File.Exists(filePath))
+            var candidate = Path.Combine(targetDirectory, entry.ResRef + extension);
+
+            if (!IsPathInsideTarget(candidate, targetFullPath))
+                continue;
+
+            if (File.Exists(candidate))
                 conflicts.Add(entry.ResRef);
         }
 
@@ -31,6 +46,7 @@ public class ErfImportService
 
     /// <summary>
     /// Import selected resources from an ERF archive into the target directory.
+    /// Entries with invalid ResRefs (path traversal, illegal chars) are rejected and logged (#2245).
     /// </summary>
     public async Task<ErfImportResult> ImportResourcesAsync(
         string erfPath,
@@ -41,6 +57,7 @@ public class ErfImportService
         CancellationToken cancellationToken = default)
     {
         var result = new ErfImportResult();
+        var targetFullPath = Path.GetFullPath(targetDirectory);
         int processed = 0;
 
         foreach (var entry in entries)
@@ -49,7 +66,6 @@ public class ErfImportService
 
             var extension = ResourceTypes.GetExtension(entry.ResourceType);
             var fileName = entry.ResRef + extension;
-            var targetPath = Path.Combine(targetDirectory, fileName);
 
             progress?.Report(new ImportProgress
             {
@@ -57,6 +73,30 @@ public class ErfImportService
                 Total = entries.Count,
                 CurrentResRef = entry.ResRef
             });
+
+            // Layer 1: strict ResRef validation.
+            if (!IsResRefSafe(entry.ResRef))
+            {
+                UnifiedLogger.LogApplication(LogLevel.WARN,
+                    $"ERF import: rejected entry with invalid ResRef '{entry.ResRef}' (must match {ValidResRef})");
+                result.Errors.Add((entry.ResRef, "Invalid ResRef: must be 1-16 chars alphanumeric/underscore/hyphen"));
+                result.ErrorCount++;
+                processed++;
+                continue;
+            }
+
+            var targetPath = Path.Combine(targetDirectory, fileName);
+
+            // Layer 2: defense-in-depth — verify resolved path stays inside targetDirectory.
+            if (!IsPathInsideTarget(targetPath, targetFullPath))
+            {
+                UnifiedLogger.LogApplication(LogLevel.WARN,
+                    $"ERF import: rejected entry '{entry.ResRef}' — resolved path escapes target directory");
+                result.Errors.Add((entry.ResRef, "Path escapes target directory"));
+                result.ErrorCount++;
+                processed++;
+                continue;
+            }
 
             var fileExists = File.Exists(targetPath);
 
@@ -98,6 +138,28 @@ public class ErfImportService
         }
 
         return result;
+    }
+
+    private static bool IsResRefSafe(string? resRef)
+        => !string.IsNullOrEmpty(resRef) && ValidResRef.IsMatch(resRef);
+
+    private static bool IsPathInsideTarget(string candidatePath, string targetFullPath)
+    {
+        string resolved;
+        try
+        {
+            resolved = Path.GetFullPath(candidatePath);
+        }
+        catch
+        {
+            return false;
+        }
+
+        var expectedPrefix = targetFullPath.EndsWith(Path.DirectorySeparatorChar)
+            ? targetFullPath
+            : targetFullPath + Path.DirectorySeparatorChar;
+
+        return resolved.StartsWith(expectedPrefix, StringComparison.OrdinalIgnoreCase);
     }
 }
 


### PR DESCRIPTION
## Summary

CRITICAL security fix. `ErfImportService` passed ERF-extracted ResRef into `Path.Combine` with no sanitization. Crafted ERF/HAK with `ResRef = "../../tmp/pwned"` could write arbitrary paths outside `targetDirectory`.

## Fix

`Trebuchet/Services/ErfImportService.cs`:
- **Layer 1**: validate ResRef matches `^[a-zA-Z0-9_-]{1,16}$` (Aurora spec)
- **Layer 2**: defense-in-depth `Path.GetFullPath` check that resolved path starts with `targetDirectory + DirectorySeparatorChar`
- Rejected entries logged at WARN and recorded as errors; legitimate ResRefs unaffected
- Applies to both `DetectConflicts` and `ImportResourcesAsync`

## Verification

`Trebuchet.Tests/ErfImportServiceTests.cs`:
- 6 parametrized cases proving `DetectConflicts` ignores traversal ResRefs even with decoy file planted at escape target
- 4 parametrized cases proving `ImportResourcesAsync` writes 0 files outside target (verified by file-existence + size checks)
- 5 parametrized cases proving legitimate ResRefs (`valid_name`, `abcdefghij012345` at 16-char max, dashes, etc.) still import
- All 184 Trebuchet.Tests pass

## Pre-Merge

- ✅ Privacy scan
- ✅ Tech debt scan (no large files)
- ✅ Theme scan
- ✅ Unit tests (184/184)
- ✅ CHANGELOG updated (1.36.3-alpha, PR #2274, dated 2026-05-26)

## Related

- Closes #2245
- Source review: `NonPublic/Radoub/Reviews/2026-05-25/trebuchet.md` (Critical #2)
- Underlying raw-ASCII ResRef read: `Radoub.Formats/Erf/ErfReader.cs:149-151`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)