### PR TITLE
[Radoub.Dictionary] Fix: Dual-singleton + no file locking causes user custom-word loss (#2263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.Dictionary 0.2.3-alpha] - 2026-05-29
+**Branch**: `radoub/issue-2263` | **PR**: #TBD
+
+### Fix: Dual-singleton + no file locking causes user custom-word loss (#2263)
+
+- Single source of truth for custom-word writes and atomic, cross-process-safe save of the user dictionary so words no longer vanish when tools run together.
+
+---
+
 ## [Radoub.Formats 0.2.62-alpha] - 2026-05-29
 **Branch**: `fence/issue-2256` | **PR**: #2306
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Radoub.Dictionary 0.2.3-alpha] - 2026-05-29
-**Branch**: `radoub/issue-2263` | **PR**: #TBD
+**Branch**: `radoub/issue-2263` | **PR**: #2308
 
 ### Fix: Dual-singleton + no file locking causes user custom-word loss (#2263)
 

--- a/Radoub.Dictionary/Radoub.Dictionary.Tests/UserDictionaryServiceConcurrencyTests.cs
+++ b/Radoub.Dictionary/Radoub.Dictionary.Tests/UserDictionaryServiceConcurrencyTests.cs
@@ -1,0 +1,113 @@
+using System.Text.Json;
+using Radoub.Dictionary.Models;
+using Xunit;
+
+namespace Radoub.Dictionary.Tests;
+
+/// <summary>
+/// Tests for cross-instance / cross-process custom-word persistence (#2263).
+///
+/// The bug: two writers each hold their own in-memory word set and save the whole
+/// file with last-writer-wins semantics, so a word added by writer A is silently
+/// dropped when writer B saves. The fix routes all writes through a single
+/// read-merge-write + atomic save path so concurrent writers' words both survive.
+///
+/// Each <see cref="UserDictionaryService"/> instance built with the internal
+/// custom-path constructor models a separate process: separate HashSet, same files.
+/// </summary>
+public class UserDictionaryServiceConcurrencyTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _jsonPath;
+    private readonly string _textPath;
+
+    public UserDictionaryServiceConcurrencyTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"RadoubDictConc_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+        _jsonPath = Path.Combine(_dir, "custom.dic");
+        _textPath = Path.Combine(_dir, "custom_dictionary.txt");
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch { }
+    }
+
+    private UserDictionaryService NewInstance() => new(_jsonPath, _textPath);
+
+    private List<string> ReadWordsFromDisk()
+    {
+        var json = File.ReadAllText(_jsonPath);
+        var dict = JsonSerializer.Deserialize<CustomDictionary>(json,
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        return dict!.AllWords.ToList();
+    }
+
+    [Fact]
+    public void AddWord_RoundTripsThroughDisk()
+    {
+        var a = NewInstance();
+        a.AddWord("Foobar");
+
+        var reloaded = NewInstance();
+        Assert.Contains("Foobar", reloaded.Words);
+    }
+
+    [Fact]
+    public void TwoWriters_BothWordsSurvive_NoLastWriterWins()
+    {
+        // Model two tool processes that both started before either saved.
+        var writerA = NewInstance();
+        var writerB = NewInstance();
+
+        writerA.AddWord("Foobar");   // A saves {Foobar}
+        writerB.AddWord("Bazquux");  // B must merge with disk, save {Foobar, Bazquux}
+
+        var onDisk = ReadWordsFromDisk();
+        Assert.Contains("Foobar", onDisk);   // <-- dropped today (B clobbers A)
+        Assert.Contains("Bazquux", onDisk);
+    }
+
+    [Fact]
+    public void Save_MergesExternalWordsAddedSinceLoad()
+    {
+        var writer = NewInstance();   // loaded empty
+
+        // Another process writes a word to the file after `writer` loaded.
+        var external = new CustomDictionary { Words = new List<string> { "External" } };
+        File.WriteAllText(_jsonPath, JsonSerializer.Serialize(external,
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
+
+        writer.AddWord("Local");      // save must not clobber "External"
+
+        var onDisk = ReadWordsFromDisk();
+        Assert.Contains("External", onDisk);
+        Assert.Contains("Local", onDisk);
+    }
+
+    [Fact]
+    public void Save_LeavesNoTempFileBehind()
+    {
+        var writer = NewInstance();
+        writer.AddWord("Cleanup");
+
+        var leftovers = Directory.GetFiles(_dir, "*.tmp");
+        Assert.Empty(leftovers);
+    }
+
+    [Fact]
+    public void Save_ProducesValidJson_NotTruncated()
+    {
+        var writer = NewInstance();
+        writer.AddWord("ValidJsonCheck");
+
+        // Must parse cleanly — a half-written file would throw here.
+        var dict = JsonSerializer.Deserialize<CustomDictionary>(
+            File.ReadAllText(_jsonPath),
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        Assert.NotNull(dict);
+        Assert.Contains("ValidJsonCheck", dict!.AllWords);
+    }
+}

--- a/Radoub.Dictionary/Radoub.Dictionary/Radoub.Dictionary.csproj
+++ b/Radoub.Dictionary/Radoub.Dictionary/Radoub.Dictionary.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Radoub.Dictionary.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="WeCantSpell.Hunspell" />
   </ItemGroup>
 

--- a/Radoub.Dictionary/Radoub.Dictionary/UserDictionaryService.cs
+++ b/Radoub.Dictionary/Radoub.Dictionary/UserDictionaryService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Radoub.Dictionary.Models;
+using Radoub.Formats.Common;
 using Radoub.Formats.Logging;
 
 namespace Radoub.Dictionary;
@@ -286,37 +287,154 @@ public class UserDictionaryService
     }
 
     /// <summary>
-    /// Save user dictionary to disk (JSON format).
+    /// Cross-process lock acquisition retry budget for <see cref="Save"/>. Each attempt
+    /// opens the lock file with <see cref="FileShare.None"/>; a sharing violation means
+    /// another tool process is mid-save, so we back off and retry.
+    /// </summary>
+    private const int SaveLockRetries = 10;
+    private const int SaveLockDelayMs = 25;
+
+    private static readonly object _saveSerializer = new();
+
+    /// <summary>
+    /// Save the user dictionary to disk (JSON format), merging any words written by
+    /// other tool instances/processes since this instance last read the file (#2263).
+    ///
+    /// Read-merge-write + atomic swap: the on-disk dictionary is re-read and unioned with
+    /// this instance's words before writing, so concurrent writers no longer clobber each
+    /// other (last-writer-wins becomes merge-then-write). The write goes to a sibling temp
+    /// file and is swapped in via <see cref="AtomicFile.Replace"/>, so a reader never sees
+    /// a half-written file. A coarse in-process lock plus a cross-process file lock serialize
+    /// concurrent savers.
     /// </summary>
     public void Save()
     {
+        // Serialize savers within this process first (the file lock handles other processes).
+        lock (_saveSerializer)
+        {
+            FileStream? lockStream = null;
+            try
+            {
+                lockStream = AcquireSaveLock();
+
+                // Merge external words written since we loaded, folding them back into our
+                // own set so this instance's view stays consistent with disk.
+                var merged = MergeWithDisk();
+
+                var dict = new CustomDictionary
+                {
+                    Source = "Radoub User Dictionary",
+                    Description = "Custom words added by the user (shared across all Radoub tools)",
+                    Words = merged
+                };
+
+                var options = new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                };
+                var json = JsonSerializer.Serialize(dict, options);
+
+                var tempPath = _dictionaryPath + ".tmp";
+                var backupPath = _dictionaryPath + ".bak";
+                try
+                {
+                    File.WriteAllText(tempPath, json);
+                    // Back up the prior file so a corrupt/overwritten dictionary is recoverable.
+                    AtomicFile.Replace(tempPath, _dictionaryPath, backupPath);
+                }
+                finally
+                {
+                    // AtomicFile.Replace consumes tempPath on success; on failure (serialize/write
+                    // threw, or the swap failed) it may remain — never leave a partial temp behind.
+                    if (File.Exists(tempPath))
+                    {
+                        try { File.Delete(tempPath); } catch { /* best-effort cleanup */ }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                UnifiedLogger.Log(LogLevel.WARN, $"Failed to save user dictionary: {ex.Message}", "UserDictionaryService", "Dictionary");
+            }
+            finally
+            {
+                lockStream?.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Re-read the on-disk dictionary and union it with this instance's in-memory words,
+    /// updating <see cref="_userWords"/> so the instance reflects external additions.
+    /// Returns the merged, sorted snapshot to persist.
+    /// </summary>
+    private List<string> MergeWithDisk()
+    {
+        var diskWords = ReadDiskWords();
+
+        lock (_wordsLock)
+        {
+            foreach (var word in diskWords)
+            {
+                if (!string.IsNullOrWhiteSpace(word))
+                    _userWords.Add(word.Trim());
+            }
+            return _userWords.OrderBy(w => w, StringComparer.OrdinalIgnoreCase).ToList();
+        }
+    }
+
+    /// <summary>
+    /// Read the current words from the on-disk JSON dictionary. Returns an empty list if
+    /// the file is absent or unreadable (a transient/partial read must not drop in-memory
+    /// words — the union still contains them).
+    /// </summary>
+    private List<string> ReadDiskWords()
+    {
+        if (!File.Exists(_dictionaryPath))
+            return new List<string>();
+
         try
         {
-            List<string> snapshot;
-            lock (_wordsLock)
-            {
-                snapshot = _userWords.OrderBy(w => w, StringComparer.OrdinalIgnoreCase).ToList();
-            }
-
-            var dict = new CustomDictionary
-            {
-                Source = "Radoub User Dictionary",
-                Description = "Custom words added by the user (shared across all Radoub tools)",
-                Words = snapshot
-            };
-
-            var options = new JsonSerializerOptions
-            {
-                WriteIndented = true,
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-            };
-            var json = JsonSerializer.Serialize(dict, options);
-            File.WriteAllText(_dictionaryPath, json);
+            var json = File.ReadAllText(_dictionaryPath);
+            var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+            var dict = JsonSerializer.Deserialize<CustomDictionary>(json, options);
+            return dict?.AllWords.ToList() ?? new List<string>();
         }
         catch (Exception ex)
         {
-            UnifiedLogger.Log(LogLevel.WARN, $"Failed to save user dictionary: {ex.Message}", "UserDictionaryService", "Dictionary");
+            UnifiedLogger.Log(LogLevel.WARN, $"Could not read existing dictionary for merge: {ex.Message}", "UserDictionaryService", "Dictionary");
+            return new List<string>();
         }
+    }
+
+    /// <summary>
+    /// Acquire a cross-process advisory lock by opening a sidecar lock file with
+    /// <see cref="FileShare.None"/>. Retries on sharing violation; returns null if the
+    /// lock cannot be acquired within the retry budget (the save then proceeds best-effort).
+    /// </summary>
+    private FileStream? AcquireSaveLock()
+    {
+        var lockPath = _dictionaryPath + ".lock";
+        for (int attempt = 0; attempt < SaveLockRetries; attempt++)
+        {
+            try
+            {
+                return new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+            }
+            catch (IOException)
+            {
+                Thread.Sleep(SaveLockDelayMs);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Cannot create/open lock file at all; proceed without the cross-process lock.
+                return null;
+            }
+        }
+
+        UnifiedLogger.Log(LogLevel.WARN, "Timed out acquiring user-dictionary save lock; saving without cross-process lock", "UserDictionaryService", "Dictionary");
+        return null;
     }
 
     /// <summary>

--- a/Radoub.UI/Radoub.UI/Services/SpellCheckService.cs
+++ b/Radoub.UI/Radoub.UI/Services/SpellCheckService.cs
@@ -49,14 +49,13 @@ public class SpellCheckService : IDisposable
     private readonly SemaphoreSlim _initLock = new(1, 1);
 
     /// <summary>
-    /// Tracks words added by the user (separate from loaded dictionaries).
-    /// </summary>
-    private readonly HashSet<string> _userAddedWords = new(StringComparer.OrdinalIgnoreCase);
-
-    /// <summary>
     /// Path to the Radoub-wide custom dictionary file.
     /// Located at ~/Radoub/Dictionaries/custom.dic
     /// </summary>
+    /// <remarks>
+    /// Retained for diagnostics/logging only. As of #2263, <see cref="UserDictionaryService"/>
+    /// is the single owner of reads and writes to this file; SpellCheckService is a consumer.
+    /// </remarks>
     private readonly string _customDictionaryPath;
 
     /// <summary>
@@ -137,9 +136,6 @@ public class SpellCheckService : IDisposable
 
         // Clear discovery cache to pick up any new dictionaries
         _discovery?.ClearCache();
-
-        // Clear user-added words tracking (will be repopulated from file)
-        _userAddedWords.Clear();
 
         // Create fresh dictionary manager and spell checker
         _dictionaryManager = new DictionaryManager();
@@ -321,12 +317,15 @@ public class SpellCheckService : IDisposable
         if (!string.IsNullOrWhiteSpace(word))
         {
             var trimmedWord = word.Trim();
-            _dictionaryManager.AddWord(trimmedWord);
-            _userAddedWords.Add(trimmedWord);
-            UnifiedLogger.LogApplication(LogLevel.DEBUG, $"Added '{trimmedWord}' to custom dictionary");
 
-            // Save immediately
-            _ = SaveCustomDictionaryAsync();
+            // Update the live spell-checker so the word stops being flagged immediately.
+            _dictionaryManager.AddWord(trimmedWord);
+
+            // Persist through the single source of truth (#2263). UserDictionaryService owns
+            // the atomic, cross-process-safe write to custom.dic; we no longer write it here.
+            UserDictionaryService.Instance.AddWord(trimmedWord);
+
+            UnifiedLogger.LogApplication(LogLevel.DEBUG, $"Added '{trimmedWord}' to custom dictionary");
         }
     }
 
@@ -391,86 +390,56 @@ public class SpellCheckService : IDisposable
     }
 
     /// <summary>
-    /// Load the Radoub-wide custom dictionary if it exists.
+    /// Load the Radoub-wide custom dictionary words into the live spell-checker.
+    /// Words come from <see cref="UserDictionaryService"/> (the single source of truth, #2263),
+    /// which owns reading custom.dic and custom_dictionary.txt.
     /// </summary>
-    private async Task LoadCustomDictionaryInternalAsync()
+    private Task LoadCustomDictionaryInternalAsync()
     {
-        if (!File.Exists(_customDictionaryPath))
-        {
-            UnifiedLogger.LogApplication(LogLevel.DEBUG, "No custom dictionary file found, starting fresh");
-            return;
-        }
-
         try
         {
-            // Load the file to get words
-            var json = await File.ReadAllTextAsync(_customDictionaryPath);
-            var dict = System.Text.Json.JsonSerializer.Deserialize<CustomDictionary>(json,
-                new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase });
-
-            if (dict != null)
+            int count = 0;
+            foreach (var word in UserDictionaryService.Instance.Words)
             {
-                // Track user-added words separately
-                foreach (var word in dict.AllWords)
+                if (!string.IsNullOrWhiteSpace(word))
                 {
-                    if (!string.IsNullOrWhiteSpace(word))
-                    {
-                        _userAddedWords.Add(word.Trim());
-                        _dictionaryManager.AddWord(word.Trim());
-                    }
+                    _dictionaryManager.AddWord(word.Trim());
+                    count++;
                 }
-
-                UnifiedLogger.LogApplication(LogLevel.INFO,
-                    $"Loaded custom dictionary: {_userAddedWords.Count} user words");
             }
+
+            UnifiedLogger.LogApplication(LogLevel.INFO, $"Loaded custom dictionary: {count} user words");
         }
         catch (Exception ex)
         {
             UnifiedLogger.LogApplication(LogLevel.WARN, $"Failed to load custom dictionary: {ex.Message}");
         }
+
+        return Task.CompletedTask;
     }
 
     /// <summary>
-    /// Save the custom dictionary to disk (only user-added words).
+    /// Persist the custom dictionary. As of #2263, persistence is owned by
+    /// <see cref="UserDictionaryService"/> (words are saved when added via
+    /// <see cref="AddToCustomDictionary"/>); this method forces a save of the
+    /// current user-dictionary state and is retained for API compatibility.
     /// </summary>
-    public async Task SaveCustomDictionaryAsync()
+    public Task SaveCustomDictionaryAsync()
     {
-        try
-        {
-            var dict = new CustomDictionary
-            {
-                Source = "Radoub Custom Dictionary",
-                Description = "User-added custom words for spell checking",
-                Words = _userAddedWords.OrderBy(w => w, StringComparer.OrdinalIgnoreCase).ToList()
-            };
-
-            var json = System.Text.Json.JsonSerializer.Serialize(dict,
-                new System.Text.Json.JsonSerializerOptions
-                {
-                    WriteIndented = true,
-                    PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase
-                });
-
-            await File.WriteAllTextAsync(_customDictionaryPath, json);
-
-            UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                $"Saved custom dictionary: {_userAddedWords.Count} user words");
-        }
-        catch (Exception ex)
-        {
-            UnifiedLogger.LogApplication(LogLevel.WARN, $"Failed to save custom dictionary: {ex.Message}");
-        }
+        UserDictionaryService.Instance.Save();
+        return Task.CompletedTask;
     }
 
     /// <summary>
-    /// Reload the custom dictionary from disk.
-    /// Useful when another Radoub tool has updated the dictionary.
+    /// Reload the custom dictionary so words another Radoub tool added become visible.
+    /// Reloads <see cref="UserDictionaryService"/> from disk, then re-applies its words
+    /// to the live spell-checker.
     /// </summary>
     public async Task ReloadCustomDictionaryAsync()
     {
         try
         {
-            // Clear and reload
+            UserDictionaryService.Instance.Load();
             await LoadCustomDictionaryInternalAsync();
             UnifiedLogger.LogApplication(LogLevel.INFO, "Reloaded custom dictionary");
         }


### PR DESCRIPTION
## Summary

Fixes silent loss of user custom-dictionary words (#2263).

`~/Radoub/Dictionaries/custom.dic` had two uncoordinated writers (`UserDictionaryService` + `Radoub.UI.SpellCheckService`), each saving the whole file from its own in-memory set with plain `File.WriteAllText` and no inter-process lock. Two tools open at once clobbered each other (last-writer-wins); a reader catching a half-written file silently dropped the whole dictionary.

### Changes
- `UserDictionaryService` is now the single owner of `custom.dic`. `Save()` does read-merge-write (re-reads on-disk words, unions before writing) + atomic swap via `AtomicFile.Replace` (#2256) with a `.bak` backup, serialized by a cross-process `.lock` (FileShare.None retry) and an in-process lock. Temp file deleted on any failure.
- `SpellCheckService.AddToCustomDictionary` delegates persistence to `UserDictionaryService.Instance.AddWord`; load reads its `Words`; the duplicate `_userAddedWords` save path is removed. Public shims (`SaveCustomDictionaryAsync`/`ReloadCustomDictionaryAsync`) kept for API compatibility.

### Tests (TDD)
- New `UserDictionaryServiceConcurrencyTests` (5): two-writers-no-clobber + external-merge **failed RED**, now pass; round-trip / no-temp-leak / valid-json guards.
- `InternalsVisibleTo` added for the path-injected test constructor.

## Related Issues

- Closes #2263
- Sibling: #2264 (Radoub.Dictionary regex/perf/thread-safety — separate PR)

## Pre-Merge Checklist

| Check | Status |
|-------|--------|
| Privacy scan | ✅ No hardcoded paths |
| Tech debt | ✅ No files >800 lines |
| Unit tests | ✅ Radoub.Formats 1318, Radoub.UI 763, Radoub.Dictionary 59; Manifest 104, Parley 839 |
| UI tests | ⏭️ Skipped (no .axaml/Views/Controls changes) |
| CHANGELOG | ✅ Radoub.Dictionary 0.2.3-alpha, PR #2308, 2026-05-29 |
| [Unreleased] | ✅ Empty |
| Wiki | ✅ Spell-Check current (2026-05-24) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)