### PR TITLE
[Fence] Fix: Modal picker, ContinueWith fault handling, non-atomic save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.Formats 0.2.62-alpha] - 2026-05-29
+**Branch**: `fence/issue-2256` | **PR**: #2306
+
+### Feat: Shared cross-OS atomic file-replace helper (`AtomicFile.Replace`) (#2256)
+
+- New `Radoub.Formats.Common.AtomicFile.Replace(source, dest, backupPath?)` consolidates the write-temp-then-swap pattern with a single `File.Move(overwrite:true)` — atomic on the same volume on Windows (MoveFileEx) and Unix (rename(2)). Optional `.bak` backup, handles the create-new case, and throws on a missing source. `ErfWriter.UpdateResource` and Fence's UTM save now route through it instead of inline rename logic.
+
+---
+
 ## [Radoub.UI 0.1.61-alpha] - 2026-05-28
 **Branch**: `radoub/issue-2262` | **PR**: #2288
 

--- a/Fence/CHANGELOG.md
+++ b/Fence/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.1.36-alpha] - 2026-05-29
-**Branch**: `fence/issue-2256` | **PR**: #TBD
+**Branch**: `fence/issue-2256` | **PR**: #2306
 
 ### Fix: Modal picker, ContinueWith fault handling, non-atomic save (#2256)
 

--- a/Fence/CHANGELOG.md
+++ b/Fence/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.1.36-alpha] - 2026-05-29
+**Branch**: `fence/issue-2256` | **PR**: #TBD
+
+### Fix: Modal picker, ContinueWith fault handling, non-atomic save (#2256)
+
+- File-open flow hardening: guard inventory-population faults so the editor can't get stuck loading, set `IsLoading` before reading, switch save to atomic `File.Replace`, and resolve the modal-vs-non-modal picker inconsistency against Fence's own UI doc.
+
+---
+
 ## [0.1.35-alpha] - 2026-05-26
 **Branch**: `radoub/issue-2244` | **PR**: #2266
 

--- a/Fence/CLAUDE.md
+++ b/Fence/CLAUDE.md
@@ -171,14 +171,24 @@ Follow Quartermaster patterns:
 
 ### Modal vs Non-Modal
 
-**IMPORTANT**: This tool uses non-modal windows exclusively:
+**IMPORTANT**: Informational windows (Settings, About, warnings, notifications) are
+non-modal — they must never block the main window:
 ```csharp
-// ❌ WRONG - blocks main window
+// ❌ WRONG - blocks main window for an info/notification window
 await dialog.ShowDialog(this);
 
 // ✅ CORRECT - non-blocking
 dialog.Show(this);
 ```
+
+**Carve-outs (modal is correct)** — consistent with the root CLAUDE.md UI/UX guidelines:
+
+- **Resource selection pickers** (e.g. `StoreBrowserWindow` open picker) are modal.
+  The open flow has no meaningful work to do until the user picks a file or cancels,
+  and the selection is read back from the closed window. This matches the rest of the
+  toolset's browser pickers.
+- **Destructive-action confirmations** (delete, overwrite) may be modal — the user
+  must answer before the destructive action proceeds.
 
 ---
 

--- a/Fence/Fence/Views/MainWindow.FileOps.cs
+++ b/Fence/Fence/Views/MainWindow.FileOps.cs
@@ -113,9 +113,12 @@ public partial class MainWindow
                 _documentState.IsReadOnly = true;
             }
 
+            // Set IsLoading before the read so any subscriber reacting to the
+            // _currentStore change is already guarded against treating the load as a
+            // user edit (#2256).
+            _documentState.IsLoading = true;
             _currentStore = UtmReader.Read(filePath);
             _currentFilePath = filePath;
-            _documentState.IsLoading = true;
 
             // Infer module path from file location (#1208)
             RadoubSettings.Instance.TryInferModuleFromFile(filePath);
