### PR TITLE
[Fence] Feat: Promote Fence from Alpha to Beta (#2321)

### DIFF
--- a/.claude/commands/pre-merge.md
+++ b/.claude/commands/pre-merge.md
@@ -271,7 +271,7 @@ The `/release` command reads this file to generate GitHub release notes.
 |------|---------|----------|
 | Parley | TBD | Beta |
 | Manifest | TBD | Beta |
-| Fence | TBD | Alpha |
+| Fence | TBD | Beta |
 | Trebuchet | TBD | Alpha |
 | Quartermaster | TBD | Alpha |
 

--- a/Fence/CHANGELOG.md
+++ b/Fence/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.1.37-alpha] - 2026-05-30
+**Branch**: `fence/issue-2321` | **PR**: #TBD
+
+### Feat: Promote Fence from Alpha to Beta (#2321)
+
+- Maturity label updated from Alpha to Beta across Trebuchet tile/sidebar badge, wiki, and release notes.
+
+---
+
 ## [0.1.36-alpha] - 2026-05-29
 **Branch**: `fence/issue-2256` | **PR**: #2306
 

--- a/Fence/CHANGELOG.md
+++ b/Fence/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.1.37-alpha] - 2026-05-30
-**Branch**: `fence/issue-2321` | **PR**: #TBD
+**Branch**: `fence/issue-2321` | **PR**: #2325
 
 ### Feat: Promote Fence from Alpha to Beta (#2321)
 

--- a/Fence/README.md
+++ b/Fence/README.md
@@ -8,14 +8,14 @@
 
 Fence is a cross-platform merchant/store editor for Neverwinter Nights `.utm` files. Built with modern technology while maintaining Aurora Engine compatibility.
 
-**Status**: Alpha
+**Status**: Beta
 **Platforms**: Windows, Linux, macOS (experimental)
 
 ---
 
-## Alpha Status
+## Beta Status
 
-**This is alpha software. Always work with backup copies of your module files.**
+**This is beta software. Always work with backup copies of your module files.**
 
 See [Known Issues](https://github.com/LordOfMyatar/Radoub/issues?q=is%3Aissue+is%3Aopen+label%3Afence) for current bug list.
 

--- a/Fence/version.json
+++ b/Fence/version.json
@@ -1,5 +1,5 @@
 {
   "inherit": true,
-  "version": "0.2-alpha",
+  "version": "0.2-beta",
   "pathFilters": ["."]
 }

--- a/Trebuchet/Trebuchet/Services/ToolLauncherService.cs
+++ b/Trebuchet/Trebuchet/Services/ToolLauncherService.cs
@@ -112,7 +112,7 @@ public class ToolLauncherService
                 Name = "Fence",
                 Description = "Merchant Editor",
                 FileTypes = ".utm",
-                Maturity = ToolMaturity.Alpha
+                Maturity = ToolMaturity.Beta
             },
             new ToolInfo
             {


### PR DESCRIPTION
## Summary

Promote Fence (merchant/store editor) from Alpha to Beta across every surface where its maturity is shown.

## Changes

- `Trebuchet/Trebuchet/Services/ToolLauncherService.cs` — Fence `ToolInfo.Maturity` Alpha → Beta (drives tile/sidebar badge)
- `Fence/version.json` — NBGV prerelease suffix `0.2-alpha` → `0.2-beta` (source of the About-dialog version string via `VersionHelper.GetVersion()`)
- `Fence/README.md` — status + heading Alpha → Beta
- `Radoub.wiki/Trebuchet.md` — tool table Alpha → Beta (wiki repo, pushed separately)
- `NonPublic/release-notes.md` — Tool Versions table + What-changed entry (gitignored draft)
- `.claude/commands/pre-merge.md` — release-notes template Tool Versions table

## Related Issues

- Closes #2321

## Tests

- Fence unit + privacy + tech-debt + theme: 138/138 PASS
- Trebuchet unit + privacy + tech-debt + theme: 228/228 PASS
- NBGV computed version verified: `0.2.57-beta`; compiled `Fence.dll` ProductVersion `0.2.57-beta`

## Manual Spot-Check (running app)

- [ ] Trebuchet sidebar/tile shows Fence badge as **Beta**
- [ ] Fence About dialog version reads `0.2.x-beta`

## Checklist

- [x] Implementation complete
- [x] Tests pass (138 Fence, 228 Trebuchet)
- [x] CHANGELOG updated with date + PR number
- [x] Docs (wiki, README, release-notes) updated

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)