### PR TITLE
[Trebuchet] Fix: Process launch + lifecycle hygiene (#2248)

### DIFF
--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [1.36.6-alpha] - 2026-05-29
-**Branch**: `trebuchet/issue-2248` | **PR**: #TBD
+**Branch**: `trebuchet/issue-2248` | **PR**: #2312
 
 ### Fix: Process launch + lifecycle hygiene (#2248)
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.36.6-alpha] - 2026-05-29
+**Branch**: `trebuchet/issue-2248` | **PR**: #TBD
+
+### Fix: Process launch + lifecycle hygiene (#2248)
+
+- Process launches (tool/file, external editor, NWScript compiler) switched to `ProcessStartInfo.ArgumentList` so paths containing quotes parse correctly.
+- DefaultBic save no longer silently overwrites unsaved in-memory IFO edits; timer/singleton/HttpClient lifecycle hardened; username leak in update log sanitized; version comparison uses `TryParse`; bare-catch blocks narrowed to specific I/O exceptions.
+
+---
+
 ## [1.36.5-alpha] - 2026-05-28
 **Branch**: `trebuchet/issue-2246` | **PR**: #2281
 

--- a/Trebuchet/Trebuchet.Tests/ProcessArgumentBuilderTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ProcessArgumentBuilderTests.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using RadoubLauncher.Services;
+using Xunit;
+
+namespace Trebuchet.Tests;
+
+/// <summary>
+/// Unit tests for ProcessArgumentBuilder — pure helpers that produce
+/// ProcessStartInfo.ArgumentList entries (one element per argument, NO surrounding
+/// quotes). Replaces the old string-concat-with-quotes pattern flagged in #2248,
+/// which broke when a file path contained a literal double-quote.
+/// </summary>
+public class ProcessArgumentBuilderTests
+{
+    [Fact]
+    public void FileOpenArgs_EmitsFileFlagAndRawPath_NoQuotes()
+    {
+        var args = ProcessArgumentBuilder.FileOpenArgs(@"C:\Users\me\my dialog.dlg");
+
+        Assert.Equal(new[] { "--file", @"C:\Users\me\my dialog.dlg" }, args);
+    }
+
+    [Fact]
+    public void FileOpenArgs_PathWithLiteralQuote_PassedThroughVerbatim()
+    {
+        // A path containing a double-quote is legal on Linux/macOS. The old
+        // $"--file \"{path}\"" concat would corrupt parsing; ArgumentList must
+        // carry the raw path so the OS layer escapes it correctly.
+        var weird = "/home/me/od\"d.dlg";
+        var args = ProcessArgumentBuilder.FileOpenArgs(weird);
+
+        Assert.Equal(new[] { "--file", weird }, args);
+    }
+
+    [Fact]
+    public void SingleFileArg_EmitsRawPath_NoQuotes()
+    {
+        var args = ProcessArgumentBuilder.SingleFileArg(@"C:\tmp\a b.txt");
+
+        Assert.Equal(new[] { @"C:\tmp\a b.txt" }, args);
+    }
+
+    [Fact]
+    public void CompileArgs_SingleScript_NoGamePath()
+    {
+        var args = ProcessArgumentBuilder.CompileArgs(
+            new[] { @"C:\m\scr.nss" }, gamePath: null);
+
+        Assert.Equal(new[] { "-c", @"C:\m\scr.nss" }, args);
+    }
+
+    [Fact]
+    public void CompileArgs_SingleScript_WithGamePath()
+    {
+        var args = ProcessArgumentBuilder.CompileArgs(
+            new[] { @"C:\m\scr.nss" }, gamePath: @"C:\Games\NWN");
+
+        Assert.Equal(
+            new[] { "-c", @"C:\m\scr.nss", "--root", @"C:\Games\NWN" }, args);
+    }
+
+    [Fact]
+    public void CompileArgs_Batch_AppendsContinueAndThreads()
+    {
+        var args = ProcessArgumentBuilder.CompileArgs(
+            new[] { @"C:\m\a.nss", @"C:\m\b.nss" },
+            gamePath: @"C:\Games\NWN",
+            continueOnError: true,
+            threadCount: 4);
+
+        Assert.Equal(new[]
+        {
+            "-c", @"C:\m\a.nss", @"C:\m\b.nss", "-y", "-j", "4", "--root", @"C:\Games\NWN"
+        }, args);
+    }
+
+    [Fact]
+    public void CompileArgs_EmptyGamePath_OmitsRoot()
+    {
+        var args = ProcessArgumentBuilder.CompileArgs(
+            new[] { @"C:\m\scr.nss" }, gamePath: "");
+
+        Assert.Equal(new[] { "-c", @"C:\m\scr.nss" }, args);
+    }
+}