@@ -143,24 +146,47 @@ public partial class MainWindow
             // Scan module directory for loose .uti files
             PopulateModuleItems();
 
-            // Load inventory async to avoid blocking UI during item resolution
+            // Load inventory async to avoid blocking UI during item resolution.
             // Keep IsLoading true until inventory is fully populated to prevent
-            // collection change events from marking the document dirty (#1743)
-            _ = PopulateStoreInventoryAsync(filePath).ContinueWith(_ =>
-            {
-                Avalonia.Threading.Dispatcher.UIThread.Post(() =>
-                {
-                    _documentState.IsLoading = false;
-                    _documentState.ClearDirty();
-                    UpdateTitle();
-                });
-            });
+            // collection change events from marking the document dirty (#1743).
+            // Always clear IsLoading — even if population faults — so the editor
+            // can't get permanently stuck in the loading state (#2256).
+            _ = LoadInventoryAndFinalizeAsync(filePath);
         }
         catch (Exception ex)
         {
             _documentState.IsLoading = false;
             ShowError($"Failed to load file: {ex.Message}");
             UnifiedLogger.LogApplication(LogLevel.ERROR, $"Failed to load store: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Populates the store inventory and finalizes the load state. IsLoading is cleared
+    /// in a finally block so a fault during population can't leave the editor stuck
+    /// loading (no dirty events, ClearDirty never runs) (#2256).
+    /// </summary>
+    private async Task LoadInventoryAndFinalizeAsync(string filePath)
+    {
+        try
+        {
+            await PopulateStoreInventoryAsync(filePath);
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.ERROR,
+                $"Failed to populate store inventory: {ex.Message}");
+            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
+                UpdateStatusBar("Loaded with errors — some inventory items may be missing."));
+        }
+        finally
+        {
+            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                _documentState.IsLoading = false;
+                _documentState.ClearDirty();
+                UpdateTitle();
+            });
         }
     }
 
@@ -314,35 +340,21 @@ public partial class MainWindow
             var resRef = Path.GetFileNameWithoutExtension(filePath).ToLowerInvariant();
             _currentStore.ResRef = resRef;
 
