### PR TITLE
[Manifest] Fix: Model-mutation rollback + async lifecycle hygiene (#2254)

### DIFF
--- a/Manifest/CHANGELOG.md
+++ b/Manifest/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.15.9-alpha] - 2026-05-29
+**Branch**: `manifest/issue-2254` | **PR**: #TBD
+
+### Fix: Model-mutation rollback + async lifecycle hygiene (#2254)
+
+- Add-category/add-entry handlers now roll back the model if tree refresh throws (#2166 pattern). Window closing guarded against re-entrant double-save. Startup `OnWindowOpened` wrapped in try/catch with cancellation.
+
+---
+
 ## [0.15.8-alpha] - 2026-05-26
 **Branch**: `radoub/issue-2244` | **PR**: #2266
 

--- a/Manifest/CHANGELOG.md
+++ b/Manifest/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.15.9-alpha] - 2026-05-29
-**Branch**: `manifest/issue-2254` | **PR**: #TBD
+**Branch**: `manifest/issue-2254` | **PR**: #2316
 
 ### Fix: Model-mutation rollback + async lifecycle hygiene (#2254)
 

--- a/Manifest/Manifest.Tests/EditOpsTests.cs
+++ b/Manifest/Manifest.Tests/EditOpsTests.cs
@@ -84,4 +84,48 @@ public class EditOpsTests
     }
 
     #endregion
+
+    #region TryMutateWithRollback (#2254)
+
+    [Fact]
+    public void TryMutateWithRollback_RefreshSucceeds_KeepsItemAndReturnsTrue()
+    {
+        var list = new List<string> { "a", "b" };
+        var refreshed = false;
+
+        var result = MainWindow.TryMutateWithRollback(list, "c", () => refreshed = true);
+
+        Assert.True(result);
+        Assert.True(refreshed);
+        Assert.Equal(new[] { "a", "b", "c" }, list);
+    }
+
+    [Fact]
+    public void TryMutateWithRollback_RefreshThrows_RemovesItemAndReturnsFalse()
+    {
+        var list = new List<string> { "a", "b" };
+
+        var result = MainWindow.TryMutateWithRollback(
+            list, "c", () => throw new InvalidOperationException("refresh blew up"));
+
+        Assert.False(result);
+        // Model rolled back to pre-add state — the half-added item is gone.
+        Assert.Equal(new[] { "a", "b" }, list);
+    }
+
+    [Fact]
+    public void TryMutateWithRollback_RefreshThrows_OnlyRemovesTheAddedItem()
+    {
+        // Rollback must remove the specific item it added, not blindly the last element.
+        var list = new List<string> { "a", "b" };
+
+        MainWindow.TryMutateWithRollback(
+            list, "c", () => throw new InvalidOperationException());
+
+        // "b" (a pre-existing last element) must survive.
+        Assert.Contains("b", list);
+        Assert.DoesNotContain("c", list);
+    }
+
+    #endregion
 }

--- a/Manifest/Manifest/Views/MainWindow.EditOps.cs
+++ b/Manifest/Manifest/Views/MainWindow.EditOps.cs
@@ -37,15 +37,46 @@ public partial class MainWindow
             Comment = ""
         };
 
-        _currentJrl.Categories.Add(newCategory);
+        // #2254 — guard the model.Add → UpdateTree sequence: if UpdateTree throws,
+        // the category is rolled back so the model never ends up dirty + half-rendered.
+        if (!TryMutateWithRollback(_currentJrl.Categories, newCategory, UpdateTree))
+        {
+            UnifiedLogger.LogJournal(LogLevel.ERROR, $"Add category rolled back (tree refresh failed): {uniqueTag}");
+            UpdateStatus("Could not add category — change was rolled back.");
+            return;
+        }
+
         MarkDirty();
-        UpdateTree();
         UpdateStatusBarCounts();
 
         // Select the new category and focus the name field
         SelectNewCategory(newCategory);
 
         UnifiedLogger.LogJournal(LogLevel.INFO, $"Added new category with tag: {uniqueTag}");
+    }
+
+    /// <summary>
+    /// Add <paramref name="item"/> to <paramref name="list"/>, then run <paramref name="refresh"/>.
+    /// If the refresh throws, the item is removed (model rolled back) and the exception is
+    /// swallowed after logging, so callers never leave a dirty model behind a failed UI refresh.
+    /// Canonical #2166 rollback pattern (see Relique MainWindow.ItemProperties.TryAddProperty).
+    /// </summary>
+    /// <returns>True if the refresh succeeded; false if it threw and the add was rolled back.</returns>
+    internal static bool TryMutateWithRollback<T>(IList<T> list, T item, Action refresh)
+    {
+        list.Add(item);
+        try
+        {
+            refresh();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            list.Remove(item);
+            UnifiedLogger.LogJournal(LogLevel.ERROR,
+                $"Refresh failed after add — rolled back: {ex.GetType().Name}: {ex.Message}");
+            return false;
+        }
     }
 
     internal static string GenerateUniqueTag(string baseTag, HashSet<string> existingTags)
@@ -98,9 +129,15 @@ public partial class MainWindow
             End = false
         };
 
-        category.Entries.Add(newEntry);
+        // #2254 — same rollback guard as OnAddCategoryClick.
+        if (!TryMutateWithRollback(category.Entries, newEntry, UpdateTree))
+        {
+            UnifiedLogger.LogJournal(LogLevel.ERROR, $"Add entry rolled back (tree refresh failed): ID {nextId}");
+            UpdateStatus("Could not add entry — change was rolled back.");
+            return;
+        }
+
         MarkDirty();