--- a/Trebuchet/Trebuchet.Tests/ProcessArgumentBuilderTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ProcessArgumentBuilderTests.cs
@@ -15,9 +15,9 @@ public class ProcessArgumentBuilderTests
     [Fact]
     public void FileOpenArgs_EmitsFileFlagAndRawPath_NoQuotes()
     {
-        var args = ProcessArgumentBuilder.FileOpenArgs(@"C:\Users\me\my dialog.dlg");
+        var args = ProcessArgumentBuilder.FileOpenArgs(@"C:\data\my dialog.dlg");
 
-        Assert.Equal(new[] { "--file", @"C:\Users\me\my dialog.dlg" }, args);
+        Assert.Equal(new[] { "--file", @"C:\data\my dialog.dlg" }, args);
     }
 
     [Fact]
@@ -26,7 +26,7 @@ public class ProcessArgumentBuilderTests
         // A path containing a double-quote is legal on Linux/macOS. The old
         // $"--file \"{path}\"" concat would corrupt parsing; ArgumentList must
         // carry the raw path so the OS layer escapes it correctly.
-        var weird = "/home/me/od\"d.dlg";
+        var weird = "/srv/od\"d.dlg";
         var args = ProcessArgumentBuilder.FileOpenArgs(weird);
 
         Assert.Equal(new[] { "--file", weird }, args);

--- a/Trebuchet/Trebuchet.Tests/UpdateServiceVersionTests.cs
+++ b/Trebuchet/Trebuchet.Tests/UpdateServiceVersionTests.cs
@@ -1,0 +1,51 @@
+using RadoubLauncher.Services;
+using Xunit;
+
+namespace Trebuchet.Tests;
+
+/// <summary>
+/// Unit tests for UpdateService.IsNewerVersion — pure version comparison.
+/// Covers #2248: a non-numeric version segment (e.g. "0.1.0+abc123") must not throw
+/// and silently suppress updates; TryParse treats unparseable segments as 0.
+/// </summary>
+public class UpdateServiceVersionTests
+{
+    [Theory]
+    [InlineData("1.0.0", "0.9.0", true)]
+    [InlineData("0.2.0", "0.1.0", true)]
+    [InlineData("0.1.1", "0.1.0", true)]
+    [InlineData("0.1.0", "0.1.0", false)]
+    [InlineData("0.1.0", "0.2.0", false)]
+    [InlineData("0.9.0", "1.0.0", false)]
+    public void IsNewerVersion_NumericComparison(string latest, string current, bool expected)
+    {
+        Assert.Equal(expected, UpdateService.IsNewerVersion(latest, current));
+    }
+
+    [Fact]
+    public void IsNewerVersion_ReleaseNewerThanPrerelease_SameBase()
+    {
+        Assert.True(UpdateService.IsNewerVersion("0.1.0", "0.1.0-alpha"));
+    }
+
+    [Fact]
+    public void IsNewerVersion_PrereleaseNotNewerThanRelease_SameBase()
+    {
+        Assert.False(UpdateService.IsNewerVersion("0.1.0-alpha", "0.1.0"));
+    }
+
+    [Fact]
+    public void IsNewerVersion_GitHashSuffix_DoesNotSuppressRealUpdate()
+    {
+        // "0.2.0+abc123" segment "0+abc123"... here the higher minor must still win
+        // instead of throwing FormatException and returning false.
+        Assert.True(UpdateService.IsNewerVersion("0.2.0+abc123", "0.1.0"));
+    }
+
+    [Fact]
+    public void IsNewerVersion_NonNumericSegment_TreatedAsZero_NotThrow()
+    {
+        // Equal numeric prefix, junk suffix → not newer, but must NOT throw.
+        Assert.False(UpdateService.IsNewerVersion("0.1.0+abc123", "0.1.0"));
+    }
+}

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
@@ -122,8 +122,11 @@ public partial class MarlinspikePanel : UserControl
             var di = new DirectoryInfo(path);
             return di.Exists ? di.LastWriteTimeUtc : (DateTime?)null;
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException
+                                   or System.Security.SecurityException or ArgumentException)
         {
+            UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                $"GetDirectoryMtime failed for {UnifiedLogger.SanitizePath(path)}: {ex.Message}");
             return null;
         }
     }

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
@@ -356,8 +356,8 @@ public partial class MarlinspikePanel : UserControl
                 return;
 
             case DispatchAction.ToolLaunch:
