### PR TITLE
[Parley] Fix: TTS arg string-concat + AddNode rollback + empty catches (#2260)

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Parley. One-line highlights per version; full details in 
 ---
 
 ## [0.1.172-alpha] - 2026-05-30
-**Branch**: `parley/issue-2260` | **PR**: #TBD
+**Branch**: `parley/issue-2260` | **PR**: #2323
 
 ### Fix: TTS arg string-concat + AddNode rollback + empty catches + UndoManager trim (#2260)
 

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Parley. One-line highlights per version; full details in 
 
 ---
 
+## [0.1.172-alpha] - 2026-05-30
+**Branch**: `parley/issue-2260` | **PR**: #TBD
+
+### Fix: TTS arg string-concat + AddNode rollback + empty catches + UndoManager trim (#2260)
+
+- Switched TTS/external-process argument building from string concatenation to `ProcessStartInfo.ArgumentList`, added rollback to `AddNodeWithUndoAndRefresh`, logged previously-empty catch, linked the reflection-trampoline TODO, and made `UndoManager` stack trim O(1).
+
+---
+
 ## [0.1.171-alpha] - 2026-05-29
 **Branch**: `parley/issue-2259` | **PR**: #2309
 

--- a/Parley/Parley.Tests/GUI/AddNodeRollbackTests.cs
+++ b/Parley/Parley.Tests/GUI/AddNodeRollbackTests.cs
@@ -1,0 +1,78 @@
+using System;
+using Avalonia.Headless.XUnit;
+using DialogEditor.Models;
+using DialogEditor.ViewModels;
+using Xunit;
+
+namespace Parley.Tests.GUI
+{
+    /// <summary>
+    /// Tests for AddNodeWithUndoAndRefresh rollback (#2260).
+    /// If CoordinatedRefreshAndSelect throws mid-refresh after the new node is attached,
+    /// the model must be rolled back (node removed) rather than left half-attached with
+    /// HasUnsavedChanges=true. Mirrors the Relique #2166 rollback precedent.
+    /// </summary>
+    public class AddNodeRollbackTests
+    {
+        /// <summary>
+        /// MainViewModel subclass that simulates a refresh failure after node attachment.
+        /// </summary>
+        private sealed class FaultingRefreshViewModel : MainViewModel
+        {
+            public bool FaultEnabled { get; set; } = true;
+
+            internal override void CoordinatedRefreshAndSelect(DialogNode target)
+            {
+                if (FaultEnabled)
+                    throw new InvalidOperationException("Simulated refresh failure");
+                base.CoordinatedRefreshAndSelect(target);
+            }
+        }
+
+        [AvaloniaFact]
+        public void AddEntryNode_WhenRefreshThrows_RollsBackModelAndDirtyFlag()
+        {
+            // Arrange
+            var viewModel = new FaultingRefreshViewModel();
+            viewModel.NewDialog();
+            Assert.NotNull(viewModel.CurrentDialog);
+
+            int entriesBefore = viewModel.CurrentDialog.Entries.Count;
+            int startsBefore = viewModel.CurrentDialog.Starts.Count;
+            bool dirtyBefore = viewModel.HasUnsavedChanges;
+
+            // Act: refresh throws after the node is attached
+            viewModel.AddEntryNode(null);
+
+            // Assert: model rolled back - no leftover node, no spurious dirty flag
+            Assert.Equal(entriesBefore, viewModel.CurrentDialog.Entries.Count);
+            Assert.Equal(startsBefore, viewModel.CurrentDialog.Starts.Count);
+            Assert.Equal(dirtyBefore, viewModel.HasUnsavedChanges);
+        }
+
+        [AvaloniaFact]
+        public void AddPCReplyNode_WhenRefreshThrows_RollsBackReply()
+        {
+            // Arrange: seed one entry with the fault disabled, then enable it.
+            var viewModel = new FaultingRefreshViewModel { FaultEnabled = false };
+            viewModel.NewDialog();
+            viewModel.AddEntryNode(null);
+            viewModel.FaultEnabled = true;
+            Assert.NotNull(viewModel.CurrentDialog);
+
+            var rootNode = viewModel.DialogNodes[0] as TreeViewRootNode;
+            var entryNode = rootNode?.Children?.Count > 0 ? rootNode.Children[0] : null;
+            Assert.NotNull(entryNode);
+
+            int repliesBefore = viewModel.CurrentDialog.Replies.Count;
+            bool dirtyBefore = viewModel.HasUnsavedChanges;
+
+            // Act
+            viewModel.AddPCReplyNode(entryNode!);
+
+            // Assert: reply removed on rollback
+            Assert.Equal(repliesBefore, viewModel.CurrentDialog.Replies.Count);
+            Assert.Equal(dirtyBefore, viewModel.HasUnsavedChanges);
+        }
+    }
+}

--- a/Parley/Parley.Tests/TtsArgumentBuilderTests.cs
+++ b/Parley/Parley.Tests/TtsArgumentBuilderTests.cs
@@ -1,0 +1,85 @@
+using DialogEditor.Services;
+using Xunit;
+
+namespace Parley.Tests
+{
+    /// <summary>
+    /// Tests for TTS / external-process argument construction (#2260).
+    /// Args must be built as a token list for ProcessStartInfo.ArgumentList — no manual
+    /// quoting or shell escaping. ArgumentList passes each token verbatim to the child,
+    /// so shell metacharacters (backticks, $(), quotes) in the spoken text must survive
+    /// as literal data rather than being mangled by a naive Replace("\"","\\\"").
+    /// </summary>
+    public class TtsArgumentBuilderTests
+    {
+        [Fact]
+        public void Espeak_BuildArguments_IncludesSpeedVoiceAndVerbatimText()
+        {
+            var args = EspeakTtsService.BuildArguments(speed: 175, espeakVoiceCode: "en+m3", text: "Hello world");
+
+            Assert.Equal("-s", args[0]);
+            Assert.Equal("175", args[1]);
+            Assert.Equal("-v", args[2]);
+            Assert.Equal("en+m3", args[3]);
+            Assert.Equal("Hello world", args[^1]);
+        }
+
+        [Fact]
+        public void Espeak_BuildArguments_DoesNotEscapeOrQuoteShellMetacharacters()
+        {
+            var text = "say $(whoami) and `id` \"quoted\"";
+            var args = EspeakTtsService.BuildArguments(speed: 175, espeakVoiceCode: null, text: text);
+
+            // Text token must be the literal string — no backslash-escaping, no wrapping quotes.
+            Assert.Equal(text, args[^1]);
+            Assert.DoesNotContain("\\\"", args[^1]);
+        }
+
+        [Fact]
+        public void Espeak_BuildArguments_OmitsVoiceWhenNull()
+        {
+            var args = EspeakTtsService.BuildArguments(speed: 200, espeakVoiceCode: null, text: "hi");
+
+            Assert.DoesNotContain("-v", args);
+            Assert.Equal("-s", args[0]);
+            Assert.Equal("200", args[1]);
+            Assert.Equal("hi", args[2]);
+        }
+
+        [Fact]
+        public void MacOsSay_BuildArguments_IncludesRateVoiceAndVerbatimText()
+        {
+            var args = MacOsSayTtsService.BuildArguments(rate: 175, voiceName: "Alex", text: "Hello $(id)");
+
+            Assert.Equal("-r", args[0]);
+            Assert.Equal("175", args[1]);
+            Assert.Equal("-v", args[2]);
+            Assert.Equal("Alex", args[3]);
+            Assert.Equal("Hello $(id)", args[^1]);
+        }
+
+        [Fact]
+        public void MacOsSay_BuildArguments_OmitsVoiceWhenEmpty()
+        {
+            var args = MacOsSayTtsService.BuildArguments(rate: 150, voiceName: "", text: "hi");
+
+            Assert.DoesNotContain("-v", args);
+        }
+
+        [Fact]
+        public void Piper_BuildArguments_IncludesModelOutputAndScaleVerbatim()
+        {
+            var args = PiperTtsService.BuildArguments(
+                modelPath: "/tmp/voice model.onnx",
+                outputFile: "/tmp/out file.wav",
+                lengthScale: 1.25);
+
+            Assert.Equal("--model", args[0]);
+            Assert.Equal("/tmp/voice model.onnx", args[1]); // path with space, no quotes added
+            Assert.Equal("--output_file", args[2]);
+            Assert.Equal("/tmp/out file.wav", args[3]);
+            Assert.Equal("--length_scale", args[4]);
+            Assert.Equal("1.25", args[5]);
+        }
+    }
+}

--- a/Parley/Parley.Tests/UndoStackLimitTests.cs
+++ b/Parley/Parley.Tests/UndoStackLimitTests.cs
@@ -60,6 +60,69 @@ namespace Parley.Tests
         }
 
         [Fact]
