### PR TITLE
[Radoub] Fix: Marlinspike NSS search (#2314) + Radoub.Dictionary HIGH findings (#2264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.Dictionary 0.2.4-alpha] - 2026-05-29
+**Branch**: `radoub/issue-2314` | **PR**: #2315
+
+### Fix: Color-token regex hole, CheckText O(N²), thread-unsafe DictionaryManager (#2264)
+
+- Spell-check now ignores NWN `<cRGB>` color tokens even when a raw channel byte is `0x3E` (`>`), `CheckText` is linear in token count, and `DictionaryManager` is thread-safe.
+
+---
+
 ## [Radoub.Dictionary 0.2.3-alpha] - 2026-05-29
 **Branch**: `radoub/issue-2263` | **PR**: #2308
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.1.62-alpha] - 2026-05-29
+**Branch**: `radoub/issue-2314` | **PR**: #TBD
+
+### Fix: Marlinspike NSS checkbox is dead code — .nss files never searched (#2314)
+
+- Marlinspike content search now discovers `.nss` (NWN script) files, so the "Include NSS" filter actually returns results.
+
+---
+
 ## [Radoub.UI 0.1.61-alpha] - 2026-05-28
 **Branch**: `radoub/issue-2262` | **PR**: #2288
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Radoub.UI 0.1.62-alpha] - 2026-05-29
-**Branch**: `radoub/issue-2314` | **PR**: #TBD
+**Branch**: `radoub/issue-2314` | **PR**: #2315
 
 ### Fix: Marlinspike NSS checkbox is dead code — .nss files never searched (#2314)
 

--- a/Radoub.Dictionary/Radoub.Dictionary.Tests/DictionaryDiscoveryTests.cs
+++ b/Radoub.Dictionary/Radoub.Dictionary.Tests/DictionaryDiscoveryTests.cs
@@ -1,0 +1,92 @@
+using Radoub.Dictionary.Models;
+using Xunit;
+
+namespace Radoub.Dictionary.Tests;
+
+/// <summary>
+/// Tests for user-dictionary discovery: malformed files are skipped (not crashed on),
+/// valid JSON custom dictionaries are surfaced, and the scan cache behaves (#2264).
+/// </summary>
+public class DictionaryDiscoveryTests : IDisposable
+{
+    private readonly string _dir;
+
+    public DictionaryDiscoveryTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"RadoubDictDisc_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch { }
+    }
+
+    [Fact]
+    public void ScanForDictionaries_MalformedJson_IsSkippedNotThrown()
+    {
+        // A garbage .dic file in the user folder must not abort discovery.
+        File.WriteAllText(Path.Combine(_dir, "broken.dic"), "{ this is not valid json ");
+
+        var discovery = new DictionaryDiscovery(_dir);
+
+        // Should not throw; broken file simply absent from results.
+        var results = discovery.GetAvailableCustomDictionaries();
+        Assert.DoesNotContain(results, d => d.Id == "broken");
+    }
+
+    [Fact]
+    public void ScanForDictionaries_ValidCustomJson_IsDiscovered()
+    {
+        var dict = new CustomDictionary
+        {
+            Source = "Test Pack",
+            Description = "unit-test dictionary",
+            Words = new List<string> { "Aribeth", "Fenthick" }
+        };
+        var json = System.Text.Json.JsonSerializer.Serialize(dict,
+            new System.Text.Json.JsonSerializerOptions
+            {
+                PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase
+            });
+        File.WriteAllText(Path.Combine(_dir, "testpack.dic"), json);
+
+        var discovery = new DictionaryDiscovery(_dir);
+        var results = discovery.GetAvailableCustomDictionaries();
+
+        var found = Assert.Single(results, d => d.Id == "testpack");
+        Assert.Equal("Test Pack", found.Name);
+        Assert.Equal(2, found.WordCount);
+    }
+
+    [Fact]
+    public void ScanForDictionaries_SkipsSettingsAndCustomFiles()
+    {
+        File.WriteAllText(Path.Combine(_dir, "settings.json"), "{}");
+        File.WriteAllText(Path.Combine(_dir, "custom.dic"), "{\"words\":[\"x\"]}");
+
+        var discovery = new DictionaryDiscovery(_dir);
+        var results = discovery.GetAvailableCustomDictionaries();
+
+        Assert.DoesNotContain(results, d => d.Id == "settings");
+        Assert.DoesNotContain(results, d => d.Id == "custom");
+    }
+
+    [Fact]
+    public void ScanForDictionaries_CachesUntilCleared()
+    {
+        var discovery = new DictionaryDiscovery(_dir);
+        var first = discovery.ScanForDictionaries();
+
+        // Add a file after the first scan — cached result must not see it.
+        File.WriteAllText(Path.Combine(_dir, "late.dic"), "{\"source\":\"Late\",\"words\":[\"z\"]}");
+        var cached = discovery.ScanForDictionaries();
+        Assert.Equal(first.Count, cached.Count);
+
+        // After clearing, the rescan picks it up.
+        discovery.ClearCache();
+        var rescanned = discovery.ScanForDictionaries();
+        Assert.Contains(rescanned, d => d.Id == "late");
+    }
+}

--- a/Radoub.Dictionary/Radoub.Dictionary.Tests/DictionaryManagerTests.cs
+++ b/Radoub.Dictionary/Radoub.Dictionary.Tests/DictionaryManagerTests.cs
@@ -229,4 +229,62 @@ public class DictionaryManagerTests
         Assert.Equal(3, manager.WordCount); // Aribeth, Fenthick, Desther
         Assert.Equal(2, manager.DictionaryCount);
     }
