### PR TITLE
[Trebuchet] Fix: Module pack + faction reindex — atomic write + backup (#2246)

### DIFF
--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.36.5-alpha] - 2026-05-27
+**Branch**: `trebuchet/issue-2246` | **PR**: #TBD
+
+### Fix: Module pack + faction reindex — atomic write + backup (#2246)
+
+- `PackDirectoryToMod`, `RecompileSelectedScripts`, and faction reindex (`ReindexGitFiles` / `ReindexUtcFiles`) now snapshot to `~/Radoub/Backups/` and write via temp-file + `File.Replace` so a crash or locked-file mid-pack can no longer destroy the user's only `.mod` or leave faction references inconsistent across UTC/GIT files.
+
+---
+
 ## [1.36.4-alpha] - 2026-05-27
 **Branch**: `trebuchet/issue-2247` | **PR**: #2279
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [1.36.5-alpha] - 2026-05-27
-**Branch**: `trebuchet/issue-2246` | **PR**: #TBD
+**Branch**: `trebuchet/issue-2246` | **PR**: #2281
 
 ### Fix: Module pack + faction reindex — atomic write + backup (#2246)
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [1.36.5-alpha] - 2026-05-27
+## [1.36.5-alpha] - 2026-05-28
 **Branch**: `trebuchet/issue-2246` | **PR**: #2281
 
 ### Fix: Module pack + faction reindex — atomic write + backup (#2246)

--- a/Trebuchet/Trebuchet.Tests/AreaScanServiceReindexBackupTests.cs
+++ b/Trebuchet/Trebuchet.Tests/AreaScanServiceReindexBackupTests.cs
@@ -1,0 +1,141 @@
+using Radoub.Formats.Gff;
+using RadoubLauncher.Services;
+
+namespace Trebuchet.Tests;
+
+/// <summary>
+/// Backup + atomic-write tests for AreaScanService.ReindexFactions.
+/// Regression: #2246 — partial reindex failure used to leave inconsistent state
+/// across .git/.utc files with no way to roll back.
+/// </summary>
+public class AreaScanServiceReindexBackupTests : IDisposable
+{
+    private readonly string _workingDir;
+    private readonly string _backupRoot;
+    private readonly string _root;
+
+    public AreaScanServiceReindexBackupTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"ReindexBackup_{Guid.NewGuid():N}");
+        _workingDir = Path.Combine(_root, "mymodule");
+        Directory.CreateDirectory(_workingDir);
+        _backupRoot = Path.Combine(_root, "Backups");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, true); } catch { }
+    }
+
+    private string CreateGitFile(string name, uint[] creatureFactionIds)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        var creatureList = new GffList();
+        foreach (var f in creatureFactionIds)
+        {
+            var creature = new GffStruct { Type = 4 };
+            GffFieldBuilder.AddWordField(creature, "FactionID", (ushort)f);
+            GffFieldBuilder.AddCResRefField(creature, "TemplateResRef", "test_creature");
+            creatureList.Elements.Add(creature);
+        }
+        creatureList.Count = (uint)creatureList.Elements.Count;
+        GffFieldBuilder.AddListField(root, "Creature List", creatureList);
+        var encounterList = new GffList { Count = 0 };
+        GffFieldBuilder.AddListField(root, "Encounter List", encounterList);
+
+        var gff = new GffFile { FileType = "GIT ", FileVersion = "V3.2", RootStruct = root };
+        var path = Path.Combine(_workingDir, name + ".git");
+        GffWriter.Write(gff, path);
+        return path;
+    }
+
+    private string CreateUtcFile(string name, uint factionId)
+    {
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        GffFieldBuilder.AddWordField(root, "FactionID", (ushort)factionId);
+        GffFieldBuilder.AddCResRefField(root, "TemplateResRef", name);
+
+        var gff = new GffFile { FileType = "UTC ", FileVersion = "V3.2", RootStruct = root };
+        var path = Path.Combine(_workingDir, name + ".utc");
+        GffWriter.Write(gff, path);
+        return path;
+    }
+
+    [Fact]
+    public void ReindexFactions_BackupRootProvided_BacksUpModifiedGitFiles()
+    {
+        var area1 = CreateGitFile("area001", new uint[] { 5 }); // deleted
+        var area2 = CreateGitFile("area002", new uint[] { 7 }); // > deleted, decrement
+        var unchanged = CreateGitFile("area003", new uint[] { 2 }); // < deleted
+
+        var originalArea1 = File.ReadAllBytes(area1);
+        var originalArea2 = File.ReadAllBytes(area2);
+
+        var result = AreaScanService.ReindexFactions(_workingDir, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot);
+
+        Assert.True(result.FilesModified >= 2);
+        Assert.True(Directory.Exists(_backupRoot));
+
+        var backups = Directory.GetFiles(_backupRoot, "*.git", SearchOption.AllDirectories);
+        var backupNames = backups.Select(Path.GetFileName).ToArray();
+        Assert.Contains("area001.git", backupNames);
+        Assert.Contains("area002.git", backupNames);
+        // area003 not modified, not backed up
+        Assert.DoesNotContain("area003.git", backupNames);
+
+        var area1Backup = backups.First(b => Path.GetFileName(b) == "area001.git");
+        Assert.Equal(originalArea1, File.ReadAllBytes(area1Backup));
+        var area2Backup = backups.First(b => Path.GetFileName(b) == "area002.git");
+        Assert.Equal(originalArea2, File.ReadAllBytes(area2Backup));
+    }
+
+    [Fact]
+    public void ReindexFactions_BackupRootProvided_BacksUpModifiedUtcFiles()
+    {
+        var utc1 = CreateUtcFile("blueprint01", 5); // deleted
+        var utc2 = CreateUtcFile("blueprint02", 2); // unchanged
+
+        var originalUtc1 = File.ReadAllBytes(utc1);
+
+        var result = AreaScanService.ReindexFactions(_workingDir, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot);
+
+        Assert.True(result.BlueprintsReindexed >= 1);
+        var backups = Directory.GetFiles(_backupRoot, "*.utc", SearchOption.AllDirectories);
+        var names = backups.Select(Path.GetFileName).ToArray();
+        Assert.Contains("blueprint01.utc", names);
+        Assert.DoesNotContain("blueprint02.utc", names);
+
+        var utc1Backup = backups.First(b => Path.GetFileName(b) == "blueprint01.utc");
+        Assert.Equal(originalUtc1, File.ReadAllBytes(utc1Backup));
+    }
+
+    [Fact]
+    public void ReindexFactions_NoFilesModified_NoBackupDirectoryCreated()
+    {
+        CreateGitFile("area001", new uint[] { 2 }); // unchanged
+        CreateUtcFile("blueprint01", 1); // unchanged
+
+        var result = AreaScanService.ReindexFactions(_workingDir, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot);
+
+        Assert.Equal(0, result.FilesModified);
+        // Empty backup dir is OK; what we care about is no bogus backup file content
+        if (Directory.Exists(_backupRoot))
+        {
+            var files = Directory.GetFiles(_backupRoot, "*.*", SearchOption.AllDirectories);
+            Assert.Empty(files);
+        }
+    }
+
+    [Fact]
+    public void ReindexFactions_NoBackupRoot_StillWritesAtomically()
+    {
+        var area1 = CreateGitFile("area001", new uint[] { 5 });
+
+        var result = AreaScanService.ReindexFactions(_workingDir, deletedIndex: 5, parentFactionId: 3);
+
+        Assert.Equal(1, result.FilesModified);
+        // No .tmp leftover after success
+        var tempFiles = Directory.GetFiles(_workingDir, "*.tmp");
+        Assert.Empty(tempFiles);
+    }
+}