+        public void UndoManager_PreservesLifoOrder_AfterTrim()
+        {
+            // Arrange: maxStackSize = 3 so trimming kicks in quickly (#2260 LinkedList refactor).
+            var undoManager = new UndoManager(maxStackSize: 3);
+            var dialog = new Dialog();
+            var entry = new DialogNode { Type = DialogNodeType.Entry, Text = new LocString() };
+            entry.Text.Add(0, "v0");
+            dialog.Entries.Add(entry);
+
+            // Act: save 5 states "v0".."v4"; only the newest 3 (v2,v3,v4) survive.
+            for (int i = 0; i < 5; i++)
+            {
+                entry.Text.Strings[0] = $"v{i}";
+                undoManager.SaveState(dialog, $"State {i}");
+            }
+
+            // Assert: undo returns newest-first (LIFO): v4, v3, v2, then empty.
+            Dialog? current = dialog;
+            var seen = new System.Collections.Generic.List<string>();
+            while (undoManager.CanUndo)
+            {
+                var state = undoManager.Undo(current!);
+                Assert.NotNull(state);
+                current = state!.Dialog;
+                seen.Add(current.Entries[0].Text.Strings[0]);
+            }
+
+            Assert.Equal(new[] { "v4", "v3", "v2" }, seen);
+        }
+
+        [Fact]
+        public void UndoManager_DiscardLastSavedState_RemovesNewestOnly()
+        {
+            // Arrange
+            var undoManager = new UndoManager();
+            var dialog = new Dialog();
+            var entry = new DialogNode { Type = DialogNodeType.Entry, Text = new LocString() };
+            entry.Text.Add(0, "a");
+            dialog.Entries.Add(entry);
+
+            undoManager.SaveState(dialog, "first");
+            entry.Text.Strings[0] = "b";
+            undoManager.SaveState(dialog, "second");
+
+            // Act: discard the most recent ("second")
+            bool discarded = undoManager.DiscardLastSavedState();
+
+            // Assert: one state discarded, one remains
+            Assert.True(discarded);
+            Assert.True(undoManager.CanUndo);
+            var state = undoManager.Undo(dialog);
+            Assert.NotNull(state);
+            Assert.False(undoManager.CanUndo); // only "first" was left
+        }
+
+        [Fact]
+        public void UndoManager_DiscardLastSavedState_OnEmpty_ReturnsFalse()
+        {
+            var undoManager = new UndoManager();
+            Assert.False(undoManager.DiscardLastSavedState());
+        }
+
+        [Fact]
         public void UndoManager_PreservesIsLinkFlags_AtStackLimit()
         {
             // Arrange: Create UndoManager and dialog with linked structure

--- a/Parley/Parley/Models/UndoManager.cs
+++ b/Parley/Parley/Models/UndoManager.cs
@@ -24,8 +24,11 @@ namespace Parley.Models
     /// </summary>
     public class UndoManager
     {
-        private readonly Stack<UndoState> _undoStack = new();
-        private readonly Stack<UndoState> _redoStack = new();
+        // LinkedList instead of Stack so that trimming the oldest item when the stack is
+        // over capacity is O(1) (RemoveFirst) instead of O(N) array copy (#2260).
+        // Newest item is at the tail (Last); oldest is at the head (First).
+        private readonly LinkedList<UndoState> _undoStack = new();
+        private readonly LinkedList<UndoState> _redoStack = new();
         private readonly int _maxStackSize;
         private bool _isRestoring = false;
 
@@ -78,22 +81,17 @@ namespace Parley.Models
                     ExpandedNodePaths = expandedNodePaths != null ? new HashSet<string>(expandedNodePaths) : new HashSet<string>()
                 };
 
-                // Add to undo stack
-                _undoStack.Push(undoState);
+                // Add newest state to the tail
+                _undoStack.AddLast(undoState);
 
                 // Clear redo stack when new action is performed
                 _redoStack.Clear();
 
-                // Limit stack size to prevent excessive memory usage
+                // Limit stack size to prevent excessive memory usage.
+                // O(1) per trim: drop the oldest (head) item.
                 while (_undoStack.Count > _maxStackSize)
                 {
-                    // Remove oldest item from bottom of stack
-                    var items = _undoStack.ToArray();
-                    _undoStack.Clear();
-                    for (int i = 1; i < items.Length; i++)
-                    {
-                        _undoStack.Push(items[items.Length - i]);
-                    }
+                    _undoStack.RemoveFirst();
                 }
 
                 UnifiedLogger.LogApplication(LogLevel.DEBUG, $"Saved undo state: {description} (Stack size: {_undoStack.Count})");
@@ -125,10 +123,11 @@ namespace Parley.Models
                     SelectedNodePath = currentSelectedPath,
                     ExpandedNodePaths = currentExpandedPaths != null ? new HashSet<string>(currentExpandedPaths) : new HashSet<string>()
                 };
