### PR TITLE
[Reliquary] Sprint 1: PortraitBrowser extract + PlaceableAppearanceService + ModelService spike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.1.66-alpha] - 2026-05-30
+**Branch**: `reliquary/issue-2291` | **PR**: #TBD
+
+### Sprint 1: PortraitBrowser extract (#2291)
+
+- `PortraitBrowserWindow` moved into `Radoub.UI` driven by the shared `IPortraitBrowserContext`, so any tool can reuse it. Reliquary epic #2289 pre-work.
+
+---
+
+## [Radoub.Formats 0.2.63-alpha] - 2026-05-30
+**Branch**: `reliquary/issue-2291` | **PR**: #TBD
+
+### Sprint 1: PlaceableAppearanceService (#2291)
+
+- New `IPlaceableAppearanceService` reads `placeables.2da` for placeable model/display names (StrRef→TLK with LABEL fallback). Reliquary epic #2289 pre-work.
+
+---
+
 ## [Radoub docs] - 2026-05-30
 **Branch**: `reliquary/issue-2290` | **PR**: #2327
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Sprint 1: PortraitBrowser extract (#2291)
 
 - `PortraitBrowserWindow` moved into `Radoub.UI` driven by the shared `IPortraitBrowserContext`, so any tool can reuse it. Reliquary epic #2289 pre-work.
+- Portrait thumbnails now decode on a background thread instead of blocking the dialog open.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Radoub.UI 0.1.66-alpha] - 2026-05-30
-**Branch**: `reliquary/issue-2291` | **PR**: #TBD
+**Branch**: `reliquary/issue-2291` | **PR**: #2328
 
 ### Sprint 1: PortraitBrowser extract (#2291)
 
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Radoub.Formats 0.2.63-alpha] - 2026-05-30
-**Branch**: `reliquary/issue-2291` | **PR**: #TBD
+**Branch**: `reliquary/issue-2291` | **PR**: #2328
 
 ### Sprint 1: PlaceableAppearanceService (#2291)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.115-alpha] - 2026-05-30
+**Branch**: `reliquary/issue-2291` | **PR**: #2328
+
+### Fix: Blank portraits leading the browser list (#2291)
+
+- Portrait browser now skips any blank or all-asterisk `portraits.2da` cell (e.g. CEP `***` padding), not just exact `****`, so empty tiles no longer sort to the front.
+
+---
+
 ## [0.2.114-alpha] - 2026-05-30
 **Branch**: `quartermaster/issue-2220` | **PR**: #2326
 

--- a/Quartermaster/Quartermaster.Tests/PortraitBrowserContextTests.cs
+++ b/Quartermaster/Quartermaster.Tests/PortraitBrowserContextTests.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using Quartermaster.Services;
+using Radoub.Formats.TwoDA;
+using Radoub.TestUtilities.Mocks;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Quartermaster.Tests;
+
+/// <summary>
+/// Tests for QuartermasterPortraitBrowserContext.ListPortraits — padding-row
+/// filtering. Real portraits.2da uses "****" for empty cells, but custom/CEP
+/// content can use shorter asterisk runs like "***" (#2291). Any all-asterisk
+/// or blank BaseResRef must be skipped so blank tiles don't lead the list.
+/// </summary>
+public class PortraitBrowserContextTests
+{
+    private static QuartermasterPortraitBrowserContext BuildContext(MockGameDataService mock)
+        => new QuartermasterPortraitBrowserContext(mock, new ItemIconService(mock));
+
+    [Fact]
+    public void ListPortraits_SkipsAsteriskAndBlankBaseResRefs()
+    {
+        var mock = new MockGameDataService(includeSampleData: false);
+        var twoDA = new TwoDAFile { Columns = new() { "BaseResRef", "Race", "Sex" } };
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "hu_m_01_", "6", "0" } }); // real
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "****", "****", "****" } }); // 4-star pad
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "***", "****", "4" } });      // 3-star pad (#2291)
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "*", "****", "4" } });        // 1-star pad
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "  ", "****", "4" } });       // whitespace
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "el_f_02_", "1", "1" } });    // real
+        mock.With2DA("portraits", twoDA);
+
+        var result = BuildContext(mock).ListPortraits().ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, p => Assert.DoesNotContain('*', p.ResRef));
+        Assert.Contains(result, p => p.ResRef == "hu_m_01_");
+        Assert.Contains(result, p => p.ResRef == "el_f_02_");
+    }
+}