-                var launched = ToolLauncherService.Instance.LaunchTool(
-                    plan.ToolName!, $"--file \"{plan.FilePath}\"");
+                var launched = ToolLauncherService.Instance.LaunchToolWithFile(
+                    plan.ToolName!, plan.FilePath!);
                 if (!launched && _viewModel != null)
                     _viewModel.StatusText =
                         $"Could not launch {plan.ToolName} for: {Path.GetFileName(plan.FilePath)}";
@@ -380,9 +380,12 @@ public partial class MarlinspikePanel : UserControl
             var startInfo = new System.Diagnostics.ProcessStartInfo
             {
                 FileName = editorPath,
-                Arguments = $"\"{filePath}\"",
                 UseShellExecute = false
             };
+            foreach (var arg in ProcessArgumentBuilder.SingleFileArg(filePath))
+            {
+                startInfo.ArgumentList.Add(arg);
+            }
             System.Diagnostics.Process.Start(startInfo)?.Dispose();
         }
         catch (Exception ex)

--- a/Trebuchet/Trebuchet/Services/ModuleFileLockService.cs
+++ b/Trebuchet/Trebuchet/Services/ModuleFileLockService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using Radoub.Formats.Logging;
 
 namespace RadoubLauncher.Services;
 
@@ -29,8 +30,13 @@ public static class ModuleFileLockService
         {
             return true;
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException
+                                   or System.Security.SecurityException)
         {
+            // Non-sharing I/O error, or no write permission — not a lock we hold-out for.
+            // Treat as "not locked by another process" so the caller proceeds.
+            UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                $"IsFileLocked probe failed for {UnifiedLogger.SanitizePath(filePath)}: {ex.Message}");
             return false;
         }
     }