-                _redoStack.Push(currentState);
+                _redoStack.AddLast(currentState);
 
-                // Pop and restore previous state
-                var previousState = _undoStack.Pop();
+                // Pop and restore previous state (newest = tail)
+                var previousState = _undoStack.Last!.Value;
+                _undoStack.RemoveLast();
 
                 UnifiedLogger.LogApplication(LogLevel.INFO, $"Undo performed (Remaining: {_undoStack.Count}, RestoreSelection: {previousState.SelectedNodePath ?? "none"})");
                 return previousState;
@@ -164,10 +163,11 @@ namespace Parley.Models
                     SelectedNodePath = currentSelectedPath,
                     ExpandedNodePaths = currentExpandedPaths != null ? new HashSet<string>(currentExpandedPaths) : new HashSet<string>()
                 };
-                _undoStack.Push(currentState);
+                _undoStack.AddLast(currentState);
 
-                // Pop and restore next state
-                var nextState = _redoStack.Pop();
+                // Pop and restore next state (newest = tail)
+                var nextState = _redoStack.Last!.Value;
+                _redoStack.RemoveLast();
 
                 UnifiedLogger.LogApplication(LogLevel.INFO, $"Redo performed (Remaining: {_redoStack.Count}, RestoreSelection: {nextState.SelectedNodePath ?? "none"})");
                 return nextState;