--- a/Quartermaster/Quartermaster/Services/QuartermasterPortraitBrowserContext.cs
+++ b/Quartermaster/Quartermaster/Services/QuartermasterPortraitBrowserContext.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using Avalonia.Media.Imaging;
+using Radoub.Formats.Logging;
+using Radoub.Formats.Services;
+using Radoub.Formats.Settings;
+using Radoub.UI.Services;
+
+namespace Quartermaster.Services;
+
+/// <summary>
+/// Quartermaster's implementation of <see cref="IPortraitBrowserContext"/>.
+/// Sources portraits from portraits.2da and images from the shared
+/// <see cref="ItemIconService"/> for the shared PortraitBrowserWindow (#2291).
+/// </summary>
+public class QuartermasterPortraitBrowserContext : IPortraitBrowserContext
+{
+    private readonly IGameDataService _gameDataService;
+    private readonly ItemIconService _itemIconService;
+
+    public QuartermasterPortraitBrowserContext(IGameDataService gameDataService, ItemIconService itemIconService)
+    {
+        _gameDataService = gameDataService;
+        _itemIconService = itemIconService;
+    }
+
+    public string? CurrentFileDirectory => null;
+
+    public string? NeverwinterNightsPath => RadoubSettings.Instance.NeverwinterNightsPath;
+
+    public bool GameResourcesAvailable => _gameDataService?.IsConfigured ?? false;
+
+    public IEnumerable<PortraitEntry> ListPortraits()
+    {
+        var portraits = new List<PortraitEntry>();
+
+        int rowCount = _gameDataService.Get2DA("portraits")?.RowCount ?? 500;
+        for (int i = 0; i < rowCount; i++)
+        {
+            var baseResRef = _gameDataService.Get2DAValue("portraits", i, "BaseResRef");
+            if (string.IsNullOrEmpty(baseResRef) || baseResRef == "****")
+                continue;
+
+            var raceStr = _gameDataService.Get2DAValue("portraits", i, "Race");
+            var sexStr = _gameDataService.Get2DAValue("portraits", i, "Sex");
+
+            int race = -1;
+            int sex = -1;
+
+            if (!string.IsNullOrEmpty(raceStr) && raceStr != "****")
+                int.TryParse(raceStr, out race);
+
+            if (!string.IsNullOrEmpty(sexStr) && sexStr != "****")
+                int.TryParse(sexStr, out sex);
+
+            portraits.Add(new PortraitEntry
+            {
+                Id = (ushort)i,
+                ResRef = baseResRef,
+                Race = race,
+                Sex = sex
+            });
+        }
+
+        UnifiedLogger.LogApplication(LogLevel.INFO, $"PortraitBrowserContext: Loaded {portraits.Count} portraits from portraits.2da");
+        return portraits;
+    }
+
+    public Bitmap? GetPortraitBitmap(string resRef) => _itemIconService.GetPortrait(resRef);
+
+    public string GetRaceName(int raceId)
+    {
+        if (raceId < 0)
+            return "Unknown";
+
+        var strRef = _gameDataService.Get2DAValue("racialtypes", raceId, "Name");
+        if (!string.IsNullOrEmpty(strRef) && strRef != "****" && uint.TryParse(strRef, out var tlkRef))
+        {
+            var name = _gameDataService.GetString(tlkRef);
+            if (!string.IsNullOrEmpty(name))
+                return name;
+        }
+
+        // Fallback names for common races when TLK lookup fails.
+        return raceId switch
+        {
+            0 => "Dwarf",
+            1 => "Elf",
+            2 => "Gnome",
+            3 => "Halfling",
+            4 => "Half-Elf",
+            5 => "Half-Orc",
+            6 => "Human",
+            _ => $"Race {raceId}"
+        };
+    }
+}

--- a/Quartermaster/Quartermaster/Services/QuartermasterPortraitBrowserContext.cs
+++ b/Quartermaster/Quartermaster/Services/QuartermasterPortraitBrowserContext.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Avalonia.Media.Imaging;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Services;
@@ -37,8 +38,9 @@ public class QuartermasterPortraitBrowserContext : IPortraitBrowserContext
         for (int i = 0; i < rowCount; i++)
         {
             var baseResRef = _gameDataService.Get2DAValue("portraits", i, "BaseResRef");
-            if (string.IsNullOrEmpty(baseResRef) || baseResRef == "****")
+            if (IsEmptyCell(baseResRef))
                 continue;
+            baseResRef = baseResRef!.Trim();
 
             var raceStr = _gameDataService.Get2DAValue("portraits", i, "Race");
             var sexStr = _gameDataService.Get2DAValue("portraits", i, "Sex");
@@ -63,6 +65,17 @@ public class QuartermasterPortraitBrowserContext : IPortraitBrowserContext
 
         UnifiedLogger.LogApplication(LogLevel.INFO, $"PortraitBrowserContext: Loaded {portraits.Count} portraits from portraits.2da");
         return portraits;
+    }
+
+    /// <summary>
+    /// True for 2DA "empty" cells: null, blank/whitespace, or any all-asterisk run.
+    /// Aurora writes "****" but custom/CEP content uses shorter runs like "***" (#2291).
+    /// </summary>
+    private static bool IsEmptyCell(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return true;
+        return value.Trim().All(c => c == '*');
     }
 
     public Bitmap? GetPortraitBitmap(string resRef) => _itemIconService.GetPortrait(resRef);

--- a/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Identity.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Identity.cs
@@ -4,6 +4,7 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Quartermaster.Services;
 using Radoub.UI.Services;
+using Radoub.UI.Views;
 
 namespace Quartermaster.Views.Dialogs;
 
@@ -87,7 +88,8 @@ public partial class NewCharacterWizardWindow
         if (_itemIconService == null)
             return;
 
-        var browser = new PortraitBrowserWindow(_gameDataService, _itemIconService);
+        var context = new QuartermasterPortraitBrowserContext(_gameDataService, _itemIconService);
+        var browser = PortraitBrowserWindow.Create(context);
         browser.SetInitialFilters(_selectedRaceId, _selectedGender);
 
         var result = await browser.ShowDialog<ushort?>(this);