+
+    [Fact]
+    public void ConcurrentAddAndRead_DoesNotThrowOrCorrupt()
+    {
+        // Finding #5: HashSet is documented unsafe for concurrent write+read.
+        // Hammer AddWord from several writers while readers call IsKnown / GetAllWords / WordCount.
+        var manager = new DictionaryManager();
+        const int writers = 4;
+        const int perWriter = 2000;
+
+        var exceptions = new System.Collections.Concurrent.ConcurrentQueue<Exception>();
+        using var start = new ManualResetEventSlim(false);
+        var tasks = new List<Task>();
+
+        for (int w = 0; w < writers; w++)
+        {
+            int writerId = w;
+            tasks.Add(Task.Run(() =>
+            {
+                start.Wait();
+                try
+                {
+                    for (int i = 0; i < perWriter; i++)
+                        manager.AddWord($"word_{writerId}_{i}");
+                }
+                catch (Exception ex) { exceptions.Enqueue(ex); }
+            }));
+        }
+
+        // Readers
+        for (int r = 0; r < 2; r++)
+        {
+            tasks.Add(Task.Run(() =>
+            {
+                start.Wait();
+                try
+                {
+                    for (int i = 0; i < perWriter * writers; i++)
+                    {
+                        _ = manager.IsKnown($"word_0_{i % perWriter}");
+                        if (i % 256 == 0)
+                        {
+                            _ = manager.WordCount;
+                            foreach (var _ in manager.GetAllWords()) { /* force enumeration */ }
+                        }
+                    }
+                }
+                catch (Exception ex) { exceptions.Enqueue(ex); }
+            }));
+        }
+
+        start.Set();
+        Task.WaitAll(tasks.ToArray());
+
+        Assert.True(exceptions.IsEmpty,
+            $"Concurrent access threw: {string.Join("; ", exceptions.Select(e => e.GetType().Name + ": " + e.Message))}");
+        Assert.Equal(writers * perWriter, manager.WordCount);
+    }
 }

--- a/Radoub.Dictionary/Radoub.Dictionary.Tests/DictionarySettingsServiceTests.cs
+++ b/Radoub.Dictionary/Radoub.Dictionary.Tests/DictionarySettingsServiceTests.cs
@@ -1,0 +1,84 @@
+using Xunit;
+
+namespace Radoub.Dictionary.Tests;
+
+/// <summary>
+/// Tests for dictionary settings persistence + change notifications (#2264).
+/// Uses the internal custom-path constructor so each test gets an isolated settings file.
+/// </summary>
+public class DictionarySettingsServiceTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _settingsPath;
+
+    public DictionarySettingsServiceTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"RadoubDictSettings_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+        _settingsPath = Path.Combine(_dir, "settings.json");
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch { }
+    }
+
+    private DictionarySettingsService New() => new(_settingsPath);
+
+    [Fact]
+    public void PrimaryLanguage_RoundTripsThroughDisk()
+    {
+        var a = New();
+        a.PrimaryLanguage = "de_DE";
+
+        var reloaded = New();
+        Assert.Equal("de_DE", reloaded.PrimaryLanguage);
+    }
+
+    [Fact]
+    public void SpellCheckEnabled_RoundTripsThroughDisk()
+    {
+        var a = New();
+        a.SpellCheckEnabled = false;
+
+        var reloaded = New();
+        Assert.False(reloaded.SpellCheckEnabled);
+    }
+
+    [Fact]
+    public void SetCustomDictionaryEnabled_RoundTripsThroughDisk()
+    {
+        var a = New();
+        a.SetCustomDictionaryEnabled("lotr", false);
+        Assert.False(a.IsCustomDictionaryEnabled("lotr"));
+
+        var reloaded = New();
+        Assert.False(reloaded.IsCustomDictionaryEnabled("lotr"));
+    }
+
+    [Fact]
+    public async Task PrimaryLanguageChanged_FiresOnChange()
+    {
+        var svc = New();
+        var tcs = new TaskCompletionSource<string>();
+        svc.PrimaryLanguageChanged += (_, lang) => tcs.TrySetResult(lang);
+
+        svc.PrimaryLanguage = "fr_FR";
+
+        // Event is dispatched off the caller thread (Finding #4) — await with a timeout.
+        var completed = await Task.WhenAny(tcs.Task, Task.Delay(2000));
+        Assert.Same(tcs.Task, completed);
+        Assert.Equal("fr_FR", await tcs.Task);
+    }
+
+    [Fact]
+    public void PrimaryLanguage_NoChange_DoesNotRewrite()
+    {
+        var svc = New();
+        svc.PrimaryLanguage = "en_US"; // default — same value, no event/save expected
+        // Setting the same value again must be a no-op (no throw).
+        svc.PrimaryLanguage = "en_US";
+        Assert.Equal("en_US", svc.PrimaryLanguage);
+    }
+}

--- a/Radoub.Dictionary/Radoub.Dictionary.Tests/SpellCheckerTests.cs
+++ b/Radoub.Dictionary/Radoub.Dictionary.Tests/SpellCheckerTests.cs
@@ -316,4 +316,81 @@ public class SpellCheckerTests
         // Should not throw on second dispose
         checker.Dispose();
     }