@@ -303,6 +303,18 @@ namespace Parley.Models
                 clone.Add(kvp.Key, kvp.Value);
             }
             return clone;
+        }
+
+        /// <summary>
+        /// Discards the most recently saved undo state (#2260).
+        /// Used to revert undo state when an operation rolls back after calling SaveState.
+        /// Returns true if a state was discarded.
+        /// </summary>
+        public bool DiscardLastSavedState()
+        {
+            if (_undoStack.Count == 0) return false;
+            _undoStack.RemoveLast();
+            return true;
         }
 
         /// <summary>

--- a/Parley/Parley/Services/EspeakTtsService.cs
+++ b/Parley/Parley/Services/EspeakTtsService.cs
@@ -237,22 +237,12 @@ namespace DialogEditor.Services
                 int speed = (int)(175 * rate);
                 speed = Math.Clamp(speed, 80, 450);
 
-                var args = $"-s {speed}";
-                if (!string.IsNullOrEmpty(voiceName))
-                {
-                    // Translate display name to espeak voice code (e.g., "English (Male)" -> "en+m3")
-                    var espeakCode = GetVoiceCode(voiceName);
-                    args += $" -v \"{espeakCode}\"";
-                }
-
-                // Escape text for shell
-                var escapedText = text.Replace("\"", "\\\"");
-                args += $" \"{escapedText}\"";
+                // Translate display name to espeak voice code (e.g., "English (Male)" -> "en+m3")
+                string? espeakCode = string.IsNullOrEmpty(voiceName) ? null : GetVoiceCode(voiceName);
 
                 var psi = new ProcessStartInfo
                 {
                     FileName = _espeakPath,
-                    Arguments = args,
                     UseShellExecute = false,
                     CreateNoWindow = true,
                     // Don't redirect stdout/stderr - espeak-ng needs direct audio device access
@@ -260,6 +250,11 @@ namespace DialogEditor.Services
                     RedirectStandardOutput = false,
                     RedirectStandardError = false
                 };
