### PR TITLE
[Radoub.Dictionary] Fix: Color-token regex hole, CheckText O(N²), thread-unsafe DictionaryManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.Dictionary 0.2.4-alpha] - 2026-05-29
+**Branch**: `radoub/issue-2264` | **PR**: #TBD
+
+### Fix: Color-token regex hole, CheckText O(N²), thread-unsafe DictionaryManager (#2264)
+
+- Spell-check now ignores NWN `<cRGB>` color tokens even when a raw channel byte is `0x3E` (`>`), and `DictionaryManager` is thread-safe.
+
+---
+
 ## [Radoub.Dictionary 0.2.3-alpha] - 2026-05-29
 **Branch**: `radoub/issue-2263` | **PR**: #2308
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Radoub.Dictionary 0.2.4-alpha] - 2026-05-29
-**Branch**: `radoub/issue-2264` | **PR**: #TBD
+**Branch**: `radoub/issue-2264` | **PR**: #2313
 
 ### Fix: Color-token regex hole, CheckText O(N²), thread-unsafe DictionaryManager (#2264)
 


### PR DESCRIPTION
## Summary

Addresses HIGH-severity findings from the 2026-05-25 Radoub.Dictionary code review.

- `SpellChecker` color-token regex `<[^>]+>` breaks on NWN `<cRGB>` tokens when a channel byte is `0x3E` (`>`) — colored span gets spell-checked as plain text (false positives).
- `CheckText` is O(words × tokens) — quadratic on long Relique descriptions with many color tokens.
- `DictionaryManager` `HashSet<string>` has no synchronization — racy read/write during background dictionary load.
- Plus: re-entrant `WordAdded` event, synchronous event dispatch deadlock risk, bare-catch swallowing malformed dict files, unlocked `ScanForDictionaries` cache mutation, and test gaps.

Findings need confirmation first — focused failing tests using NWN color tokens before fixes.

## Related Issues

- Closes #2264

## Checklist

- [ ] Implementation complete
- [ ] Tests added/updated
- [ ] CHANGELOG updated with date
- [ ] Documentation updated (if needed)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)