+
+    #region Color-token exclusion (#2264)
+
+    // Builds an NWN color tag: "<c" + 3 raw RGB bytes + ">".
+    private static string ColorTag(byte r, byte g, byte b)
+        => "<c" + (char)r + (char)g + (char)b + ">";
+
+    [Fact]
+    public void CheckText_ColorTokenWithGtByteInRed_DoesNotLeakTagBytes()
+    {
+        // R byte = 0x3E ('>') — the legacy <[^>]+> token regex truncates the open tag here,
+        // leaking the remaining tag bytes (G, B) as plain text and spell-checking them.
+        var manager = new DictionaryManager();
+        manager.AddWord("Hello");
+        var checker = new SpellChecker(manager);
+
+        var text = ColorTag(0x3E, 0xFF, 0xFF) + "Hello" + "</c>";
+        var errors = checker.CheckText(text).ToList();
+
+        // The colored CONTENT "Hello" is valid; the raw tag bytes must not surface as errors.
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void CheckText_ColorTokenWithGtByteInGreen_DoesNotLeakTagBytes()
+    {
+        var manager = new DictionaryManager();
+        manager.AddWord("Hello");
+        var checker = new SpellChecker(manager);
+
+        var text = ColorTag(0xFE, 0x3E, 0x20) + "Hello" + "</c>";
+        var errors = checker.CheckText(text).ToList();
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void CheckText_ColorTokenContent_IsStillSpellChecked()
+    {
+        // Colored content is real display text — a misspelling inside it must still be flagged.
+        var manager = new DictionaryManager();
+        var checker = new SpellChecker(manager);
+
+        var text = ColorTag(0xFE, 0x20, 0x20) + "Neverwinter" + "</c>";
+        var errors = checker.CheckText(text).ToList();
+
+        Assert.Single(errors);
+        Assert.Equal("Neverwinter", errors[0].Word);
+    }
+
+    [Fact]
+    public void CheckText_StandardToken_StillExcluded()
+    {
+        // Regression: standard NWN tokens like <FirstName> are excluded entirely.
+        var manager = new DictionaryManager();
+        manager.AddWord("Hello");
+        var checker = new SpellChecker(manager);
+
+        var errors = checker.CheckText("Hello <FirstName>").ToList();
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void CheckText_ColorTokenWithNormalBytes_ContentChecked()
+    {
+        var manager = new DictionaryManager();
+        manager.AddWord("red");
+        var checker = new SpellChecker(manager);
+
+        var text = ColorTag(0xFE, 0x20, 0x20) + "red" + "</c>";
+        var errors = checker.CheckText(text).ToList();
+
+        Assert.Empty(errors);
+    }
+
+    #endregion
 }

--- a/Radoub.Dictionary/Radoub.Dictionary.Tests/UserDictionaryServiceConcurrencyTests.cs
+++ b/Radoub.Dictionary/Radoub.Dictionary.Tests/UserDictionaryServiceConcurrencyTests.cs
@@ -110,4 +110,29 @@ public class UserDictionaryServiceConcurrencyTests : IDisposable
         Assert.NotNull(dict);
         Assert.Contains("ValidJsonCheck", dict!.AllWords);
     }
+
+    [Fact]
+    public void WordAdded_HandlerThatAddsAnotherWord_DoesNotThrowAndBothPersist()
+    {
+        // Finding #3: a WordAdded handler that calls back into AddWord must not deadlock,
+        // recurse unboundedly, or lose either word. The handler adds a derived word exactly once.
+        var writer = NewInstance();
+        var added = new List<string>();
+
+        writer.WordAdded += (_, w) =>
+        {
+            added.Add(w);
+            if (w == "Seed")
+                writer.AddWord("Derived");   // re-entrant add from inside the notification
+        };
+
+        writer.AddWord("Seed");
+
+        Assert.Contains("Seed", added);
+        Assert.Contains("Derived", added);
+
+        var onDisk = ReadWordsFromDisk();
+        Assert.Contains("Seed", onDisk);
+        Assert.Contains("Derived", onDisk);
+    }
 }

--- a/Radoub.Dictionary/Radoub.Dictionary/DictionaryDiscovery.cs
+++ b/Radoub.Dictionary/Radoub.Dictionary/DictionaryDiscovery.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Text.Json;
 using Radoub.Dictionary.Models;
+using Radoub.Formats.Logging;
 
 namespace Radoub.Dictionary;
 
@@ -38,6 +39,7 @@ public class DictionaryDiscovery
     };
 
     private readonly string _userDictionaryPath;
+    private readonly object _cacheLock = new();
     private List<DictionaryInfo>? _cachedDictionaries;
 
     /// <summary>
@@ -64,19 +66,24 @@ public class DictionaryDiscovery
     /// <param name="forceRescan">If true, ignores cached results.</param>
     public List<DictionaryInfo> ScanForDictionaries(bool forceRescan = false)
     {
-        if (_cachedDictionaries != null && !forceRescan)
-            return _cachedDictionaries;
+        // Lock so two concurrent callers don't both see a null cache and both rescan
+        // (wasted I/O), and so the cache field is published safely (Finding #7).
+        lock (_cacheLock)
+        {
+            if (_cachedDictionaries != null && !forceRescan)
+                return _cachedDictionaries;
 
-        var dictionaries = new List<DictionaryInfo>();
+            var dictionaries = new List<DictionaryInfo>();
 
-        // Discover bundled dictionaries
-        dictionaries.AddRange(DiscoverBundledDictionaries());
+            // Discover bundled dictionaries
+            dictionaries.AddRange(DiscoverBundledDictionaries());
 
-        // Discover user-installed dictionaries
-        dictionaries.AddRange(DiscoverUserDictionaries());
+            // Discover user-installed dictionaries
+            dictionaries.AddRange(DiscoverUserDictionaries());
 
-        _cachedDictionaries = dictionaries;
-        return dictionaries;
+            _cachedDictionaries = dictionaries;
+            return dictionaries;
+        }
     }
 
     /// <summary>