+
+                // Use ArgumentList (not a concatenated string) so shell metacharacters in the
+                // spoken text are passed verbatim and never reinterpreted (#2260).
+                foreach (var token in BuildArguments(speed, espeakCode, text))
+                    psi.ArgumentList.Add(token);
 
                 _currentProcess = Process.Start(psi);
                 _isSpeaking = true;
@@ -282,6 +277,22 @@ namespace DialogEditor.Services
                 UnifiedLogger.LogApplication(LogLevel.ERROR,
                     $"EspeakTtsService: Speak failed - {ex.Message}");
             }
+        }
+
+        /// <summary>
+        /// Builds the espeak-ng argument token list for ProcessStartInfo.ArgumentList (#2260).
+        /// Each element is a separate, unquoted, unescaped token; the text is passed verbatim.
+        /// </summary>
+        public static IReadOnlyList<string> BuildArguments(int speed, string? espeakVoiceCode, string text)
+        {
+            var args = new List<string> { "-s", speed.ToString() };
+            if (!string.IsNullOrEmpty(espeakVoiceCode))
+            {
+                args.Add("-v");
+                args.Add(espeakVoiceCode);
+            }
+            args.Add(text);
+            return args;
         }
 
         public void Stop()

--- a/Parley/Parley/Services/ExternalEditorService.cs
+++ b/Parley/Parley/Services/ExternalEditorService.cs
@@ -59,12 +59,14 @@ namespace DialogEditor.Services
                     UnifiedLogger.LogApplication(LogLevel.INFO,
                         $"OpenScript: Opening '{UnifiedLogger.SanitizePath(scriptPath)}' with '{UnifiedLogger.SanitizePath(editorPath)}'");
 