--- a/Trebuchet/Trebuchet/Services/ProcessArgumentBuilder.cs
+++ b/Trebuchet/Trebuchet/Services/ProcessArgumentBuilder.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+
+namespace RadoubLauncher.Services;
+
+/// <summary>
+/// Builds process argument lists for <see cref="System.Diagnostics.ProcessStartInfo.ArgumentList"/>.
+///
+/// Each list element is ONE argument with NO surrounding quotes — the runtime escapes
+/// each element correctly for the target OS. Replaces the old
+/// <c>$"--file \"{path}\""</c> string-concat pattern (#2248), which corrupted parsing
+/// when a path contained a literal double-quote (legal on Linux/macOS).
+///
+/// Pure + static so the arg construction is unit-testable without spawning a process.
+/// </summary>
+public static class ProcessArgumentBuilder
+{
+    /// <summary>Args to open a file in a Radoub tool: <c>--file &lt;path&gt;</c>.</summary>
+    public static IReadOnlyList<string> FileOpenArgs(string filePath)
+        => new[] { "--file", filePath };
+
+    /// <summary>Args to pass a single bare path (e.g. external editor): <c>&lt;path&gt;</c>.</summary>
+    public static IReadOnlyList<string> SingleFileArg(string filePath)
+        => new[] { filePath };
+
+    /// <summary>
+    /// NWScript compiler args: <c>-c &lt;scripts...&gt; [-y -j N] [--root &lt;gamePath&gt;]</c>.
+    /// </summary>
+    /// <param name="scriptPaths">Scripts to compile (at least one expected).</param>
+    /// <param name="gamePath">NWN install root for includes; omitted if null/empty.</param>
+    /// <param name="continueOnError">Add <c>-y</c> (batch mode keeps going past errors).</param>
+    /// <param name="threadCount">When &gt; 0 and continueOnError, adds <c>-j &lt;n&gt;</c>.</param>
+    public static IReadOnlyList<string> CompileArgs(
+        IReadOnlyList<string> scriptPaths,
+        string? gamePath,
+        bool continueOnError = false,
+        int threadCount = 0)
+    {
+        var args = new List<string> { "-c" };
+        foreach (var path in scriptPaths)
+        {
+            args.Add(path);
+        }
+
+        if (continueOnError)
+        {
+            // -j requires an explicit thread count; omitting it makes the compiler
+            // parse the next flag as the integer.
+            args.Add("-y");
+            if (threadCount > 0)
+            {
+                args.Add("-j");
+                args.Add(threadCount.ToString());
+            }
+        }
+
+        if (!string.IsNullOrEmpty(gamePath))
+        {
+            args.Add("--root");
+            args.Add(gamePath);
+        }
+
+        return args;
+    }
+}

--- a/Trebuchet/Trebuchet/Services/ScriptCompilerService.cs
+++ b/Trebuchet/Trebuchet/Services/ScriptCompilerService.cs
@@ -294,29 +294,27 @@ public class ScriptCompilerService
 
         try
         {
-            var args = new StringBuilder();
-            args.Append("-c ");
-            args.Append($"\"{nssPath}\"");
-
-            // Add game path for includes if available (--root for NWN installation)
-            if (!string.IsNullOrEmpty(gamePath) && Directory.Exists(gamePath))
-            {
-                args.Append($" --root \"{gamePath}\"");
-            }
+            var includeRoot = (!string.IsNullOrEmpty(gamePath) && Directory.Exists(gamePath))
+                ? gamePath
+                : null;
+            var argList = ProcessArgumentBuilder.CompileArgs(new[] { nssPath }, includeRoot);
 
             var startInfo = new ProcessStartInfo
             {
                 FileName = CompilerPath,
-                Arguments = args.ToString(),
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 CreateNoWindow = true,
                 WorkingDirectory = Path.GetDirectoryName(nssPath) ?? "."
             };
+            foreach (var arg in argList)
+            {
+                startInfo.ArgumentList.Add(arg);
+            }
 
             UnifiedLogger.LogApplication(LogLevel.INFO,
-                $"Running: {CompilerPath} {args} (cwd: {startInfo.WorkingDirectory})");
+                $"Running: {CompilerPath} {string.Join(' ', argList)} (cwd: {startInfo.WorkingDirectory})");
 
             using var process = new Process { StartInfo = startInfo };
             var output = new StringBuilder();
@@ -503,19 +501,11 @@ public class ScriptCompilerService
         // Build args: -c <files...> -y (continue on error) -j N (parallel)
         // -j requires an explicit thread count; omitting it causes the next flag to be parsed as the integer
         var threadCount = Math.Max(1, Environment.ProcessorCount);