@@ -108,7 +115,10 @@ public class DictionaryDiscovery
     /// </summary>
     public void ClearCache()
     {
-        _cachedDictionaries = null;
+        lock (_cacheLock)
+        {
+            _cachedDictionaries = null;
+        }
     }
 
     private List<DictionaryInfo> DiscoverBundledDictionaries()
@@ -254,9 +264,13 @@ public class DictionaryDiscovery
                 WordCount = dict.Words.Count + (dict.Entries?.Count ?? 0)
             };
         }
-        catch
+        catch (Exception ex)
         {
-            // Invalid JSON or not a dictionary file - skip it
+            // Invalid JSON or not a dictionary file — skip it, but log so a user whose custom
+            // dictionary silently failed to appear has a breadcrumb (Finding #6).
+            UnifiedLogger.Log(LogLevel.DEBUG,
+                $"Skipped malformed dictionary file '{Path.GetFileName(filePath)}': {ex.Message}",
+                "DictionaryDiscovery", "Dictionary");
             return null;
         }
     }

--- a/Radoub.Dictionary/Radoub.Dictionary/DictionaryManager.cs
+++ b/Radoub.Dictionary/Radoub.Dictionary/DictionaryManager.cs
@@ -14,6 +14,10 @@ public class DictionaryManager
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
+    // Guards _words, _ignoredWords, and _loadedDictionaries. HashSet/List are not safe for
+    // concurrent write+read, and SpellCheckService loads dictionaries on a worker thread while
+    // the UI reads via IsKnown (Finding #5).
+    private readonly object _lock = new();
     private readonly HashSet<string> _words = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<string> _ignoredWords = new(StringComparer.OrdinalIgnoreCase);
     private readonly List<CustomDictionary> _loadedDictionaries = [];
@@ -21,24 +25,24 @@ public class DictionaryManager
     /// <summary>
     /// Gets the count of unique words in all loaded dictionaries.
     /// </summary>
-    public int WordCount => _words.Count;
+    public int WordCount { get { lock (_lock) return _words.Count; } }
 
     /// <summary>
     /// Gets the count of ignored words.
     /// </summary>
-    public int IgnoredWordCount => _ignoredWords.Count;
+    public int IgnoredWordCount { get { lock (_lock) return _ignoredWords.Count; } }
 
     /// <summary>
     /// Gets the number of dictionaries currently loaded.
     /// </summary>
-    public int DictionaryCount => _loadedDictionaries.Count;
+    public int DictionaryCount { get { lock (_lock) return _loadedDictionaries.Count; } }
 
     /// <summary>
     /// Checks if a word exists in any loaded dictionary.
     /// </summary>
     public bool ContainsWord(string word)
     {
-        return _words.Contains(word);
+        lock (_lock) return _words.Contains(word);
     }
 
     /// <summary>
@@ -46,7 +50,7 @@ public class DictionaryManager
     /// </summary>
     public bool IsIgnored(string word)
     {
-        return _ignoredWords.Contains(word);
+        lock (_lock) return _ignoredWords.Contains(word);
     }
 
     /// <summary>
@@ -54,7 +58,7 @@ public class DictionaryManager
     /// </summary>
     public bool IsKnown(string word)
     {
-        return ContainsWord(word) || IsIgnored(word);
+        lock (_lock) return _words.Contains(word) || _ignoredWords.Contains(word);
     }
 
     /// <summary>
@@ -85,23 +89,26 @@ public class DictionaryManager
     /// </summary>
     public void MergeDictionary(CustomDictionary dictionary)
     {
-        foreach (var word in dictionary.AllWords)
+        lock (_lock)
         {
-            if (!string.IsNullOrWhiteSpace(word))
+            foreach (var word in dictionary.AllWords)
             {
-                _words.Add(word.Trim());
+                if (!string.IsNullOrWhiteSpace(word))
+                {
+                    _words.Add(word.Trim());
+                }
             }
-        }
 
-        foreach (var word in dictionary.IgnoredWords)
-        {
-            if (!string.IsNullOrWhiteSpace(word))
+            foreach (var word in dictionary.IgnoredWords)
             {
-                _ignoredWords.Add(word.Trim());
+                if (!string.IsNullOrWhiteSpace(word))
+                {
+                    _ignoredWords.Add(word.Trim());
+                }
             }
-        }
 
-        _loadedDictionaries.Add(dictionary);
+            _loadedDictionaries.Add(dictionary);
+        }
     }
 
     /// <summary>
@@ -111,7 +118,7 @@ public class DictionaryManager
     {
         if (!string.IsNullOrWhiteSpace(word))
         {
-            _words.Add(word.Trim());
+            lock (_lock) _words.Add(word.Trim());
         }
     }
 
@@ -122,7 +129,7 @@ public class DictionaryManager
     {
         if (!string.IsNullOrWhiteSpace(word))
         {
-            _ignoredWords.Add(word.Trim());
+            lock (_lock) _ignoredWords.Add(word.Trim());
         }
     }
 
@@ -131,7 +138,7 @@ public class DictionaryManager
     /// </summary>
     public void RemoveIgnoredWord(string word)
     {
-        _ignoredWords.Remove(word);
+        lock (_lock) _ignoredWords.Remove(word);
     }
 
     /// <summary>