-                    Process.Start(new ProcessStartInfo
+                    var editorPsi = new ProcessStartInfo
                     {
                         FileName = editorPath,
-                        Arguments = $"\"{scriptPath}\"",
                         UseShellExecute = false
-                    });
+                    };
+                    // ArgumentList passes the path verbatim — no manual quoting (#2260).
+                    editorPsi.ArgumentList.Add(scriptPath);
+                    Process.Start(editorPsi);
                 }
                 else
                 {

--- a/Parley/Parley/Services/MacOsSayTtsService.cs
+++ b/Parley/Parley/Services/MacOsSayTtsService.cs
@@ -128,25 +128,19 @@ namespace DialogEditor.Services
                 int speed = (int)(175 * rate);
                 speed = Math.Clamp(speed, 1, 500);
 
-                var args = $"-r {speed}";
-                if (!string.IsNullOrEmpty(voiceName))
-                {
-                    args += $" -v \"{voiceName}\"";
-                }
-
-                // Escape text for shell - replace quotes
-                var escapedText = text.Replace("\"", "\\\"");
-                args += $" \"{escapedText}\"";
-
                 var psi = new ProcessStartInfo
                 {
                     FileName = "say",
-                    Arguments = args,
                     UseShellExecute = false,
                     CreateNoWindow = true,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true
                 };
+
+                // Use ArgumentList so shell metacharacters in the spoken text are passed
+                // verbatim and never reinterpreted (#2260).
+                foreach (var token in BuildArguments(speed, voiceName, text))
+                    psi.ArgumentList.Add(token);
 
                 _currentProcess = Process.Start(psi);
                 _isSpeaking = true;
@@ -169,6 +163,22 @@ namespace DialogEditor.Services
                 UnifiedLogger.LogApplication(LogLevel.ERROR,
                     $"MacOsSayTtsService: Speak failed - {ex.Message}");
             }
+        }
+
+        /// <summary>
+        /// Builds the macOS `say` argument token list for ProcessStartInfo.ArgumentList (#2260).
+        /// Each element is a separate, unquoted, unescaped token; the text is passed verbatim.
+        /// </summary>
+        public static IReadOnlyList<string> BuildArguments(int rate, string? voiceName, string text)
+        {
+            var args = new List<string> { "-r", rate.ToString() };
+            if (!string.IsNullOrEmpty(voiceName))
+            {
+                args.Add("-v");
+                args.Add(voiceName);
+            }
+            args.Add(text);
+            return args;
         }
 
         public void Stop()

--- a/Parley/Parley/Services/PiperTtsService.cs
+++ b/Parley/Parley/Services/PiperTtsService.cs
@@ -215,20 +215,20 @@ namespace DialogEditor.Services
                 var tempWavFile = Path.Combine(Path.GetTempPath(), $"piper_tts_{Guid.NewGuid()}.wav");
                 _currentTempFile = tempWavFile;
 
-                // Build piper command
-                // piper --model <path> --output_file <file> --length_scale <scale>
-                var args = $"--model \"{modelPath}\" --output_file \"{tempWavFile}\" --length_scale {lengthScale:F2}";
-
                 var psi = new ProcessStartInfo
                 {
                     FileName = _piperPath,
-                    Arguments = args,
                     RedirectStandardInput = true,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     UseShellExecute = false,
                     CreateNoWindow = true
                 };
+
+                // Use ArgumentList so model/output paths with spaces or metacharacters are
+                // passed verbatim (#2260). The spoken text is fed via stdin below, not args.
+                foreach (var token in BuildArguments(modelPath, tempWavFile, lengthScale))
+                    psi.ArgumentList.Add(token);
 
                 _currentProcess = Process.Start(psi);
                 if (_currentProcess == null)
@@ -285,6 +285,21 @@ namespace DialogEditor.Services
                 UnifiedLogger.LogApplication(LogLevel.ERROR,
                     $"PiperTtsService: Speak failed - {ex.Message}");
             }
+        }
+
+        /// <summary>
+        /// Builds the piper argument token list for ProcessStartInfo.ArgumentList (#2260).
+        /// Each element is a separate, unquoted token so paths with spaces survive verbatim.
+        /// The spoken text is supplied via stdin, not via these arguments.
+        /// </summary>
+        public static IReadOnlyList<string> BuildArguments(string modelPath, string outputFile, double lengthScale)
+        {
+            return new List<string>
+            {
+                "--model", modelPath,
+                "--output_file", outputFile,
+                "--length_scale", lengthScale.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)
+            };
         }
 
         private void PlayWavFile(string wavFile)

