### PR TITLE
[Quartermaster] Fix: Down-Level corrupts .bic files + CreatureCopy strips BIC-only fields (#2249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.Formats 0.2.61-alpha] - 2026-05-27
+**Branch**: `quartermaster/issue-2249` | **PR**: #2275
+
+### Feat: Add CreatureCloning helper for runtime-type-preserving deep clone + extension-dispatched save (#2249)
+
+- New `Radoub.Formats.Utc.CreatureCloning` with `Clone` (preserves `BicFile` runtime type so player-only fields survive a round-trip) and `Save` (dispatches BIC/UTC based on file extension, throws on `.bic` paired with non-BIC). Used by Quartermaster's Down-Level flow to stop silent BIC→UTC corruption. 14 new tests.
+
+---
+
 ## [Radoub.Formats 0.2.60-alpha] - 2026-05-26
 **Branch**: `radoub/issue-2242` | **PR**: #2272
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.96-alpha] - 2026-05-26
+**Branch**: `quartermaster/issue-2249` | **PR**: #TBD
+
+### Fix: Down-Level corrupts .bic files + CreatureCopy strips BIC-only fields (#2249)
+
+---
+
 ## [0.2.95-alpha] - 2026-05-26
 **Branch**: `radoub/issue-2244` | **PR**: #2266
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.96-alpha] - 2026-05-26
-**Branch**: `quartermaster/issue-2249` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2249` | **PR**: #2275
 
 ### Fix: Down-Level corrupts .bic files + CreatureCopy strips BIC-only fields (#2249)
 

--- a/Quartermaster/Quartermaster/Views/MainWindow.MenuDialogs.cs
+++ b/Quartermaster/Quartermaster/Views/MainWindow.MenuDialogs.cs
@@ -8,6 +8,7 @@ using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Quartermaster.Services;
 using Quartermaster.Views.Dialogs;
+using Radoub.Formats.Bic;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Utc;
 using DialogHelper = Quartermaster.Views.Helpers.DialogHelper;
@@ -307,23 +308,24 @@ public partial class MainWindow
 
         try
         {
-            // Create a deep copy (serialize and deserialize)
-            var copy = CreateCreatureCopy(_currentCreature);
+            // Deep clone preserving runtime type — a BicFile source stays a
+            // BicFile so player-only fields (Age, Gold, Experience, QBList,
+            // ReputationList, LvlStatList) survive the copy.
+            var copy = CreatureCloning.Clone(_currentCreature);
+
+            // If saving to .bic but the source was a UTC, promote to BIC so
+            // CreatureCloning.Save can dispatch correctly. Player-only fields
+            // get default values from FromUtcFile.
+            if (savePath.EndsWith(".bic", StringComparison.OrdinalIgnoreCase) && copy is not BicFile)
+            {
+                copy = BicFile.FromUtcFile(copy);
+            }
 
             // Strip the copy to level 1
             StripCreatureToLevelOne(copy);
 
-            // Save the copy
-            if (savePath.EndsWith(".bic", StringComparison.OrdinalIgnoreCase))
-            {
-                // BIC files wrap the UTC data in an additional layer
-                // For simplicity, just save as UTC for now
-                Radoub.Formats.Utc.UtcWriter.Write(copy, savePath);
-            }
-            else
-            {
-                Radoub.Formats.Utc.UtcWriter.Write(copy, savePath);
-            }
+            // Dispatches to BicWriter for .bic, UtcWriter otherwise.
+            CreatureCloning.Save(copy, savePath);
 
             UpdateStatus($"Saved level 1 copy to {System.IO.Path.GetFileName(savePath)}");
         }
@@ -331,13 +333,6 @@ public partial class MainWindow
         {
             ShowErrorDialog("Save Failed", $"Failed to save level 1 copy: {ex.Message}");
         }
-    }
-
-    private UtcFile CreateCreatureCopy(UtcFile original)
-    {
-        // Create a copy by serializing and deserializing
-        var buffer = Radoub.Formats.Utc.UtcWriter.Write(original);
-        return Radoub.Formats.Utc.UtcReader.Read(buffer);
     }
 
     private void StripCreatureToLevelOne(UtcFile creature)
@@ -376,6 +371,20 @@ public partial class MainWindow
         // Reset all skills to 0
         for (int i = 0; i < creature.SkillList.Count; i++)
             creature.SkillList[i] = 0;
+
+        // BIC-only: reset XP to level-1 minimum (0) and truncate LvlStatList to
+        // match the new class structure. Gold, Age, QBList, ReputationList,
+        // FirstName/LastName, and Portrait are preserved as user data.
+        if (creature is BicFile bic)
+        {
+            bic.Experience = 0u;
+            if (bic.LvlStatList.Count > 1)
+            {
+                var firstLevel = bic.LvlStatList[0];
+                bic.LvlStatList.Clear();
+                bic.LvlStatList.Add(firstLevel);
+            }
+        }
     }
 
     private void ShowErrorDialog(string title, string message)

--- a/Radoub.Formats/Radoub.Formats.Tests/CreatureCloneTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/CreatureCloneTests.cs
@@ -1,0 +1,277 @@
+using Radoub.Formats.Bic;
+using Radoub.Formats.Utc;
+using Xunit;
+
+namespace Radoub.Formats.Tests;
+
+/// <summary>
+/// Tests for CreatureCloning helper used by Quartermaster's Down-Level and
+/// "save level 1 copy" flows. Verifies that cloning a BIC preserves player-only
+/// fields (Age, Gold, Experience, QBList, LvlStatList, ReputationList) and that
+/// extension-based save dispatch writes BIC bytes for .bic paths.
+///
+/// Regression coverage for #2249.
+/// </summary>
+public class CreatureCloneTests
+{
+    [Fact]
+    public void Clone_BicSource_ReturnsBicFileInstance()
+    {
+        var bic = CreateTestBic();
+
+        var clone = CreatureCloning.Clone(bic);
+
+        Assert.IsType<BicFile>(clone);
+    }
+
+    [Fact]
+    public void Clone_BicSource_PreservesAge()
+    {
+        var bic = CreateTestBic();
+        bic.Age = 37;
+
+        var clone = (BicFile)CreatureCloning.Clone(bic);
+
+        Assert.Equal(37, clone.Age);
+    }
+
+    [Fact]
+    public void Clone_BicSource_PreservesGold()
+    {
+        var bic = CreateTestBic();
+        bic.Gold = 12345u;
+
+        var clone = (BicFile)CreatureCloning.Clone(bic);
+
+        Assert.Equal(12345u, clone.Gold);
+    }
+
+    [Fact]
+    public void Clone_BicSource_PreservesExperience()
+    {
+        var bic = CreateTestBic();
+        bic.Experience = 90000u;
+
+        var clone = (BicFile)CreatureCloning.Clone(bic);
+
+        Assert.Equal(90000u, clone.Experience);
+    }
+
+    [Fact]
+    public void Clone_BicSource_PreservesQuickBar()
+    {
+        var bic = CreateTestBic();
+        bic.QBList.Clear();
+        for (int i = 0; i < 36; i++)
+            bic.QBList.Add(new QuickBarSlot { ObjectType = QuickBarObjectType.Empty });
+        bic.QBList[5] = new QuickBarSlot
+        {
+            ObjectType = QuickBarObjectType.Spell,
+            INTParam1 = 42,
+            MultiClass = 1
+        };
+
+        var clone = (BicFile)CreatureCloning.Clone(bic);
+
+        Assert.Equal(36, clone.QBList.Count);
+        Assert.Equal(QuickBarObjectType.Spell, clone.QBList[5].ObjectType);
+        Assert.Equal(42, clone.QBList[5].INTParam1);
+        Assert.Equal(1, clone.QBList[5].MultiClass);
+    }
+
+    [Fact]
+    public void Clone_BicSource_PreservesLvlStatList()
+    {
+        var bic = CreateTestBic();
+        bic.LvlStatList.Add(new LevelStatEntry
+        {
+            LvlStatClass = 4,
+            LvlStatHitDie = 8,
+            EpicLevel = 0,
+            SkillPoints = 3
+        });
+
+        var clone = (BicFile)CreatureCloning.Clone(bic);
+
+        Assert.Single(clone.LvlStatList);
+        Assert.Equal((byte)4, clone.LvlStatList[0].LvlStatClass);
+        Assert.Equal((byte)8, clone.LvlStatList[0].LvlStatHitDie);
+        Assert.Equal((short)3, clone.LvlStatList[0].SkillPoints);
+    }
+
+    [Fact]
+    public void Clone_BicSource_PreservesReputationList()
+    {
+        var bic = CreateTestBic();
+        bic.ReputationList.Add(50);
+        bic.ReputationList.Add(75);
+
+        var clone = (BicFile)CreatureCloning.Clone(bic);
+
+        Assert.Equal(2, clone.ReputationList.Count);
+        Assert.Equal(50, clone.ReputationList[0]);
+        Assert.Equal(75, clone.ReputationList[1]);
+    }
+
+    [Fact]
+    public void Clone_BicSource_IsDeepCopy()
+    {
+        var bic = CreateTestBic();
+        bic.Gold = 100u;
+
+        var clone = (BicFile)CreatureCloning.Clone(bic);
+        clone.Gold = 999u;
+        clone.ClassList[0].ClassLevel = 99;
+
+        Assert.Equal(100u, bic.Gold);
+        Assert.Equal(1, bic.ClassList[0].ClassLevel);
+    }
+
+    [Fact]
+    public void Clone_UtcSource_ReturnsUtcFile()
+    {
+        var utc = CreateTestUtc();
+
+        var clone = CreatureCloning.Clone(utc);
+
+        Assert.IsType<UtcFile>(clone);
+        Assert.False(clone is BicFile);
+    }
+
+    [Fact]
+    public void Clone_UtcSource_RoundTripPreservesAbilityScores()
+    {
+        var utc = CreateTestUtc();
+        utc.Str = 18;
+        utc.Dex = 14;
+
+        var clone = CreatureCloning.Clone(utc);
+
+        Assert.Equal(18, clone.Str);
+        Assert.Equal(14, clone.Dex);
+    }
+
+    [Fact]
+    public void Save_BicExtension_WritesBicFileType()
+    {
+        var bic = CreateTestBic();
+        var path = Path.Combine(Path.GetTempPath(), $"qm_test_{Guid.NewGuid():N}.bic");
+
+        try
+        {
+            CreatureCloning.Save(bic, path);
+            var reloaded = BicReader.Read(path);
+
+            Assert.Equal("BIC ", reloaded.FileType);
+            Assert.True(reloaded.IsPC);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Save_BicExtension_PreservesBicFieldsThroughDisk()
+    {
+        var bic = CreateTestBic();
+        bic.Age = 42;
+        bic.Gold = 555u;
+        bic.Experience = 6000u;
+        var path = Path.Combine(Path.GetTempPath(), $"qm_test_{Guid.NewGuid():N}.bic");
+
+        try
+        {
+            CreatureCloning.Save(bic, path);
+            var reloaded = BicReader.Read(path);
+
+            Assert.Equal(42, reloaded.Age);
+            Assert.Equal(555u, reloaded.Gold);
+            Assert.Equal(6000u, reloaded.Experience);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Save_UtcExtension_WritesUtcFileType()
+    {
+        var utc = CreateTestUtc();
+        var path = Path.Combine(Path.GetTempPath(), $"qm_test_{Guid.NewGuid():N}.utc");
+
+        try
+        {
+            CreatureCloning.Save(utc, path);
+            var reloaded = UtcReader.Read(File.ReadAllBytes(path));
+
+            Assert.Equal("UTC ", reloaded.FileType);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Save_BicUpcastAsUtcReference_StillWritesBicForBicExtension()
+    {
+        // Quartermaster holds the current creature as UtcFile? but it may actually
+        // be a BicFile. Save must dispatch on runtime type + extension, not the
+        // compile-time reference.
+        UtcFile reference = CreateTestBic();
+        ((BicFile)reference).Gold = 222u;
+        var path = Path.Combine(Path.GetTempPath(), $"qm_test_{Guid.NewGuid():N}.bic");
+
+        try
+        {
+            CreatureCloning.Save(reference, path);
+            var reloaded = BicReader.Read(path);
+
+            Assert.Equal("BIC ", reloaded.FileType);
+            Assert.Equal(222u, reloaded.Gold);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    private static BicFile CreateTestBic()
+    {
+        var bic = new BicFile
+        {
+            Str = 10, Dex = 10, Con = 10, Int = 10, Wis = 10, Cha = 10,
+            Race = 6,
+            Gender = 0,
+            HitPoints = 8,
+            MaxHitPoints = 8,
+            CurrentHitPoints = 8,
+            Age = 25,
+            Experience = 0,
+            Gold = 0
+        };
+        bic.FirstName.SetString(0, "TestPC");
+        bic.ClassList.Add(new CreatureClass { Class = 0, ClassLevel = 1 });
+        for (int i = 0; i < 28; i++) bic.SkillList.Add(0);
+        return bic;
+    }
+
+    private static UtcFile CreateTestUtc()
+    {
+        var utc = new UtcFile
+        {
+            Str = 10, Dex = 10, Con = 10, Int = 10, Wis = 10, Cha = 10,
+            Race = 6,
+            Gender = 0,
+            HitPoints = 8,
+            MaxHitPoints = 8,
+            CurrentHitPoints = 8
+        };
+        utc.FirstName.SetString(0, "TestNPC");
+        utc.ClassList.Add(new CreatureClass { Class = 0, ClassLevel = 1 });
+        for (int i = 0; i < 28; i++) utc.SkillList.Add(0);
+        return utc;
+    }
+}

--- a/Radoub.Formats/Radoub.Formats/Utc/CreatureCloning.cs
+++ b/Radoub.Formats/Radoub.Formats/Utc/CreatureCloning.cs
@@ -1,0 +1,61 @@
+using Radoub.Formats.Bic;
+
+namespace Radoub.Formats.Utc;
+
+/// <summary>
+/// Helpers for deep-cloning creature files and dispatching writes based on
+/// runtime type + target extension. Used by Quartermaster's Down-Level / "save
+/// level 1 copy" flow so a BIC source survives a copy → mutate → save cycle
+/// without losing BIC-only fields (Age, Gold, Experience, QBList, ReputationList,
+/// LvlStatList) and without being saved as UTC bytes under a .bic path.
+///
+/// Regression coverage: see CreatureCloneTests in Radoub.Formats.Tests.
+/// Issue: #2249.
+/// </summary>
+public static class CreatureCloning
+{
+    /// <summary>
+    /// Deep clone a creature, preserving its runtime type. A BicFile in produces
+    /// a BicFile out (with all player-only fields intact); a plain UtcFile in
+    /// produces a UtcFile out. The clone is independent of the original — mutating
+    /// one does not affect the other.
+    /// </summary>
+    public static UtcFile Clone(UtcFile source)
+    {
+        if (source is BicFile bicSource)
+        {
+            var buffer = BicWriter.Write(bicSource);
+            return BicReader.Read(buffer);
+        }
+
+        var utcBuffer = UtcWriter.Write(source);
+        return UtcReader.Read(utcBuffer);
+    }
+
+    /// <summary>
+    /// Save a creature to a file path, dispatching to the correct writer based
+    /// on file extension. A .bic path requires the runtime type to be BicFile;
+    /// any other extension writes UTC.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a .bic path is paired with a non-BIC creature. The caller
+    /// should convert the UTC to a BIC via BicFile.FromUtcFile first.
+    /// </exception>
+    public static void Save(UtcFile creature, string filePath)
+    {
+        if (filePath.EndsWith(".bic", System.StringComparison.OrdinalIgnoreCase))
+        {
+            if (creature is BicFile bic)
+            {
+                BicWriter.Write(bic, filePath);
+                return;
+            }
+
+            throw new InvalidOperationException(
+                $"Cannot save a UTC creature to a .bic path ('{filePath}'). " +
+                "Convert via BicFile.FromUtcFile first.");
+        }
+
+        UtcWriter.Write(creature, filePath);
+    }
+}

--- a/TestingTools/BicInspector/BicInspector.csproj
+++ b/TestingTools/BicInspector/BicInspector.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>BicInspector</RootNamespace>
+    <AssemblyName>BicInspector</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Radoub.Formats\Radoub.Formats\Radoub.Formats.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TestingTools/BicInspector/Program.cs
+++ b/TestingTools/BicInspector/Program.cs
@@ -1,0 +1,140 @@
+using Radoub.Formats.Bic;
+using Radoub.Formats.Utc;
+
+if (args.Length < 1)
+{
+    Console.WriteLine("Usage: BicInspector <file1> [file2]");
+    Console.WriteLine("  Dumps key creature fields; if two files given, diffs them.");
+    return 1;
+}
+
+var snapshots = args.Select(LoadSnapshot).ToList();
+
+for (int i = 0; i < snapshots.Count; i++)
+{
+    Console.WriteLine($"=== File {i + 1}: {args[i]} ===");
+    PrintSnapshot(snapshots[i]);
+    Console.WriteLine();
+}
+
+if (snapshots.Count == 2)
+{
+    Console.WriteLine("=== DIFF (file1 vs file2) ===");
+    Diff(snapshots[0], snapshots[1]);
+}
+
+return 0;
+
+static Snapshot LoadSnapshot(string path)
+{
+    var bytes = File.ReadAllBytes(path);
+    var ext = Path.GetExtension(path).ToLowerInvariant();
+
+    UtcFile creature;
+    bool isBic;
+    string detectedType;
+
+    var fileTypeMarker = System.Text.Encoding.ASCII.GetString(bytes, 0, 4).TrimEnd();
+    detectedType = fileTypeMarker;
+
+    if (fileTypeMarker == "BIC")
+    {
+        creature = BicReader.Read(bytes);
+        isBic = true;
+    }
+    else
+    {
+        creature = UtcReader.Read(bytes);
+        isBic = false;
+    }
+
+    return new Snapshot(path, bytes.Length, detectedType, isBic, creature);
+}
+
+static void PrintSnapshot(Snapshot s)
+{
+    var c = s.Creature;
+    Console.WriteLine($"  Size:           {s.SizeBytes} bytes");
+    Console.WriteLine($"  FileType:       '{c.FileType}' (detected: '{s.DetectedType}')");
+    Console.WriteLine($"  Version:        {c.FileVersion}");
+    Console.WriteLine($"  IsPC:           {c.IsPC}");
+    Console.WriteLine($"  TemplateResRef: '{c.TemplateResRef}'");
+    Console.WriteLine($"  Tag:            '{c.Tag}'");
+    Console.WriteLine($"  FirstName:      '{c.FirstName.GetDefault() ?? ""}'");
+    Console.WriteLine($"  LastName:       '{c.LastName.GetDefault() ?? ""}'");
+    Console.WriteLine($"  Race:           {c.Race}");
+    Console.WriteLine($"  Gender:         {c.Gender}");
+    Console.WriteLine($"  Str/Dex/Con/Int/Wis/Cha: {c.Str}/{c.Dex}/{c.Con}/{c.Int}/{c.Wis}/{c.Cha}");
+    Console.WriteLine($"  HP (cur/max):   {c.CurrentHitPoints}/{c.MaxHitPoints} (base {c.HitPoints})");
+    Console.WriteLine($"  Portrait:       PortraitId={c.PortraitId} '{c.Portrait ?? ""}'");
+    Console.WriteLine($"  Total Level:    {c.ClassList.Sum(cl => cl.ClassLevel)}");
+    Console.WriteLine($"  Classes:");
+    foreach (var cl in c.ClassList)
+        Console.WriteLine($"    Class={cl.Class} Level={cl.ClassLevel}");
+    Console.WriteLine($"  Feats:          {c.FeatList.Count}");
+    Console.WriteLine($"  SkillList:      {c.SkillList.Count} entries, sum={c.SkillList.Sum(b => (int)b)}");
+    Console.WriteLine($"  Inventory:      {c.ItemList.Count} items, {c.EquipItemList.Count} equipped");
+
+    if (s.IsBic && c is BicFile bic)
+    {
+        Console.WriteLine($"  --- BIC-only ---");
+        Console.WriteLine($"  Age:            {bic.Age}");
+        Console.WriteLine($"  Experience:     {bic.Experience}");
+        Console.WriteLine($"  Gold:           {bic.Gold}");
+        Console.WriteLine($"  QBList:         {bic.QBList.Count} slots");
+        Console.WriteLine($"  ReputationList: {bic.ReputationList.Count} entries");
+        Console.WriteLine($"  LvlStatList:    {bic.LvlStatList.Count} entries");
+        for (int i = 0; i < bic.LvlStatList.Count; i++)
+        {
+            var l = bic.LvlStatList[i];
+            Console.WriteLine($"    [{i}] Class={l.LvlStatClass} HitDie={l.LvlStatHitDie} Epic={l.EpicLevel} SkillPts={l.SkillPoints}");
+        }
+    }
+}
+
+static void Diff(Snapshot a, Snapshot b)
+{
+    Cmp("FileType",       $"'{a.Creature.FileType}'", $"'{b.Creature.FileType}'");
+    Cmp("IsPC",           a.Creature.IsPC, b.Creature.IsPC);
+    Cmp("TotalLevel",     a.Creature.ClassList.Sum(c => c.ClassLevel), b.Creature.ClassList.Sum(c => c.ClassLevel));
+    Cmp("FirstName",      a.Creature.FirstName.GetDefault() ?? "", b.Creature.FirstName.GetDefault() ?? "");
+    Cmp("LastName",       a.Creature.LastName.GetDefault() ?? "", b.Creature.LastName.GetDefault() ?? "");
+    Cmp("Tag",            a.Creature.Tag, b.Creature.Tag);
+    Cmp("Race",           a.Creature.Race, b.Creature.Race);
+    Cmp("Str",            a.Creature.Str, b.Creature.Str);
+    Cmp("Dex",            a.Creature.Dex, b.Creature.Dex);
+    Cmp("Con",            a.Creature.Con, b.Creature.Con);
+    Cmp("Int",            a.Creature.Int, b.Creature.Int);
+    Cmp("Wis",            a.Creature.Wis, b.Creature.Wis);
+    Cmp("Cha",            a.Creature.Cha, b.Creature.Cha);
+    Cmp("ClassList.Count",a.Creature.ClassList.Count, b.Creature.ClassList.Count);
+    Cmp("FeatList.Count", a.Creature.FeatList.Count, b.Creature.FeatList.Count);
+    Cmp("SkillSum",       a.Creature.SkillList.Sum(s => (int)s), b.Creature.SkillList.Sum(s => (int)s));
+    Cmp("Portrait",       a.Creature.Portrait ?? "", b.Creature.Portrait ?? "");
+    Cmp("Inventory",      a.Creature.ItemList.Count, b.Creature.ItemList.Count);
+    Cmp("Equipped",       a.Creature.EquipItemList.Count, b.Creature.EquipItemList.Count);
+
+    if (a.Creature is BicFile ab && b.Creature is BicFile bb)
+    {
+        Console.WriteLine("--- BIC-only ---");
+        Cmp("Age",        ab.Age, bb.Age);
+        Cmp("Experience", ab.Experience, bb.Experience);
+        Cmp("Gold",       ab.Gold, bb.Gold);
+        Cmp("QBList",     ab.QBList.Count, bb.QBList.Count);
+        Cmp("ReputationList", ab.ReputationList.Count, bb.ReputationList.Count);
+        Cmp("LvlStatList",ab.LvlStatList.Count, bb.LvlStatList.Count);
+    }
+    else if (a.IsBic != b.IsBic)
+    {
+        Console.WriteLine("(Cross-format diff: BIC-only fields not comparable)");
+    }
+}
+
+static void Cmp(string label, object? x, object? y)
+{
+    var match = Equals(x, y) ? "==" : "!=";
+    var mark = Equals(x, y) ? " " : "*";
+    Console.WriteLine($"  {mark} {label,-20} {x,-30} {match} {y}");
+}
+
+record Snapshot(string Path, long SizeBytes, string DetectedType, bool IsBic, UtcFile Creature);


### PR DESCRIPTION
## Summary

Fix CRITICAL data-loss bug from full-codebase code review 2026-05-25.

- `OnDownLevelClick` wrote UTC bytes to every `.bic` save path (Aurora silently rejected on load).
- `CreateCreatureCopy` round-tripped through `UtcWriter`/`UtcReader`, silently dropping every BIC-only field (Age, Gold, Experience, QBList, ReputationList, LvlStatList).

## Changes

- **Radoub.Formats**: New `Radoub.Formats.Utc.CreatureCloning` helper. `Clone` preserves runtime type (`BicFile` stays `BicFile`); `Save` dispatches BIC vs UTC writer by extension; throws on `.bic` paired with non-BIC source so the caller must convert via `BicFile.FromUtcFile` first.
- **Quartermaster**: `OnDownLevelClick` uses `Clone` + `Save`. A UTC source bound to a `.bic` path is promoted via `BicFile.FromUtcFile` (player-only fields get FromUtcFile defaults). `StripCreatureToLevelOne` resets `Experience` to 0 and truncates `LvlStatList` for BIC sources; Gold, Age, QBList, ReputationList preserved as user data.
- **TestingTools/BicInspector**: New console app for inspecting/diffing UTC/BIC creature files. Used to verify this fix and surface the follow-up bugs in #2277.
- **CHANGELOG**: Quartermaster `0.2.96-alpha`; Radoub.Formats `0.2.61-alpha` (shared lib).

## Tests

14 new `CreatureCloneTests` covering:
- Field preservation (Age, Gold, Experience, QBList, LvlStatList, ReputationList)
- Deep-copy independence
- Runtime-type dispatch (BIC stays BIC, UTC stays UTC)
- Disk round-trip for both `.bic` and `.utc`
- Upcast-as-UtcFile reference still dispatches correctly by runtime type + extension

**Pre-merge results** (`run-tests.ps1 -Tool Quartermaster -UnitOnly -TechDebt`):

- Privacy scan: PASS
- Tech debt scan: PASS (no large files)
- Theme warnings: 21 pre-existing (not touched by this PR)
- Radoub.Formats.Tests: 1309 / 1310 (1 pre-existing skip)
- Radoub.UI.Tests: 746 / 746
- Radoub.Dictionary.Tests: 54 / 54
- Quartermaster.Tests: 1195 / 1195
- **Total: 3304 passed, 0 failed**

## Verified

Down-leveled real BIC (Bucky.utc lvl 10 → bucky.bic lvl 1) and inspected via BicInspector: `FileType='BIC '`, `IsPC=True`, identity preserved, class collapsed from 5/4/1=10 → 1 Fighter, FeatList kept racial + class-granted, LvlStatList truncated to 1 entry. In-game load by user pending.

Follow-up bugs (HP not recalculated, feats/skills/stats incorrect at lvl 1) tracked separately in #2277 — out of scope for this PR.

## Related Issues

- Closes #2249
- Spawns #2277 (Down-Level correctness follow-up)
- Source review: `NonPublic/Radoub/Reviews/2026-05-25/quartermaster.md` (Critical #1, #2)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)