@@ -139,9 +146,12 @@ public class DictionaryManager
     /// </summary>
     public void Clear()
     {
-        _words.Clear();
-        _ignoredWords.Clear();
-        _loadedDictionaries.Clear();
+        lock (_lock)
+        {
+            _words.Clear();
+            _ignoredWords.Clear();
+            _loadedDictionaries.Clear();
+        }
     }
 
     /// <summary>
@@ -149,13 +159,16 @@ public class DictionaryManager
     /// </summary>
     public CustomDictionary CreateDictionary(string source, string? description = null)
     {
-        return new CustomDictionary
+        lock (_lock)
         {
-            Source = source,
-            Description = description,
-            Words = _words.OrderBy(w => w, StringComparer.OrdinalIgnoreCase).ToList(),
-            IgnoredWords = _ignoredWords.OrderBy(w => w, StringComparer.OrdinalIgnoreCase).ToList()
-        };
+            return new CustomDictionary
+            {
+                Source = source,
+                Description = description,
+                Words = _words.OrderBy(w => w, StringComparer.OrdinalIgnoreCase).ToList(),
+                IgnoredWords = _ignoredWords.OrderBy(w => w, StringComparer.OrdinalIgnoreCase).ToList()
+            };
+        }
     }
 
     /// <summary>
@@ -182,7 +195,9 @@ public class DictionaryManager
     /// </summary>
     public IEnumerable<string> GetAllWords()
     {
-        return _words.OrderBy(w => w, StringComparer.OrdinalIgnoreCase);
+        // Materialize the snapshot under the lock; callers enumerate the returned list freely.
+        lock (_lock)
+            return _words.OrderBy(w => w, StringComparer.OrdinalIgnoreCase).ToList();
     }
 
     /// <summary>
@@ -190,6 +205,7 @@ public class DictionaryManager
     /// </summary>
     public IEnumerable<string> GetIgnoredWords()
     {
-        return _ignoredWords.OrderBy(w => w, StringComparer.OrdinalIgnoreCase);
+        lock (_lock)
+            return _ignoredWords.OrderBy(w => w, StringComparer.OrdinalIgnoreCase).ToList();
     }
 }

--- a/Radoub.Dictionary/Radoub.Dictionary/DictionarySettingsService.cs
+++ b/Radoub.Dictionary/Radoub.Dictionary/DictionarySettingsService.cs
@@ -48,6 +48,12 @@ public class DictionarySettingsService
     /// </summary>
     public event EventHandler<bool>? SpellCheckEnabledChanged;
 
+    // Settings setters are typically called on the UI thread, while consumers
+    // (e.g. SpellCheckService) respond by awaiting a SemaphoreSlim-guarded reload.
+    // Dispatching event invocations off the caller's thread keeps a synchronous setter
+    // call from re-entering a consumer that is mid-reload (Finding #4).
+    private static void RaiseOffThread(Action raise) => Task.Run(raise);
+
     private DictionarySettingsService()
     {
         var userDictPath = DictionaryDiscovery.GetDefaultUserDictionaryPath();
@@ -109,7 +115,9 @@ public class DictionarySettingsService
             {
                 _settings.PrimaryLanguage = value;
                 SaveSettings();
-                PrimaryLanguageChanged?.Invoke(this, value);
+                var handler = PrimaryLanguageChanged;
+                if (handler != null)
+                    RaiseOffThread(() => handler(this, value));
             }
         }
     }
@@ -126,7 +134,9 @@ public class DictionarySettingsService
             {
                 _settings.SpellCheckEnabled = value;
                 SaveSettings();
-                SpellCheckEnabledChanged?.Invoke(this, value);
+                var handler = SpellCheckEnabledChanged;
+                if (handler != null)
+                    RaiseOffThread(() => handler(this, value));
             }
         }
     }
@@ -163,7 +173,9 @@ public class DictionarySettingsService
         if (changed)
         {
             SaveSettings();
-            CustomDictionaryToggled?.Invoke(this, new DictionaryToggleEventArgs(dictionaryId, enabled));
+            var handler = CustomDictionaryToggled;
+            if (handler != null)
+                RaiseOffThread(() => handler(this, new DictionaryToggleEventArgs(dictionaryId, enabled)));
         }
     }
 

--- a/Radoub.Dictionary/Radoub.Dictionary/SpellChecker.cs
+++ b/Radoub.Dictionary/Radoub.Dictionary/SpellChecker.cs
@@ -133,22 +133,25 @@ public partial class SpellChecker : IDisposable
         if (string.IsNullOrWhiteSpace(text))
             yield break;
 
-        // Find all <TOKEN> ranges to exclude from spell checking (NWN variables like <FirstName>)
-        var tokenRanges = new List<(int Start, int End)>();
-        var tokenMatches = TokenPattern().Matches(text);
-        foreach (Match tokenMatch in tokenMatches)
-        {
-            tokenRanges.Add((tokenMatch.Index, tokenMatch.Index + tokenMatch.Length));
-        }
+        // Build sorted, non-overlapping token-tag ranges to exclude from spell checking
+        // (NWN variables like <FirstName> and color tags like <cRGB>).
+        var tokenRanges = BuildTokenRanges(text);
 
         var matches = WordPattern().Matches(text);