--- a/Parley/Parley/Services/UndoRedoService.cs
+++ b/Parley/Parley/Services/UndoRedoService.cs
@@ -148,6 +148,15 @@ namespace DialogEditor.Services
         }
 
         /// <summary>
+        /// Discards the most recently saved undo state (#2260).
+        /// Used to revert undo state when an operation rolls back after SaveState.
+        /// </summary>
+        public bool DiscardLastSavedState()
+        {
+            return _undoManager.DiscardLastSavedState();
+        }
+
+        /// <summary>
         /// Clears all undo/redo history
         /// </summary>
         public void Clear()

--- a/Parley/Parley/ViewModels/MainViewModel.NodeOperations.cs
+++ b/Parley/Parley/ViewModels/MainViewModel.NodeOperations.cs
@@ -41,12 +41,44 @@ namespace DialogEditor.ViewModels
             // Create node via delegate
             var newNode = createNode(parentNode, parentPtr);
 
-            // Focus on the newly created node after tree refresh
-            CoordinatedRefreshAndSelect(newNode);
+            try
+            {
+                // Focus on the newly created node after tree refresh
+                CoordinatedRefreshAndSelect(newNode);
+            }
+            catch (Exception ex)
+            {
+                // Refresh threw after the node was attached. Roll back the model so it is
+                // not left half-attached with HasUnsavedChanges flipped (Relique #2166 pattern, #2260).
+                UnifiedLogger.LogApplication(LogLevel.ERROR,
+                    $"AddNodeWithUndoAndRefresh: refresh failed, rolling back '{undoDescription}': {ex.Message}");
+                DetachCreatedNode(CurrentDialog!, newNode);
+                _undoRedoService.DiscardLastSavedState();
+                StatusMessage = $"Failed to add node: {ex.Message}";
+                return newNode;
+            }
+
             HasUnsavedChanges = true;
             StatusMessage = successMessage;
 
             return newNode;
+        }
+
+        /// <summary>
+        /// Removes a just-created leaf node from the dialog model. Used to roll back a failed
+        /// add when the tree refresh throws (#2260). The node has no children yet, so it is
+        /// enough to drop it from Entries/Replies and remove any pointer that references it.
+        /// </summary>
+        private static void DetachCreatedNode(Dialog dialog, DialogNode newNode)
+        {
+            dialog.Starts.RemoveAll(ptr => ptr.Node == newNode);
+            foreach (var entry in dialog.Entries)
+                entry.Pointers.RemoveAll(ptr => ptr.Node == newNode);
+            foreach (var reply in dialog.Replies)
+                reply.Pointers.RemoveAll(ptr => ptr.Node == newNode);
+
+            dialog.Entries.Remove(newNode);
+            dialog.Replies.Remove(newNode);
         }
 
         public void AddSmartNode(TreeViewSafeNode? selectedNode = null)
@@ -169,7 +201,7 @@ namespace DialogEditor.ViewModels
         }
 
         // COMPATIBILITY: Kept for existing tests that use reflection to access this method