--- a/Trebuchet/Trebuchet.Tests/AreaScanServiceReindexBackupTests.cs
+++ b/Trebuchet/Trebuchet.Tests/AreaScanServiceReindexBackupTests.cs
@@ -191,14 +191,15 @@ public class AreaScanServiceReindexBackupTests : IDisposable
     }
 
     [Fact]
-    public void ReindexFactions_NoBackupRoot_StillWritesAtomically()
+    public void ReindexFactions_LeavesNoTempFiles()
     {
+        // Atomicity check: even with backup wired, the .tmp sibling created by
+        // SafeWriteGff must be cleaned up after a successful File.Move.
         var area1 = CreateGitFile("area001", new uint[] { 5 });
 
-        var result = AreaScanService.ReindexFactions(_workingDir, deletedIndex: 5, parentFactionId: 3);
+        var result = AreaScanService.ReindexFactions(_workingDir, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot);
 
         Assert.Equal(1, result.FilesModified);
-        // No .tmp leftover after success
         var tempFiles = Directory.GetFiles(_workingDir, "*.tmp");
         Assert.Empty(tempFiles);
     }

--- a/Trebuchet/Trebuchet.Tests/AreaScanServiceReindexBackupTests.cs
+++ b/Trebuchet/Trebuchet.Tests/AreaScanServiceReindexBackupTests.cs
@@ -127,6 +127,70 @@ public class AreaScanServiceReindexBackupTests : IDisposable
     }
 
     [Fact]
+    public void ReindexFactions_OnSingleThreadedSyncContext_DoesNotDeadlock()
+    {
+        // Regression for the hardlock when deleting a faction: BackupService
+        // awaits without ConfigureAwait(false), so a naive sync-over-async
+        // bridge deadlocks if the caller holds a captured sync context (the
+        // Avalonia UI thread is exactly that shape).
+        CreateGitFile("area001", new uint[] { 5 });
+
+        var previous = SynchronizationContext.Current;
+        var ctx = new SingleThreadSyncContext();
+        SynchronizationContext.SetSynchronizationContext(ctx);
+
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var task = Task.Run(() =>
+                AreaScanService.ReindexFactions(_workingDir, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot));
+
+            // Pump the sync context until the work completes, with a hard
+            // timeout. A deadlock would leave task.IsCompleted false forever.
+            while (!task.IsCompleted)
+            {
+                if (cts.IsCancellationRequested)
+                    throw new TimeoutException("ReindexFactions deadlocked under a single-threaded sync context");
+                ctx.RunPending();
+                Thread.Sleep(10);
+            }
+
+            Assert.Equal(1, task.Result.FilesModified);
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(previous);
+        }
+    }
+
+    private sealed class SingleThreadSyncContext : SynchronizationContext
+    {
+        private readonly Queue<(SendOrPostCallback cb, object? state)> _queue = new();
+        private readonly object _gate = new();
+
+        public override void Post(SendOrPostCallback d, object? state)
+        {
+            lock (_gate) _queue.Enqueue((d, state));
+        }
+
+        public override void Send(SendOrPostCallback d, object? state) => d(state);
+
+        public void RunPending()
+        {
+            while (true)
+            {
+                (SendOrPostCallback cb, object? state) item;
+                lock (_gate)
+                {
+                    if (_queue.Count == 0) return;
+                    item = _queue.Dequeue();
+                }
+                item.cb(item.state);
+            }
+        }
+    }
+
+    [Fact]
     public void ReindexFactions_NoBackupRoot_StillWritesAtomically()
     {
         var area1 = CreateGitFile("area001", new uint[] { 5 });

--- a/Trebuchet/Trebuchet.Tests/AreaScanServiceTests.cs
+++ b/Trebuchet/Trebuchet.Tests/AreaScanServiceTests.cs
@@ -10,11 +10,13 @@ namespace Trebuchet.Tests;
 public class AreaScanServiceTests : IDisposable
 {
     private readonly string _testDirectory;
+    private readonly string _backupRoot;
 
     public AreaScanServiceTests()
     {
         _testDirectory = Path.Combine(Path.GetTempPath(), $"AreaScanTest_{Guid.NewGuid():N}");
         Directory.CreateDirectory(_testDirectory);
+        _backupRoot = Path.Combine(_testDirectory, "_Backups");
     }
 
     public void Dispose()
@@ -262,7 +264,7 @@ public class AreaScanServiceTests : IDisposable
         // Creature has FactionID=5, deleting faction 5 with parent 3
         var filePath = CreateGitFile("area001", new uint[] { 5 });
 
-        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3);
+        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot);
 
         Assert.Equal(1, result.FilesModified);
         Assert.Equal(1, result.CreaturesReindexed);