+        int rangeCursor = 0;
         foreach (Match match in matches)
         {
-            // Skip words that are inside a <TOKEN> range
             var wordStart = match.Index;
             var wordEnd = match.Index + match.Length;
-            var isInsideToken = tokenRanges.Any(range =>
-                wordStart >= range.Start && wordEnd <= range.End);
+
+            // Ranges are sorted by Start and words are enumerated left-to-right, so we can
+            // advance a cursor instead of re-scanning every range per word (Finding #2: was O(words × tokens)).
+            while (rangeCursor < tokenRanges.Count && tokenRanges[rangeCursor].End <= wordStart)
+                rangeCursor++;
+
+            var isInsideToken = rangeCursor < tokenRanges.Count
+                && wordStart >= tokenRanges[rangeCursor].Start
+                && wordEnd <= tokenRanges[rangeCursor].End;
 
             if (isInsideToken)
                 continue;
@@ -282,10 +285,54 @@ public partial class SpellChecker : IDisposable
         return d[m, n];
     }
 
+    /// <summary>
+    /// Builds the sorted, non-overlapping list of token-tag ranges (the tags themselves, not their
+    /// content) that should be skipped during spell checking.
+    ///
+    /// NWN color tags are "&lt;c" + exactly three raw RGB bytes + "&gt;". A channel byte can legally be
+    /// 0x3E ('&gt;'), so the generic "&lt;[^&gt;]+&gt;" token pattern truncates the tag and leaks the
+    /// remaining tag bytes as plain text (Finding #1). Color tags are therefore matched first by
+    /// consuming three chars after "&lt;c" and then the following "&gt;", before the generic pass.
+    /// </summary>
+    private static List<(int Start, int End)> BuildTokenRanges(string text)
+    {
+        var ranges = new List<(int Start, int End)>();
+
+        // Pass 1: color open tags "<c" + 3 RGB bytes (i+2..i+4) + ">" (i+5),
+        // regardless of '>' bytes inside the RGB triplet.
+        for (int i = 0; i + 5 < text.Length; i++)
+        {
+            if (text[i] == '<' && text[i + 1] == 'c' && text[i + 5] == '>')
+            {
+                ranges.Add((i, i + 6));
+                i += 5; // skip past this tag (loop's i++ moves to the char after '>')
+            }
+        }
+
+        // Pass 2: generic tokens "<...>" (standard variables, "</c>", "<CUSTOM####>", etc.),
+        // skipping anything already covered by a color tag.
+        foreach (Match m in TokenPattern().Matches(text))
+        {
+            var start = m.Index;
+            var end = m.Index + m.Length;
+            bool overlaps = false;
+            foreach (var r in ranges)
+            {
+                if (start < r.End && r.Start < end) { overlaps = true; break; }
+            }
+            if (!overlaps)
+                ranges.Add((start, end));
+        }
+
+        ranges.Sort((a, b) => a.Start.CompareTo(b.Start));
+        return ranges;
+    }
+
     [GeneratedRegex(@"\b[\w']+\b", RegexOptions.Compiled)]
     private static partial Regex WordPattern();
 
-    // Matches NWN token variables like <FirstName>, <CUSTOM1016>, etc.
+    // Matches NWN token variables like <FirstName>, <CUSTOM1016>, and "</c>" close tags.
+    // Color OPEN tags are handled separately in BuildTokenRanges because a channel byte may be '>'.
     [GeneratedRegex(@"<[^>]+>", RegexOptions.Compiled)]
     private static partial Regex TokenPattern();
 

--- a/Radoub.Dictionary/Radoub.Dictionary/UserDictionaryService.cs
+++ b/Radoub.Dictionary/Radoub.Dictionary/UserDictionaryService.cs
@@ -129,12 +129,15 @@ public class UserDictionaryService
 
         if (added)
         {
-            WordAdded?.Invoke(this, trimmedWord);
-
+            // Save first, then notify. Notifying before the save lets a handler that calls back
+            // into AddWord kick off a nested Save that races the one below (Finding #3). Snapshot
+            // the delegate so a handler subscribing/unsubscribing mid-fire can't tear the list.
             if (autoSave)
             {
                 Save();
             }
+
+            WordAdded?.Invoke(this, trimmedWord);
         }
     }
 
@@ -162,14 +165,19 @@ public class UserDictionaryService
             }
         }
 