-        // TODO: Update tests to use public DeleteNode API instead
+        // TODO (#2324): Update tests to use public DeleteNode API and remove this trampoline
         #pragma warning disable IDE0051 // Remove unused private members
         private void DeleteNodeRecursive(DialogNode node)
         {

--- a/Parley/Parley/ViewModels/MainViewModel.cs
+++ b/Parley/Parley/ViewModels/MainViewModel.cs
@@ -63,7 +63,7 @@ namespace DialogEditor.ViewModels
 
         public TreeRefreshCoordinator? TreeRefreshCoordinator { get; set; }
 
-        internal void CoordinatedRefreshAndSelect(DialogNode target)
+        internal virtual void CoordinatedRefreshAndSelect(DialogNode target)
         {
             if (TreeRefreshCoordinator != null)
                 TreeRefreshCoordinator.RefreshAndSelectNode(target);

--- a/Parley/Parley/Views/QuestBrowserWindow.axaml.cs
+++ b/Parley/Parley/Views/QuestBrowserWindow.axaml.cs
@@ -321,23 +321,27 @@ namespace DialogEditor.Views
                     UnifiedLogger.LogApplication(LogLevel.INFO, "Manifest already running - opening file in existing instance");
                 }
 
-                // Build command line arguments
-                // Format: Manifest.exe --file "path/to/module.jrl" --quest "quest_tag" [--entry 123]
-                var args = $"--file \"{journalPath}\" --quest \"{_selectedCategory.Tag}\"";
-                if (_selectedEntry != null)
-                {
-                    args += $" --entry {_selectedEntry.ID}";
-                }
-
-                UnifiedLogger.LogApplication(LogLevel.INFO, $"Opening Manifest: {UnifiedLogger.SanitizePath(manifestPath)} {args}");
-
-                // Launch Manifest
+                // Build command line arguments via ArgumentList so paths/tags with spaces or
+                // metacharacters are passed verbatim — no manual quoting (#2260).
+                // Format: Manifest.exe --file <module.jrl> --quest <quest_tag> [--entry 123]
                 var startInfo = new ProcessStartInfo
                 {
                     FileName = manifestPath,
-                    Arguments = args,
                     UseShellExecute = false
                 };
+                startInfo.ArgumentList.Add("--file");
+                startInfo.ArgumentList.Add(journalPath);
+                startInfo.ArgumentList.Add("--quest");
+                startInfo.ArgumentList.Add(_selectedCategory.Tag);
+                if (_selectedEntry != null)
+                {
+                    startInfo.ArgumentList.Add("--entry");
+                    startInfo.ArgumentList.Add(_selectedEntry.ID.ToString());
+                }
+
+                UnifiedLogger.LogApplication(LogLevel.INFO,
+                    $"Opening Manifest: {UnifiedLogger.SanitizePath(manifestPath)} {string.Join(" ", startInfo.ArgumentList)}");
+
                 _manifestProcess = Process.Start(startInfo);
 
                 // Save the path if it wasn't already set (auto-detection success)
@@ -439,7 +443,11 @@ namespace DialogEditor.Views
                         UseShellExecute = true
                     });
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    UnifiedLogger.LogApplication(LogLevel.WARN,
+                        $"Failed to open releases URL in browser: {ex.Message}");
+                }
             };
             panel.Children.Add(linkButton);
 


### PR DESCRIPTION
## Summary

Addresses all 5 HIGH findings from the 2026-05-25 Parley codebase review (#2260):

- **TTS / external-process args** → `ProcessStartInfo.ArgumentList` (espeak, macOS `say`, piper, external editor, Manifest launch). Shell metacharacters in paths/spoken text pass verbatim; no naive quote-escape.
- **AddNode rollback** — `AddNodeWithUndoAndRefresh` removes the created node + discards the undo snapshot if `CoordinatedRefreshAndSelect` throws (#2166 pattern).
- **Empty catch** on the releases-link click now logs at WARN.
- **Reflection trampoline TODO** linked to new tech-debt issue #2324.
- **UndoManager O(N²) trim** → O(1) via `LinkedList`.

## Tests

- Parley.Tests: **850/850 pass** (added 9: rollback ×2, arg-builders ×6, undo-order/discard ×3)
- Parley FlaUI: 26/27; the lone fail (`CreaturePicker_LoadsCreaturesFromTestModule`) is an unrelated focus/timing flake — **passed on isolated re-run**, untouched by this diff.
- CI: build + unit green on Linux + Windows.

## Related Issues

- Closes #2260
- Spun off: #2324 (reflection trampoline)
- Rollback precedent: #2166

## Checklist

- [x] Implementation complete
- [x] Tests added/updated
- [x] CHANGELOG updated with date + PR number
- [x] No new build warnings

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)