-            // Create backup before overwriting (if file exists)
-            if (File.Exists(filePath))
-            {
-                var bakPath = filePath + ".bak";
-                try
-                {
-                    File.Copy(filePath, bakPath, overwrite: true);
-                }
-                catch (IOException ex)
-                {
-                    UnifiedLogger.LogApplication(LogLevel.WARN, $"Failed to create backup: {ex.Message}");
-                }
-            }
-
-            // Write to temp file first, then atomic replace
+            // Write to a temp file beside the destination (same volume = atomic move),
+            // then swap it into place with the shared cross-OS atomic helper. The helper
+            // backs up the previous file to .bak and performs a single File.Move
+            // (overwrite:true) so the original is never missing mid-save (#2256).
             var tempPath = filePath + ".tmp";
             var store = _currentStore;
             try
             {
                 await Task.Run(() => UtmWriter.Write(store, tempPath));
 
-                // Replace original with temp (atomic on same volume)
-                if (File.Exists(filePath))
-                    File.Delete(filePath);
-                File.Move(tempPath, filePath);
+                Radoub.Formats.Common.AtomicFile.Replace(tempPath, filePath, filePath + ".bak");
             }
             finally
             {
-                // Clean up temp file if it still exists (write failed)
+                // Clean up temp file if it still exists (write failed before the move)
                 if (File.Exists(tempPath))
                 {
                     try { File.Delete(tempPath); }

--- a/Radoub.Formats/Radoub.Formats.Tests/AtomicFileTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/AtomicFileTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.IO;
+using System.Text;
+using Radoub.Formats.Common;
+using Xunit;
+
+namespace Radoub.Formats.Tests;
+
+/// <summary>
+/// Tests for AtomicFile.Replace — the shared cross-OS atomic file-replace helper (#2256).
+///
+/// The helper consolidates the atomic write-then-replace pattern that each tool was
+/// re-solving inline. It must behave correctly on Windows (NTFS) and Unix (POSIX):
+/// File.Move(overwrite:true) maps to MoveFileEx / rename(2), which is atomic on the
+/// same volume on every OS. The race window (process killed mid-rename) cannot be
+/// observed in a synchronous test without a kill harness, so these tests pin the
+/// post-condition contracts that guarantee the success path is correct end-to-end.
+/// </summary>
+public class AtomicFileTests
+{
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "RadoubAtomic_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void Replace_ExistingDestination_GetsSourceContent_SourceConsumed()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var dest = Path.Combine(dir, "store.utm");
+            var source = dest + ".tmp";
+            File.WriteAllText(dest, "OLD");
+            File.WriteAllText(source, "NEW");
+
+            AtomicFile.Replace(source, dest, backupPath: null);
+
+            Assert.True(File.Exists(dest));
+            Assert.Equal("NEW", File.ReadAllText(dest));
+            Assert.False(File.Exists(source), "Source (temp) must be consumed by the move.");
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Replace_DestinationMissing_MovesSourceIntoPlace()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var dest = Path.Combine(dir, "newstore.utm");
+            var source = dest + ".tmp";
+            File.WriteAllText(source, "FIRST");
+
+            // Destination does not exist yet (brand-new file).
+            Assert.False(File.Exists(dest));
+
+            AtomicFile.Replace(source, dest, backupPath: null);
+
+            Assert.True(File.Exists(dest));
+            Assert.Equal("FIRST", File.ReadAllText(dest));
+            Assert.False(File.Exists(source));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Replace_WithBackupPath_BackupContainsPreviousContent()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var dest = Path.Combine(dir, "store.utm");
+            var source = dest + ".tmp";
+            var backup = dest + ".bak";
+            File.WriteAllText(dest, "ORIGINAL");
+            File.WriteAllText(source, "REPLACEMENT");
+
+            AtomicFile.Replace(source, dest, backupPath: backup);
+
+            Assert.Equal("REPLACEMENT", File.ReadAllText(dest));
+            Assert.True(File.Exists(backup), "Backup must be created when destination existed.");
+            Assert.Equal("ORIGINAL", File.ReadAllText(backup));
+            Assert.False(File.Exists(source));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Replace_WithBackupPath_DestinationMissing_NoBackupCreated()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var dest = Path.Combine(dir, "newstore.utm");
+            var source = dest + ".tmp";
+            var backup = dest + ".bak";
+            File.WriteAllText(source, "DATA");
+
+            AtomicFile.Replace(source, dest, backupPath: backup);
+
+            Assert.True(File.Exists(dest));
+            Assert.False(File.Exists(backup), "No backup when there was nothing to back up.");
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Replace_OverwritesExistingBackup()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var dest = Path.Combine(dir, "store.utm");
+            var source = dest + ".tmp";
+            var backup = dest + ".bak";
+            File.WriteAllText(backup, "STALE_BACKUP");
+            File.WriteAllText(dest, "CURRENT");
+            File.WriteAllText(source, "NEXT");
+
+            AtomicFile.Replace(source, dest, backupPath: backup);
+
+            Assert.Equal("CURRENT", File.ReadAllText(backup));
+            Assert.Equal("NEXT", File.ReadAllText(dest));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Replace_MissingSource_Throws()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var dest = Path.Combine(dir, "store.utm");
+            var source = dest + ".tmp"; // never created
+            File.WriteAllText(dest, "EXISTING");
+
+            Assert.Throws<FileNotFoundException>(() =>
+                AtomicFile.Replace(source, dest, backupPath: null));
+
+            // Destination must be untouched on a precondition failure.
+            Assert.Equal("EXISTING", File.ReadAllText(dest));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Replace_NullOrEmptyArguments_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => AtomicFile.Replace("", "dest", null));
+        Assert.Throws<ArgumentException>(() => AtomicFile.Replace("src", "", null));
+        Assert.Throws<ArgumentException>(() => AtomicFile.Replace(null!, "dest", null));
+    }
+
+    [Fact]
+    public void Replace_PreservesBinaryContentExactly()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var dest = Path.Combine(dir, "store.utm");
+            var source = dest + ".tmp";
+            var payload = new byte[] { 0x00, 0xFF, 0xAA, 0x55, 0x01, 0x02, 0x03 };
+            File.WriteAllText(dest, "junk-to-be-replaced");
+            File.WriteAllBytes(source, payload);
+
+            AtomicFile.Replace(source, dest, backupPath: null);
+
+            Assert.Equal(payload, File.ReadAllBytes(dest));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}