-        var args = new StringBuilder();
-        args.Append("-c");
-        foreach (var scriptPath in scriptPaths)
-        {
-            args.Append($" \"{scriptPath}\"");
-        }
-        args.Append($" -y -j {threadCount}");
-
-        // Add game path for includes if available
-        if (!string.IsNullOrEmpty(gamePath) && Directory.Exists(gamePath))
-        {
-            args.Append($" --root \"{gamePath}\"");
-        }
+        var includeRoot = (!string.IsNullOrEmpty(gamePath) && Directory.Exists(gamePath))
+            ? gamePath
+            : null;
+        var argList = ProcessArgumentBuilder.CompileArgs(
+            scriptPaths, includeRoot, continueOnError: true, threadCount: threadCount);
 
         // Use the directory of the first script as working directory
         var workingDir = Path.GetDirectoryName(scriptPaths[0]) ?? ".";
@@ -523,13 +513,16 @@ public class ScriptCompilerService
         var startInfo = new ProcessStartInfo
         {
             FileName = CompilerPath,
-            Arguments = args.ToString(),
             UseShellExecute = false,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             CreateNoWindow = true,
             WorkingDirectory = workingDir
         };
+        foreach (var arg in argList)
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
 
         UnifiedLogger.LogApplication(LogLevel.INFO,
             $"Running: {Path.GetFileName(CompilerPath!)} -c [{scriptPaths.Count} files] -y -j (cwd: {workingDir})");

--- a/Trebuchet/Trebuchet/Services/ToolLauncherService.cs
+++ b/Trebuchet/Trebuchet/Services/ToolLauncherService.cs
@@ -193,12 +193,45 @@ public class ToolLauncherService
     }
 
     /// <summary>
+    /// Launch a tool by name, opening a file via the --file argument.
+    /// Uses ProcessStartInfo.ArgumentList so paths containing special characters
+    /// (including a literal quote, legal on Linux/macOS) parse correctly (#2248).
+    /// </summary>
+    public bool LaunchToolWithFile(string toolName, string filePath)
+    {
+        var tool = _tools.FirstOrDefault(t => t.Name.Equals(toolName, StringComparison.OrdinalIgnoreCase));
+        if (tool == null)
+        {
+            UnifiedLogger.LogApplication(LogLevel.ERROR, $"Unknown tool: {toolName}");
+            return false;
+        }
+
+        return LaunchToolWithFile(tool, filePath);
+    }
+
+    /// <summary>
     /// Launch a tool.
     /// </summary>
     /// <param name="tool">Tool to launch</param>
     /// <param name="arguments">Optional command line arguments</param>
     /// <returns>True if launched successfully</returns>
     public bool LaunchTool(ToolInfo tool, string? arguments = null)
