### PR TITLE
[Radoub] Sprint: Dependabot Avalonia + SkiaSharp patch bumps (#2332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub 0.1.0-deps] - 2026-06-03
+**Branch**: `radoub/issue-2332` | **PR**: #TBD
+
+### Dependabot: Avalonia + SkiaSharp patch bumps
+
+- Avalonia framework 11.3.16 → 11.3.17 (all core packages + Headless.XUnit); SkiaSharp 3.119.2 → 3.119.4. Consolidates #2333, #2334, #2335, #2336, #2338, #2339, #2340.
+
+---
+
 ## [Radoub.UI 0.1.67-alpha] - 2026-05-30
 **Branch**: `reliquary/issue-2293` | **PR**: #2330
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Radoub 0.1.0-deps] - 2026-06-03
-**Branch**: `radoub/issue-2332` | **PR**: #TBD
+**Branch**: `radoub/issue-2332` | **PR**: #2342
 
 ### Dependabot: Avalonia + SkiaSharp patch bumps
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,17 +5,17 @@
 
   <ItemGroup>
     <!-- Avalonia UI Framework -->
-    <PackageVersion Include="Avalonia" Version="11.3.16" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.16" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.16" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.16" />
+    <PackageVersion Include="Avalonia" Version="11.3.17" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.3.17" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.17" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.17" />
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.3.13" />
-    <PackageVersion Include="Avalonia.Skia" Version="11.3.16" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.16" />
+    <PackageVersion Include="Avalonia.Skia" Version="11.3.17" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.17" />
 
     <!-- SkiaSharp -->
-    <PackageVersion Include="SkiaSharp" Version="3.119.2" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />
 
     <!-- MVVM -->
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
@@ -47,7 +47,7 @@
     <PackageVersion Include="AvaloniaGraphControl" Version="0.7.0" />
 
     <!-- Testing -->
-    <PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.16" />
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.17" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />


### PR DESCRIPTION
## Summary

Patch-level dependency bumps (low risk only). Excludes Microsoft.NET.Test.Sdk minor (#2332) and the Svg.Controls.Skia.Avalonia 11→12 major (#2193), which need separate review.

| Package | From | To |
|---------|------|----|
| Avalonia (+ Desktop, Themes.Fluent, Fonts.Inter, Skia, Diagnostics) | 11.3.16 | 11.3.17 |
| Avalonia.Headless.XUnit | 11.3.16 | 11.3.17 |
| SkiaSharp | 3.119.2 | 3.119.4 |
| SkiaSharp.NativeAssets.Linux | 3.119.2 | 3.119.4 |

Consolidates dependabot PRs: #2333, #2334, #2335, #2336, #2338, #2339, #2340

## Test Results

- Build: 7 warnings (all pre-existing xUnit analyzer + CS0414), 0 errors
- Unit tests: 5117 passed, 1 skipped, 0 failed (9 projects)
- Integration tests (FlaUI): not run

## Risk Assessment

| Package | Bump | Risk |
|---------|------|------|
| Avalonia 11.3.16→11.3.17 | Patch | Low |
| SkiaSharp 3.119.2→3.119.4 | Patch | Low |

## Excluded (separate review)

- #2332 Microsoft.NET.Test.Sdk 18.5.1→18.6.0 (minor)
- #2193 Svg.Controls.Skia.Avalonia 11.3.9.5→12.0.0.11 (major)

## Checklist

- [x] Build passes
- [x] Unit tests pass
- [x] CHANGELOG updated
- [ ] Close superseded dependabot PRs after merge

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)