### PR TITLE
[Relique] Sprint: Critical lock + HAK cache fixes (#2257, #2261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.1.60-alpha] - 2026-05-28
+**Branch**: `relique/issue-2257-2261` | **PR**: #2283
+
+### Fix: Stale HAK cache + ItemBrowserPanel HAK scan asymmetry (#2261)
+
+- `SharedPaletteCacheService.HasValidSourceCache` and `LoadSourceCache` now invalidate HAK caches when the underlying HAK file no longer exists; previously deleted HAKs left their caches marked valid forever, producing ghost browser entries no extraction path could resolve. Affects every tool consuming `ISharedPaletteCacheService` (Relique, Fence, Quartermaster).
+- `ItemBrowserPanel.LoadHakItemsAsync` now resolves HAK paths through `ModuleHakResolver` instead of scanning every HAK in the module + NWN/hak folders, matching `StoreBrowserPanel` and `CreatureBrowserPanel`. Eliminates slow Relique cold starts on large HAK collections (CEP, PRC) and removes irrelevant items from the item browser. Tool-specific notes in [Relique CHANGELOG](Relique/CHANGELOG.md#01020-alpha--2026-05-28).
+
+---
+
 ## [Radoub.Formats 0.2.61-alpha] - 2026-05-27
 **Branch**: `quartermaster/issue-2249` | **PR**: #2275
 

--- a/Radoub.UI/Radoub.UI.Tests/SharedPaletteCacheServiceTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/SharedPaletteCacheServiceTests.cs
@@ -183,6 +183,41 @@ public class SharedPaletteCacheServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task HasValidSourceCache_Hak_ReturnsFalse_WhenHakFileDeleted()
+    {
+        // #2261 — deleted HAK must invalidate its cache. Previously fell through to return true.
+        var hakPath = Path.Combine(_testCacheDir, "ephemeral.hak");
+        File.WriteAllText(hakPath, "original");
+        var modTime = File.GetLastWriteTimeUtc(hakPath);
+
+        await _service.SaveSourceCacheAsync("hak", CreateTestItems(),
+            validationPath: hakPath, sourceModified: modTime);
+        Assert.True(_service.HasValidSourceCache("hak", hakPath));
+
+        // Delete the underlying HAK
+        File.Delete(hakPath);
+
+        // Cache must report invalid now — otherwise ghost entries forever
+        Assert.False(_service.HasValidSourceCache("hak", hakPath));
+    }
+
+    [Fact]
+    public async Task LoadSourceCache_Hak_ReturnsNull_WhenHakFileDeleted()
+    {
+        // #2261 — LoadSourceCache must also check source existence for HAKs.
+        var hakPath = Path.Combine(_testCacheDir, "ephemeral_load.hak");
+        File.WriteAllText(hakPath, "original");
+
+        await _service.SaveSourceCacheAsync("hak", CreateTestItems(),
+            validationPath: hakPath, sourceModified: File.GetLastWriteTimeUtc(hakPath));
+        Assert.NotNull(_service.LoadSourceCache("hak", hakPath));
+
+        File.Delete(hakPath);
+
+        Assert.Null(_service.LoadSourceCache("hak", hakPath));
+    }
+
+    [Fact]
     public async Task HasValidSourceCache_ReturnsFalse_WhenCacheFileCorrupted()
     {
         await _service.SaveSourceCacheAsync("bif", CreateTestItems(), validationPath: "/path");

--- a/Radoub.UI/Radoub.UI/Controls/ItemBrowserPanel.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ItemBrowserPanel.cs
@@ -8,6 +8,7 @@ using Avalonia.Controls;
 using Radoub.Formats.Common;
 using Radoub.Formats.Erf;
 using Radoub.Formats.Logging;
+using Radoub.Formats.Resolver;
 using Radoub.Formats.Services;
 using Radoub.Formats.Settings;
 using Radoub.UI.Services;
@@ -562,34 +563,26 @@ public class ItemBrowserPanel : FileBrowserPanelBase, IBrowserRowRefresher
         {
             _hakItems.Clear();
 
-            var hakPaths = new List<string>();
-
-            if (!string.IsNullOrEmpty(ModulePath) && Directory.Exists(ModulePath))
+            // Restrict to module-referenced HAKs only — match StoreBrowserPanel / CreatureBrowserPanel (#2261)
+            if (string.IsNullOrEmpty(ModulePath) || !Directory.Exists(ModulePath))
             {
-                hakPaths.AddRange(GetHakFilesFromPath(ModulePath));
-            }
-
-            var userPath = RadoubSettings.Instance.NeverwinterNightsPath;
-            if (!string.IsNullOrEmpty(userPath) && Directory.Exists(userPath))
-            {
-                var hakFolder = Path.Combine(userPath, "hak");
-                if (Directory.Exists(hakFolder))
-                {
-                    hakPaths.AddRange(GetHakFilesFromPath(hakFolder));
-                }
-            }
-
-            hakPaths = hakPaths.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
-
-            if (hakPaths.Count == 0)
-            {
-                UnifiedLogger.LogApplication(LogLevel.INFO, "ItemBrowserPanel: No HAK files found to scan");
+                UnifiedLogger.LogApplication(LogLevel.INFO, "ItemBrowserPanel: No module path for HAK scanning");
                 _hakItemsLoaded = true;
                 return;
             }
 
-            ShowLoading($"Scanning {hakPaths.Count} HAK files...");
-            UnifiedLogger.LogApplication(LogLevel.INFO, $"ItemBrowserPanel: Scanning {hakPaths.Count} HAK files");
+            var hakSearchPaths = RadoubSettings.Instance.GetAllHakSearchPaths().ToList();
+            var hakPaths = ModuleHakResolver.ResolveModuleHakPaths(ModulePath, hakSearchPaths);
+
+            if (hakPaths.Count == 0)
+            {
+                UnifiedLogger.LogApplication(LogLevel.INFO, "ItemBrowserPanel: No module-referenced HAK files found");
+                _hakItemsLoaded = true;
+                return;
+            }
+
+            ShowLoading($"Scanning {hakPaths.Count} module HAK files...");
+            UnifiedLogger.LogApplication(LogLevel.INFO, $"ItemBrowserPanel: Scanning {hakPaths.Count} module-referenced HAK files");
 
             for (int i = 0; i < hakPaths.Count; i++)
             {

--- a/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheService.cs
+++ b/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheService.cs
@@ -81,10 +81,17 @@ public class SharedPaletteCacheService : ISharedPaletteCacheService, IDisposable
                 return false;
             }
 
-            // HAK-specific: validate file modification time
+            // HAK-specific: validate that source file still exists, then check mod time. #2261
             if (source.Equals("hak", StringComparison.OrdinalIgnoreCase) &&
-                !string.IsNullOrEmpty(sourcePath) && File.Exists(sourcePath))
+                !string.IsNullOrEmpty(sourcePath))
             {
+                if (!File.Exists(sourcePath))
+                {
+                    UnifiedLogger.LogApplication(LogLevel.INFO,
+                        $"Shared palette HAK cache invalidated - {Path.GetFileName(sourcePath)} missing");
+                    return false;
+                }
+
                 var hakModified = File.GetLastWriteTimeUtc(sourcePath);
                 if (cache.SourceModified != hakModified)
                 {
@@ -109,6 +116,15 @@ public class SharedPaletteCacheService : ISharedPaletteCacheService, IDisposable
         var cacheFile = GetCacheFilePath(source, sourcePath);
         if (!File.Exists(cacheFile))
             return null;
+
+        // HAK source: refuse to return cache for a HAK that no longer exists. #2261
+        if (source.Equals("hak", StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrEmpty(sourcePath) && !File.Exists(sourcePath))
+        {
+            UnifiedLogger.LogApplication(LogLevel.INFO,
+                $"Shared palette HAK cache skipped - {Path.GetFileName(sourcePath)} missing");
+            return null;
+        }
 
         try
         {

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.10.20-alpha] - 2026-05-28
+**Branch**: `relique/issue-2257-2261` | **PR**: #TBD
+
+### Sprint: Critical lock + HAK cache fixes (#2257, #2261)
+
+- File lock leaks on close/delete/open-failure paths + disabled Undo/Redo menu stubs (#2257)
+- Shared HAK cache marked valid forever after HAK deletion; `ItemBrowserPanel` scans every HAK instead of module-referenced subset, unlike sibling Store/Creature panels (#2261)
+
+---
+
 ## [0.10.19-alpha] - 2026-05-26
 **Branch**: `radoub/issue-2244` | **PR**: #2266
 

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.10.20-alpha] - 2026-05-28
-**Branch**: `relique/issue-2257-2261` | **PR**: #TBD
+**Branch**: `relique/issue-2257-2261` | **PR**: #2283
 
 ### Sprint: Critical lock + HAK cache fixes (#2257, #2261)
 

--- a/Relique/Relique/Views/MainWindow.FileOps.cs
+++ b/Relique/Relique/Views/MainWindow.FileOps.cs
@@ -16,16 +16,17 @@ public partial class MainWindow
 
     private async Task<bool> OpenFileAsync(string filePath)
     {
+        // Hold the previous path's lock until the new file is successfully read.
+        // If UtiReader.Read throws we must NOT have orphaned the old lock or kept
+        // a lock on a file we failed to open. (#2257)
+        var previousFilePath = _currentFilePath;
+        var newLockAcquired = false;
+        var newLockIsReadOnly = false;
+
         try
         {
             _isLoading = true;
             UpdateStatus($"Opening {Path.GetFileName(filePath)}...");
-
-            // Release lock on previous file if any
-            if (!string.IsNullOrEmpty(_currentFilePath))
-            {
-                FileSessionLockService.ReleaseLock(_currentFilePath);
-            }
 
             // Reset read-only — about to open a real file from disk (#2106)
             _documentState.IsReadOnly = false;
@@ -39,9 +40,22 @@ public partial class MainWindow
                 UnifiedLogger.LogApplication(LogLevel.WARN, $"File locked by {toolName} — opening read-only: {UnifiedLogger.SanitizePath(filePath)}");
                 UpdateStatus($"File is open in {toolName} — opening read-only");
                 _documentState.IsReadOnly = true;
+                newLockIsReadOnly = true;
+            }
+            else if (lockResult == LockResult.Acquired)
+            {
+                newLockAcquired = true;
             }
 
             var item = UtiReader.Read(filePath);
+
+            // Read succeeded — safe to release the previous file's lock now.
+            if (!string.IsNullOrEmpty(previousFilePath) &&
+                !string.Equals(previousFilePath, filePath, System.StringComparison.OrdinalIgnoreCase))
+            {
+                FileSessionLockService.ReleaseLock(previousFilePath);
+            }
+
             _currentItem = item;
             _currentFilePath = filePath;
             _documentState.ClearDirty();
@@ -76,6 +90,13 @@ public partial class MainWindow
         }
         catch (System.Exception ex)
         {
+            // Release any lock we just acquired on the file we failed to read.
+            // Do NOT touch the previous file's lock — it was never released. (#2257)
+            if (newLockAcquired && !newLockIsReadOnly)
+            {
+                FileSessionLockService.ReleaseLock(filePath);
+            }
+
             UpdateStatus("Error opening file");
             UnifiedLogger.LogApplication(LogLevel.ERROR, $"Failed to open {UnifiedLogger.SanitizePath(filePath)}: {ex.Message}");
             await ShowErrorAsync($"Failed to open file:\n{ex.Message}");

--- a/Relique/Relique/Views/MainWindow.Lifecycle.cs
+++ b/Relique/Relique/Views/MainWindow.Lifecycle.cs
@@ -381,6 +381,14 @@ public partial class MainWindow
         {
             var isDeletingCurrent = string.Equals(_currentFilePath, entry.FilePath, StringComparison.OrdinalIgnoreCase);
 
+            // Release the file session lock before deleting — the lock sidecar lives
+            // next to the file and would otherwise survive the delete, blocking other
+            // tools from editing a recreated file with the same path (#2257).
+            if (isDeletingCurrent && !string.IsNullOrEmpty(_currentFilePath))
+            {
+                Radoub.UI.Services.FileSessionLockService.ReleaseLock(_currentFilePath);
+            }
+
             File.Delete(entry.FilePath);
             UnifiedLogger.LogApplication(LogLevel.INFO, $"Deleted item file: {fileName}");
 

--- a/Relique/Relique/Views/MainWindow.MenuHandlers.cs
+++ b/Relique/Relique/Views/MainWindow.MenuHandlers.cs
@@ -100,6 +100,13 @@ public partial class MainWindow
             _itemViewModel.PropertyChanged -= OnItemPropertyChanged;
         }
 
+        // Release file session lock before clearing the path — otherwise the lock
+        // sidecar persists until window close, blocking other Radoub tools (#2257).
+        if (!string.IsNullOrEmpty(_currentFilePath))
+        {
+            Radoub.UI.Services.FileSessionLockService.ReleaseLock(_currentFilePath);
+        }
+
         _currentItem = null;
         _currentFilePath = null;
         _itemViewModel = null;

--- a/Relique/Relique/Views/MainWindow.axaml
+++ b/Relique/Relique/Views/MainWindow.axaml
@@ -50,9 +50,6 @@
                 <MenuItem Header="E_xit" Click="OnExitClick" InputGesture="Alt+F4"/>
             </MenuItem>
             <MenuItem Header="_Edit">
-                <MenuItem Header="_Undo" InputGesture="Ctrl+Z" IsEnabled="False" ToolTip.Tip="Not yet implemented"/>
-                <MenuItem Header="_Redo" InputGesture="Ctrl+Y" IsEnabled="False" ToolTip.Tip="Not yet implemented"/>
-                <Separator/>
                 <MenuItem Header="_Find..." Click="OnFindClick" InputGesture="Ctrl+F" IsEnabled="{Binding HasFile, ElementName=MainWindowInstance}"/>
                 <MenuItem Header="_Replace..." Click="OnFindReplaceClick" InputGesture="Ctrl+H" IsEnabled="{Binding HasFile, ElementName=MainWindowInstance}"/>
             </MenuItem>


### PR DESCRIPTION
## Summary

Sprint bundling two critical findings from the 2026-05-25 full-codebase review:

- **#2257** — Relique file lock leaks on Close, Delete, and open-failure paths; disabled Undo/Redo menu stubs violate UI Uniformity Checklist (#2231)
- **#2261** — `Radoub.UI/SharedPaletteCacheService.HasValidSourceCache` returns true for deleted HAKs (ghost browser entries forever); `ItemBrowserPanel.LoadHakItemsAsync` scans every HAK in module + NWN/hak folder instead of using `ModuleHakResolver` like `StoreBrowserPanel` / `CreatureBrowserPanel`

## Related Issues

- Closes #2257
- Closes #2261

## Changes

| File | Change |
|------|--------|
| `Radoub.UI/Services/SharedPaletteCacheService.cs` | `HasValidSourceCache` returns false when `source=="hak"` and HAK missing; `LoadSourceCache` rejects the same case |
| `Radoub.UI/Controls/ItemBrowserPanel.cs` | `LoadHakItemsAsync` uses `ModuleHakResolver.ResolveModuleHakPaths` like `StoreBrowserPanel` / `CreatureBrowserPanel` |
| `Radoub.UI/Radoub.UI.Tests/SharedPaletteCacheServiceTests.cs` | 2 new TDD tests for HAK-deleted invalidation paths |
| `Relique/Views/MainWindow.MenuHandlers.cs` | `OnCloseFileClick` releases lock before nulling `_currentFilePath` |
| `Relique/Views/MainWindow.Lifecycle.cs` | `OnItemBrowserFileDeleteRequested` releases lock before `File.Delete` |
| `Relique/Views/MainWindow.FileOps.cs` | `OpenFileAsync` defers prior-lock release until `UtiReader.Read` succeeds; catch releases newly-acquired lock |
| `Relique/Views/MainWindow.axaml` | Disabled Undo/Redo stubs removed per #2231 |
| `Relique/CHANGELOG.md` | Sprint entry `[0.10.20-alpha]` |
| `CHANGELOG.md` (root) | `Radoub.UI 0.1.60-alpha` entry for cross-tool shared-lib fix |

## Pre-Merge Results

| Check | Result |
|-------|--------|
| Privacy scan | ✅ PASS |
| Tech debt (>1000 lines) | ✅ None |
| Tech debt (800-1000 warn) | ✅ None |
| Theme compatibility | ⚠️ 16 pre-existing warnings (none in changed files) |
| Radoub.Formats.Tests | ✅ 1309/1309 |
| Radoub.UI.Tests | ✅ 748/748 (+2 new TDD tests) |
| Radoub.Dictionary.Tests | ✅ 54/54 |
| Relique.Tests | ✅ 375/375 |
| FlaUI integration tests | ⏭️ No Relique tests in `Radoub.IntegrationTests/` yet (gap flagged for future) |
| CHANGELOG (Relique + root) | ✅ Versioned, PR number filled, no `[Unreleased]` |
| Wiki freshness (Relique) | ✅ 3 days old |
| Release notes draft | ✅ Updated |

## Manual Spot-Checks

Lock-leak handler fixes are mechanical line-ordering changes inside `private async void` Avalonia handlers — not unit-testable without extracting a test seam (scope creep). Verify behavior manually:

- [ ] Open UTI in Relique → File → Close. Open same UTI in Trebuchet (or QM inventory). Should NOT be blocked.
- [ ] Open UTI in Relique → delete via browser. Same cross-tool test.
- [ ] Open UTI A → attempt to open invalid/corrupt UTI B → confirm A's lock is released and B's lock is not orphaned.
- [ ] Build palette cache for a HAK → delete the HAK from the module folder → restart Relique → browser must NOT show ghost entries.
- [ ] Open same module in Relique vs Fence with "Show HAK" on → result sets should be consistent (both module-referenced HAKs only).
- [ ] Edit menu in Relique no longer shows greyed-out Undo/Redo entries.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)