+    {
+        // Legacy string-arg entry point: callers that pass "--file \"path\"" should
+        // use LaunchToolWithFile instead. A bare flag (no embedded paths) is split on
+        // whitespace into ArgumentList elements.
+        var argList = string.IsNullOrWhiteSpace(arguments)
+            ? System.Array.Empty<string>()
+            : arguments.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        return LaunchTool(tool, argList);
+    }
+
+    /// <summary>
+    /// Launch a tool with an explicit argument list. Each element is one argument
+    /// with no surrounding quotes — ArgumentList escapes per-OS so paths with spaces
+    /// or quotes survive intact (#2248).
+    /// </summary>
+    public bool LaunchTool(ToolInfo tool, IReadOnlyList<string> arguments)
     {
         if (!tool.IsAvailable)
         {
@@ -212,10 +245,13 @@ public class ToolLauncherService
             var startInfo = new ProcessStartInfo
             {
                 FileName = tool.ExecutablePath!,
-                Arguments = arguments ?? "",
-                UseShellExecute = true,
+                UseShellExecute = false,
                 WorkingDirectory = toolDir ?? ""
             };
+            foreach (var arg in arguments)
+            {
+                startInfo.ArgumentList.Add(arg);
+            }
 
             Process.Start(startInfo)?.Dispose();
             UnifiedLogger.LogApplication(LogLevel.INFO, $"Launched {tool.Name}: {UnifiedLogger.SanitizePath(tool.ExecutablePath!)}");
@@ -236,7 +272,7 @@ public class ToolLauncherService
     /// <returns>True if launched successfully</returns>
     public bool LaunchToolWithFile(ToolInfo tool, string filePath)
     {
-        return LaunchTool(tool, $"--file \"{filePath}\"");
+        return LaunchTool(tool, ProcessArgumentBuilder.FileOpenArgs(filePath));
     }
 
     private void DiscoverTools()

--- a/Trebuchet/Trebuchet/Services/UpdateService.cs
+++ b/Trebuchet/Trebuchet/Services/UpdateService.cs
@@ -22,6 +22,8 @@ public class UpdateService : INotifyPropertyChanged, IDisposable
     private static UpdateService? _instance;
     public static UpdateService Instance => _instance ??= new UpdateService();
 
+    private bool _disposed;
+
     private const string GitHubOwner = "LordOfMyatar";
     private const string GitHubRepo = "Radoub";
     private const string ReleasesApiUrl = $"https://api.github.com/repos/{GitHubOwner}/{GitHubRepo}/releases/latest";
@@ -88,7 +90,10 @@ public class UpdateService : INotifyPropertyChanged, IDisposable
 
     private UpdateService()
     {
-        _httpClient = new HttpClient();
+        // No client-wide timeout: downloads can legitimately run long. The update *check*
+        // applies its own 15s budget via a linked CTS (#2248); the streamed download relies
+        // on caller cancellation.
+        _httpClient = new HttpClient { Timeout = Timeout.InfiniteTimeSpan };
         _httpClient.DefaultRequestHeaders.Add("User-Agent", "Radoub-Trebuchet");
         _httpClient.DefaultRequestHeaders.Add("Accept", "application/vnd.github+json");
 
@@ -147,7 +152,11 @@ public class UpdateService : INotifyPropertyChanged, IDisposable
         {
             UnifiedLogger.LogApplication(LogLevel.INFO, "Checking for updates...");
 
-            var response = await _httpClient.GetAsync(ReleasesApiUrl, cancellationToken);
+            // 15s budget for the check so a flaky network can't hang it (#2248).
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var response = await _httpClient.GetAsync(ReleasesApiUrl, timeoutCts.Token);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -155,7 +164,7 @@ public class UpdateService : INotifyPropertyChanged, IDisposable
                 return false;
             }
 
-            var release = await response.Content.ReadFromJsonAsync<GitHubRelease>(cancellationToken);
+            var release = await response.Content.ReadFromJsonAsync<GitHubRelease>(timeoutCts.Token);
             if (release == null)
             {
                 UnifiedLogger.LogApplication(LogLevel.WARN, "Failed to parse release response");
@@ -182,6 +191,11 @@ public class UpdateService : INotifyPropertyChanged, IDisposable
             }
 
             UnifiedLogger.LogApplication(LogLevel.INFO, $"No update available (current: {CurrentVersion}, latest: {LatestVersion})");
+            return false;
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN, "Update check timed out after 15s");
             return false;
         }
         catch (OperationCanceledException)
@@ -260,40 +274,42 @@ public class UpdateService : INotifyPropertyChanged, IDisposable
     /// <summary>
     /// Compare two version strings to determine if the first is newer.
     /// </summary>
-    private bool IsNewerVersion(string latest, string current)
+    internal static bool IsNewerVersion(string latest, string current)
     {
-        try
+        // Strip prerelease (-alpha) and build-metadata (+gitHash) suffixes so a segment
+        // like "0+abc123" doesn't blow up the numeric compare. Unparseable segments are
+        // treated as 0 via TryParse rather than throwing and silently suppressing the
+        // update (#2248).
+        var latestClean = StripSuffixes(latest);
+        var currentClean = StripSuffixes(current);
+
+        var latestParts = latestClean.Split('.');
+        var currentParts = currentClean.Split('.');
+
+        for (int i = 0; i < Math.Max(latestParts.Length, currentParts.Length); i++)
         {
-            // Handle alpha/beta suffixes
-            var latestClean = latest.Split('-')[0];
-            var currentClean = current.Split('-')[0];
+            int latestNum = i < latestParts.Length && int.TryParse(latestParts[i], out var ln) ? ln : 0;
+            int currentNum = i < currentParts.Length && int.TryParse(currentParts[i], out var cn) ? cn : 0;
 
-            var latestParts = latestClean.Split('.');
-            var currentParts = currentClean.Split('.');
-
-            for (int i = 0; i < Math.Max(latestParts.Length, currentParts.Length); i++)
-            {
-                int latestNum = i < latestParts.Length ? int.Parse(latestParts[i]) : 0;
-                int currentNum = i < currentParts.Length ? int.Parse(currentParts[i]) : 0;
-
-                if (latestNum > currentNum) return true;
-                if (latestNum < currentNum) return false;
-            }
-
-            // If base versions are equal, check for alpha/beta
-            // Released version (no suffix) is newer than alpha/beta
-            bool latestIsPrerelease = latest.Contains('-');
-            bool currentIsPrerelease = current.Contains('-');
-
-            if (!latestIsPrerelease && currentIsPrerelease) return true;
-
-            return false;
+            if (latestNum > currentNum) return true;
+            if (latestNum < currentNum) return false;
         }
-        catch (FormatException)
-        {
-            // Version string parsing failed - assume no update available
-            return false;
-        }
+
+        // If base versions are equal, a released version (no -prerelease suffix) is
+        // newer than an alpha/beta.
+        bool latestIsPrerelease = latest.Contains('-');
+        bool currentIsPrerelease = current.Contains('-');
+
+        if (!latestIsPrerelease && currentIsPrerelease) return true;
+
+        return false;
+    }
+
+    private static string StripSuffixes(string version)
+    {
+        var s = version.Split('-')[0];
+        var plus = s.IndexOf('+');
+        return plus >= 0 ? s[..plus] : s;
     }
 
     /// <summary>
@@ -357,7 +373,7 @@ public class UpdateService : INotifyPropertyChanged, IDisposable
                 }
             }
 