@@ -277,7 +279,7 @@ public class AreaScanServiceTests : IDisposable
         // Creature has FactionID=7, deleting faction 5 — should become 6
         var filePath = CreateGitFile("area001", new uint[] { 7 });
 
-        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3);
+        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot);
 
         Assert.Equal(1, result.FilesModified);
         var factionIds = ReadCreatureFactionIds(filePath);
@@ -290,7 +292,7 @@ public class AreaScanServiceTests : IDisposable
         // Creature has FactionID=2, deleting faction 5 — should stay 2
         var filePath = CreateGitFile("area001", new uint[] { 2 });
 
-        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3);
+        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot);
 
         Assert.Equal(0, result.FilesModified);
         var factionIds = ReadCreatureFactionIds(filePath);
@@ -302,7 +304,7 @@ public class AreaScanServiceTests : IDisposable
     {
         var filePath = CreateGitFile("area001", Array.Empty<uint>(), new uint[] { 5 });
 
-        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3);
+        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot);
 
         Assert.Equal(1, result.FilesModified);
         Assert.Equal(1, result.EncountersReindexed);
@@ -316,7 +318,7 @@ public class AreaScanServiceTests : IDisposable
     {
         var filePath = CreateGitFile("area001", Array.Empty<uint>(), new uint[] { 8 });
 
-        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3);
+        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot);
 
         var factions = ReadEncounterFactions(filePath);
         Assert.Equal(7u, factions[0]);
@@ -331,7 +333,7 @@ public class AreaScanServiceTests : IDisposable
             new uint[] { 5, 7, 2 },
             new uint[] { 5 });
 
-        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3);
+        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot);
 
         Assert.Equal(1, result.FilesModified);
         Assert.Equal(1, result.CreaturesReindexed);
@@ -358,7 +360,7 @@ public class AreaScanServiceTests : IDisposable
         // Small delay to ensure timestamp difference
         System.Threading.Thread.Sleep(50);
 
-        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3);
+        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot);
 
         Assert.Equal(1, result.FilesModified);
         Assert.Equal(2, result.FilesScanned);
@@ -370,7 +372,7 @@ public class AreaScanServiceTests : IDisposable
         CreateGitFile("area001", new uint[] { 0, 1, 2 });
         CreateGitFile("area002", new uint[] { 3 });
 
-        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3);
+        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot);
 
         Assert.Equal(0, result.FilesModified);
         Assert.Equal(0, result.CreaturesReindexed);
@@ -379,7 +381,7 @@ public class AreaScanServiceTests : IDisposable
     [Fact]
     public void ReindexFactions_EmptyDirectory_ZeroResult()
     {
-        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3);
+        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot);
 
         Assert.Equal(0, result.FilesScanned);
         Assert.Equal(0, result.FilesModified);
@@ -393,7 +395,7 @@ public class AreaScanServiceTests : IDisposable
         // So creature should end up at 6.
         var filePath = CreateGitFile("area001", new uint[] { 5 });
 
-        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 7);
+        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 7, backupRoot: _backupRoot);
 
         var factionIds = ReadCreatureFactionIds(filePath);
         // Parent 7 is above deleted 5, so the new parent index after deletion is 6
@@ -406,7 +408,7 @@ public class AreaScanServiceTests : IDisposable
         // Deleting faction 5 with no parent (0xFFFFFFFF)
         var filePath = CreateGitFile("area001", new uint[] { 5 });
 
-        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 0xFFFFFFFF);
+        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 0xFFFFFFFF, backupRoot: _backupRoot);
 
         var factionIds = ReadCreatureFactionIds(filePath);
         // 0xFFFFFFFF means "no parent" — fall back to Commoner (2), a safe neutral faction.
@@ -420,7 +422,7 @@ public class AreaScanServiceTests : IDisposable
         // Creature FactionID is WORD (ushort) in .git files — verify type preserved after reindex
         var filePath = CreateGitFile("area001", new uint[] { 5 });
 
-        AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3);
+        AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot);
 
         var gff = GffReader.Read(filePath);
         var creatureList = gff.RootStruct.GetField("Creature List")?.Value as GffList;
@@ -439,7 +441,7 @@ public class AreaScanServiceTests : IDisposable
     {
         var utcPath = CreateUtcFile("bandit001", 5);
 
-        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3);
+        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot);
 
         Assert.Equal(1, result.BlueprintsReindexed);
         Assert.Equal(3u, ReadUtcFactionId(utcPath));
@@ -450,7 +452,7 @@ public class AreaScanServiceTests : IDisposable
     {
         var utcPath = CreateUtcFile("guard001", 7);
 
-        AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3);
+        AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot);
 
         Assert.Equal(6u, ReadUtcFactionId(utcPath));
     }
@@ -460,7 +462,7 @@ public class AreaScanServiceTests : IDisposable
     {
         var utcPath = CreateUtcFile("merchant001", 2);
 
-        AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3);
+        AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot);
 
         Assert.Equal(2u, ReadUtcFactionId(utcPath));
     }
@@ -471,7 +473,7 @@ public class AreaScanServiceTests : IDisposable
         var gitPath = CreateGitFile("area001", new uint[] { 5 });
         var utcPath = CreateUtcFile("bandit001", 5);
 
-        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3);
+        var result = AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot);
 
         Assert.Equal(1, result.CreaturesReindexed);
         Assert.Equal(1, result.BlueprintsReindexed);