--- a/Quartermaster/Quartermaster/Views/Panels/CharacterPanel.Dialogs.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/CharacterPanel.Dialogs.cs
@@ -46,7 +46,8 @@ public partial class CharacterPanel
             }
 
             UnifiedLogger.Log(LogLevel.INFO, "CharacterPanel: Opening portrait browser", "CharacterPanel", "UI");
-            var browser = new PortraitBrowserWindow(_gameDataService, _itemIconService);
+            var context = new QuartermasterPortraitBrowserContext(_gameDataService, _itemIconService);
+            var browser = PortraitBrowserWindow.Create(context);
 
             var topLevel = TopLevel.GetTopLevel(this);
             if (topLevel is Window parentWindow)

--- a/Radoub.Formats/Radoub.Formats.Tests/Services/PlaceableAppearanceServiceTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Services/PlaceableAppearanceServiceTests.cs
@@ -1,0 +1,53 @@
+using Radoub.Formats.Services;
+using Radoub.Formats.TwoDA;
+using Radoub.TestUtilities.Mocks;
+using Xunit;
+
+namespace Radoub.Formats.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="PlaceableAppearanceService"/> — placeables.2da
+/// model/display-name resolution (#2291, Reliquary epic #2289 pre-work).
+/// </summary>
+public class PlaceableAppearanceServiceTests
+{
+    // placeables.2da columns used by the service: LABEL, ModelName, StrRef
+    private static MockGameDataService FakeGameData()
+    {
+        var mock = new MockGameDataService(includeSampleData: false);
+        var twoDA = new TwoDAFile { Columns = new() { "LABEL", "ModelName", "StrRef" } };
+        // Row 0 (id 0): Barrel — has StrRef 1000 → TLK name wins
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "Barrel", "plc_barrel", "1000" } });
+        // Rows 1..63 padding so row index 64 is addressable (placeables.2da is dense by id)
+        for (int i = 1; i < 64; i++)
+            twoDA.Rows.Add(new TwoDARow { Values = new() { "****", "****", "****" } });
+        // Row 64 (id 64): Boulder — StrRef "****" → LABEL fallback
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "Boulder", "plc_boulder01", "****" } });
+        mock.With2DA("placeables", twoDA);
+        mock.WithString(1000, "Barrel");
+        return mock;
+    }
+
+    [Fact]
+    public void GetModelName_ReturnsModelColumn()
+        => Assert.Equal("plc_boulder01", new PlaceableAppearanceService(FakeGameData()).GetModelName(64));
+
+    [Fact]
+    public void GetDisplayName_FallsBackToLabelWhenStrRefMissing()
+        => Assert.Equal("Boulder", new PlaceableAppearanceService(FakeGameData()).GetDisplayName(64));
+
+    [Fact]
+    public void GetDisplayName_PrefersTlkOverLabel()
+        => Assert.Equal("Barrel", new PlaceableAppearanceService(FakeGameData()).GetDisplayName(0));
+
+    [Fact]
+    public void GetById_UnknownId_ReturnsNull()
+        => Assert.Null(new PlaceableAppearanceService(FakeGameData()).GetById(9999));
+
+    [Fact]
+    public void GetAll_SkipsPaddingRows()
+    {
+        // GetAll filters rows whose LABEL is "****"/empty → 2 real entries (Barrel, Boulder)
+        Assert.Equal(2, new PlaceableAppearanceService(FakeGameData()).GetAll().Count);
+    }
+}

--- a/Radoub.Formats/Radoub.Formats/Services/IPlaceableAppearanceService.cs
+++ b/Radoub.Formats/Radoub.Formats/Services/IPlaceableAppearanceService.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+
+namespace Radoub.Formats.Services;
+
+/// <summary>
+/// Resolves placeable appearance IDs to model and display names from
+/// placeables.2da (StrRef → TLK with LABEL fallback). Cascade-aware via
+/// <see cref="IGameDataService"/> so custom content (CEP, PRC) is honored.
+/// </summary>
+public interface IPlaceableAppearanceService
+{
+    /// <summary>
+    /// Gets the appearance entry for an ID, or null if the row is padding/missing.
+    /// </summary>
+    PlaceableAppearance? GetById(uint id);
+
+    /// <summary>
+    /// Gets all real placeable appearances (padding rows skipped). Cached.
+    /// </summary>
+    IReadOnlyList<PlaceableAppearance> GetAll();
+
+    /// <summary>
+    /// Gets the MDL model name (ModelName column) for an appearance ID, or null.
+    /// </summary>
+    string? GetModelName(uint id);
+
+    /// <summary>
+    /// Gets the display name (TLK via StrRef, falling back to LABEL, then a synthetic name).
+    /// </summary>
+    string GetDisplayName(uint id);
+
+    /// <summary>
+    /// Clears the cached <see cref="GetAll"/> snapshot. Call after the 2DA chain changes.
+    /// </summary>
+    void InvalidateCache();
+}
+
+/// <summary>
+/// A single placeable appearance from placeables.2da.
+/// </summary>
+public record PlaceableAppearance(uint Id, string Label, string ModelName, string DisplayName);