-        UpdateTree();
         UpdateStatusBarCounts();
 
         // Select the new entry and focus the text field

--- a/Manifest/Manifest/Views/MainWindow.FileOps.cs
+++ b/Manifest/Manifest/Views/MainWindow.FileOps.cs
@@ -117,7 +117,6 @@ public partial class MainWindow
 
     private async Task LoadFile(string filePath)
     {
-        await Task.CompletedTask; // Async signature preserved for future async I/O
         try
         {
             // Release lock on previous file if any
@@ -138,7 +137,9 @@ public partial class MainWindow
                 _documentState.IsReadOnly = true;
             }
 
-            _currentJrl = JrlReader.Read(filePath);
+            // #2254 — actually-async parse: JrlReader.Read does blocking disk I/O + GFF
+            // parse. Push to Task.Run so the UI thread stays responsive on large journals.
+            _currentJrl = await Task.Run(() => JrlReader.Read(filePath));
             _documentState.CurrentFilePath = filePath;
             _documentState.ClearDirty();
 
@@ -193,7 +194,6 @@ public partial class MainWindow
 
     private async Task SaveFile()
     {
-        await Task.CompletedTask; // Async signature preserved for future async I/O
         if (_currentJrl == null || string.IsNullOrEmpty(_currentFilePath)) return;
 
         if (_documentState.IsReadOnly)
@@ -205,7 +205,10 @@ public partial class MainWindow
 
         try
         {
-            JrlWriter.Write(_currentJrl, _currentFilePath);
+            // #2254 — actually-async write so multi-MB journals don't block the UI thread.
+            var jrl = _currentJrl;
+            var path = _currentFilePath!;
+            await Task.Run(() => JrlWriter.Write(jrl, path));
             _documentState.ClearDirty();
             UpdateTitle();
             UpdateStatus($"Saved: {Path.GetFileName(_currentFilePath)}");

--- a/Manifest/Manifest/Views/MainWindow.axaml.cs
+++ b/Manifest/Manifest/Views/MainWindow.axaml.cs
@@ -39,6 +39,14 @@ public partial class MainWindow : Window, INotifyPropertyChanged
     private object? _selectedItem;
     private Language _currentViewLanguage = Language.English;
 
+    // #2254 — guard against OnWindowClosing re-entry. HandleClosingAsync sets e.Cancel=true
+    // and we call Close() again to actually close; without this flag the second Close() re-runs
+    // the dirty-check/save dialog (double-save hazard / recursion).
+    private bool _isClosingConfirmed;
+
+    // #2254 — cancellation for async startup work in OnWindowOpened.
+    private System.Threading.CancellationTokenSource? _windowCts;
+
     // Convenience accessor for document state file path
     private string? _currentFilePath
     {
@@ -106,9 +114,24 @@ public partial class MainWindow : Window, INotifyPropertyChanged
         // Only handle once
         Opened -= OnWindowOpened;
 
-        UpdateRecentFilesMenu();
-        UpdateModuleIndicator();
-        await HandleStartupFileAsync();
+        // #2254 — async void with no guard previously swallowed any startup exception,
+        // leaving the app silently empty. Wrap in try/catch + cancellation (QM Lifecycle pattern).
+        _windowCts = new System.Threading.CancellationTokenSource();
+        try
+        {
+            UpdateRecentFilesMenu();
+            UpdateModuleIndicator();
+            await HandleStartupFileAsync();
+        }
+        catch (OperationCanceledException)
+        {
+            UnifiedLogger.LogApplication(LogLevel.DEBUG, "Window initialization cancelled");
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.ERROR, $"Startup initialization failed: {ex.Message}");
+            UpdateStatus("Startup failed — see logs.");
+        }
     }
 
     private void RestoreWindowPosition()
@@ -137,11 +160,18 @@ public partial class MainWindow : Window, INotifyPropertyChanged
 
     private async void OnWindowClosing(object? sender, WindowClosingEventArgs e)
     {
+        // #2254 — second entry from our own Close() call below: allow the close to proceed
+        // without re-running the dirty-check/save dialog.
+        if (_isClosingConfirmed)
+            return;
+
         var shouldClose = await FileOperationsHelper.HandleClosingAsync(
             this, e, _documentState.IsDirty, async () => { await SaveFile(); return true; });
 
         if (shouldClose)
         {
+            _isClosingConfirmed = true;
+            _windowCts?.Cancel();
             _documentState.ClearDirty();
             Radoub.UI.Services.ThemeManager.Instance.ThemeApplied -= OnThemeApplied;
             Radoub.UI.Services.FileSessionLockService.ReleaseAllLocks();


### PR DESCRIPTION
## Summary

Apply #2166 rollback pattern to Manifest add-category/add-entry handlers, plus async lifecycle hardening (closing re-entry guard, OnWindowOpened try/catch + CT, fake-async review).

## Related Issues

- Closes #2254
- Pattern source: #2166 (Relique canonical rollback)
- Sibling: #2252 (Quartermaster lifecycle, merged)

## Checklist

- [ ] Rollback handlers wrapped (EditOps.cs OnAddCategoryClick/OnAddEntryClick)
- [ ] OnWindowClosing re-entry guard
- [ ] OnWindowOpened try/catch + CancellationToken
- [ ] Fake-async LoadFile/SaveFile addressed
- [ ] Tests added/updated
- [ ] CHANGELOG updated with date

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)