@@ -485,7 +487,7 @@ public class AreaScanServiceTests : IDisposable
     {
         var utcPath = CreateUtcFile("bandit001", 5);
 
-        AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3);
+        AreaScanService.ReindexFactions(_testDirectory, deletedIndex: 5, parentFactionId: 3, backupRoot: _backupRoot);
 
         var gff = GffReader.Read(utcPath);
         var field = gff.RootStruct.GetField("FactionID");

--- a/Trebuchet/Trebuchet.Tests/FactionEditorReindexTests.cs
+++ b/Trebuchet/Trebuchet.Tests/FactionEditorReindexTests.cs
@@ -15,11 +15,17 @@ public class FactionEditorReindexTests : IDisposable
     private readonly string _testDirectory;
     private readonly FactionEditorViewModel _viewModel;
 
+    private readonly string _backupRoot;
+
     public FactionEditorReindexTests()
     {
         _testDirectory = Path.Combine(Path.GetTempPath(), $"FactionReindexTest_{Guid.NewGuid():N}");
         Directory.CreateDirectory(_testDirectory);
-        _viewModel = new FactionEditorViewModel();
+        _backupRoot = Path.Combine(_testDirectory, "_Backups");
+        _viewModel = new FactionEditorViewModel
+        {
+            BackupRootOverride = _backupRoot
+        };
     }
 
     public void Dispose()

--- a/Trebuchet/Trebuchet.Tests/ModulePackServiceTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ModulePackServiceTests.cs
@@ -103,6 +103,46 @@ public class ModulePackServiceTests : IDisposable
     }
 
     [Fact]
+    public void PackDirectoryToMod_InjectedReaderThrows_LeavesPreviousModIntact()
+    {
+        // Deterministic equivalent of the locked-source-file scenario without
+        // relying on OS file-lock semantics (Windows shares reads liberally).
+        WriteScript("good01", "void main() {}");
+        WriteScript("good02", "void main() {}");
+        WriteScript("bad01", "void main() {}");
+        var marker = MakeMarkerModBytes();
+        File.WriteAllBytes(_modPath, marker);
+
+        var failingReader = new ThrowOnNameReader(failOnFileNameContaining: "bad01");
+
+        var ex = Record.Exception(() =>
+            ModulePackService.PackDirectoryToMod(_workingDir, _modPath, _backupRoot, failingReader));
+
+        Assert.NotNull(ex);
+        Assert.IsType<IOException>(ex);
+        // Prior .mod untouched
+        Assert.Equal(marker, File.ReadAllBytes(_modPath));
+        // No .tmp leftover
+        var tempFiles = Directory.GetFiles(Path.GetDirectoryName(_modPath)!, "*.tmp");
+        Assert.Empty(tempFiles);
+    }
+
+    private sealed class ThrowOnNameReader : IFileBytesReader
+    {
+        private readonly string _failOnFileNameContaining;
+        public ThrowOnNameReader(string failOnFileNameContaining)
+        {
+            _failOnFileNameContaining = failOnFileNameContaining;
+        }
+        public byte[] ReadAllBytes(string path)
+        {
+            if (Path.GetFileName(path).Contains(_failOnFileNameContaining, StringComparison.OrdinalIgnoreCase))
+                throw new IOException($"Simulated read failure for {Path.GetFileName(path)}");
+            return File.ReadAllBytes(path);
+        }
+    }
+
+    [Fact]
     public void PackDirectoryToMod_RoundTrip_ProducesValidErf()
     {
         WriteScript("nw_s0_test", "void main() {}");

--- a/Trebuchet/Trebuchet.Tests/ModulePackServiceTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ModulePackServiceTests.cs
@@ -1,0 +1,117 @@
+using Radoub.Formats.Erf;
+using RadoubLauncher.Services;
+
+namespace Trebuchet.Tests;
+
+/// <summary>
+/// Tests for ModulePackService — atomic .mod write + backup of prior .mod.
+/// Regression: #2246 (crash mid-pack used to destroy the only .mod copy).
+/// </summary>
+public class ModulePackServiceTests : IDisposable
+{
+    private readonly string _workingDir;
+    private readonly string _modPath;
+    private readonly string _backupRoot;
+
+    public ModulePackServiceTests()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"ModulePackTest_{Guid.NewGuid():N}");
+        _workingDir = Path.Combine(root, "mymodule");
+        Directory.CreateDirectory(_workingDir);
+        _modPath = Path.Combine(root, "mymodule.mod");
+        _backupRoot = Path.Combine(root, "Backups");
+    }
+
+    public void Dispose()
+    {
+        var root = Path.GetDirectoryName(_workingDir);
+        if (root != null)
+        {
+            try { Directory.Delete(root, true); } catch { }
+        }
+    }
+
+    private void WriteScript(string resRef, string body)
+    {
+        File.WriteAllText(Path.Combine(_workingDir, resRef + ".nss"), body);
+    }
+
+    private static byte[] MakeMarkerModBytes() => System.Text.Encoding.ASCII.GetBytes("ORIGINAL_MOD_CONTENT_DO_NOT_OVERWRITE");
+
+    [Fact]
+    public void PackDirectoryToMod_Success_WritesAtomicallyAndBacksUpPriorMod()
+    {
+        WriteScript("nw_s0_test", "void main() {}");
+        WriteScript("nw_s1_test", "void main() {}");
+        var marker = MakeMarkerModBytes();
+        File.WriteAllBytes(_modPath, marker);
+
+        var count = ModulePackService.PackDirectoryToMod(_workingDir, _modPath, _backupRoot);
+
+        Assert.True(count >= 2);
+        Assert.True(File.Exists(_modPath));
+        var written = File.ReadAllBytes(_modPath);
+        Assert.NotEqual(marker, written); // .mod was replaced
+
+        // Backup of prior .mod present
+        var backupModuleDir = Path.Combine(_backupRoot, "mymodule");
+        Assert.True(Directory.Exists(backupModuleDir));
+        var backupFiles = Directory.GetFiles(backupModuleDir, "mymodule.mod", SearchOption.AllDirectories);
+        Assert.NotEmpty(backupFiles);
+        Assert.Equal(marker, File.ReadAllBytes(backupFiles[0]));
+    }
+
+    [Fact]
+    public void PackDirectoryToMod_UnreadableSourceFile_LeavesPreviousModIntact()
+    {
+        WriteScript("nw_s0_test", "void main() {}");
+        var lockedPath = Path.Combine(_workingDir, "locked.nss");
+        File.WriteAllText(lockedPath, "void main() {}");
+        var marker = MakeMarkerModBytes();
+        File.WriteAllBytes(_modPath, marker);
+
+        using var lockStream = new FileStream(lockedPath, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        var ex = Record.Exception(() => ModulePackService.PackDirectoryToMod(_workingDir, _modPath, _backupRoot));
+
+        Assert.NotNull(ex);
+        Assert.True(File.Exists(_modPath));
+        Assert.Equal(marker, File.ReadAllBytes(_modPath)); // .mod NOT destroyed
+    }
+
+    [Fact]
+    public void PackDirectoryToMod_NoPreExistingMod_StillWritesNewMod()
+    {
+        WriteScript("nw_s0_test", "void main() {}");
+        Assert.False(File.Exists(_modPath));
+
+        var count = ModulePackService.PackDirectoryToMod(_workingDir, _modPath, _backupRoot);
+
+        Assert.True(count >= 1);
+        Assert.True(File.Exists(_modPath));
+    }
+
+    [Fact]
+    public void PackDirectoryToMod_TempFileCleanedUp_AfterSuccessfulWrite()
+    {
+        WriteScript("nw_s0_test", "void main() {}");
+
+        ModulePackService.PackDirectoryToMod(_workingDir, _modPath, _backupRoot);
+
+        var tempFiles = Directory.GetFiles(Path.GetDirectoryName(_modPath)!, "*.tmp");
+        Assert.Empty(tempFiles);
+    }
+
+    [Fact]
+    public void PackDirectoryToMod_RoundTrip_ProducesValidErf()
+    {
+        WriteScript("nw_s0_test", "void main() {}");
+        WriteScript("nw_s1_other", "void main() {}");
+
+        ModulePackService.PackDirectoryToMod(_workingDir, _modPath, _backupRoot);
+
+        var erf = ErfReader.Read(_modPath);
+        Assert.Equal("MOD ", erf.FileType);
+        Assert.Equal(2, erf.Resources.Count);
+    }
+}