--- a/Radoub.Formats/Radoub.Formats/Services/PlaceableAppearanceService.cs
+++ b/Radoub.Formats/Radoub.Formats/Services/PlaceableAppearanceService.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using Radoub.Formats.Logging;
+
+namespace Radoub.Formats.Services;
+
+/// <summary>
+/// Reads placeables.2da to resolve placeable appearance IDs to model and display
+/// names. Mirrors the access pattern of Quartermaster's AppearanceService
+/// (ModelName column, StrRef → GetString, LABEL fallback). #2291.
+/// </summary>
+public class PlaceableAppearanceService : IPlaceableAppearanceService
+{
+    private const string TwoDAName = "placeables";
+
+    private readonly IGameDataService _gameDataService;
+    private readonly object _cacheLock = new();
+    private List<PlaceableAppearance>? _allCache;
+
+    public PlaceableAppearanceService(IGameDataService gameDataService)
+    {
+        _gameDataService = gameDataService;
+    }
+
+    public string? GetModelName(uint id)
+    {
+        var modelName = _gameDataService.Get2DAValue(TwoDAName, (int)id, "ModelName");
+        if (string.IsNullOrEmpty(modelName) || modelName == "****")
+            return null;
+        return modelName;
+    }
+
+    public string GetDisplayName(uint id)
+    {
+        // TLK name (StrRef) wins.
+        var strRef = _gameDataService.Get2DAValue(TwoDAName, (int)id, "StrRef");
+        if (!string.IsNullOrEmpty(strRef) && strRef != "****" && uint.TryParse(strRef, out var tlkRef))
+        {
+            var tlkName = _gameDataService.GetString(tlkRef);
+            if (!string.IsNullOrEmpty(tlkName))
+                return tlkName;
+        }
+
+        // Fall back to LABEL.
+        var label = _gameDataService.Get2DAValue(TwoDAName, (int)id, "LABEL");
+        if (!string.IsNullOrEmpty(label) && label != "****")
+            return label;
+
+        return $"Placeable {id}";
+    }
+
+    public PlaceableAppearance? GetById(uint id)
+    {
+        var label = _gameDataService.Get2DAValue(TwoDAName, (int)id, "LABEL");
+        if (string.IsNullOrEmpty(label) || label == "****")
+            return null;
+
+        return new PlaceableAppearance(
+            id,
+            label,
+            GetModelName(id) ?? "",
+            GetDisplayName(id));
+    }
+
+    public IReadOnlyList<PlaceableAppearance> GetAll()
+    {
+        lock (_cacheLock)
+        {
+            if (_allCache != null)
+                return _allCache;
+        }
+
+        var appearances = new List<PlaceableAppearance>();
+        int rowCount = _gameDataService.Get2DA(TwoDAName)?.RowCount ?? 0;
+        for (int i = 0; i < rowCount; i++)
+        {
+            try
+            {
+                var entry = GetById((uint)i);
+                if (entry != null)
+                    appearances.Add(entry);
+            }
+            catch (Exception ex)
+            {
+                UnifiedLogger.LogApplication(LogLevel.WARN,
+                    $"PlaceableAppearanceService: failed to read placeables.2da row {i}: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        lock (_cacheLock)
+        {
+            _allCache ??= appearances;
+            return _allCache;
+        }
+    }
+
+    public void InvalidateCache()
+    {
+        lock (_cacheLock)
+        {
+            _allCache = null;
+        }
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/Views/PortraitBrowserWindowTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Views/PortraitBrowserWindowTests.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media.Imaging;
+using Radoub.UI.Services;
+using Radoub.UI.Views;
+using Xunit;
+
+namespace Radoub.UI.Tests.Views;
+
+/// <summary>
+/// Tests for the shared <see cref="PortraitBrowserWindow"/> (extracted from
+/// Quartermaster, #2291). Verifies the window populates from an
+/// <see cref="IPortraitBrowserContext"/> rather than tool-specific services.
+/// </summary>
+public class PortraitBrowserWindowTests
+{
+    [AvaloniaFact]
+    public void Create_WithContext_PopulatesPortraitsFromContext()
+    {
+        var ctx = new FakePortraitBrowserContext(new[]
+        {
+            new PortraitEntry { Id = 1, ResRef = "po_plc_c05_", Race = -1, Sex = -1 }
+        });
+
+        var window = PortraitBrowserWindow.Create(ctx);
+
+        Assert.Equal(1, window.PortraitCount);
+    }
+
+    private sealed class FakePortraitBrowserContext : IPortraitBrowserContext
+    {
+        private readonly List<PortraitEntry> _portraits;
+
+        public FakePortraitBrowserContext(IEnumerable<PortraitEntry> portraits)
+            => _portraits = portraits.ToList();
+
+        public string? CurrentFileDirectory => null;
+        public string? NeverwinterNightsPath => null;
+        public bool GameResourcesAvailable => true;
+
+        public IEnumerable<PortraitEntry> ListPortraits() => _portraits;
+        public Bitmap? GetPortraitBitmap(string resRef) => null;
+        public string GetRaceName(int raceId) => $"Race {raceId}";
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/Views/PortraitBrowserWindowTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Views/PortraitBrowserWindowTests.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Avalonia.Headless.XUnit;
 using Avalonia.Media.Imaging;
+using Avalonia.Threading;
 using Radoub.UI.Services;
 using Radoub.UI.Views;
 using Xunit;
@@ -28,19 +30,63 @@ public class PortraitBrowserWindowTests
         Assert.Equal(1, window.PortraitCount);
     }
 
+    [AvaloniaFact]
+    public void Create_DecodesThumbnailsOffTheUiThread()
+    {
+        // Thumbnail decode is expensive (BIF/disk → SkiaSharp). It must NOT run
+        // on the UI thread or the dialog lags on open (#2291). The decode is
+        // allowed (lazily, in the background) — but never on the dispatcher thread.
+        var ctx = new FakePortraitBrowserContext(new[]
+        {
+            new PortraitEntry { Id = 1, ResRef = "po_a_", Race = -1, Sex = -1 },
+            new PortraitEntry { Id = 2, ResRef = "po_b_", Race = -1, Sex = -1 },
+            new PortraitEntry { Id = 3, ResRef = "po_c_", Race = -1, Sex = -1 }
+        });
+
+        var window = PortraitBrowserWindow.Create(ctx);
+        Assert.Equal(3, window.PortraitCount);
+
+        // Let the background decodes run and report which thread they used.
+        ctx.WaitForDecodes(expected: 3, timeoutMs: 5000);
+
+        Assert.True(ctx.DecodeCount > 0, "expected thumbnails to be decoded");
+        Assert.False(ctx.AnyDecodeOnUiThread, "thumbnail decode ran on the UI thread (would lag dialog open)");
+    }
+
     private sealed class FakePortraitBrowserContext : IPortraitBrowserContext
     {
         private readonly List<PortraitEntry> _portraits;
+        private readonly CountdownEvent _decoded;
+        private int _decodeCount;
+        private volatile bool _anyOnUiThread;
 
         public FakePortraitBrowserContext(IEnumerable<PortraitEntry> portraits)
-            => _portraits = portraits.ToList();
+        {
+            _portraits = portraits.ToList();
+            _decoded = new CountdownEvent(_portraits.Count == 0 ? 1 : _portraits.Count);
+            if (_portraits.Count == 0) _decoded.Signal();
+        }
+
+        public int DecodeCount => _decodeCount;
+        public bool AnyDecodeOnUiThread => _anyOnUiThread;
+
+        public void WaitForDecodes(int expected, int timeoutMs) => _decoded.Wait(timeoutMs);
 
         public string? CurrentFileDirectory => null;
         public string? NeverwinterNightsPath => null;
         public bool GameResourcesAvailable => true;
 
         public IEnumerable<PortraitEntry> ListPortraits() => _portraits;
-        public Bitmap? GetPortraitBitmap(string resRef) => null;
+
+        public Bitmap? GetPortraitBitmap(string resRef)
+        {
+            if (Dispatcher.UIThread.CheckAccess())
+                _anyOnUiThread = true;
+            Interlocked.Increment(ref _decodeCount);
+            if (!_decoded.IsSet) _decoded.Signal();
+            return null;
+        }
+
         public string GetRaceName(int raceId) => $"Race {raceId}";
     }
 }

--- a/Radoub.UI/Radoub.UI/Views/PortraitBrowserWindow.axaml
+++ b/Radoub.UI/Radoub.UI/Views/PortraitBrowserWindow.axaml
@@ -1,6 +1,6 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        x:Class="Quartermaster.Views.PortraitBrowserWindow"
+        x:Class="Radoub.UI.Views.PortraitBrowserWindow"
         Title="Portrait Browser"
         AutomationProperties.AutomationId="PortraitBrowserWindow"
         Width="700" Height="550"

--- a/Radoub.UI/Radoub.UI/Views/PortraitBrowserWindow.axaml
+++ b/Radoub.UI/Radoub.UI/Views/PortraitBrowserWindow.axaml
@@ -188,7 +188,7 @@
                            TextAlignment="Center"
                            TextTrimming="CharacterEllipsis"
                            Margin="10,5,10,10"
-                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"/>
             </Grid>
         </Border>
 

--- a/Radoub.UI/Radoub.UI/Views/PortraitBrowserWindow.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Views/PortraitBrowserWindow.axaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -8,6 +9,8 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
 using Radoub.Formats.Logging;
 using Radoub.UI.Services;
 
@@ -34,6 +37,10 @@ public partial class PortraitBrowserWindow : Window
     private List<PortraitEntry> _allPortraits = new();
     private List<PortraitEntry> _filteredPortraits = new();
     private PortraitEntry? _selectedPortrait;
+
+    // Incremented on each list rebuild; in-flight async thumbnail loads from an
+    // older filter state stop applying when this changes (#2291).
+    private int _thumbnailGeneration;
 
     /// <summary>
     /// Gets the selected portrait ID, or null if cancelled.
@@ -200,23 +207,69 @@ public partial class PortraitBrowserWindow : Window
             .OrderBy(p => p.ResRef)
             .ToList();
 
-        // Populate with mini icon items
+        // Populate with mini icon items. Thumbnails are decoded lazily off the
+        // UI thread (LoadThumbnailsAsync) so the dialog opens instantly even with
+        // hundreds of portraits (#2291) — decoding inline here blocked on open.
+        var pending = new List<(PortraitEntry Portrait, Image Image)>(_filteredPortraits.Count);
         foreach (var portrait in _filteredPortraits)
         {
-            var item = CreatePortraitItem(portrait);
+            var item = CreatePortraitItem(portrait, out var image);
             _portraitListBox.Items.Add(item);
+            pending.Add((portrait, image));
         }
 
         _portraitCountLabel.Text = $"{_filteredPortraits.Count} portrait{(_filteredPortraits.Count == 1 ? "" : "s")}";
+
+        // Bump the generation so any in-flight load from a previous filter state
+        // stops applying stale bitmaps to recycled images.
+        int generation = ++_thumbnailGeneration;
+        _ = LoadThumbnailsAsync(pending, generation);
     }
 
-    private ListBoxItem CreatePortraitItem(PortraitEntry portrait)
+    /// <summary>
+    /// Decodes portrait thumbnails on a background thread and applies them to the
+    /// list images on the UI thread. Cancels itself if a newer filter pass has
+    /// started (generation mismatch).
+    /// </summary>
+    private async Task LoadThumbnailsAsync(List<(PortraitEntry Portrait, Image Image)> pending, int generation)
     {
-        // Create mini icon (roughly 50% size = ~32x40 for typical NWN portraits)
+        if (_context == null)
+            return;
+
+        foreach (var (portrait, image) in pending)
+        {
+            if (generation != _thumbnailGeneration)
+                return; // a newer filter pass superseded this one
+
+            Bitmap? bitmap = null;
+            try
+            {
+                bitmap = await Task.Run(() => _context.GetPortraitBitmap(portrait.ResRef));
+            }
+            catch (Exception ex)
+            {
+                UnifiedLogger.LogApplication(LogLevel.DEBUG, $"Failed to load thumbnail for {portrait.ResRef}: {ex.Message}");
+            }
+
+            if (bitmap == null || generation != _thumbnailGeneration)
+                continue;
+
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                if (generation == _thumbnailGeneration)
+                    image.Source = bitmap;
+            });
+        }
+    }
+
+    private ListBoxItem CreatePortraitItem(PortraitEntry portrait, out Image image)
+    {
+        // Create mini icon (roughly 50% size = ~32x40 for typical NWN portraits).
+        // Source is left null here and filled in by LoadThumbnailsAsync.
         const int thumbnailWidth = 32;
         const int thumbnailHeight = 40;
 
-        var image = new Image
+        image = new Image
         {
             Width = thumbnailWidth,
             Height = thumbnailHeight,
@@ -224,16 +277,6 @@ public partial class PortraitBrowserWindow : Window
             VerticalAlignment = VerticalAlignment.Center,
             HorizontalAlignment = HorizontalAlignment.Center
         };
-
-        // Try to load the portrait thumbnail
-        try
-        {
-            image.Source = _context?.GetPortraitBitmap(portrait.ResRef);
-        }
-        catch (Exception ex)
-        {
-            UnifiedLogger.LogApplication(LogLevel.DEBUG, $"Failed to load thumbnail for {portrait.ResRef}: {ex.Message}");
-        }
 
         // Wrap image in a border for visual feedback
         var border = new Border

--- a/Radoub.UI/Radoub.UI/Views/PortraitBrowserWindow.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Views/PortraitBrowserWindow.axaml.cs
@@ -8,20 +8,20 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
-using Quartermaster.Services;
 using Radoub.Formats.Logging;
-using Radoub.Formats.Services;
 using Radoub.UI.Services;
 
-namespace Quartermaster.Views;
+namespace Radoub.UI.Views;
 
 /// <summary>
-/// Portrait browser window with race/gender filtering and preview.
+/// Shared portrait browser window with race/gender filtering and preview.
+/// Driven by an <see cref="IPortraitBrowserContext"/> so any tool can reuse it
+/// without depending on tool-specific game-data or icon services (#2291,
+/// Epic #959 UI Uniformity).
 /// </summary>
 public partial class PortraitBrowserWindow : Window
 {
-    private readonly IGameDataService? _gameDataService;
-    private readonly ItemIconService? _itemIconService;
+    private readonly IPortraitBrowserContext? _context;
     private readonly ListBox _portraitListBox;
     private readonly ComboBox _raceFilterComboBox;
     private readonly ComboBox _genderFilterComboBox;
@@ -31,14 +31,20 @@ public partial class PortraitBrowserWindow : Window
     private readonly TextBlock _portraitNameLabel;
     private readonly Image _portraitPreviewImage;
 
-    private List<PortraitInfo> _allPortraits = new();
-    private List<PortraitInfo> _filteredPortraits = new();
-    private PortraitInfo? _selectedPortrait;
+    private List<PortraitEntry> _allPortraits = new();
+    private List<PortraitEntry> _filteredPortraits = new();
+    private PortraitEntry? _selectedPortrait;
 
     /// <summary>
     /// Gets the selected portrait ID, or null if cancelled.
     /// </summary>
     public ushort? SelectedPortraitId => _selectedPortrait?.Id;
+
+    /// <summary>
+    /// Number of portraits currently loaded from the context (pre-filter).
+    /// Exposed for tests and host diagnostics.
+    /// </summary>
+    public int PortraitCount => _allPortraits.Count;
 
     /// <summary>
     /// Parameterless constructor for XAML designer.
@@ -56,19 +62,20 @@ public partial class PortraitBrowserWindow : Window
         _portraitPreviewImage = this.FindControl<Image>("PortraitPreviewImage")!;
     }
 
-    /// <summary>
-    /// Creates a new portrait browser window.
-    /// </summary>
-    /// <param name="gameDataService">Game data service for 2DA lookups</param>
-    /// <param name="itemIconService">Item icon service for loading portrait images</param>
-    public PortraitBrowserWindow(IGameDataService gameDataService, ItemIconService itemIconService) : this()
+    private PortraitBrowserWindow(IPortraitBrowserContext context) : this()
     {
-        _gameDataService = gameDataService ?? throw new ArgumentNullException(nameof(gameDataService));
-        _itemIconService = itemIconService ?? throw new ArgumentNullException(nameof(itemIconService));
+        _context = context ?? throw new ArgumentNullException(nameof(context));
 
         InitializeFilters();
         LoadPortraits();
     }
+
+    /// <summary>
+    /// Creates a new portrait browser window driven by the given context.
+    /// </summary>
+    /// <param name="context">Tool-provided portrait data source.</param>
+    public static PortraitBrowserWindow Create(IPortraitBrowserContext context)
+        => new PortraitBrowserWindow(context);
 
     /// <summary>
     /// Pre-selects the race and gender filters before the window is shown.
@@ -131,85 +138,31 @@ public partial class PortraitBrowserWindow : Window
 
     private void LoadPortraits()
     {
-        if (_gameDataService == null)
+        if (_context == null)
         {
-            UnifiedLogger.LogApplication(LogLevel.WARN, "PortraitBrowser: GameDataService is null");
+            UnifiedLogger.LogApplication(LogLevel.WARN, "PortraitBrowser: context is null");
             return;
         }
 
-        UnifiedLogger.LogApplication(LogLevel.INFO, "PortraitBrowser: Loading portraits from portraits.2da");
-        _allPortraits.Clear();
+        UnifiedLogger.LogApplication(LogLevel.INFO, "PortraitBrowser: Loading portraits from context");
+        _allPortraits = _context.ListPortraits().ToList();
+
         var races = new HashSet<int>();
-
-        // Load portraits from portraits.2da
-        int rowCount = _gameDataService.Get2DA("portraits")?.RowCount ?? 500;
-        for (int i = 0; i < rowCount; i++)
+        foreach (var portrait in _allPortraits)
         {
-            var baseResRef = _gameDataService.Get2DAValue("portraits", i, "BaseResRef");
-            if (string.IsNullOrEmpty(baseResRef) || baseResRef == "****")
-                continue;
-
-            // Get race and sex columns
-            var raceStr = _gameDataService.Get2DAValue("portraits", i, "Race");
-            var sexStr = _gameDataService.Get2DAValue("portraits", i, "Sex");
-
-            int race = -1;
-            int sex = -1;
-
-            if (!string.IsNullOrEmpty(raceStr) && raceStr != "****")
-                int.TryParse(raceStr, out race);
-
-            if (!string.IsNullOrEmpty(sexStr) && sexStr != "****")
-                int.TryParse(sexStr, out sex);
-
-            if (race >= 0)
-                races.Add(race);
-
-            _allPortraits.Add(new PortraitInfo
-            {
-                Id = (ushort)i,
-                ResRef = baseResRef,
-                Race = race,
-                Sex = sex
-            });
+            if (portrait.Race >= 0)
+                races.Add(portrait.Race);
         }
 
         // Populate race filter with found races
         foreach (var raceId in races.OrderBy(r => r))
         {
-            var raceName = GetRaceName(raceId);
+            var raceName = _context.GetRaceName(raceId);
             _raceFilterComboBox.Items.Add(new ComboBoxItem { Content = raceName, Tag = raceId });
         }
 
-        UnifiedLogger.LogApplication(LogLevel.INFO, $"PortraitBrowser: Loaded {_allPortraits.Count} portraits from portraits.2da");
+        UnifiedLogger.LogApplication(LogLevel.INFO, $"PortraitBrowser: Loaded {_allPortraits.Count} portraits from context");
         UpdatePortraitList();
-    }
-
-    private string GetRaceName(int raceId)
-    {
-        if (raceId < 0 || _gameDataService == null)
-            return "Unknown";
-
-        var strRef = _gameDataService.Get2DAValue("racialtypes", raceId, "Name");
-        if (!string.IsNullOrEmpty(strRef) && strRef != "****" && uint.TryParse(strRef, out var tlkRef))
-        {
-            var name = _gameDataService.GetString(tlkRef);
-            if (!string.IsNullOrEmpty(name))
-                return name;
-        }
-
-        // Fallback names for common races
-        return raceId switch
-        {
-            0 => "Dwarf",
-            1 => "Elf",
-            2 => "Gnome",
-            3 => "Halfling",
-            4 => "Half-Elf",
-            5 => "Half-Orc",
-            6 => "Human",
-            _ => $"Race {raceId}"
-        };
     }
 
     private void UpdatePortraitList()
@@ -257,7 +210,7 @@ public partial class PortraitBrowserWindow : Window
         _portraitCountLabel.Text = $"{_filteredPortraits.Count} portrait{(_filteredPortraits.Count == 1 ? "" : "s")}";
     }
 
-    private ListBoxItem CreatePortraitItem(PortraitInfo portrait)
+    private ListBoxItem CreatePortraitItem(PortraitEntry portrait)
     {
         // Create mini icon (roughly 50% size = ~32x40 for typical NWN portraits)
         const int thumbnailWidth = 32;
@@ -273,17 +226,13 @@ public partial class PortraitBrowserWindow : Window
         };
 
         // Try to load the portrait thumbnail
-        if (_itemIconService != null)
+        try
         {
-            try
-            {
-                var bitmap = _itemIconService.GetPortrait(portrait.ResRef);
-                image.Source = bitmap;
-            }
-            catch (Exception ex)
-            {
-                UnifiedLogger.LogApplication(LogLevel.DEBUG, $"Failed to load thumbnail for {portrait.ResRef}: {ex.Message}");
-            }
+            image.Source = _context?.GetPortraitBitmap(portrait.ResRef);
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.DEBUG, $"Failed to load thumbnail for {portrait.ResRef}: {ex.Message}");
         }
 
         // Wrap image in a border for visual feedback
@@ -324,7 +273,7 @@ public partial class PortraitBrowserWindow : Window
     {
         try
         {
-            if (_portraitListBox.SelectedItem is ListBoxItem item && item.Tag is PortraitInfo portrait)
+            if (_portraitListBox.SelectedItem is ListBoxItem item && item.Tag is PortraitEntry portrait)
             {
                 UnifiedLogger.LogApplication(LogLevel.DEBUG, $"PortraitBrowser: Selected portrait ID={portrait.Id} ResRef='{portrait.ResRef}'");
                 _selectedPortrait = portrait;
@@ -332,19 +281,16 @@ public partial class PortraitBrowserWindow : Window
                 _portraitNameLabel.Text = portrait.ResRef;
 
                 // Load portrait preview
-                if (_itemIconService != null)
+                try
                 {
-                    try
-                    {
-                        var bitmap = _itemIconService.GetPortrait(portrait.ResRef);
-                        _portraitPreviewImage.Source = bitmap;
-                        UnifiedLogger.LogApplication(LogLevel.DEBUG, $"PortraitBrowser: Preview loaded: {(bitmap != null ? "success" : "null")}");
-                    }
-                    catch (Exception ex)
-                    {
-                        UnifiedLogger.LogApplication(LogLevel.WARN, $"Failed to load portrait preview: {ex.Message}");
-                        _portraitPreviewImage.Source = null;
-                    }
+                    var bitmap = _context?.GetPortraitBitmap(portrait.ResRef);
+                    _portraitPreviewImage.Source = bitmap;
+                    UnifiedLogger.LogApplication(LogLevel.DEBUG, $"PortraitBrowser: Preview loaded: {(bitmap != null ? "success" : "null")}");
+                }
+                catch (Exception ex)
+                {
+                    UnifiedLogger.LogApplication(LogLevel.WARN, $"Failed to load portrait preview: {ex.Message}");
+                    _portraitPreviewImage.Source = null;
                 }
             }
             else
@@ -402,17 +348,6 @@ public partial class PortraitBrowserWindow : Window
     {
         UnifiedLogger.LogApplication(LogLevel.DEBUG, "PortraitBrowser: Cancel clicked");
         Close(null);
-    }
-
-    /// <summary>
-    /// Internal class to hold portrait information.
-    /// </summary>
-    private class PortraitInfo
-    {
-        public ushort Id { get; set; }
-        public string ResRef { get; set; } = "";
-        public int Race { get; set; } = -1;
-        public int Sex { get; set; } = -1;
     }
 
     #region Title Bar Events


### PR DESCRIPTION
## Summary

Reliquary epic #2289 pre-work, Sprint 1 — shared-library changes that unblock the placeable editor:

- **Task 1.1 — Spike:** `ModelPreviewGLControl` already takes a parsed `MdlModel` directly (no `ModelService` coupling) and `ModelService.LoadModel` is already the raw-MDL path. Outcome A — **Sprint 2 (factor-out) is a no-op.** Findings in `NonPublic/PlaceableEditor/Research/`.
- **Task 1.2 — PortraitBrowser → Radoub.UI:** moved `PortraitBrowserWindow` into `Radoub.UI/Views`, driven by the shared `IPortraitBrowserContext`. QM provides `QuartermasterPortraitBrowserContext` and consumes the shared window via `Create(ctx)`.
- **Task 1.3 — PlaceableAppearanceService:** new `Radoub.Formats` service + interface + record reading `placeables.2da` (StrRef→TLK, LABEL fallback, cached GetAll).

### Spot-check fixes (rode along)

- Thumbnails decode on a background thread — dialog no longer lags on open.
- Portrait list skips any blank/all-asterisk `BaseResRef` (CEP `***` padding), not just exact `****`, so blank tiles no longer lead the list.
- Reverted an inadvertent name-label brush change so the moved AXAML matches the original.

## Related Issues

- Closes #2291
- Part of epic #2289
- Follow-up: #2329 (portrait duplicates + thumbnail size — separate investigation)

## Tests

- Unit: 3408 pass, 0 fail (Radoub.Formats, Radoub.UI, Dictionary, Quartermaster)
- New: `PortraitBrowserWindowTests` (context populate + off-UI-thread decode), `PlaceableAppearanceServiceTests` (5), `PortraitBrowserContextTests` (padding filter)
- FlaUI QM smoke: 1/1 pass
- Privacy scan clean; no large files

## Checklist

- [x] Implementation complete
- [x] Tests added/updated
- [x] CHANGELOG updated with date
- [x] Spike findings documented

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)