-        foreach (var added in addedWords)
-        {
-            WordAdded?.Invoke(this, added);
-        }
-
+        // Save first, then notify (see AddWord — avoids a handler triggering a nested racing Save).
         if (anyAdded && autoSave)
         {
             Save();
+        }
+
+        var handler = WordAdded;
+        if (handler != null)
+        {
+            foreach (var added in addedWords)
+            {
+                handler(this, added);
+            }
         }
     }
 

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/ModuleSearchServiceTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/ModuleSearchServiceTests.cs
@@ -132,17 +132,117 @@ public class ModuleSearchServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task ScanModule_IgnoresNonGffFiles()
+    public async Task ScanModule_IgnoresUnsupportedExtensions()
     {
         WriteDlgFile("test.dlg", "Searchable text.");
         File.WriteAllText(Path.Combine(_tempDir, "readme.txt"), "Searchable text.");
-        File.WriteAllText(Path.Combine(_tempDir, "script.nss"), "Searchable text.");
 
         var criteria = new SearchCriteria { Pattern = "Searchable" };
         var results = await _service.ScanModuleAsync(_tempDir, criteria);
 
-        // Only the DLG file should be scanned (txt and nss are not GFF)
+        // .txt is not a searchable extension; only the DLG is scanned.
         Assert.Equal(1, results.TotalFilesScanned);
+    }
+
+    #endregion
+
+    #region ScanModuleAsync — NSS Content Search (#2314)
+
+    private string WriteNssFile(string name, string source)
+    {
+        var filePath = Path.Combine(_tempDir, name);
+        File.WriteAllText(filePath, source);
+        return filePath;
+    }
+
+    [Fact]
+    public async Task ScanModule_SearchesNssContent()
+    {
+        WriteNssFile("door_open.nss", "void main()\n{\n    ActionOpenDoor(GetObjectByTag(\"front_gate\"));\n}\n");
+
+        var criteria = new SearchCriteria { Pattern = "front_gate" };
+        var results = await _service.ScanModuleAsync(_tempDir, criteria);
+
+        Assert.Equal(1, results.TotalFilesScanned);
+        Assert.Equal(1, results.FilesWithMatches);
+        var file = Assert.Single(results.Files);
+        Assert.Equal(ResourceTypes.Nss, file.ResourceType);
+        Assert.Equal("nss", file.Extension);
+        Assert.True(file.MatchCount >= 1);
+    }
+
+    [Fact]
+    public async Task ScanModule_NssContent_HonorsFileTypeFilter_Excluded()
+    {
+        WriteNssFile("door_open.nss", "ActionOpenDoor(GetObjectByTag(\"front_gate\"));");
+
+        // NSS not in the filter — must not be searched.
+        var criteria = new SearchCriteria
+        {
+            Pattern = "front_gate",
+            FileTypeFilter = new[] { ResourceTypes.Dlg }
+        };
+        var results = await _service.ScanModuleAsync(_tempDir, criteria);
+
+        Assert.Equal(0, results.TotalFilesScanned);
+        Assert.Equal(0, results.TotalMatches);
+    }
+
+    [Fact]
+    public async Task ScanModule_NssContent_HonorsFileTypeFilter_Included()
+    {
+        WriteNssFile("door_open.nss", "ActionOpenDoor(GetObjectByTag(\"front_gate\"));");
+
+        var criteria = new SearchCriteria
+        {
+            Pattern = "front_gate",
+            FileTypeFilter = new[] { ResourceTypes.Nss }
+        };
+        var results = await _service.ScanModuleAsync(_tempDir, criteria);
+
+        Assert.Equal(1, results.TotalFilesScanned);
+        Assert.Equal(1, results.FilesWithMatches);
+    }
+
+    [Fact]
+    public async Task ScanModule_NssContent_ReportsLineNumber()
+    {
+        WriteNssFile("greet.nss", "void main()\n{\n    SpeakString(\"Welcome traveller\");\n}\n");
+
+        var criteria = new SearchCriteria { Pattern = "Welcome traveller" };
+        var results = await _service.ScanModuleAsync(_tempDir, criteria);
+
+        var file = Assert.Single(results.Files);
+        var match = Assert.Single(file.Matches);
+        Assert.Equal("Welcome traveller", match.MatchedText);
+        // Match is on line 3.
+        Assert.Equal("Line 3", match.Location?.ToString());
+    }
+
+    [Fact]
+    public async Task ScanModule_NssContent_NoMatch_NotReported()
+    {
+        WriteNssFile("idle.nss", "void main() { }");
+
+        var criteria = new SearchCriteria { Pattern = "front_gate" };
+        var results = await _service.ScanModuleAsync(_tempDir, criteria);
+
+        Assert.Equal(1, results.TotalFilesScanned);
+        Assert.Equal(0, results.FilesWithMatches);
+    }
+
+    [Fact]
+    public void SearchSingleFile_NssContent_FindsMatches()
+    {
+        var filePath = WriteNssFile("script.nss", "AssignCommand(oPC, ActionSpeakString(\"hello\"));");
+        var criteria = new SearchCriteria { Pattern = "ActionSpeakString" };
+
+        var result = _service.SearchSingleFile(filePath, criteria);
+
+        Assert.True(result.MatchCount >= 1);
+        Assert.Equal("nss", result.Extension);
+        Assert.Equal(ResourceTypes.Nss, result.ResourceType);
+        Assert.False(result.HadParseError);
     }
 
     #endregion

--- a/Radoub.UI/Radoub.UI/Services/Search/ModuleSearchService.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/ModuleSearchService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 using Radoub.Formats.Common;
 using Radoub.Formats.Gff;
 using Radoub.Formats.Logging;
@@ -15,11 +16,24 @@ public class ModuleSearchService
 {
     private readonly SearchProviderFactory _factory;
 
-    /// <summary>Known GFF file extensions that can be searched</summary>
+    /// <summary>Searchable file extensions. GFF formats are parsed and searched by field;
+    /// .nss is plain NWScript source, searched line-by-line as text (#2314).</summary>
     private static readonly HashSet<string> SearchableExtensions = new(StringComparer.OrdinalIgnoreCase)
     {
         ".dlg", ".utc", ".bic", ".uti", ".utm", ".jrl", ".ifo", ".fac",
-        ".are", ".git", ".utp", ".ute", ".utt", ".utw", ".utd", ".uts", ".itp"
+        ".are", ".git", ".utp", ".ute", ".utt", ".utw", ".utd", ".uts", ".itp",
+        ".nss"
+    };
+
+    /// <summary>Virtual field for NSS source-content matches (not a GFF field).</summary>
+    private static readonly FieldDefinition NssSourceField = new()
+    {
+        Name = "Script Source",
+        GffPath = "<nss-source>",
+        FieldType = SearchFieldType.Text,
+        Category = SearchFieldCategory.Script,
+        Description = "NWScript source line",
+        IsReplaceable = false
     };
 
     /// <summary>Map resource type to Radoub tool identifier for dispatch</summary>
@@ -186,6 +200,10 @@ public class ModuleSearchService
         var resourceType = GetResourceType(filePath);
         var toolId = GetToolId(resourceType);
 
+        // NSS is plain NWScript source, not GFF — search it as text.
+        if (resourceType == ResourceTypes.Nss)
+            return SearchNssFileInternal(filePath, resourceType, toolId, criteria);
+
         try
         {
             var gffFile = GffReader.Read(filePath);
@@ -228,6 +246,78 @@ public class ModuleSearchService
                 ParseError = ex.Message
             };
         }