-            UnifiedLogger.LogApplication(LogLevel.INFO, $"Update downloaded to: {tempPath}");
+            UnifiedLogger.LogApplication(LogLevel.INFO, $"Update downloaded to: {UnifiedLogger.SanitizePath(tempPath)}");
             return tempPath;
         }
         catch (OperationCanceledException)
@@ -374,7 +390,16 @@ public class UpdateService : INotifyPropertyChanged, IDisposable
 
     public void Dispose()
     {
+        if (_disposed) return;
+        _disposed = true;
         _httpClient.Dispose();
+
+        // Clear the singleton so a later Instance access constructs a fresh service
+        // instead of handing back this disposed one (#2248).
+        if (ReferenceEquals(_instance, this))
+        {
+            _instance = null;
+        }
     }
 
     protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/Trebuchet/Trebuchet/ViewModels/MainWindowViewModel.DefaultBic.cs
+++ b/Trebuchet/Trebuchet/ViewModels/MainWindowViewModel.DefaultBic.cs
@@ -192,6 +192,35 @@ public partial class MainWindowViewModel
     /// </summary>
     private async Task SaveDefaultBicToModuleAsync(string defaultBic, CancellationToken cancellationToken = default)
     {
+        // If the module editor is loaded it owns the in-memory IFO (name, scripts,
+        // HAKs, variables, etc.). A direct disk round-trip here would re-read the
+        // on-disk IFO, mutate only DefaultBic, and write it back — silently discarding
+        // every other unsaved editor edit (#2248). Route the change through the editor
+        // so the full in-memory IFO is persisted together.
+        if (_moduleEditorViewModel != null)
+        {
+            _moduleEditorViewModel.UseDefaultBic = !string.IsNullOrEmpty(defaultBic);
+            _moduleEditorViewModel.DefaultBic = defaultBic;
+
+            try
+            {
+                await _moduleEditorViewModel.SaveCommand.ExecuteAsync(null);
+            }
+            catch (Exception ex)
+            {
+                UnifiedLogger.LogApplication(LogLevel.ERROR, $"Failed to save DefaultBic via editor: {ex.Message}");
+                return;
+            }
+
+            RadoubSettings.Instance.CurrentModuleDefaultBic = defaultBic;
+            OnPropertyChanged(nameof(CanLoadModule));
+            OnPropertyChanged(nameof(LoadModuleTooltip));
+            UnifiedLogger.LogApplication(LogLevel.INFO,
+                string.IsNullOrEmpty(defaultBic) ? "Cleared DefaultBic (via editor)" : $"Saved DefaultBic: {defaultBic} (via editor)");
+            return;
+        }
+
+        // No editor loaded: no in-memory edits at risk, so a direct disk write is safe.
         var workingDir = GetWorkingDirectoryPath();
         if (string.IsNullOrEmpty(workingDir))
         {

--- a/Trebuchet/Trebuchet/ViewModels/MainWindowViewModel.cs
+++ b/Trebuchet/Trebuchet/ViewModels/MainWindowViewModel.cs
@@ -491,7 +491,19 @@ public partial class MainWindowViewModel : ObservableObject
     /// </summary>
     public void Cleanup()
     {
-        _lockPollTimer?.Dispose();
+        // Block until any in-flight PollModFileLock callback finishes before we cancel
+        // the CTS and unsubscribe — the parameterless Dispose() returns immediately and
+        // lets a running callback race the rest of Cleanup (#2248).
+        if (_lockPollTimer != null)
+        {
+            using var timerDisposed = new System.Threading.ManualResetEvent(false);
+            if (_lockPollTimer.Dispose(timerDisposed))
+            {
+                timerDisposed.WaitOne(TimeSpan.FromSeconds(2));
+            }
+            _lockPollTimer = null;
+        }
+
         _cts.Cancel();
         _cts.Dispose();
         RadoubSettings.Instance.PropertyChanged -= OnSharedSettingsChanged;


### PR DESCRIPTION
## Summary

HIGH-severity hygiene fixes from the 2026-05-25 Trebuchet code review (#2248). Process arg quoting, lifecycle disposal races, privacy, version-parse robustness, and bare-catch cleanup. All findings confirmed before fixing.

## Findings Addressed

| # | Finding | Fix |
|---|---------|-----|
| 1 | Process arg string concat | `ProcessArgumentBuilder` + `ArgumentList` at 4 sites (tool launch, external editor, single + batch compile); tool launch switched to `UseShellExecute=false` |
| 2 | DefaultBic overwrites unsaved IFO edits | Route through `_moduleEditorViewModel` so full IFO persists together; direct disk write only when no editor loaded |
| 3 | Timer disposal race | `Dispose(WaitHandle)` + bounded block in `Cleanup` |
| 4 | Username leak in update log | `SanitizePath` on download temp path |
| 5 | ContinueWith fault audit | No `ContinueWith` in Trebuchet — clean |
| 6 | UpdateService singleton dispose | `_disposed` guard + null `_instance` |
| 7 | Version comparison no TryParse | `int.TryParse` + strip `+gitHash` / `-prerelease` suffixes |
| 8 | HttpClient 100s timeout | Infinite client timeout; update check gets its own 15s linked-CTS budget |
| 9 | Bare-catch hygiene | Narrowed to specific I/O exceptions (`MarlinspikePanel`, `ModuleFileLockService`) |

## Tests

- 17 new unit tests (7 `ProcessArgumentBuilder`, 10 `IsNewerVersion`)
- 228/228 Trebuchet unit tests pass
- 14/14 Trebuchet FlaUI integration tests pass
- Privacy / tech-debt / theme scans pass

## Manual Spot-Check

- [ ] Module editor: edit Name (unsaved) → toggle DefaultBic → confirm Name edit retained (finding #2)

## Related Issues

- Closes #2248

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)