### PR TITLE
[Radoub] Feat: Add Copy and Rename to file browser right-click menu

### DIFF
--- a/.claude/commands/pre-merge.md
+++ b/.claude/commands/pre-merge.md
@@ -312,8 +312,9 @@ Flag if >30 days old and code changed.
 |-------|--------|
 | Privacy scan | ✅/⚠️ |
 | Tech debt | ✅ / ⚠️ Warning (800+) / ⚠️ Tracked (#N) / ⚠️ NEW issue created (#N) |
-| Unit tests | ✅ N passed / ❌ N failed |
+| Unit tests (local, Windows) | ✅ N passed / ❌ N failed |
 | UI tests | ⏭️ Skipped / 🔄 Auto-triggered / ✅ N passed / ❌ N failed |
+| CI checks (incl. Linux) | ✅ All pass / ⏳ In progress / ❌ [N] failed (see Step 7c) |
 
 **UI Test Reason**: [Manual --ui-tests / Auto-detected UI changes / Skipped (no UI changes)]
 **UIFilter**: [filter expression / "all" / N/A]
@@ -348,6 +349,44 @@ If any tech debt issues were created (`gh issue create`) or the PR was edited, r
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Refresh-GitHubCache.ps1" -Force
 ```
 
+### Step 7c: Verify CI Checks (catch cross-platform failures)
+
+Local tests only run on Windows. CI also runs the test suite on **ubuntu-latest**, which catches platform-specific bugs the local run cannot — most commonly path-handling tests that assume Windows semantics (`Path.Combine("C:", ...)` is absolute on Windows but **relative** on Linux, so `Path.GetFullPath` resolves it against the runner CWD and string-equality assertions diverge). The Linux/Windows test split is exactly the gap that slipped a green local pre-merge into a red PR.
+
+After marking the PR ready, check the live CI check status:
+
+```bash
+gh pr checks [number]
+```
+
+**Interpret the result**:
+
+| State | Action |
+|-------|--------|
+| All checks `pass` | ✅ Report "CI green" in the checklist. |
+| Any check `pending`/`in progress` | ⏳ CI still running. Report "CI in progress — re-run `gh pr checks [number]` before merge." Do NOT claim ready. |
+| Any check `fail` | ❌ **Block.** Pull the failing job's log and fix before declaring ready (see below). |
+
+**On failure**, get the real assertion (not the runner's summary line — the `##[error]Unable to process file command 'env'` / `Invalid format` annotations are often a downstream symptom, not the cause):
+
+```bash
+# List failing checks and their run/job URLs
+gh pr checks [number]
+
+# Pull only the failed steps for the job ID from the URL
+gh run view --job [jobId] --log-failed 2>&1 | grep -iE "\[FAIL\]|Assert|Expected:|Actual:|error CS|\.cs\(" | head -30
+```
+
+Common Linux-only failure: a unit test asserts a literal Windows path. Fix the **test** (root paths at `Path.GetTempPath()` and compute the expected value with the same `Path.GetFullPath` the code under test uses) — not the production code, which is usually correct. Re-run local tests, push, and re-check `gh pr checks` until green.
+
+**Report in the checklist**:
+
+```
+| CI checks (incl. Linux) | ✅ All pass / ⏳ In progress / ❌ [N] failed — [job], fix before merge |
+```
+
+A pre-merge is only "Ready" when CI is green (or explicitly deferred by the user). Green-local + unknown-CI is **not** ready.
+
 ## Test Script Reference
 
 ```powershell
@@ -368,3 +407,4 @@ powershell -ExecutionPolicy Bypass -File "d:\LOM\workspace\Radoub\Radoub.Integra
 - Shared library changes → include shared tests
 - Wiki updates done separately with `/documentation`
 - **Hands-off keyboard during UI tests** - focus stealing can cause failures
+- **CI runs on Linux too** (Step 7c) - local pre-merge only runs Windows. Always check `gh pr checks` after marking ready; never claim "Ready" on green-local + unknown-CI. The classic miss is a test asserting a Windows-literal path that fails under Linux `Path.GetFullPath`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Radoub.UI 0.1.64-alpha] - 2026-05-29
-**Branch**: `radoub/issue-2320` | **PR**: #TBD
+**Branch**: `radoub/issue-2320` | **PR**: #2322
 
 ### Feat: Copy and Rename in file browser right-click menu (#2320)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.1.64-alpha] - 2026-05-29
+**Branch**: `radoub/issue-2320` | **PR**: #TBD
+
+### Feat: Copy and Rename in file browser right-click menu (#2320)
+
+- Shared `FileBrowserPanelBase` context menu now offers Copy (duplicate to a new ResRef) and Rename (rename the on-disk file) alongside Delete, with Aurora 16-char filename validation and browser-row refresh. Every tool's file browser gains both at once.
+
+---
+
 ## [Radoub.UI 0.1.63-alpha] - 2026-05-29
 **Branch**: `quartermaster/issue-1735` | **PR**: #2317
 

--- a/Fence/Fence/Views/MainWindow.FileOps.cs
+++ b/Fence/Fence/Views/MainWindow.FileOps.cs
@@ -540,6 +540,61 @@ public partial class MainWindow
     }
 
     /// <summary>
+    /// Rename the currently-open store to an already-validated path (the shared
+    /// browser menu prompted + validated; #2320). Lock-aware: save-if-dirty →
+    /// release lock(old) → move → update ResRef + re-save → reacquire lock(new)
+    /// → refresh browser. Editor state stays bound in place (no reload).
+    /// </summary>
+    private async Task RenameOpenFileAsync(string oldPath, string newPath)
+    {
+        if (_currentStore == null || string.IsNullOrEmpty(_currentFilePath))
+            return;
+        if (!string.Equals(_currentFilePath, oldPath, StringComparison.OrdinalIgnoreCase))
+            return; // selection changed underneath us
+
+        try
+        {
+            if (_isDirty)
+                await SaveFile(oldPath);
+
+            FileSessionLockService.ReleaseLock(oldPath);
+            _documentState.IsReadOnly = false;
+
+            File.Move(oldPath, newPath);
+            UnifiedLogger.LogApplication(LogLevel.INFO,
+                $"Renamed open store: {UnifiedLogger.SanitizePath(oldPath)} -> {UnifiedLogger.SanitizePath(newPath)}");
+
+            var newName = Path.GetFileNameWithoutExtension(newPath);
+            _currentStore.ResRef = newName;
+            _currentFilePath = newPath;
+            await SaveFile(newPath); // persist new ResRef
+
+            // Reacquire the session lock on the new path so the editor keeps
+            // ownership and other tools see it as open.
+            FileSessionLockService.AcquireLock(newPath, "Fence");
+
+            StoreResRefBox.Text = newName;
+            UpdateTitle();
+            UpdateRecentFilesMenu();
+
+            var storeBrowserPanel = this.FindControl<StoreBrowserPanel>("StoreBrowserPanel");
+            if (storeBrowserPanel != null)
+            {
+                storeBrowserPanel.CurrentFilePath = newPath;
+                storeBrowserPanel.RemoveEntryByFilePath(oldPath);
+                await storeBrowserPanel.RefreshAsync();
+            }
+
+            UpdateStatusBar($"Renamed to: {Path.GetFileName(newPath)}");
+        }
+        catch (IOException ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.ERROR, $"Failed to rename open store: {ex.Message}");
+            ShowError($"Could not rename file:\n\n{ex.Message}");
+        }
+    }
+
+    /// <summary>
     /// Renames the current file using a safe save-rename-reload workflow.
     /// </summary>
     private async Task RenameCurrentFileAsync()

--- a/Fence/Fence/Views/MainWindow.StoreBrowser.cs
+++ b/Fence/Fence/Views/MainWindow.StoreBrowser.cs
@@ -77,13 +77,11 @@ public partial class MainWindow
         {
             UpdateStatusBar($"Renamed to: {Path.GetFileName(args.NewPath)}");
         };
-        // Renaming the OPEN store isn't supported from the browser yet — it holds
-        // a session lock and an in-memory ResRef. Guide the user (#2320).
-        storeBrowserPanel.FileRenameRequested += (_, _) =>
+        // Renaming the OPEN store: base prompted + validated; run lock-aware
+        // save → move → re-save → refresh here (#2320).
+        storeBrowserPanel.FileRenameRequested += async (_, args) =>
         {
-            UpdateStatusBar("Close the file (or use Save As) to rename the store that's open.");
-            UnifiedLogger.LogApplication(LogLevel.INFO,
-                "Browser rename of the open store deferred — not yet supported in Fence.");
+            await RenameOpenFileAsync(args.OldPath, args.NewPath);
         };
 
         // Restore panel state from settings

--- a/Fence/Fence/Views/MainWindow.StoreBrowser.cs
+++ b/Fence/Fence/Views/MainWindow.StoreBrowser.cs
@@ -67,6 +67,25 @@ public partial class MainWindow
             UpdateStatusBar($"Copied to module: {Path.GetFileName(destPath)}");
         };
 
+        // Shared browser Copy/Rename context-menu feedback (#2320). The panel
+        // performs the disk op + refresh for non-open files; we just report it.
+        storeBrowserPanel.FileCopied += (_, args) =>
+        {
+            UpdateStatusBar($"Copied: {Path.GetFileName(args.NewPath)}");
+        };
+        storeBrowserPanel.FileRenamed += (_, args) =>
+        {
+            UpdateStatusBar($"Renamed to: {Path.GetFileName(args.NewPath)}");
+        };
+        // Renaming the OPEN store isn't supported from the browser yet — it holds
+        // a session lock and an in-memory ResRef. Guide the user (#2320).
+        storeBrowserPanel.FileRenameRequested += (_, _) =>
+        {
+            UpdateStatusBar("Close the file (or use Save As) to rename the store that's open.");
+            UnifiedLogger.LogApplication(LogLevel.INFO,
+                "Browser rename of the open store deferred — not yet supported in Fence.");
+        };
+
         // Restore panel state from settings
         RestoreStoreBrowserPanelState();
 

--- a/Parley/Parley/Views/Helpers/DialogBrowserController.cs
+++ b/Parley/Parley/Views/Helpers/DialogBrowserController.cs
@@ -109,13 +109,11 @@ namespace Parley.Views.Helpers
             {
                 _viewModel.StatusMessage = $"Renamed to: {Path.GetFileName(args.NewPath)}";
             };
-            // Renaming the OPEN dialog isn't supported from the browser yet — it
-            // holds a session lock. Guide the user (#2320).
-            dialogBrowserPanel.FileRenameRequested += (_, _) =>
+            // Renaming the OPEN dialog: the base prompted + validated; run the
+            // lock-aware save → move → reload here (#2320).
+            dialogBrowserPanel.FileRenameRequested += async (_, args) =>
             {
-                _viewModel.StatusMessage = "Close the file (or use Save As) to rename the dialog that's open.";
-                UnifiedLogger.LogApplication(LogLevel.INFO,
-                    "Browser rename of the open dialog deferred — not yet supported in Parley.");
+                await RenameOpenFileAsync(args.OldPath, args.NewPath);
             };
 
             // Update menu item checkmark
@@ -219,6 +217,51 @@ namespace Parley.Views.Helpers
             {
                 UnifiedLogger.LogApplication(LogLevel.ERROR, $"Failed to delete {fileName}: {ex.Message}");
                 _viewModel.StatusMessage = $"Delete failed: {ex.Message}";
+            }
+        }
+
+        /// <summary>
+        /// Rename the currently-open dialog to an already-validated path (the
+        /// shared browser menu prompted + validated; #2320). DLG has no internal
+        /// ResRef field, so this is save-if-dirty → release lock(old) → move →
+        /// reload(new), where reload reacquires the lock and rebinds the editor.
+        /// </summary>
+        private async Task RenameOpenFileAsync(string oldPath, string newPath)
+        {
+            if (string.IsNullOrEmpty(_viewModel.CurrentFilePath))
+                return;
+            if (!string.Equals(_viewModel.CurrentFilePath, oldPath, StringComparison.OrdinalIgnoreCase))
+                return; // selection changed underneath us
+
+            try
+            {
+                if (_viewModel.HasUnsavedChanges)
+                    await _viewModel.SaveDialogAsync(oldPath);
+
+                // Release the lock before moving; LoadDialogAsync reacquires on the new path.
+                Radoub.UI.Services.FileSessionLockService.ReleaseLock(oldPath);
+
+                File.Move(oldPath, newPath);
+                UnifiedLogger.LogApplication(LogLevel.INFO,
+                    $"Renamed open dialog: {UnifiedLogger.SanitizePath(oldPath)} -> {UnifiedLogger.SanitizePath(newPath)}");
+
+                await _viewModel.LoadDialogAsync(newPath);
+
+                var dialogBrowserPanel = _window.FindControl<DialogBrowserPanel>("DialogBrowserPanel");
+                if (dialogBrowserPanel != null)
+                {
+                    dialogBrowserPanel.CurrentFilePath = newPath;
+                    dialogBrowserPanel.RemoveEntryByFilePath(oldPath);
+                    await dialogBrowserPanel.RefreshAsync();
+                }
+
+                _viewModel.StatusMessage = $"Renamed to: {Path.GetFileName(newPath)}";
+                _populateRecentFilesMenu();
+            }
+            catch (Exception ex)
+            {
+                UnifiedLogger.LogApplication(LogLevel.ERROR, $"Failed to rename open dialog: {ex.Message}");
+                _viewModel.StatusMessage = $"Rename failed: {ex.Message}";
             }
         }
 

--- a/Parley/Parley/Views/Helpers/DialogBrowserController.cs
+++ b/Parley/Parley/Views/Helpers/DialogBrowserController.cs
@@ -99,6 +99,25 @@ namespace Parley.Views.Helpers
                 _viewModel.StatusMessage = $"Copied to module: {Path.GetFileName(destPath)}";
             };
 
+            // Shared browser Copy/Rename context-menu feedback (#2320). The panel
+            // performs the disk op + refresh for non-open files; we just report it.
+            dialogBrowserPanel.FileCopied += (_, args) =>
+            {
+                _viewModel.StatusMessage = $"Copied: {Path.GetFileName(args.NewPath)}";
+            };
+            dialogBrowserPanel.FileRenamed += (_, args) =>
+            {
+                _viewModel.StatusMessage = $"Renamed to: {Path.GetFileName(args.NewPath)}";
+            };
+            // Renaming the OPEN dialog isn't supported from the browser yet — it
+            // holds a session lock. Guide the user (#2320).
+            dialogBrowserPanel.FileRenameRequested += (_, _) =>
+            {
+                _viewModel.StatusMessage = "Close the file (or use Save As) to rename the dialog that's open.";
+                UnifiedLogger.LogApplication(LogLevel.INFO,
+                    "Browser rename of the open dialog deferred — not yet supported in Parley.");
+            };
+
             // Update menu item checkmark
             UpdateMenuState();
         }

--- a/Quartermaster/Quartermaster/Views/MainWindow.CreatureBrowser.cs
+++ b/Quartermaster/Quartermaster/Views/MainWindow.CreatureBrowser.cs
@@ -71,6 +71,23 @@ public partial class MainWindow
             UpdateStatus($"Copied to module: {System.IO.Path.GetFileName(destPath)}");
         };
 
+        // Shared browser Copy/Rename context-menu feedback (#2320). The panel
+        // performs the disk op + refresh for non-open files; we just report it.
+        creatureBrowserPanel.FileCopied += (_, args) =>
+        {
+            UpdateStatus($"Copied: {System.IO.Path.GetFileName(args.NewPath)}");
+        };
+        creatureBrowserPanel.FileRenamed += (_, args) =>
+        {
+            UpdateStatus($"Renamed to: {System.IO.Path.GetFileName(args.NewPath)}");
+        };
+        // Renaming the OPEN creature routes to the existing lock-aware
+        // save-rename-reload flow (#2285 / #2320).
+        creatureBrowserPanel.FileRenameRequested += async (_, _) =>
+        {
+            await RenameCurrentFileAsync();
+        };
+
         // Restore panel state from settings
         RestoreCreatureBrowserPanelState();
 

--- a/Quartermaster/Quartermaster/Views/MainWindow.CreatureBrowser.cs
+++ b/Quartermaster/Quartermaster/Views/MainWindow.CreatureBrowser.cs
@@ -81,11 +81,11 @@ public partial class MainWindow
         {
             UpdateStatus($"Renamed to: {System.IO.Path.GetFileName(args.NewPath)}");
         };
-        // Renaming the OPEN creature routes to the existing lock-aware
-        // save-rename-reload flow (#2285 / #2320).
-        creatureBrowserPanel.FileRenameRequested += async (_, _) =>
+        // Renaming the OPEN creature: the base already prompted + validated the
+        // new path; run the lock-aware save → move → reload here (#2285 / #2320).
+        creatureBrowserPanel.FileRenameRequested += async (_, args) =>
         {
-            await RenameCurrentFileAsync();
+            await RenameOpenFileAsync(args.OldPath, args.NewPath);
         };
 
         // Restore panel state from settings

--- a/Quartermaster/Quartermaster/Views/MainWindow.FileValidation.cs
+++ b/Quartermaster/Quartermaster/Views/MainWindow.FileValidation.cs
@@ -122,9 +122,12 @@ public partial class MainWindow
 
     /// <summary>
     /// Rename the currently-open creature file to an already-validated path
-    /// (the shared browser menu prompted + validated; #2320). Lock-aware:
-    /// save-if-dirty → release lock(old) → move → reload(new) which reacquires
-    /// the lock, syncs ResRef to the new filename, and refreshes the browser.
+    /// (the shared browser menu prompted + validated; #2320). Lock-aware and
+    /// in-place: save-if-dirty → release lock(old) → move → update ResRef +
+    /// path → re-save → reacquire lock(new) → refresh browser. The creature is
+    /// already in memory and correct, so we do NOT reload — a full LoadFile
+    /// re-parses the UTC and rebuilds every panel (appearance/feats/spells),
+    /// which caused a visible lag after the dialog closed.
     /// </summary>
     private async Task RenameOpenFileAsync(string oldPath, string newPath)
     {
@@ -146,7 +149,7 @@ public partial class MainWindow
                 await SaveFile();
 
             // Release the lock on the old path before moving so the sidecar
-            // doesn't orphan; LoadFile reacquires on the new path.
+            // doesn't orphan; we reacquire on the new path below.
             FileSessionLockService.ReleaseLock(oldPath);
             _documentState.IsReadOnly = false;
 
@@ -154,16 +157,22 @@ public partial class MainWindow
             UnifiedLogger.LogApplication(LogLevel.INFO,
                 $"Renamed open file: {UnifiedLogger.SanitizePath(oldPath)} -> {UnifiedLogger.SanitizePath(newPath)}");
 
-            // Reload from the new path: reacquires lock, rebinds editor, sets
-            // _currentFilePath. The save-syncs-ResRef-to-filename rule means the
-            // next save fixes the internal ResRef; do it now so disk matches.
-            await LoadFile(newPath);
-            _currentCreature!.TemplateResRef = Path.GetFileNameWithoutExtension(newPath).ToLowerInvariant();
+            // In-place: point at the new file, sync ResRef to the new filename,
+            // re-save to persist it, then reacquire the session lock.
+            var newName = Path.GetFileNameWithoutExtension(newPath).ToLowerInvariant();
+            _currentFilePath = newPath;
+            _currentCreature.TemplateResRef = newName;
             await SaveFile();
+            FileSessionLockService.AcquireLock(newPath, "Quartermaster");
+
+            AdvancedPanelContent.UpdateResRefDisplay(newName);
+            UpdateTitle();
+            UpdateRecentFilesMenu();
 
             var creatureBrowserPanel = this.FindControl<CreatureBrowserPanel>("CreatureBrowserPanel");
             if (creatureBrowserPanel != null)
             {
+                creatureBrowserPanel.CurrentFilePath = newPath;
                 creatureBrowserPanel.RemoveEntryByFilePath(oldPath);
                 await creatureBrowserPanel.RefreshAsync();
             }

--- a/Quartermaster/Quartermaster/Views/MainWindow.FileValidation.cs
+++ b/Quartermaster/Quartermaster/Views/MainWindow.FileValidation.cs
@@ -7,6 +7,7 @@ using Quartermaster.Services;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Utc;
 using Radoub.UI.Controls;
+using Radoub.UI.Services;
 using Radoub.UI.Views;
 using DialogHelper = Quartermaster.Views.Helpers.DialogHelper;
 
@@ -117,6 +118,63 @@ public partial class MainWindow
     private async void OnRenameRequested(object? sender, EventArgs e)
     {
         await RenameCurrentFileAsync();
+    }
+
+    /// <summary>
+    /// Rename the currently-open creature file to an already-validated path
+    /// (the shared browser menu prompted + validated; #2320). Lock-aware:
+    /// save-if-dirty → release lock(old) → move → reload(new) which reacquires
+    /// the lock, syncs ResRef to the new filename, and refreshes the browser.
+    /// </summary>
+    private async Task RenameOpenFileAsync(string oldPath, string newPath)
+    {
+        if (_currentCreature == null || string.IsNullOrEmpty(_currentFilePath))
+            return;
+        if (!string.Equals(_currentFilePath, oldPath, StringComparison.OrdinalIgnoreCase))
+            return; // selection changed underneath us
+
+        if (_isBicFile)
+        {
+            DialogHelper.ShowMessageDialog(this, "Cannot Rename",
+                "Player character (BIC) files cannot be renamed this way. Use File > Save As.");
+            return;
+        }
+
+        try
+        {
+            if (_isDirty)
+                await SaveFile();
+
+            // Release the lock on the old path before moving so the sidecar
+            // doesn't orphan; LoadFile reacquires on the new path.
+            FileSessionLockService.ReleaseLock(oldPath);
+            _documentState.IsReadOnly = false;
+
+            File.Move(oldPath, newPath);
+            UnifiedLogger.LogApplication(LogLevel.INFO,
+                $"Renamed open file: {UnifiedLogger.SanitizePath(oldPath)} -> {UnifiedLogger.SanitizePath(newPath)}");
+
+            // Reload from the new path: reacquires lock, rebinds editor, sets
+            // _currentFilePath. The save-syncs-ResRef-to-filename rule means the
+            // next save fixes the internal ResRef; do it now so disk matches.
+            await LoadFile(newPath);
+            _currentCreature!.TemplateResRef = Path.GetFileNameWithoutExtension(newPath).ToLowerInvariant();
+            await SaveFile();
+
+            var creatureBrowserPanel = this.FindControl<CreatureBrowserPanel>("CreatureBrowserPanel");
+            if (creatureBrowserPanel != null)
+            {
+                creatureBrowserPanel.RemoveEntryByFilePath(oldPath);
+                await creatureBrowserPanel.RefreshAsync();
+            }
+
+            UpdateStatus($"Renamed to: {Path.GetFileName(newPath)}");
+        }
+        catch (IOException ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.ERROR, $"Failed to rename open file: {ex.Message}");
+            DialogHelper.ShowMessageDialog(this, "Rename Failed", $"Could not rename file:\n\n{ex.Message}");
+        }
     }
 
     /// <summary>

--- a/Radoub.UI/Radoub.UI.Tests/FileBrowserOperationsTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/FileBrowserOperationsTests.cs
@@ -9,34 +9,46 @@ namespace Radoub.UI.Tests;
 /// for the shared file-browser Copy and Rename context-menu actions (#2320).
 /// The disk I/O (File.Copy / File.Move) and dialog UI live in
 /// FileBrowserPanelBase; this covers the testable decision logic.
+///
+/// Paths are built from a rooted base (Path.GetTempPath) and expectations are
+/// computed with the same Path.GetFullPath the implementation uses, so the
+/// tests pass identically on Windows and Linux (CI runs both). A bare
+/// Path.Combine("C:", ...) is a relative path on Linux and breaks GetFullPath.
 /// </summary>
 public class FileBrowserOperationsTests
 {
+    // Rooted directory that exists on both OSes (e.g. C:\Temp\... or /tmp/...).
+    private static readonly string ModDir = Path.Combine(Path.GetTempPath(), "radoub_mod");
+    private static readonly string SubDir = Path.Combine(ModDir, "sub");
+
+    private static string Expected(string dir, string stem, string ext)
+        => Path.GetFullPath(Path.Combine(dir, stem + ext));
+
     // ---- ResolveCopyDestination ---------------------------------------
 
     [Fact]
     public void ResolveCopyDestination_BuildsPathFromNewResRefAndExtension()
     {
         var result = FileBrowserOperations.ResolveCopyDestination(
-            sourcePath: Path.Combine("C:", "mod", "sword.uti"),
+            sourcePath: Path.Combine(ModDir, "sword.uti"),
             newResRef: "sword_copy",
             extension: ".uti");
 
         Assert.True(result.IsValid);
-        Assert.Equal(Path.Combine("C:", "mod", "sword_copy.uti"), result.DestinationPath);
+        Assert.Equal(Expected(ModDir, "sword_copy", ".uti"), result.DestinationPath);
     }
 
     [Fact]
     public void ResolveCopyDestination_DestinationInSameDirectoryAsSource()
     {
         var result = FileBrowserOperations.ResolveCopyDestination(
-            sourcePath: Path.Combine("C:", "mod", "sub", "ring.uti"),
+            sourcePath: Path.Combine(SubDir, "ring.uti"),
             newResRef: "ring2",
             extension: ".uti");
 
         Assert.True(result.IsValid);
         Assert.Equal(
-            Path.GetDirectoryName(Path.Combine("C:", "mod", "sub", "ring.uti")),
+            Path.GetFullPath(SubDir),
             Path.GetDirectoryName(result.DestinationPath));
     }
 
@@ -44,7 +56,7 @@ public class FileBrowserOperationsTests
     public void ResolveCopyDestination_InvalidResRef_IsInvalid()
     {
         var result = FileBrowserOperations.ResolveCopyDestination(
-            sourcePath: Path.Combine("C:", "mod", "sword.uti"),
+            sourcePath: Path.Combine(ModDir, "sword.uti"),
             newResRef: "Has Spaces",
             extension: ".uti");
 
@@ -56,7 +68,7 @@ public class FileBrowserOperationsTests
     public void ResolveCopyDestination_TooLongResRef_IsInvalid()
     {
         var result = FileBrowserOperations.ResolveCopyDestination(
-            sourcePath: Path.Combine("C:", "mod", "sword.uti"),
+            sourcePath: Path.Combine(ModDir, "sword.uti"),
             newResRef: "this_name_is_way_too_long",
             extension: ".uti");
 
@@ -67,7 +79,7 @@ public class FileBrowserOperationsTests
     public void ResolveCopyDestination_EmptyResRef_IsInvalid()
     {
         var result = FileBrowserOperations.ResolveCopyDestination(
-            sourcePath: Path.Combine("C:", "mod", "sword.uti"),
+            sourcePath: Path.Combine(ModDir, "sword.uti"),
             newResRef: "",
             extension: ".uti");
 
@@ -80,19 +92,19 @@ public class FileBrowserOperationsTests
     public void ResolveRenameDestination_BuildsPathInSameDirectory()
     {
         var result = FileBrowserOperations.ResolveRenameDestination(
-            sourcePath: Path.Combine("C:", "mod", "old_name.utc"),
+            sourcePath: Path.Combine(ModDir, "old_name.utc"),
             newResRef: "new_name",
             extension: ".utc");
 
         Assert.True(result.IsValid);
-        Assert.Equal(Path.Combine("C:", "mod", "new_name.utc"), result.DestinationPath);
+        Assert.Equal(Expected(ModDir, "new_name", ".utc"), result.DestinationPath);
     }
 
     [Fact]
     public void ResolveRenameDestination_InvalidResRef_IsInvalid()
     {
         var result = FileBrowserOperations.ResolveRenameDestination(
-            sourcePath: Path.Combine("C:", "mod", "old_name.utc"),
+            sourcePath: Path.Combine(ModDir, "old_name.utc"),
             newResRef: "BadName",
             extension: ".utc");
 
@@ -100,13 +112,26 @@ public class FileBrowserOperationsTests
     }
 
     [Fact]
-    public void ResolveRenameDestination_TraversalAttempt_IsInvalid()
+    public void ResolveRenameDestination_BackslashTraversalAttempt_IsInvalid()
     {
-        // A new name that escapes the source directory must be rejected even if
-        // it would pass the Aurora character check after Path.Combine resolves it.
+        // Backslash is rejected by the Aurora character check; on Linux it's a
+        // valid filename char but still not in [a-z0-9_], so still invalid.
         var result = FileBrowserOperations.ResolveRenameDestination(
-            sourcePath: Path.Combine("C:", "mod", "old_name.utc"),
+            sourcePath: Path.Combine(ModDir, "old_name.utc"),
             newResRef: "..\\evil",
+            extension: ".utc");
+
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void ResolveRenameDestination_ForwardSlashTraversalAttempt_IsInvalid()
+    {
+        // Forward slash is a path separator on both OSes and not an Aurora-legal
+        // character — must be rejected so a name can't escape the directory.
+        var result = FileBrowserOperations.ResolveRenameDestination(
+            sourcePath: Path.Combine(ModDir, "old_name.utc"),
+            newResRef: "../evil",
             extension: ".utc");
 
         Assert.False(result.IsValid);
@@ -117,7 +142,7 @@ public class FileBrowserOperationsTests
     {
         // Renaming to the identical stem is a no-op and should be rejected.
         var result = FileBrowserOperations.ResolveRenameDestination(
-            sourcePath: Path.Combine("C:", "mod", "old_name.utc"),
+            sourcePath: Path.Combine(ModDir, "old_name.utc"),
             newResRef: "old_name",
             extension: ".utc");
 

--- a/Radoub.UI/Radoub.UI.Tests/FileBrowserOperationsTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/FileBrowserOperationsTests.cs
@@ -1,0 +1,126 @@
+using System.IO;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Tests for FileBrowserOperations — pure-logic path computation and validation
+/// for the shared file-browser Copy and Rename context-menu actions (#2320).
+/// The disk I/O (File.Copy / File.Move) and dialog UI live in
+/// FileBrowserPanelBase; this covers the testable decision logic.
+/// </summary>
+public class FileBrowserOperationsTests
+{
+    // ---- ResolveCopyDestination ---------------------------------------
+
+    [Fact]
+    public void ResolveCopyDestination_BuildsPathFromNewResRefAndExtension()
+    {
+        var result = FileBrowserOperations.ResolveCopyDestination(
+            sourcePath: Path.Combine("C:", "mod", "sword.uti"),
+            newResRef: "sword_copy",
+            extension: ".uti");
+
+        Assert.True(result.IsValid);
+        Assert.Equal(Path.Combine("C:", "mod", "sword_copy.uti"), result.DestinationPath);
+    }
+
+    [Fact]
+    public void ResolveCopyDestination_DestinationInSameDirectoryAsSource()
+    {
+        var result = FileBrowserOperations.ResolveCopyDestination(
+            sourcePath: Path.Combine("C:", "mod", "sub", "ring.uti"),
+            newResRef: "ring2",
+            extension: ".uti");
+
+        Assert.True(result.IsValid);
+        Assert.Equal(
+            Path.GetDirectoryName(Path.Combine("C:", "mod", "sub", "ring.uti")),
+            Path.GetDirectoryName(result.DestinationPath));
+    }
+
+    [Fact]
+    public void ResolveCopyDestination_InvalidResRef_IsInvalid()
+    {
+        var result = FileBrowserOperations.ResolveCopyDestination(
+            sourcePath: Path.Combine("C:", "mod", "sword.uti"),
+            newResRef: "Has Spaces",
+            extension: ".uti");
+
+        Assert.False(result.IsValid);
+        Assert.NotNull(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ResolveCopyDestination_TooLongResRef_IsInvalid()
+    {
+        var result = FileBrowserOperations.ResolveCopyDestination(
+            sourcePath: Path.Combine("C:", "mod", "sword.uti"),
+            newResRef: "this_name_is_way_too_long",
+            extension: ".uti");
+
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void ResolveCopyDestination_EmptyResRef_IsInvalid()
+    {
+        var result = FileBrowserOperations.ResolveCopyDestination(
+            sourcePath: Path.Combine("C:", "mod", "sword.uti"),
+            newResRef: "",
+            extension: ".uti");
+
+        Assert.False(result.IsValid);
+    }
+
+    // ---- ResolveRenameDestination -------------------------------------
+
+    [Fact]
+    public void ResolveRenameDestination_BuildsPathInSameDirectory()
+    {
+        var result = FileBrowserOperations.ResolveRenameDestination(
+            sourcePath: Path.Combine("C:", "mod", "old_name.utc"),
+            newResRef: "new_name",
+            extension: ".utc");
+
+        Assert.True(result.IsValid);
+        Assert.Equal(Path.Combine("C:", "mod", "new_name.utc"), result.DestinationPath);
+    }
+
+    [Fact]
+    public void ResolveRenameDestination_InvalidResRef_IsInvalid()
+    {
+        var result = FileBrowserOperations.ResolveRenameDestination(
+            sourcePath: Path.Combine("C:", "mod", "old_name.utc"),
+            newResRef: "BadName",
+            extension: ".utc");
+
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void ResolveRenameDestination_TraversalAttempt_IsInvalid()
+    {
+        // A new name that escapes the source directory must be rejected even if
+        // it would pass the Aurora character check after Path.Combine resolves it.
+        var result = FileBrowserOperations.ResolveRenameDestination(
+            sourcePath: Path.Combine("C:", "mod", "old_name.utc"),
+            newResRef: "..\\evil",
+            extension: ".utc");
+
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void ResolveRenameDestination_SameName_IsInvalid()
+    {
+        // Renaming to the identical stem is a no-op and should be rejected.
+        var result = FileBrowserOperations.ResolveRenameDestination(
+            sourcePath: Path.Combine("C:", "mod", "old_name.utc"),
+            newResRef: "old_name",
+            extension: ".utc");
+
+        Assert.False(result.IsValid);
+    }
+}

--- a/Radoub.UI/Radoub.UI/Controls/FileBrowserPanelBase.axaml
+++ b/Radoub.UI/Radoub.UI/Controls/FileBrowserPanelBase.axaml
@@ -81,6 +81,13 @@
                           Margin="4,0,4,4">
                     <DataGrid.ContextMenu>
                         <ContextMenu x:Name="FileListContextMenu">
+                            <MenuItem x:Name="CopyMenuItem"
+                                      Header="Copy..."
+                                      Click="OnCopyMenuItemClick"/>
+                            <MenuItem x:Name="RenameMenuItem"
+                                      Header="Rename..."
+                                      Click="OnRenameMenuItemClick"/>
+                            <Separator x:Name="FileOpsSeparator"/>
                             <MenuItem x:Name="DeleteMenuItem"
                                       Header="Delete"
                                       Click="OnDeleteMenuItemClick"/>

--- a/Radoub.UI/Radoub.UI/Controls/FileBrowserPanelBase.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Controls/FileBrowserPanelBase.axaml.cs
@@ -691,15 +691,6 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
             return;
         }
 
-        // Renaming the currently-open file is the host's job — it holds the
-        // session lock and the in-memory ResRef the panel can't see. Defer.
-        if (!string.IsNullOrEmpty(_currentFilePath)
-            && sourcePath.Equals(_currentFilePath, StringComparison.OrdinalIgnoreCase))
-        {
-            FileRenameRequested?.Invoke(this, new FileRenameRequestedEventArgs(entry));
-            return;
-        }
-
         var owner = TopLevel.GetTopLevel(this) as Window;
         if (owner == null) return;
 
@@ -707,6 +698,9 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
         var currentName = Path.GetFileNameWithoutExtension(sourcePath);
         var extension = Path.GetExtension(sourcePath);
 
+        // Prompt + validate up front so both paths (open / not-open) share the
+        // exact same name validation. Clicking a row to reach this menu usually
+        // also loads it, so the open-file case is the common one (#2320).
         var newName = await RenameDialog.ShowAsync(
             owner, currentName, directory, extension, actionLabel: "Rename", allowUnchanged: false);
         if (string.IsNullOrEmpty(newName)) return; // cancelled
@@ -716,6 +710,17 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
         {
             UnifiedLogger.LogApplication(LogLevel.WARN,
                 $"FileBrowserPanel: Rename rejected: {resolved.ErrorMessage}");
+            return;
+        }
+
+        // Renaming the currently-open file is the host's job — it holds the
+        // session lock and the in-memory ResRef the panel can't see. Hand it the
+        // already-validated destination and let it save → move → reload.
+        if (!string.IsNullOrEmpty(_currentFilePath)
+            && sourcePath.Equals(_currentFilePath, StringComparison.OrdinalIgnoreCase))
+        {
+            FileRenameRequested?.Invoke(this,
+                new FileRenameRequestedEventArgs(entry, sourcePath, resolved.DestinationPath));
             return;
         }
 

--- a/Radoub.UI/Radoub.UI/Controls/FileBrowserPanelBase.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Controls/FileBrowserPanelBase.axaml.cs
@@ -64,6 +64,30 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
     public event EventHandler<string>? FileCopiedToModule;
 
     /// <summary>
+    /// Raised when the user asks to rename the file CURRENTLY OPEN in the editor
+    /// (#2320). The panel does not touch the file; the host runs its own
+    /// lock-aware save-rename-reload (the open file may hold a session lock and
+    /// has an in-memory ResRef the panel can't see), then refreshes the browser.
+    /// </summary>
+    public event EventHandler<FileRenameRequestedEventArgs>? FileRenameRequested;
+
+    /// <summary>
+    /// Raised AFTER the panel renames a NON-open module file on disk and
+    /// refreshes the browser (#2320). The host updates the status bar. The disk
+    /// move and the browser refresh are already done — the host must not repeat
+    /// them. (Renaming the open file goes through <see cref="FileRenameRequested"/>
+    /// instead.)
+    /// </summary>
+    public event EventHandler<FileRenamedEventArgs>? FileRenamed;
+
+    /// <summary>
+    /// Raised AFTER the panel copies a module file on disk and refreshes the
+    /// browser (#2320). The host typically updates the status bar. The disk copy
+    /// and the browser refresh are already done.
+    /// </summary>
+    public event EventHandler<FileCopiedEventArgs>? FileCopied;
+
+    /// <summary>
     /// The header text displayed at the top of the panel.
     /// </summary>
     public static readonly StyledProperty<string> HeaderTextProperty =
@@ -567,11 +591,14 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
 
     private void OnContextMenuOpening(object? sender, System.ComponentModel.CancelEventArgs e)
     {
-        // Only enable Delete for module files (not HAK/vault resources)
-        var hasSelection = FileGrid.SelectedItem is FileBrowserEntry entry
+        // Copy/Rename/Delete operate on on-disk module files only (not HAK/BIF
+        // archive resources, which have no FilePath).
+        var isModuleFile = FileGrid.SelectedItem is FileBrowserEntry entry
             && !entry.IsFromHak
             && !string.IsNullOrEmpty(entry.FilePath);
-        DeleteMenuItem.IsEnabled = hasSelection;
+        DeleteMenuItem.IsEnabled = isModuleFile;
+        CopyMenuItem.IsEnabled = isModuleFile;
+        RenameMenuItem.IsEnabled = isModuleFile;
     }
 
     private void OnDeleteMenuItemClick(object? sender, RoutedEventArgs e)
@@ -579,6 +606,140 @@ public partial class FileBrowserPanelBase : UserControl, IFileBrowserPanel
         if (FileGrid.SelectedItem is FileBrowserEntry entry && !entry.IsFromHak && !string.IsNullOrEmpty(entry.FilePath))
         {
             FileDeleteRequested?.Invoke(this, new FileDeleteRequestedEventArgs(entry));
+        }
+    }
+
+    /// <summary>
+    /// Copy a module file to a new ResRef in the same directory (#2320). The
+    /// disk copy, browser refresh, and post-event are all handled here so every
+    /// tool gets identical behavior — no per-tool refresh drift. The host only
+    /// reacts to <see cref="FileCopied"/> for status-bar feedback.
+    /// </summary>
+    private async void OnCopyMenuItemClick(object? sender, RoutedEventArgs e)
+    {
+        if (FileGrid.SelectedItem is not FileBrowserEntry entry
+            || entry.IsFromHak || string.IsNullOrEmpty(entry.FilePath))
+            return;
+
+        var sourcePath = entry.FilePath!;
+        if (!File.Exists(sourcePath))
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"FileBrowserPanel: Copy source missing: {UnifiedLogger.SanitizePath(sourcePath)}");
+            return;
+        }
+
+        var owner = TopLevel.GetTopLevel(this) as Window;
+        if (owner == null) return;
+
+        var directory = Path.GetDirectoryName(sourcePath) ?? string.Empty;
+        var currentName = Path.GetFileNameWithoutExtension(sourcePath);
+        var extension = Path.GetExtension(sourcePath);
+
+        var newName = await RenameDialog.ShowAsync(
+            owner, currentName, directory, extension, actionLabel: "Copy", allowUnchanged: true);
+        if (string.IsNullOrEmpty(newName)) return; // cancelled
+
+        var resolved = FileBrowserOperations.ResolveCopyDestination(sourcePath, newName, extension);
+        if (!resolved.IsValid || resolved.DestinationPath == null)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"FileBrowserPanel: Copy rejected: {resolved.ErrorMessage}");
+            return;
+        }
+
+        try
+        {
+            // overwrite:false — the dialog already rejected an existing target.
+            File.Copy(sourcePath, resolved.DestinationPath, overwrite: false);
+            UnifiedLogger.LogApplication(LogLevel.INFO,
+                $"Copied file: {UnifiedLogger.SanitizePath(sourcePath)} -> {UnifiedLogger.SanitizePath(resolved.DestinationPath)}");
+
+            await RefreshAsync();
+            FileCopied?.Invoke(this, new FileCopiedEventArgs(sourcePath, resolved.DestinationPath));
+        }
+        catch (IOException ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.ERROR,
+                $"FileBrowserPanel: Copy failed: {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.ERROR,
+                $"FileBrowserPanel: Copy failed (access): {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Rename a module file on disk to a new ResRef in the same directory
+    /// (#2320). The disk move, browser refresh (drop stale row + re-scan), and
+    /// post-event are handled here. The host reacts to <see cref="FileRenamed"/>
+    /// to fix editor state — e.g. update the open-file path if the renamed file
+    /// was the one loaded — and the status bar.
+    /// </summary>
+    private async void OnRenameMenuItemClick(object? sender, RoutedEventArgs e)
+    {
+        if (FileGrid.SelectedItem is not FileBrowserEntry entry
+            || entry.IsFromHak || string.IsNullOrEmpty(entry.FilePath))
+            return;
+
+        var sourcePath = entry.FilePath!;
+        if (!File.Exists(sourcePath))
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"FileBrowserPanel: Rename source missing: {UnifiedLogger.SanitizePath(sourcePath)}");
+            return;
+        }
+
+        // Renaming the currently-open file is the host's job — it holds the
+        // session lock and the in-memory ResRef the panel can't see. Defer.
+        if (!string.IsNullOrEmpty(_currentFilePath)
+            && sourcePath.Equals(_currentFilePath, StringComparison.OrdinalIgnoreCase))
+        {
+            FileRenameRequested?.Invoke(this, new FileRenameRequestedEventArgs(entry));
+            return;
+        }
+
+        var owner = TopLevel.GetTopLevel(this) as Window;
+        if (owner == null) return;
+
+        var directory = Path.GetDirectoryName(sourcePath) ?? string.Empty;
+        var currentName = Path.GetFileNameWithoutExtension(sourcePath);
+        var extension = Path.GetExtension(sourcePath);
+
+        var newName = await RenameDialog.ShowAsync(
+            owner, currentName, directory, extension, actionLabel: "Rename", allowUnchanged: false);
+        if (string.IsNullOrEmpty(newName)) return; // cancelled
+
+        var resolved = FileBrowserOperations.ResolveRenameDestination(sourcePath, newName, extension);
+        if (!resolved.IsValid || resolved.DestinationPath == null)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"FileBrowserPanel: Rename rejected: {resolved.ErrorMessage}");
+            return;
+        }
+
+        try
+        {
+            File.Move(sourcePath, resolved.DestinationPath);
+            UnifiedLogger.LogApplication(LogLevel.INFO,
+                $"Renamed file: {UnifiedLogger.SanitizePath(sourcePath)} -> {UnifiedLogger.SanitizePath(resolved.DestinationPath)}");
+
+            // Drop the stale pre-rename row before re-scanning so it doesn't
+            // linger pointing at a path that no longer exists (#2285 pattern).
+            RemoveEntryByFilePath(sourcePath);
+            await RefreshAsync();
+            FileRenamed?.Invoke(this, new FileRenamedEventArgs(sourcePath, resolved.DestinationPath));
+        }
+        catch (IOException ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.ERROR,
+                $"FileBrowserPanel: Rename failed: {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.ERROR,
+                $"FileBrowserPanel: Rename failed (access): {ex.Message}");
         }
     }
 

--- a/Radoub.UI/Radoub.UI/Controls/IFileBrowserPanel.cs
+++ b/Radoub.UI/Radoub.UI/Controls/IFileBrowserPanel.cs
@@ -101,6 +101,66 @@ public class FileDeleteRequestedEventArgs : EventArgs
 }
 
 /// <summary>
+/// Event args raised when the user asks to rename the file that is CURRENTLY
+/// OPEN in the editor (#2320). The panel does NOT touch the file in this case —
+/// renaming an open file is entangled with the host's session lock and the
+/// editor's in-memory ResRef, which the shared panel can't see. The host runs
+/// its own lock-aware save-rename-reload, then should refresh the browser.
+/// </summary>
+public class FileRenameRequestedEventArgs : EventArgs
+{
+    /// <summary>The entry the user asked to rename (the open file).</summary>
+    public FileBrowserEntry Entry { get; }
+
+    public FileRenameRequestedEventArgs(FileBrowserEntry entry)
+    {
+        Entry = entry;
+    }
+}
+
+/// <summary>
+/// Event args raised AFTER the panel has renamed a file on disk and refreshed
+/// the browser (#2320). The host uses this to fix editor state — if the renamed
+/// file was the one open in the editor, update its current-file path — and to
+/// update the status bar. The panel has already done the disk move and the
+/// browser refresh; the host must NOT repeat those.
+/// </summary>
+public class FileRenamedEventArgs : EventArgs
+{
+    /// <summary>Full path of the file before the rename.</summary>
+    public string OldPath { get; }
+
+    /// <summary>Full path of the file after the rename.</summary>
+    public string NewPath { get; }
+
+    public FileRenamedEventArgs(string oldPath, string newPath)
+    {
+        OldPath = oldPath;
+        NewPath = newPath;
+    }
+}
+
+/// <summary>
+/// Event args raised AFTER the panel has copied a file on disk and refreshed
+/// the browser (#2320). The host uses this for status-bar feedback. The panel
+/// has already done the disk copy and the browser refresh.
+/// </summary>
+public class FileCopiedEventArgs : EventArgs
+{
+    /// <summary>Full path of the source file that was copied.</summary>
+    public string SourcePath { get; }
+
+    /// <summary>Full path of the newly created copy.</summary>
+    public string NewPath { get; }
+
+    public FileCopiedEventArgs(string sourcePath, string newPath)
+    {
+        SourcePath = sourcePath;
+        NewPath = newPath;
+    }
+}
+
+/// <summary>
 /// Interface for embeddable file browser panels.
 /// Implemented by tool-specific panels (DialogBrowserPanel, StoreBrowserPanel, etc.)
 /// </summary>

--- a/Radoub.UI/Radoub.UI/Controls/IFileBrowserPanel.cs
+++ b/Radoub.UI/Radoub.UI/Controls/IFileBrowserPanel.cs
@@ -102,19 +102,29 @@ public class FileDeleteRequestedEventArgs : EventArgs
 
 /// <summary>
 /// Event args raised when the user asks to rename the file that is CURRENTLY
-/// OPEN in the editor (#2320). The panel does NOT touch the file in this case —
-/// renaming an open file is entangled with the host's session lock and the
-/// editor's in-memory ResRef, which the shared panel can't see. The host runs
-/// its own lock-aware save-rename-reload, then should refresh the browser.
+/// OPEN in the editor (#2320). The panel has already prompted for and validated
+/// the new name (<see cref="NewPath"/>) but does NOT move the file — renaming an
+/// open file is entangled with the host's session lock and the editor's
+/// in-memory ResRef, which the shared panel can't see. The host runs its own
+/// save → release-lock → move → update-ResRef → reacquire-lock → reload, then
+/// refreshes the browser.
 /// </summary>
 public class FileRenameRequestedEventArgs : EventArgs
 {
     /// <summary>The entry the user asked to rename (the open file).</summary>
     public FileBrowserEntry Entry { get; }
 
-    public FileRenameRequestedEventArgs(FileBrowserEntry entry)
+    /// <summary>Current full path of the open file (the move source).</summary>
+    public string OldPath { get; }
+
+    /// <summary>Validated full destination path the host should move the file to.</summary>
+    public string NewPath { get; }
+
+    public FileRenameRequestedEventArgs(FileBrowserEntry entry, string oldPath, string newPath)
     {
         Entry = entry;
+        OldPath = oldPath;
+        NewPath = newPath;
     }
 }
 

--- a/Radoub.UI/Radoub.UI/Services/FileBrowserOperations.cs
+++ b/Radoub.UI/Radoub.UI/Services/FileBrowserOperations.cs
@@ -1,0 +1,110 @@
+using System;
+using System.IO;
+
+namespace Radoub.UI.Services;
+
+/// <summary>
+/// Result of resolving a Copy or Rename destination path for the shared
+/// file-browser context-menu actions (#2320). When <see cref="IsValid"/> is
+/// false, <see cref="DestinationPath"/> is null and <see cref="ErrorMessage"/>
+/// explains why.
+/// </summary>
+public sealed record FileBrowserPathResult(bool IsValid, string? DestinationPath, string? ErrorMessage)
+{
+    public static FileBrowserPathResult Ok(string destinationPath)
+        => new(true, destinationPath, null);
+
+    public static FileBrowserPathResult Fail(string message)
+        => new(false, null, message);
+}
+
+/// <summary>
+/// Pure-logic path computation and validation for the shared file-browser
+/// Copy and Rename actions. Disk I/O and dialog UI live in
+/// <c>FileBrowserPanelBase</c>; this class is the testable decision layer so
+/// every tool's browser gets identical, verified validation behavior (#2320).
+/// </summary>
+public static class FileBrowserOperations
+{
+    /// <summary>
+    /// Resolve the destination path for a Copy. The duplicate copy is written
+    /// to the SAME directory as the source with a new ResRef. Validates the
+    /// ResRef against Aurora filename rules.
+    /// </summary>
+    /// <param name="sourcePath">Full path of the file being copied.</param>
+    /// <param name="newResRef">New ResRef (filename stem, no extension).</param>
+    /// <param name="extension">File extension including the dot (e.g. ".uti").</param>
+    public static FileBrowserPathResult ResolveCopyDestination(
+        string sourcePath, string newResRef, string extension)
+        => ResolveInSameDirectory(sourcePath, newResRef, extension, requireDifferentName: false);
+
+    /// <summary>
+    /// Resolve the destination path for a Rename. The renamed file stays in the
+    /// SAME directory as the source. Validates the ResRef against Aurora
+    /// filename rules, rejects path-traversal, and rejects a no-op rename to the
+    /// same stem.
+    /// </summary>
+    /// <param name="sourcePath">Full path of the file being renamed.</param>
+    /// <param name="newResRef">New ResRef (filename stem, no extension).</param>
+    /// <param name="extension">File extension including the dot (e.g. ".utc").</param>
+    public static FileBrowserPathResult ResolveRenameDestination(
+        string sourcePath, string newResRef, string extension)
+        => ResolveInSameDirectory(sourcePath, newResRef, extension, requireDifferentName: true);
+
+    private static FileBrowserPathResult ResolveInSameDirectory(
+        string sourcePath, string newResRef, string extension, bool requireDifferentName)
+    {
+        if (string.IsNullOrEmpty(sourcePath))
+            return FileBrowserPathResult.Fail("Source path is missing.");
+
+        var trimmed = newResRef?.Trim() ?? string.Empty;
+
+        var filenameResult = AuroraFilenameValidator.Validate(trimmed);
+        if (!filenameResult.IsValid)
+            return FileBrowserPathResult.Fail(filenameResult.GetErrorMessage());
+
+        var directory = Path.GetDirectoryName(sourcePath);
+        if (string.IsNullOrEmpty(directory))
+            return FileBrowserPathResult.Fail("Source directory could not be determined.");
+
+        var currentStem = Path.GetFileNameWithoutExtension(sourcePath);
+        if (requireDifferentName &&
+            string.Equals(trimmed, currentStem, StringComparison.OrdinalIgnoreCase))
+        {
+            return FileBrowserPathResult.Fail("New name is unchanged.");
+        }
+
+        var destPath = Path.GetFullPath(Path.Combine(directory, trimmed + extension));
+
+        // Defense-in-depth: even though AuroraFilenameValidator rejects path
+        // separators, re-verify the resolved path stays inside the source
+        // directory so a future validator change can't open a traversal hole.
+        if (!IsPathWithinDirectory(destPath, directory))
+            return FileBrowserPathResult.Fail("The new name resolves outside the source directory.");
+
+        return FileBrowserPathResult.Ok(destPath);
+    }
+
+    /// <summary>
+    /// True if <paramref name="candidatePath"/> resolves to a file located inside
+    /// <paramref name="directory"/>. The directory is suffixed with a separator
+    /// before the prefix comparison so sibling directories sharing a name prefix
+    /// (e.g. "C:\mod" vs "C:\modfiles") cannot pass.
+    /// </summary>
+    private static bool IsPathWithinDirectory(string candidatePath, string directory)
+    {
+        if (string.IsNullOrEmpty(candidatePath) || string.IsNullOrEmpty(directory))
+            return false;
+
+        var fullCandidate = Path.GetFullPath(candidatePath);
+        var fullDir = Path.GetFullPath(directory);
+
+        if (!fullDir.EndsWith(Path.DirectorySeparatorChar) &&
+            !fullDir.EndsWith(Path.AltDirectorySeparatorChar))
+        {
+            fullDir += Path.DirectorySeparatorChar;
+        }
+
+        return fullCandidate.StartsWith(fullDir, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Radoub.UI/Radoub.UI/Views/RenameDialog.axaml
+++ b/Radoub.UI/Radoub.UI/Views/RenameDialog.axaml
@@ -55,6 +55,7 @@
 
         <!-- Warning about references -->
         <Border Grid.Row="4"
+                x:Name="WarningBorder"
                 Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
                 BorderBrush="{DynamicResource ThemeWarning}"
                 BorderThickness="1"
@@ -63,7 +64,8 @@
                 Margin="0,0,0,10">
             <StackPanel>
                 <TextBlock Text="⚠ Important:" FontWeight="SemiBold" Foreground="{DynamicResource ThemeWarning}" Margin="0,0,0,5"/>
-                <TextBlock TextWrapping="Wrap"
+                <TextBlock x:Name="WarningText"
+                           TextWrapping="Wrap"
                            Text="This renames the file only. You must manually update any scripts or triggers that reference this resource in Aurora Toolset."/>
             </StackPanel>
         </Border>

--- a/Radoub.UI/Radoub.UI/Views/RenameDialog.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Views/RenameDialog.axaml.cs
@@ -29,31 +29,53 @@ public partial class RenameDialog : Window
     }
 
     /// <summary>
-    /// Shows the rename dialog and returns the new filename if confirmed.
+    /// Shows the rename/copy name dialog and returns the chosen filename if confirmed.
     /// </summary>
     /// <param name="owner">Parent window</param>
     /// <param name="currentName">Current filename without extension</param>
     /// <param name="directory">Directory containing the file</param>
     /// <param name="extension">File extension including dot (e.g., ".dlg")</param>
+    /// <param name="actionLabel">Confirm-button label and dialog verb. "Rename"
+    /// (default) or "Copy" — the Copy flow reuses this validated-input dialog
+    /// (#2320) so both actions share one source of name validation.</param>
+    /// <param name="allowUnchanged">When true (Copy), an unchanged-from-source
+    /// name is permitted as long as no duplicate file exists; when false
+    /// (Rename), an unchanged name is rejected as a no-op.</param>
     /// <returns>New filename without extension, or null if cancelled</returns>
-    public static async Task<string?> ShowAsync(Window owner, string currentName, string directory, string extension)
+    public static async Task<string?> ShowAsync(
+        Window owner, string currentName, string directory, string extension,
+        string actionLabel = "Rename", bool allowUnchanged = false)
     {
         var dialog = new RenameDialog();
-        dialog.Configure(currentName, directory, extension);
+        dialog.Configure(currentName, directory, extension, actionLabel, allowUnchanged);
         await dialog.ShowDialog(owner);
         return dialog.NewName;
     }
 
-    private void Configure(string currentName, string directory, string extension)
+    private string _actionLabel = "Rename";
+    private bool _allowUnchanged;
+
+    private void Configure(string currentName, string directory, string extension,
+        string actionLabel, bool allowUnchanged)
     {
         _currentName = currentName;
         _directory = directory;
         _extension = extension;
+        _actionLabel = actionLabel;
+        _allowUnchanged = allowUnchanged;
 
-        Title = $"Rename {extension.TrimStart('.')} File";
+        Title = $"{actionLabel} {extension.TrimStart('.')} File";
+        RenameButton.Content = actionLabel;
         CurrentNameBox.Text = currentName;
         NewNameBox.Text = currentName;
         NewNameBox.SelectAll();
+
+        if (allowUnchanged)
+        {
+            // Copy flow: the "you must update references" rename warning doesn't apply.
+            WarningText.Text = "This creates a duplicate file. The copy starts with the " +
+                "same contents as the source; edit it after copying.";
+        }
 
         UpdateValidation();
     }
@@ -93,8 +115,10 @@ public partial class RenameDialog : Window
                 ?? BrushManager.GetDisabledBrush(); // theme-ok: fallback when resource unavailable
         }
 
-        // Check if unchanged
-        if (newName.Equals(_currentName, StringComparison.OrdinalIgnoreCase))
+        // Check if unchanged. For Rename this is a no-op and is rejected.
+        // For Copy (allowUnchanged) the same stem in the same directory still
+        // collides, so let the duplicate-file check below handle it.
+        if (!_allowUnchanged && newName.Equals(_currentName, StringComparison.OrdinalIgnoreCase))
         {
             ShowValidation("Name is unchanged.", isError: false);
             RenameButton.IsEnabled = false;

--- a/Relique/Relique/Views/MainWindow.FileOps.cs
+++ b/Relique/Relique/Views/MainWindow.FileOps.cs
@@ -14,6 +14,49 @@ public partial class MainWindow
 {
     // --- File Operations ---
 
+    /// <summary>
+    /// Rename the currently-open item to an already-validated path (the shared
+    /// browser menu prompted + validated; #2320). Lock-aware: save-if-dirty →
+    /// release lock(old) → move → reopen(new) which reacquires the lock, rebinds
+    /// the editor, and syncs the in-memory ResRef to the new filename.
+    /// </summary>
+    private async Task RenameOpenFileAsync(string oldPath, string newPath)
+    {
+        if (_currentItem == null || string.IsNullOrEmpty(_currentFilePath))
+            return;
+        if (!string.Equals(_currentFilePath, oldPath, System.StringComparison.OrdinalIgnoreCase))
+            return; // selection changed underneath us
+
+        try
+        {
+            if (_documentState.IsDirty)
+                await SaveCurrentFileAsync();
+
+            // Release the lock before moving; OpenFileAsync reacquires on the new path.
+            Radoub.UI.Services.FileSessionLockService.ReleaseLock(oldPath);
+            _documentState.IsReadOnly = false;
+
+            File.Move(oldPath, newPath);
+            UnifiedLogger.LogApplication(LogLevel.INFO,
+                $"Renamed open item: {UnifiedLogger.SanitizePath(oldPath)} -> {UnifiedLogger.SanitizePath(newPath)}");
+
+            // Reopen from the new path: reacquires lock, rebinds editor, and
+            // OpenFileAsync syncs TemplateResRef to the new filename on read.
+            await OpenFileAsync(newPath);
+
+            ItemBrowserPanel.CurrentFilePath = newPath;
+            ItemBrowserPanel.RemoveEntryByFilePath(oldPath);
+            await ItemBrowserPanel.RefreshAsync();
+
+            UpdateStatus($"Renamed to: {Path.GetFileName(newPath)}");
+        }
+        catch (IOException ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.ERROR, $"Failed to rename open item: {ex.Message}");
+            UpdateStatus($"Rename failed: {ex.Message}");
+        }
+    }
+
     private async Task<bool> OpenFileAsync(string filePath)
     {
         // Hold the previous path's lock until the new file is successfully read.

--- a/Relique/Relique/Views/MainWindow.Lifecycle.cs
+++ b/Relique/Relique/Views/MainWindow.Lifecycle.cs
@@ -196,6 +196,25 @@ public partial class MainWindow
             UpdateStatus($"Copied to module: {Path.GetFileName(destPath)}");
         };
 
+        // Shared browser Copy/Rename context-menu feedback (#2320). The panel
+        // performs the disk op + refresh for non-open files; we just report it.
+        ItemBrowserPanel.FileCopied += (_, args) =>
+        {
+            UpdateStatus($"Copied: {Path.GetFileName(args.NewPath)}");
+        };
+        ItemBrowserPanel.FileRenamed += (_, args) =>
+        {
+            UpdateStatus($"Renamed to: {Path.GetFileName(args.NewPath)}");
+        };
+        // Renaming the OPEN item isn't supported from the browser yet — it holds
+        // a session lock and an in-memory ResRef. Guide the user (#2320).
+        ItemBrowserPanel.FileRenameRequested += (_, _) =>
+        {
+            UpdateStatus("Close the file (or use Save As) to rename the item that's open.");
+            UnifiedLogger.LogApplication(LogLevel.INFO,
+                "Browser rename of the open item deferred — not yet supported in Relique.");
+        };
+
         UpdateItemBrowserMenuState();
         UnifiedLogger.LogUI(LogLevel.INFO, "ItemBrowserPanel initialized");
     }

--- a/Relique/Relique/Views/MainWindow.Lifecycle.cs
+++ b/Relique/Relique/Views/MainWindow.Lifecycle.cs
@@ -206,13 +206,11 @@ public partial class MainWindow
         {
             UpdateStatus($"Renamed to: {Path.GetFileName(args.NewPath)}");
         };
-        // Renaming the OPEN item isn't supported from the browser yet — it holds
-        // a session lock and an in-memory ResRef. Guide the user (#2320).
-        ItemBrowserPanel.FileRenameRequested += (_, _) =>
+        // Renaming the OPEN item: base prompted + validated; run lock-aware
+        // save → move → reopen here (#2320).
+        ItemBrowserPanel.FileRenameRequested += async (_, args) =>
         {
-            UpdateStatus("Close the file (or use Save As) to rename the item that's open.");
-            UnifiedLogger.LogApplication(LogLevel.INFO,
-                "Browser rename of the open item deferred — not yet supported in Relique.");
+            await RenameOpenFileAsync(args.OldPath, args.NewPath);
         };
 
         UpdateItemBrowserMenuState();


### PR DESCRIPTION
## Summary

Add Copy and Rename to the shared `FileBrowserPanelBase` right-click context menu (#2320, user-requested). Implementing in the shared base means every tool's file browser (Relique, Fence, Quartermaster, Parley) gains both at once.

- **Copy** — prompts for a new ResRef, writes a duplicate in the same folder, refreshes the browser row.
- **Rename** — renames the on-disk file. Filename-level (16-char Aurora ResRef), distinct from in-resource Name/Tag editing.
- **Delete** — existing behavior, unchanged.

Name validation lives once in a new pure-logic `FileBrowserOperations` helper (Aurora 16-char/lowercase/alphanumeric + traversal/no-op guards, 9 unit tests).

### Open-file rename

Single-clicking a browser row to reach the context menu also opens that file, so renaming the open file is the common case. The base prompts + validates, then hands the host the validated old/new paths via `FileRenameRequested`; each host runs a lock-aware save → release lock → move → re-save/reload (reacquire lock + sync in-memory ResRef) → refresh. Quartermaster renames in place (no full reload) to avoid a post-dialog lag.

## Related Issues

- Closes #2320

## Tests

- Radoub.UI 781, Radoub.Formats 1317, Radoub.Dictionary 75, Quartermaster 1207, Fence 138, Parley 839, Relique 375 — all pass.
- Privacy scan: clean. Tech debt: `FileBrowserPanelBase.axaml.cs` 960 lines (800-1000 warning range, no issue required).

## Checklist

- [x] Implementation complete
- [x] Tests added/updated (9 new FileBrowserOperations tests)
- [x] CHANGELOG updated with date + PR number
- [ ] Manual UI spot-check (Copy/Rename in each tool)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)