--- a/Trebuchet/Trebuchet/Services/AreaScanService.cs
+++ b/Trebuchet/Trebuchet/Services/AreaScanService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Radoub.Formats.Gff;
 using Radoub.Formats.Logging;
+using Radoub.UI.Services.Search;
 
 namespace RadoubLauncher.Services;
 
@@ -142,13 +143,21 @@ public static class AreaScanService
     /// <param name="workingDirectory">Module working directory containing .git/.utc files</param>
     /// <param name="deletedIndex">Index of the faction being deleted</param>
     /// <param name="parentFactionId">FactionParentID of the deleted faction (for reassignment)</param>
+    /// <param name="backupRoot">
+    /// Optional override for backup root (tests). Default is ~/Radoub/Backups/.
+    /// Backups snapshot every modified .git/.utc file before mutation (#2246).
+    /// </param>
     /// <returns>Summary of changes made</returns>
-    public static ReindexResult ReindexFactions(string? workingDirectory, uint deletedIndex, uint parentFactionId)
+    public static ReindexResult ReindexFactions(string? workingDirectory, uint deletedIndex, uint parentFactionId, string? backupRoot = null)
     {
         var result = new ReindexResult();
 
         if (string.IsNullOrEmpty(workingDirectory))
             return result;
+
+        var backupService = new BackupService(backupRoot);
+        var moduleName = Path.GetFileName(workingDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        if (string.IsNullOrEmpty(moduleName)) moduleName = "module";
 
         // Determine the effective reassignment target.
         // If parent is also above deleted index, it needs decrementing too.
@@ -169,10 +178,10 @@ public static class AreaScanService
         }
 
         // Reindex .git files (area creature/encounter instances)
-        ReindexGitFiles(workingDirectory, deletedIndex, reassignTarget, result);
+        ReindexGitFiles(workingDirectory, deletedIndex, reassignTarget, result, backupService, moduleName);
 
         // Reindex .utc files (creature blueprints)
-        ReindexUtcFiles(workingDirectory, deletedIndex, reassignTarget, result);
+        ReindexUtcFiles(workingDirectory, deletedIndex, reassignTarget, result, backupService, moduleName);
 
         UnifiedLogger.LogApplication(LogLevel.INFO,
             $"Faction reindex complete: {result.FilesScanned} files scanned, {result.FilesModified} modified, " +
@@ -183,7 +192,7 @@ public static class AreaScanService
     }
 
     private static void ReindexGitFiles(string workingDirectory, uint deletedIndex,
-        uint reassignTarget, ReindexResult result)
+        uint reassignTarget, ReindexResult result, BackupService backupService, string moduleName)
     {
         var gitFiles = FindGitFiles(workingDirectory);
         result.FilesScanned += gitFiles.Length;
@@ -247,7 +256,7 @@ public static class AreaScanService
 
                 if (fileModified)
                 {
-                    GffWriter.Write(gff, filePath);
+                    SafeWriteGff(gff, filePath, backupService, moduleName);
                     result.FilesModified++;
                     UnifiedLogger.LogApplication(LogLevel.INFO,
                         $"Reindexed factions in {Path.GetFileName(filePath)}");
@@ -263,7 +272,7 @@ public static class AreaScanService
     }
 
     private static void ReindexUtcFiles(string workingDirectory, uint deletedIndex,
-        uint reassignTarget, ReindexResult result)
+        uint reassignTarget, ReindexResult result, BackupService backupService, string moduleName)
     {
         var utcFiles = FindUtcFiles(workingDirectory);
         result.FilesScanned += utcFiles.Length;
@@ -293,7 +302,7 @@ public static class AreaScanService
 
                 if (modified)
                 {
-                    GffWriter.Write(gff, filePath);
+                    SafeWriteGff(gff, filePath, backupService, moduleName);
                     result.FilesModified++;
                     UnifiedLogger.LogApplication(LogLevel.INFO,
                         $"Reindexed faction in blueprint {Path.GetFileName(filePath)}");
@@ -304,6 +313,42 @@ public static class AreaScanService
                 UnifiedLogger.LogApplication(LogLevel.ERROR,
                     $"Failed to reindex faction in {Path.GetFileName(filePath)}: {ex.Message}");
                 result.Errors.Add($"{Path.GetFileName(filePath)}: {ex.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Snapshot the existing file via BackupService, then write the modified GFF
+    /// to a temp sibling and atomically rename. A crash between Phase 1 (backup)
+    /// and Phase 3 (replace) leaves the original on disk; recovery is from the
+    /// snapshot. Issue #2246.
+    /// </summary>
+    private static void SafeWriteGff(GffFile gff, string filePath, BackupService backupService, string moduleName)
+    {
+        // Snapshot the prior file before we touch it.
+        try
+        {
+            backupService.BackupArchiveAsync(filePath, moduleName).GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            // Log loudly but do not abort — the atomic write below still
+            // protects against mid-write corruption.
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"Pre-reindex backup failed for {Path.GetFileName(filePath)}: {ex.Message}");
+        }
+
+        var tempPath = filePath + ".tmp";
+        try
+        {
+            GffWriter.Write(gff, tempPath);
+            File.Move(tempPath, filePath, overwrite: true);
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+            {
+                try { File.Delete(tempPath); } catch { /* swallow cleanup failure */ }
             }
         }
     }

--- a/Trebuchet/Trebuchet/Services/AreaScanService.cs
+++ b/Trebuchet/Trebuchet/Services/AreaScanService.cs
@@ -325,10 +325,15 @@ public static class AreaScanService
     /// </summary>
     private static void SafeWriteGff(GffFile gff, string filePath, BackupService backupService, string moduleName)
     {
-        // Snapshot the prior file before we touch it.
+        // Snapshot the prior file before we touch it. Wrap in Task.Run because
+        // BackupService.BackupArchiveAsync awaits without ConfigureAwait(false)
+        // and ReindexFactions is called on the UI thread from
+        // FactionEditorViewModel — a direct .GetAwaiter().GetResult() deadlocks
+        // when the continuation tries to resume on the captured sync context.
         try
         {
-            backupService.BackupArchiveAsync(filePath, moduleName).GetAwaiter().GetResult();
+            System.Threading.Tasks.Task.Run(() =>
+                backupService.BackupArchiveAsync(filePath, moduleName)).GetAwaiter().GetResult();
         }
         catch (Exception ex)
         {

--- a/Trebuchet/Trebuchet/Services/ModulePackService.cs
+++ b/Trebuchet/Trebuchet/Services/ModulePackService.cs
@@ -9,6 +9,22 @@ using Radoub.UI.Services.Search;
 namespace RadoubLauncher.Services;
 
 /// <summary>
+/// Reads a file's bytes. Production uses File.ReadAllBytes; tests inject a
+/// fake to deterministically force read failures without OS-level file
+/// locking gymnastics (Windows shares reads liberally, so simulating an
+/// unreadable file via FileShare.None is unreliable across editors / AVs).
+/// </summary>
+public interface IFileBytesReader
+{
+    byte[] ReadAllBytes(string path);
+}
+
+internal sealed class SystemFileBytesReader : IFileBytesReader
+{
+    public byte[] ReadAllBytes(string path) => File.ReadAllBytes(path);
+}
+
+/// <summary>
 /// Packs a working directory back into a .mod (or .erf) archive with safe-write
 /// guarantees:
 ///   1. Pre-read every source file into memory before any write begins — a
@@ -28,12 +44,17 @@ public static class ModulePackService
     /// <param name="backupRoot">
     /// Optional override for backup root (tests). Default is ~/Radoub/Backups/.
     /// </param>
+    /// <param name="fileReader">
+    /// Optional injection seam for the pre-read pass. Null = real filesystem.
+    /// Tests inject a fake to force deterministic read failures.
+    /// </param>
     /// <returns>Resource count written.</returns>
-    public static int PackDirectoryToMod(string workingDir, string modFilePath, string? backupRoot = null)
+    public static int PackDirectoryToMod(string workingDir, string modFilePath, string? backupRoot = null, IFileBytesReader? fileReader = null)
     {
         if (string.IsNullOrEmpty(workingDir)) throw new ArgumentException("workingDir required", nameof(workingDir));
         if (string.IsNullOrEmpty(modFilePath)) throw new ArgumentException("modFilePath required", nameof(modFilePath));
 
+        var reader = fileReader ?? new SystemFileBytesReader();
         var files = Directory.GetFiles(workingDir);
         var resourceData = new Dictionary<(string ResRef, ushort Type), byte[]>();
         var resources = new List<ErfResourceEntry>();
@@ -48,7 +69,7 @@ public static class ModulePackService
                 continue;
 
             var resRef = Path.GetFileNameWithoutExtension(filePath);
-            var data = File.ReadAllBytes(filePath);
+            var data = reader.ReadAllBytes(filePath);
             var key = (resRef.ToLowerInvariant(), resourceType);
 
             resourceData[key] = data;

--- a/Trebuchet/Trebuchet/Services/ModulePackService.cs
+++ b/Trebuchet/Trebuchet/Services/ModulePackService.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Radoub.Formats.Common;
+using Radoub.Formats.Erf;
+using Radoub.Formats.Logging;
+using Radoub.UI.Services.Search;
+
+namespace RadoubLauncher.Services;
+
+/// <summary>
+/// Packs a working directory back into a .mod (or .erf) archive with safe-write
+/// guarantees:
+///   1. Pre-read every source file into memory before any write begins — a
+///      locked/unreadable input fails fast and leaves the prior .mod intact.
+///   2. Snapshot the prior .mod to ~/Radoub/Backups/&lt;modname&gt;/&lt;timestamp&gt;/
+///      before touching it (issue #2246).
+///   3. Write to a sibling .tmp then atomic File.Replace, so a crash mid-write
+///      cannot destroy the user's only .mod copy.
+/// </summary>
+public static class ModulePackService
+{
+    /// <summary>
+    /// Pack a working directory into a .mod file.
+    /// </summary>
+    /// <param name="workingDir">Directory holding the unpacked module resources.</param>
+    /// <param name="modFilePath">Destination .mod (or .erf) path.</param>
+    /// <param name="backupRoot">
+    /// Optional override for backup root (tests). Default is ~/Radoub/Backups/.
+    /// </param>
+    /// <returns>Resource count written.</returns>
+    public static int PackDirectoryToMod(string workingDir, string modFilePath, string? backupRoot = null)
+    {
+        if (string.IsNullOrEmpty(workingDir)) throw new ArgumentException("workingDir required", nameof(workingDir));
+        if (string.IsNullOrEmpty(modFilePath)) throw new ArgumentException("modFilePath required", nameof(modFilePath));
+
+        var files = Directory.GetFiles(workingDir);
+        var resourceData = new Dictionary<(string ResRef, ushort Type), byte[]>();
+        var resources = new List<ErfResourceEntry>();
+
+        // Phase 1 — pre-read every file. A read failure here throws BEFORE any
+        // destructive write, so the prior .mod stays intact. Issue #2246.
+        foreach (var filePath in files)
+        {
+            var extension = Path.GetExtension(filePath);
+            var resourceType = ResourceTypes.FromExtension(extension);
+            if (resourceType == ResourceTypes.Invalid)
+                continue;
+
+            var resRef = Path.GetFileNameWithoutExtension(filePath);
+            var data = File.ReadAllBytes(filePath);
+            var key = (resRef.ToLowerInvariant(), resourceType);
+
+            resourceData[key] = data;
+            resources.Add(new ErfResourceEntry
+            {
+                ResRef = resRef,
+                ResourceType = resourceType,
+                ResId = (uint)resources.Count
+            });
+        }
+
+        var erf = new ErfFile
+        {
+            FileType = "MOD ",
+            FileVersion = "V1.0",
+            BuildYear = (uint)(DateTime.Now.Year - 1900),
+            BuildDay = (uint)DateTime.Now.DayOfYear
+        };
+        erf.Resources.AddRange(resources);
+
+        // Phase 2 — snapshot prior .mod if one exists.
+        if (File.Exists(modFilePath))
+        {
+            try
+            {
+                var moduleName = Path.GetFileNameWithoutExtension(modFilePath);
+                var backupService = new BackupService(backupRoot);
+                // BackupService is async-only; block here because the pack
+                // pipeline is already running on a Task.Run worker.
+                backupService.BackupArchiveAsync(modFilePath, moduleName).GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                // Backup failure must NOT abort the pack — but log loudly.
+                UnifiedLogger.LogApplication(LogLevel.WARN,
+                    $"Pre-pack backup failed for {UnifiedLogger.SanitizePath(modFilePath)}: {ex.Message}");
+            }
+        }
+
+        // Phase 3 — write via temp + atomic replace.
+        var tempPath = modFilePath + ".tmp";
+        try
+        {
+            ErfWriter.Write(erf, tempPath, resourceData);
+
+            if (File.Exists(modFilePath))
+            {
+                // overwrite:true required because target exists.
+                File.Move(tempPath, modFilePath, overwrite: true);
+            }
+            else
+            {
+                File.Move(tempPath, modFilePath);
+            }
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+            {
+                try { File.Delete(tempPath); } catch { /* swallow cleanup failure */ }
+            }
+        }
+
+        return resources.Count;
+    }
+}

--- a/Trebuchet/Trebuchet/Services/ModulePackService.cs
+++ b/Trebuchet/Trebuchet/Services/ModulePackService.cs
@@ -76,9 +76,13 @@ public static class ModulePackService
             {
                 var moduleName = Path.GetFileNameWithoutExtension(modFilePath);
                 var backupService = new BackupService(backupRoot);
-                // BackupService is async-only; block here because the pack
-                // pipeline is already running on a Task.Run worker.
-                backupService.BackupArchiveAsync(modFilePath, moduleName).GetAwaiter().GetResult();
+                // Wrap in Task.Run so this works whether the caller is on a
+                // worker thread (Build flow) or the UI thread (future direct
+                // callers / tests). BackupService awaits without
+                // ConfigureAwait(false), so a bare .GetAwaiter().GetResult()
+                // would deadlock on the captured sync context.
+                System.Threading.Tasks.Task.Run(() =>
+                    backupService.BackupArchiveAsync(modFilePath, moduleName)).GetAwaiter().GetResult();
             }
             catch (Exception ex)
             {

--- a/Trebuchet/Trebuchet/ViewModels/FactionEditorViewModel.cs
+++ b/Trebuchet/Trebuchet/ViewModels/FactionEditorViewModel.cs
@@ -136,6 +136,13 @@ public partial class FactionEditorViewModel : ObservableObject
     private string? _workingDirectoryPath;
     private bool _isReadOnly;
 
+    /// <summary>
+    /// Test seam: override the BackupService root used by faction reindex so
+    /// unit tests don't write to the real ~/Radoub/Backups/ profile directory.
+    /// Null in production (production uses BackupService default).
+    /// </summary>
+    internal string? BackupRootOverride { get; set; }
+
     public ObservableCollection<FactionViewModel> Factions { get; } = new();
 
     [ObservableProperty]
@@ -533,7 +540,7 @@ public partial class FactionEditorViewModel : ObservableObject
         try
         {
             var result = Services.AreaScanService.ReindexFactions(
-                _workingDirectoryPath, deletedIndex, parentFactionId);
+                _workingDirectoryPath, deletedIndex, parentFactionId, BackupRootOverride);
 
             if (result.HasErrors)
             {

--- a/Trebuchet/Trebuchet/ViewModels/MainWindowViewModel.Build.cs
+++ b/Trebuchet/Trebuchet/ViewModels/MainWindowViewModel.Build.cs
@@ -111,7 +111,7 @@ public partial class MainWindowViewModel
 
             // Pack the module
             BuildStatusText = "Packing module...";
-            var resourceCount = await Task.Run(() => PackDirectoryToMod(workingDir, modFilePath));
+            var resourceCount = await Task.Run(() => ModulePackService.PackDirectoryToMod(workingDir, modFilePath));
 
             UnifiedLogger.LogApplication(LogLevel.INFO,
                 $"Built {resourceCount} resources to {UnifiedLogger.SanitizePath(modFilePath)}");
@@ -366,7 +366,7 @@ public partial class MainWindowViewModel
 
                 if (!string.IsNullOrEmpty(workingDir) && !string.IsNullOrEmpty(modFilePath))
                 {
-                    var resourceCount = await Task.Run(() => PackDirectoryToMod(workingDir, modFilePath));
+                    var resourceCount = await Task.Run(() => ModulePackService.PackDirectoryToMod(workingDir, modFilePath));
                     BuildStatusText = $"Built {resourceCount} files to {Path.GetFileName(modFilePath)}";
                     StaleScriptCount = 0;
                     IsModuleDirty = false;
@@ -456,55 +456,4 @@ public partial class MainWindowViewModel
         StaleScriptCount = staleScripts.Count;
     }
 
-    /// <summary>
-    /// Pack a working directory into a .mod file.
-    /// </summary>
-    private static int PackDirectoryToMod(string workingDir, string modFilePath)
-    {
-        // Collect all files from working directory
-        var files = Directory.GetFiles(workingDir);
-        var resourceData = new Dictionary<(string ResRef, ushort Type), byte[]>();
-        var resources = new List<ErfResourceEntry>();
-
-        foreach (var filePath in files)
-        {
-            var fileName = Path.GetFileName(filePath);
-            var extension = Path.GetExtension(filePath);
-            var resRef = Path.GetFileNameWithoutExtension(filePath);
-
-            // Get resource type from extension
-            var resourceType = ResourceTypes.FromExtension(extension);
-            if (resourceType == ResourceTypes.Invalid)
-            {
-                // Skip unknown file types
-                continue;
-            }
-
-            var data = File.ReadAllBytes(filePath);
-            var key = (resRef.ToLowerInvariant(), resourceType);
-
-            resourceData[key] = data;
-            resources.Add(new ErfResourceEntry
-            {
-                ResRef = resRef,
-                ResourceType = resourceType,
-                ResId = (uint)resources.Count
-            });
-        }
-
-        // Create ERF structure
-        var erf = new ErfFile
-        {
-            FileType = "MOD ",
-            FileVersion = "V1.0",
-            BuildYear = (uint)(DateTime.Now.Year - 1900),
-            BuildDay = (uint)DateTime.Now.DayOfYear
-        };
-        erf.Resources.AddRange(resources);
-
-        // Write to .mod file
-        ErfWriter.Write(erf, modFilePath, resourceData);
-
-        return resources.Count;
-    }
 }


### PR DESCRIPTION
## Summary

Hardens destructive write paths in Trebuchet against crash / locked-file / I/O failure mid-write:

- `PackDirectoryToMod` (Build.cs:462-509) — pre-read all source files into memory before any write; snapshot `.mod` to `~/Radoub/Backups/<modname>/<timestamp>/` via shared `BackupService`; write to `<modFilePath>.tmp` then `File.Replace` atomically
- `RecompileSelectedScripts` (Build.cs:369) — same path via the new `ModulePackService` (extracted from the private static)
- `ReindexGitFiles` / `ReindexUtcFiles` (AreaScanService.cs:185-262) — per-file snapshot to `~/Radoub/Backups/`, write to `.tmp`, atomic rename
- Pre-read pass with per-file error handling so a single unreadable file aborts safely before any destructive write

## Additional fixes in this PR

- **UI-thread deadlock on faction delete** (commit `db45f220`). `BackupService.BackupArchiveAsync` awaits without `ConfigureAwait(false)`; calling `.GetAwaiter().GetResult()` from `FactionEditorViewModel` (UI thread) hardlocked Trebuchet because the continuation could never resume on the captured Avalonia sync context. Both call sites now wrap in `Task.Run` so the continuation runs on a thread-pool worker. Regression test `ReindexFactions_OnSingleThreadedSyncContext_DoesNotDeadlock` installs a single-threaded `SynchronizationContext` with a 10-second timeout.
- **Test isolation from real user profile** (commit `3bcc9df3`). All `AreaScanService` reindex tests and the `FactionEditorViewModel` reindex tests now route backups to a per-test temp directory via a new `internal BackupRootOverride` test seam, so the suite no longer writes to `~/Radoub/Backups/` on every run.
- **Deterministic pack-failure test** (commit `4f5d657a`). New `IFileBytesReader` injection seam in `ModulePackService` lets tests force read failures without OS file-lock gymnastics (Windows shares reads liberally). Original `FileShare.None`-based test kept as belt-and-suspenders for the real OS path.

## Backups

Snapshots land at `~/Radoub/Backups/<modname>/<yyyyMMdd_HHmmss>/` — the same shape `BackupCleanupService` walks, so they age out under the existing retention slider (default 30 days, Trebuchet Settings) and are wiped by "Delete All Backups" and counted in the size summary. Configurable backup location, retention default of 5 days, and a disable toggle for git-managed modules tracked separately in #2282.

## Tests

- 211/211 Trebuchet unit tests pass
- Privacy scan: PASS (no hardcoded paths)
- Tech-debt scan: PASS (no files >800 lines)
- Theme scan: PASS

## Related Issues

- Closes #2246
- Follow-up: #2282 (configurable backup location / retention / opt-out)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)