--- a/Radoub.Formats/Radoub.Formats/Common/AtomicFile.cs
+++ b/Radoub.Formats/Radoub.Formats/Common/AtomicFile.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+using Radoub.Formats.Logging;
+
+namespace Radoub.Formats.Common;
+
+/// <summary>
+/// Cross-OS atomic file-replace helper (#2256).
+///
+/// Consolidates the "write to temp, then swap into place" pattern that tools were
+/// re-implementing inline (Fence, ErfWriter, ...). The previous inline form —
+/// File.Delete(dest) then File.Move(temp, dest) — opens a window where the
+/// destination is gone if the process dies or the move fails between the two calls.
+///
+/// This helper performs the swap with a single File.Move(temp, dest, overwrite:true),
+/// which is the correct cross-platform atomic primitive:
+///   - Windows: maps to MoveFileEx with MOVEFILE_REPLACE_EXISTING — atomic on NTFS.
+///   - Linux/macOS: maps to rename(2) — atomic POSIX rename.
+/// In both cases the rename is atomic ONLY when source and destination are on the
+/// same volume/filesystem. Callers MUST write the temp file beside the destination
+/// (e.g. dest + ".tmp"), never in the OS temp directory, or the move degrades to a
+/// non-atomic copy+delete across volumes.
+///
+/// File.Replace was deliberately NOT used: on Windows it gives a backup token and
+/// preserves ACLs, but on .NET for Unix it has weaker/edge-case behavior (throws if
+/// the destination is missing, cross-device quirks). File.Move(overwrite:true) behaves
+/// uniformly on every OS, matching the precedent set in ErfWriter (#2244).
+/// </summary>
+public static class AtomicFile
+{
+    /// <summary>
+    /// Atomically replaces <paramref name="destinationPath"/> with the contents of
+    /// <paramref name="sourcePath"/> (typically a freshly-written temp file).
+    /// </summary>
+    /// <param name="sourcePath">
+    /// The fully-written replacement file. Consumed (moved) by this call. Should be on
+    /// the same volume as <paramref name="destinationPath"/> for the move to be atomic.
+    /// </param>
+    /// <param name="destinationPath">The final path to replace (or create if absent).</param>
+    /// <param name="backupPath">
+    /// Optional path to copy the previous destination contents to before replacing.
+    /// If the destination does not exist, no backup is created. Any existing file at
+    /// this path is overwritten. Backup failures are logged but do not abort the replace.
+    /// </param>
+    /// <exception cref="ArgumentException">A path argument is null or empty.</exception>
+    /// <exception cref="FileNotFoundException">The source file does not exist.</exception>
+    public static void Replace(string sourcePath, string destinationPath, string? backupPath)
+    {
+        if (string.IsNullOrEmpty(sourcePath))
+            throw new ArgumentException("Source path is required.", nameof(sourcePath));
+        if (string.IsNullOrEmpty(destinationPath))
+            throw new ArgumentException("Destination path is required.", nameof(destinationPath));
+        if (!File.Exists(sourcePath))
+            throw new FileNotFoundException("Atomic replace source not found.", sourcePath);
+
+        // Back up the existing destination before we overwrite it. Best-effort: a
+        // backup failure should not prevent the (still-atomic) replace from happening.
+        if (!string.IsNullOrEmpty(backupPath) && File.Exists(destinationPath))
+        {
+            try
+            {
+                File.Copy(destinationPath, backupPath, overwrite: true);
+            }
+            catch (IOException ex)
+            {
+                UnifiedLogger.Log(LogLevel.WARN,
+                    $"Backup before atomic replace failed: {ex.Message}", "AtomicFile", "Common");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                UnifiedLogger.Log(LogLevel.WARN,
+                    $"Backup before atomic replace denied: {ex.Message}", "AtomicFile", "Common");
+            }
+        }
+
+        // Single atomic swap. overwrite:true handles both the replace-existing and
+        // create-new cases (File.Move(overwrite:true) succeeds when dest is absent).
+        // The original survives in place until the rename completes — no window where
+        // the destination is missing (#2256).
+        File.Move(sourcePath, destinationPath, overwrite: true);
+    }
+}