+    }
+
+    /// <summary>
+    /// Search NWScript (.nss) source as plain text, one match per regex hit, with line numbers.
+    /// </summary>
+    private FileSearchResult? SearchNssFileInternal(
+        string filePath, ushort resourceType, string toolId, SearchCriteria criteria)
+    {
+        try
+        {
+            var source = File.ReadAllText(filePath);
+            var regex = criteria.ToRegex();
+            var matches = new List<SearchMatch>();
+
+            foreach (Match m in regex.Matches(source))
+            {
+                matches.Add(new SearchMatch
+                {
+                    Field = NssSourceField,
+                    MatchedText = m.Value,
+                    FullFieldValue = LineTextAt(source, m.Index),
+                    MatchOffset = m.Index - LineStartAt(source, m.Index),
+                    MatchLength = m.Length,
+                    Location = $"Line {LineNumberAt(source, m.Index)}"
+                });
+            }
+
+            return new FileSearchResult
+            {
+                FilePath = filePath,
+                ResourceType = resourceType,
+                ToolId = toolId,
+                Matches = matches
+            };
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"Failed to search {Path.GetFileName(filePath)}: {ex.Message}");
+
+            return new FileSearchResult
+            {
+                FilePath = filePath,
+                ResourceType = resourceType,
+                ToolId = toolId,
+                Matches = Array.Empty<SearchMatch>(),
+                HadParseError = true,
+                ParseError = ex.Message
+            };
+        }
+    }
+
+    private static int LineNumberAt(string text, int index)
+    {
+        int line = 1;
+        for (int i = 0; i < index && i < text.Length; i++)
+            if (text[i] == '\n') line++;
+        return line;
+    }
+
+    private static int LineStartAt(string text, int index)
+    {
+        int start = text.LastIndexOf('\n', Math.Min(index, text.Length - 1));
+        return start < 0 ? 0 : start + 1;
+    }
+
+    private static string LineTextAt(string text, int index)
+    {
+        int start = LineStartAt(text, index);
+        int end = text.IndexOf('\n', start);
+        if (end < 0) end = text.Length;
+        return text.Substring(start, end - start).TrimEnd('\r');
     }
 
     /// <summary>

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml
@@ -95,7 +95,7 @@
                         <CheckBox Content="FAC" IsChecked="{Binding IncludeFac}" Margin="0,0,8,0" MinWidth="65"/>
                         <CheckBox Content="ITP" IsChecked="{Binding IncludeItp}" Margin="0,0,8,0" MinWidth="65"/>
                         <CheckBox Content="NSS" IsChecked="{Binding IncludeNss}" Margin="0,0,8,0" MinWidth="65"
-                                  ToolTip.Tip="Plain-text scan of .nss script source for ResRef references. Quoted matches are high confidence; bare substring matches are flagged 'verify'."/>
+                                  ToolTip.Tip="Plain-text search of .nss NWScript source. Matches are reported with line numbers."/>
                     </WrapPanel>
                 </StackPanel>
 


### PR DESCRIPTION
## Summary

Two HIGH-priority shared-library fixes bundled into one PR.

### Marlinspike NSS content search (#2314)
`.nss` was missing from `ModuleSearchService.SearchableExtensions`, so NSS files were dropped at discovery — the "Include NSS" checkbox was dead code. Added `.nss` to the allowlist + a plain-text NSS search path (GFF parser not applied to NSS); matches report line numbers.

### Radoub.Dictionary HIGH findings (#2264)
From the 2026-05-25 code review:
- **Color-token regex hole**: `<cRGB>` tags are now excluded from spell-check even when an RGB channel byte is `0x3E` (`>`). The old `<[^>]+>` exclusion truncated the tag and spell-checked the leaked bytes.
- **CheckText O(N²)**: token-range lookup is now linear (sorted ranges + advancing cursor) instead of `ranges.Any()` per word.
- **DictionaryManager thread-safety**: all `HashSet`/`List` access lock-guarded; `GetAllWords`/`GetIgnoredWords` materialize snapshots under the lock.
- **Re-entrant WordAdded**: `UserDictionaryService` notifies after save so a handler re-entering `AddWord` can't kick off a racing save.
- **Sync event dispatch deadlock**: `DictionarySettingsService` raises change events off the caller thread (`Task.Run`) to avoid a UI-thread reload deadlock.
- **Bare-catch / cache race**: `DictionaryDiscovery` logs skipped malformed files at DEBUG and locks its scan cache.

## Related Issues

- Closes #2314
- Closes #2264

## Test Results

- Radoub.UI search: 113/113 (incl. 6 new NSS tests)
- Radoub.Dictionary: 75/75 (color-token, concurrency, discovery, settings tests added)
- Parley: 839/839 · Manifest: 104/104 · Trebuchet: 228/228

## Checklist

- [x] Marlinspike NSS fix + tests
- [x] Dictionary fixes + tests
- [x] CHANGELOG updated (Radoub.UI 0.1.62-alpha, Radoub.Dictionary 0.2.4-alpha)
- [ ] Documentation updated (if needed)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)