--- a/Radoub.Formats/Radoub.Formats/Erf/ErfWriter.cs
+++ b/Radoub.Formats/Radoub.Formats/Erf/ErfWriter.cs
@@ -221,10 +221,12 @@ public static class ErfWriter
         {
             Write(erf, tempPath, resourceData);
 
-            // Atomic replace — original stays in place until the rename
-            // completes. A failure between Delete and Move (AV lock,
-            // permission, disk full) previously left no ERF on disk (#2244).
-            File.Move(tempPath, erfPath, overwrite: true);
+            // Atomic replace via the shared cross-OS helper (#2256). The original
+            // stays in place until the rename completes — a failure mid-swap (AV
+            // lock, permission, disk full) no longer leaves no ERF on disk (#2244).
+            // backupPath is null: this method already created its own timestamped
+            // backup above when createBackup was set.
+            Radoub.Formats.Common.AtomicFile.Replace(tempPath, erfPath, backupPath: null);
         }
         finally
         {


### PR DESCRIPTION
## Summary

Addresses all HIGH findings from the 2026-05-25 Fence review of the file-open/save flow (#2256), plus a shared cross-OS atomic-write helper.

- **Cross-OS atomic save**: new `Radoub.Formats.Common.AtomicFile.Replace(source, dest, backup?)` — single `File.Move(overwrite:true)`, atomic on the same volume on Windows (MoveFileEx) and Unix (rename(2)). Deliberately not `File.Replace` (edge cases on .NET-for-Unix). Fence UTM save and `ErfWriter.UpdateResource` both route through it, replacing inline Delete+Move / bare-Move logic.
- **ContinueWith fault handling**: inventory-population faults previously left `IsLoading` stuck true (editor permanently jammed). New `LoadInventoryAndFinalizeAsync` clears `IsLoading` in a `finally`.
- **IsLoading ordering**: now set before `UtmReader.Read`, not after.
- **Modal picker doc inconsistency**: Fence CLAUDE.md carves out resource-selection pickers + destructive-action confirms (correctly modal) from the non-modal-for-info-windows rule. No code change — the modal calls were correct; the doc's absolutist wording was the bug.

## Tests

- New `AtomicFileTests` (8 cases): replace-existing, dest-missing/create, backup contents, overwrite-stale-backup, missing-source throws, null-args, binary fidelity.
- Full pre-merge run: **2272 passed / 0 failed** (Radoub.Formats, Radoub.UI, Radoub.Dictionary, Fence). Privacy scan PASS, tech-debt scan PASS.

## Related Issues

- Closes #2256
- Follow-up #2307 (file browser panel does not refresh after New file — likely shared across tools)

## Checklist

- [x] Implementation complete
- [x] Tests added/updated
- [x] CHANGELOG updated with date + PR number (root for shared helper, Fence one-liner)
- [x] Documentation updated (Fence CLAUDE.md modal carve-out)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)