### PR TITLE
[Trebuchet] Sprint: Compile + Marlinspike scope fixes

### DIFF
--- a/Documentation/NEW_TOOL_BOOTSTRAP.md
+++ b/Documentation/NEW_TOOL_BOOTSTRAP.md
@@ -11,6 +11,7 @@ This guide holds the full checklist and detailed patterns for adding a new tool 
   - [Pre-Coding Checklist](#pre-coding-checklist)
   - [Required Components (Every Tool)](#required-components-every-tool)
   - [Shared Library References](#shared-library-references)
+  - [Backups Before Destructive File Operations](#backups-before-destructive-file-operations)
   - [Spell-Check Integration (Radoub.Dictionary)](#spell-check-integration-radoubdictionary)
   - [Implementation Checklist](#implementation-checklist)
   - [Trebuchet Integration](#trebuchet-integration)
@@ -92,6 +93,27 @@ Every tool should reference these shared libraries:
 | Service | Resource | Resolves |
 |---------|----------|----------|
 | `Radoub.Formats.Services.PlaceableAppearanceService` *(Sprint 1)* | placeables.2da | appearance ID → model name + display name (TLK with LABEL fallback) |
+
+### Backups Before Destructive File Operations
+
+**MANDATORY**: Any operation that deletes, overwrites, or renames a user file must back it up first. Backups are not optional — every destructive path in the toolset snapshots before touching disk, and a tool that skips this loses user data on a misclick.
+
+Use the shared `Radoub.UI.Services.Search.BackupService`. Do not roll your own.
+
+| Operation | Pattern |
+|-----------|---------|
+| Delete a file | `await backupService.BackupFilesAsync(new[]{ path }, moduleName)` → then `File.Delete(path)` |
+| Overwrite a file | Back up the existing file before writing, or write via temp + atomic replace and snapshot the prior version |
+| Rename a file | Back up source (and any reference files you rewrite) before the move — see `ResRefRenameOrchestrator` |
+| Repack an archive (.mod/.erf) | `await backupService.BackupArchiveAsync(modPath, moduleName)` before replacing — see `ModulePackService` |
+
+Rules:
+- Backups go to the shared root `~/Radoub/Backups/{moduleName}/{timestamp}/` — `BackupService` handles this; never hardcode a backup path.
+- `moduleName` = `Path.GetFileNameWithoutExtension(RadoubSettings.Instance.CurrentModulePath)` (fall back to `"unknown"`).
+- The confirm dialog for a destructive action should tell the user a backup is saved — don't say "cannot be undone" when it can.
+- Compiled/derived output that regenerates from source (e.g. `.ncs` from `.nss`) is exempt — backing it up is wasteful.
+
+Reference: Relique item delete (#2347), `ModulePackService` (#2246), `ResRefRenameOrchestrator`.
 
 ### Spell-Check Integration (Radoub.Dictionary)
 
@@ -441,6 +463,7 @@ dotnet nbgv get-version --project [ToolDir]
 | Skipping unit tests | Create ToolName.Tests from day 1 |
 | Hardcoding version in .csproj | Use NBGV `version.json` — no version properties in .csproj |
 | `<AssemblyName>` differs from tool name (built exe is `Foo.exe` for tool "Bar") | Set `<AssemblyName>ToolName</AssemblyName>` to match the folder/tool name. Sibling discovery, release workflow, cross-tool launchers, and `ToolDispatchService` all assume `Radoub/ToolName.exe` — divergence requires a settings-path migration to fix (#2080). |
+| Destructive file op with no backup (delete / overwrite / rename) | Back up via `Radoub.UI.Services.Search.BackupService` first. A bare `File.Delete` / `File.WriteAllBytes` over a user file is unrecoverable (#2347). See **Backups Before Destructive File Operations**. |
 
 [↑ TOC](#table-of-contents)
 

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/BatchReplaceServiceTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/BatchReplaceServiceTests.cs
@@ -86,6 +86,27 @@ public class BatchReplaceServiceTests : IDisposable
     }
 
     [Fact]
+    public void PreviewReplace_NssContentMatch_SkippedAndCounted()
+    {
+        // .nss content is plain-text script — Marlinspike doesn't edit it. The match
+        // is found by search but must be dropped from the preview AND counted so the
+        // UI can tell the user to use a code editor (#2341). Without the count, the
+        // preview is silently empty and reads as broken.
+        var dir = Path.Combine(_testDir, "module");
+        Directory.CreateDirectory(dir);
+        var nssPath = Path.Combine(dir, "_list.nss");
+        File.WriteAllText(nssPath, "void main() { ExecuteScript(\"louis\"); }");
+
+        var searchService = new ModuleSearchService();
+        var fileResult = searchService.SearchSingleFile(nssPath, new SearchCriteria { Pattern = "louis" });
+
+        var preview = _service.PreviewReplace(new[] { fileResult }, "lewie");
+
+        Assert.Empty(preview.Changes);              // nothing replaceable
+        Assert.True(preview.SkippedNssContentMatches > 0); // but the user is told why
+    }
+
+    [Fact]
     public void PreviewReplace_GroupsByFile()
     {
         var utcPath = WriteUtcFile("louis.utc", CreateTestUtc());

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/FilenameRenameScopeTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/FilenameRenameScopeTests.cs
@@ -10,9 +10,9 @@ namespace Radoub.UI.Tests.Services.Search;
 /// items also swept .nss scripts into the rename, so scripts "went missing"
 /// (they were silently RENAMED, not deleted — their old names vanished).
 ///
-/// Root cause under test: FilenameSearchProvider matches ALL searchable file
-/// types — including .nss — independent of the file-type checkboxes, and the
-/// rename dispatch then builds rename plans for those scripts.
+/// Fix (#2341): FilenameSearchProvider now honors SearchCriteria.FileTypeFilter
+/// with the same semantics as content search — null = all types, non-empty =
+/// only-listed. A search scoped to .uti must NOT return .nss scripts.
 /// </summary>
 public class FilenameRenameScopeTests : IDisposable
 {
@@ -33,19 +33,17 @@ public class FilenameRenameScopeTests : IDisposable
     private void Touch(string name) => File.WriteAllText(Path.Combine(_root, name), "stub");
 
     [Fact]
-    public void FilenameSearch_WithNssCheckboxUnticked_StillMatchesScripts()
+    public void FilenameSearch_ScopedToUti_DoesNotMatchScripts()
     {
         // User wants to remove items tagged "quest". They search "quest" in
-        // filename/resref mode. They did NOT check the .nss file type — they only
-        // care about items. But scripts share the token.
+        // filename/resref mode with only .uti checked. Scripts share the token but
+        // must NOT be swept into the rename.
         Touch("quest_reward.uti");   // the item they meant to find
         Touch("_quest_open.nss");    // an unrelated script — same token, leading underscore
         Touch("_quest_close.nss");   // another
 
         var provider = new FilenameSearchProvider();
 
-        // Simulate "only .uti checked" by filtering to UTI. FilenameSearchProvider
-        // documents that it ignores the file-type filter for filename matches.
         var criteria = new SearchCriteria
         {
             Pattern = "quest",
@@ -55,10 +53,54 @@ public class FilenameRenameScopeTests : IDisposable
 
         var results = provider.Search(_root, criteria);
 
-        var nssHits = results.Where(r => r.ResourceType == ResourceTypes.Nss).ToList();
+        Assert.DoesNotContain(results, r => r.ResourceType == ResourceTypes.Nss);
+        Assert.Contains(results, r => r.ResourceType == ResourceTypes.Uti);
+    }
 
-        // Documents current (buggy) behavior: scripts are pulled in even though the
-        // user scoped the search to items only.
-        Assert.NotEmpty(nssHits);
+    [Fact]
+    public void FilenameSearch_NullFilter_MatchesAllTypes()
+    {
+        // No filter (null) = surgical filename-only workflow: every searchable type
+        // is still matched, preserving the original design intent.
+        Touch("quest_reward.uti");
+        Touch("_quest_open.nss");
+
+        var provider = new FilenameSearchProvider();
+
+        var criteria = new SearchCriteria
+        {
+            Pattern = "quest",
+            IncludeFilenameResRef = true,
+            FileTypeFilter = null
+        };
+
+        var results = provider.Search(_root, criteria);
+
+        Assert.Contains(results, r => r.ResourceType == ResourceTypes.Uti);
+        Assert.Contains(results, r => r.ResourceType == ResourceTypes.Nss);
+    }
+
+    [Fact]
+    public void FilenameSearch_EmptyFilter_MatchesAllTypes()
+    {
+        // Empty filter (all 18 content checkboxes unticked) must still run the
+        // filename-only workflow — same convention as RenameDispatchHelpers
+        // (Count > 0 gates the filter). Empty != "match nothing".
+        Touch("quest_reward.uti");
+        Touch("_quest_open.nss");
+
+        var provider = new FilenameSearchProvider();
+
+        var criteria = new SearchCriteria
+        {
+            Pattern = "quest",
+            IncludeFilenameResRef = true,
+            FileTypeFilter = System.Array.Empty<ushort>()
+        };
+
+        var results = provider.Search(_root, criteria);
+
+        Assert.Contains(results, r => r.ResourceType == ResourceTypes.Uti);
+        Assert.Contains(results, r => r.ResourceType == ResourceTypes.Nss);
     }
 }

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/FilenameSearchProviderTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/FilenameSearchProviderTests.cs
@@ -97,13 +97,11 @@ public class FilenameSearchProviderTests : IDisposable
     }
 
     [Fact]
-    public void Search_FileTypeFilter_DoesNotGateFilenameSearch()
+    public void Search_NonEmptyFileTypeFilter_GatesFilenameSearch()
     {
-        // Filename search is independent of the 18 file-type content checkboxes.
-        // Those checkboxes gate file-CONTENT searching; filename matches are their
-        // own search domain enabled by SearchFilenameResRef. A user typing "louis"
-        // with only the filename/ResRef checkbox on should get matches across all
-        // file types — that's the surgical workflow.
+        // #2341: filename search now HONORS the file-type filter. A non-empty filter
+        // (e.g. only .dlg checked) must constrain filename matches too, so a rename
+        // scoped to one type can't sweep unrelated file types (esp. .nss scripts).
         Touch("louis.dlg");
         Touch("louis.utc");
         Touch("louis.git");
@@ -113,13 +111,34 @@ public class FilenameSearchProviderTests : IDisposable
         {
             Pattern = "louis",
             IncludeFilenameResRef = true,
-            FileTypeFilter = new[] { ResourceTypes.Dlg }  // narrowed content filter
+            FileTypeFilter = new[] { ResourceTypes.Dlg }
         };
 
         var results = provider.Search(_tempDir, criteria);
 
-        // All three filenames match — the file-type filter does NOT constrain
-        // filename search results.
+        Assert.Single(results);
+        Assert.Equal("louis.dlg", results[0].FileName);
+    }
+
+    [Fact]
+    public void Search_NullFileTypeFilter_MatchesAllTypes()
+    {
+        // Null filter = surgical filename-only workflow: every searchable type still
+        // matches, preserving the original design intent (#2341).
+        Touch("louis.dlg");
+        Touch("louis.utc");
+        Touch("louis.git");
+
+        var provider = new FilenameSearchProvider();
+        var criteria = new SearchCriteria
+        {
+            Pattern = "louis",
+            IncludeFilenameResRef = true,
+            FileTypeFilter = null
+        };
+
+        var results = provider.Search(_tempDir, criteria);
+
         Assert.Equal(3, results.Count);
     }
 

--- a/Radoub.UI/Radoub.UI/Services/Search/BatchReplaceService.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/BatchReplaceService.cs
@@ -122,7 +122,7 @@ public class BatchReplaceService
                 if (provider == null)
                 {
                     var skipReason = ext == ".nss"
-                        ? ".nss is plain-text script — edit it in your code editor, not Marlinspike content-replace."
+                        ? "Manage NSS files in your code editor."
                         : $"No provider for extension: {ext}";
                     allResults.AddRange(changes.Select(c => new ReplaceResult
                     {

--- a/Radoub.UI/Radoub.UI/Services/Search/BatchReplaceService.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/BatchReplaceService.cs
@@ -113,11 +113,14 @@ public class BatchReplaceService
 
                 if (provider == null)
                 {
+                    var skipReason = ext == ".nss"
+                        ? ".nss is plain-text script — edit it in your code editor, not Marlinspike content-replace."
+                        : $"No provider for extension: {ext}";
                     allResults.AddRange(changes.Select(c => new ReplaceResult
                     {
                         Success = false, Field = c.Match.Field,
                         OldValue = c.Match.FullFieldValue, NewValue = c.ReplacementText,
-                        Skipped = true, SkipReason = $"No provider for extension: {ext}"
+                        Skipped = true, SkipReason = skipReason
                     }));
                     continue;
                 }

--- a/Radoub.UI/Radoub.UI/Services/Search/BatchReplaceService.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/BatchReplaceService.cs
@@ -54,7 +54,15 @@ public class BatchReplaceService
                 var isReplaceable = match.Field.IsReplaceable
                     || (allowResRefReplace && match.Field.FieldType == SearchFieldType.ResRef);
 
-                if (!isReplaceable) continue;
+                if (!isReplaceable)
+                {
+                    // .nss script-source content matches are found by search but can't be
+                    // replaced here (plain text — edit in a code editor). Count them so the
+                    // UI can explain the otherwise-empty preview (#2341).
+                    if (match.Field.GffPath == "<nss-source>")
+                        preview.SkippedNssContentMatches++;
+                    continue;
+                }
 
                 var change = new PendingChange
                 {

--- a/Radoub.UI/Radoub.UI/Services/Search/FilenameSearchProvider.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/FilenameSearchProvider.cs
@@ -52,11 +52,15 @@ public class FilenameSearchProvider
 
             var resourceType = ResourceTypes.FromExtension(ext);
 
-            // Filename search is INDEPENDENT of the 18 file-type checkboxes.
-            // Those checkboxes gate file-CONTENT searching; filename matches are
-            // their own search domain enabled by SearchFilenameResRef. This lets
-            // the user search filenames alone (all 18 unchecked) — the surgical
-            // workflow this feature was designed for.
+            // Honor FileTypeFilter, matching RenameDispatchHelpers' convention (#2341):
+            //   null or empty = all searchable types matched (surgical filename-only
+            //                   workflow — user can search names with no type checked)
+            //   non-empty     = only the listed types are matched
+            // Previously filename search ignored the checkboxes entirely, so a search
+            // scoped to items (.uti) also swept .nss scripts into the rename — silently
+            // renaming scripts and breaking ExecuteScript/#include references.
+            if (criteria.FileTypeFilter is { Count: > 0 } filter && !filter.Contains(resourceType))
+                continue;
 
             var resRefPortion = Path.GetFileNameWithoutExtension(filePath);
             var match = pattern.Match(resRefPortion);

--- a/Radoub.UI/Radoub.UI/Services/Search/Models/BatchReplaceModels.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/Models/BatchReplaceModels.cs
@@ -53,6 +53,14 @@ public class BatchReplacePreview
     /// instances passed into provider.Replace.
     /// </summary>
     public bool AllowResRefReplace { get; init; }
+
+    /// <summary>
+    /// Count of .nss script-source content matches that were found by search but
+    /// dropped from the preview because Marlinspike does not edit plain-text script
+    /// content (#2341). The UI surfaces this so the user knows the matches exist but
+    /// must be edited in a code editor — otherwise an empty preview reads as "broken".
+    /// </summary>
+    public int SkippedNssContentMatches { get; set; }
 }
 
 /// <summary>

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.10.21-alpha] - 2026-06-04
+**Branch**: `trebuchet/sprint/compile-marlinspike-scope` | **PR**: #2345
+
+### Fix: Item delete now backs up first (#2347)
+
+- Deleting an item blueprint now saves a backup to `~/Radoub/Backups/` before removing the file, so a misclick can be restored.
+
+---
+
 ## [0.10.20-alpha] - 2026-05-28
 **Branch**: `relique/issue-2257-2261` | **PR**: #2283
 

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fix: Item delete now backs up first (#2347)
 
 - Deleting an item blueprint now saves a backup to `~/Radoub/Backups/` before removing the file, so a misclick can be restored.
+- Delete-confirm dialog now sizes to content and is resizable so the Delete/Cancel buttons are never clipped off-window (#2348).
 
 ---
 

--- a/Relique/Relique.Tests/Services/FileDeletionServiceTests.cs
+++ b/Relique/Relique.Tests/Services/FileDeletionServiceTests.cs
@@ -1,0 +1,68 @@
+using System.IO;
+using System.Threading.Tasks;
+using ItemEditor.Services;
+using Radoub.UI.Services.Search;
+using Xunit;
+
+namespace ItemEditor.Tests.Services;
+
+/// <summary>
+/// Tests for FileDeletionService — Relique item delete must back up the file
+/// before removing it (#2347). Previously delete was a bare File.Delete with no
+/// backup, making it unrecoverable despite the "cannot be undone" confirm text.
+/// </summary>
+public class FileDeletionServiceTests : System.IDisposable
+{
+    private readonly string _root;
+    private readonly string _backupRoot;
+
+    public FileDeletionServiceTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"reldel-{System.Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+        _backupRoot = Path.Combine(_root, "Backups");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+
+    [Fact]
+    public async Task DeleteWithBackupAsync_RemovesFile_AndLeavesRecoverableBackup()
+    {
+        var filePath = Path.Combine(_root, "louis.uti");
+        var content = "ORIGINAL ITEM BYTES";
+        await File.WriteAllTextAsync(filePath, content);
+
+        var backupService = new BackupService(_backupRoot);
+        var manifest = await FileDeletionService.DeleteWithBackupAsync(filePath, "LNS_DLG", backupService);
+
+        // File gone from disk
+        Assert.False(File.Exists(filePath));
+
+        // A recoverable backup exists with the original content
+        Assert.Single(manifest.Entries);
+        var backupPath = manifest.Entries[0].BackupPath;
+        Assert.True(File.Exists(backupPath));
+        Assert.Equal(content, await File.ReadAllTextAsync(backupPath));
+    }
+
+    [Fact]
+    public async Task DeleteWithBackupAsync_BackupRestores_OriginalFile()
+    {
+        var filePath = Path.Combine(_root, "apples.uti");
+        var content = "RECOVER ME";
+        await File.WriteAllTextAsync(filePath, content);
+
+        var backupService = new BackupService(_backupRoot);
+        var manifest = await FileDeletionService.DeleteWithBackupAsync(filePath, "LNS_DLG", backupService);
+
+        var restored = await backupService.RestoreAsync(manifest);
+
+        Assert.True(restored);
+        Assert.True(File.Exists(filePath));
+        Assert.Equal(content, await File.ReadAllTextAsync(filePath));
+    }
+}

--- a/Relique/Relique/Services/FileDeletionService.cs
+++ b/Relique/Relique/Services/FileDeletionService.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Radoub.UI.Services.Search;
+
+namespace ItemEditor.Services;
+
+/// <summary>
+/// Deletes item files with a backup-first guarantee (#2347). Relique previously
+/// deleted with a bare File.Delete and no backup, making the action
+/// unrecoverable. This snapshots the file to ~/Radoub/Backups/{module}/{timestamp}/
+/// (the shared backup root used by every other destructive Radoub operation)
+/// before removing it, so a misclick can be restored.
+/// </summary>
+public static class FileDeletionService
+{
+    /// <summary>
+    /// Back up <paramref name="filePath"/> then delete it. Returns the backup
+    /// manifest so callers can surface the restore location.
+    /// </summary>
+    public static async Task<BackupManifest> DeleteWithBackupAsync(
+        string filePath, string moduleName, BackupService backupService)
+    {
+        var manifest = await backupService.BackupFilesAsync(new List<string> { filePath }, moduleName);
+        System.IO.File.Delete(filePath);
+        return manifest;
+    }
+}

--- a/Relique/Relique/Views/MainWindow.Lifecycle.cs
+++ b/Relique/Relique/Views/MainWindow.Lifecycle.cs
@@ -357,13 +357,16 @@ public partial class MainWindow
         var fileName = Path.GetFileName(entry.FilePath);
 
         // Confirm deletion (destructive action — modal OK per CLAUDE.md)
+        // SizeToContent so the button row is never clipped — a fixed Height + non-resizable
+        // window pushed Delete/Cancel off-screen with no way to reach them (#2348).
         var dialog = new Avalonia.Controls.Window
         {
             Title = "Confirm Delete",
-            Width = 380,
-            Height = 150,
+            Width = 400,
+            MinHeight = 160,
+            SizeToContent = Avalonia.Controls.SizeToContent.Height,
             WindowStartupLocation = Avalonia.Controls.WindowStartupLocation.CenterOwner,
-            CanResize = false
+            CanResize = true
         };
 
         var confirmed = false;

--- a/Relique/Relique/Views/MainWindow.Lifecycle.cs
+++ b/Relique/Relique/Views/MainWindow.Lifecycle.cs
@@ -370,7 +370,7 @@ public partial class MainWindow
         var panel = new Avalonia.Controls.StackPanel { Margin = new Avalonia.Thickness(20), Spacing = 16 };
         panel.Children.Add(new Avalonia.Controls.TextBlock
         {
-            Text = $"Delete \"{fileName}\" from disk?\n\nThis cannot be undone.",
+            Text = $"Delete \"{fileName}\" from disk?\n\nA backup is saved to ~/Radoub/Backups first.",
             TextWrapping = Avalonia.Media.TextWrapping.Wrap
         });
 
@@ -406,8 +406,14 @@ public partial class MainWindow
                 Radoub.UI.Services.FileSessionLockService.ReleaseLock(_currentFilePath);
             }
 
-            File.Delete(entry.FilePath);
-            UnifiedLogger.LogApplication(LogLevel.INFO, $"Deleted item file: {fileName}");
+            // Back up before deleting so a misclick is recoverable (#2347).
+            var modulePath = RadoubSettings.Instance.CurrentModulePath;
+            var moduleName = !string.IsNullOrEmpty(modulePath)
+                ? Path.GetFileNameWithoutExtension(modulePath)
+                : "unknown";
+            await ItemEditor.Services.FileDeletionService.DeleteWithBackupAsync(
+                entry.FilePath, moduleName, new Radoub.UI.Services.Search.BackupService());
+            UnifiedLogger.LogApplication(LogLevel.INFO, $"Deleted item file (backed up): {fileName}");
 
             if (isDeletingCurrent)
             {

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.36.8-alpha] - 2026-06-04
+**Branch**: `trebuchet/sprint/compile-marlinspike-scope` | **PR**: #TBD
+
+### Sprint: Compile + Marlinspike scope fixes
+
+- Batch script compilation now chunks the file list so large modules no longer exceed the Windows command-line length limit (#2343).
+- Marlinspike filename/resref rename now respects the file-type scope, so `.nss` scripts are no longer silently renamed when cleaning up items (#2341).
+
+---
+
 ## [1.36.7-alpha] - 2026-05-30
 **Branch**: `quartermaster/issue-2220` | **PR**: #2326
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Batch script compilation now chunks the file list so large modules no longer exceed the Windows command-line length limit (#2343).
 - Marlinspike filename/resref rename now respects the file-type scope, so `.nss` scripts are no longer silently renamed when cleaning up items (#2341).
+- Marlinspike filename rename now shows a confirmation dialog listing every old → new name before renaming any files (#2346).
 
 ---
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [1.36.8-alpha] - 2026-06-04
-**Branch**: `trebuchet/sprint/compile-marlinspike-scope` | **PR**: #TBD
+**Branch**: `trebuchet/sprint/compile-marlinspike-scope` | **PR**: #2345
 
 ### Sprint: Compile + Marlinspike scope fixes
 

--- a/Trebuchet/Trebuchet.Tests/ScriptPathChunkerTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ScriptPathChunkerTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Linq;
+using RadoubLauncher.Services;
+using Xunit;
+
+namespace Trebuchet.Tests;
+
+/// <summary>
+/// Tests for ProcessArgumentBuilder.ChunkScriptPaths — splits a script list so
+/// each compiler invocation's command line stays under the OS limit (#2343).
+///
+/// On large modules (~1100 stale scripts) the old single-invocation path passed
+/// every absolute path as one command line (~88 KB), exceeding the Windows
+/// 32,767-char CreateProcess cap and throwing Win32 error 206
+/// ("filename or extension is too long") before the compiler even started.
+/// </summary>
+public class ScriptPathChunkerTests
+{
+    [Fact]
+    public void ChunkScriptPaths_AllPathsPreservedExactlyOnce_InOrder()
+    {
+        var paths = Enumerable.Range(0, 50).Select(i => $@"C:\m\script_{i:00}.nss").ToList();
+
+        var chunks = ProcessArgumentBuilder.ChunkScriptPaths(paths, fixedArgsLength: 100, maxCommandLine: 200);
+
+        var flattened = chunks.SelectMany(c => c).ToList();
+        Assert.Equal(paths, flattened); // same items, same order, no loss, no dupes
+    }
+
+    [Fact]
+    public void ChunkScriptPaths_EachChunkUnderLimit_AccountingForFixedArgs()
+    {
+        var paths = Enumerable.Range(0, 200).Select(i => $@"C:\modules\anphillia\anph_script_{i:000}.nss").ToList();
+        const int fixedArgs = 80;   // "-c -y -j 16 --root C:\Games\NWN" etc.
+        const int maxCmd = 512;
+
+        var chunks = ProcessArgumentBuilder.ChunkScriptPaths(paths, fixedArgs, maxCmd);
+
+        foreach (var chunk in chunks)
+        {
+            // Serialized length = each path + a separating space.
+            var serialized = chunk.Sum(p => p.Length + 1);
+            Assert.True(fixedArgs + serialized <= maxCmd,
+                $"Chunk command-line length {fixedArgs + serialized} exceeds limit {maxCmd}");
+            Assert.NotEmpty(chunk);
+        }
+    }
+
+    [Fact]
+    public void ChunkScriptPaths_SinglePathLongerThanLimit_StillGetsOwnChunk()
+    {
+        // A path that alone exceeds the budget can't be split — it must still be
+        // emitted in its own chunk rather than dropped or causing an infinite loop.
+        var huge = @"C:\m\" + new string('x', 500) + ".nss";
+        var paths = new List<string> { @"C:\m\a.nss", huge, @"C:\m\b.nss" };
+
+        var chunks = ProcessArgumentBuilder.ChunkScriptPaths(paths, fixedArgsLength: 50, maxCommandLine: 200);
+
+        Assert.Contains(chunks, c => c.Count == 1 && c[0] == huge);
+        Assert.Equal(paths, chunks.SelectMany(c => c).ToList());
+    }
+
+    [Fact]
+    public void ChunkScriptPaths_SmallListFitsInOneChunk()
+    {
+        var paths = new List<string> { @"C:\m\a.nss", @"C:\m\b.nss" };
+
+        var chunks = ProcessArgumentBuilder.ChunkScriptPaths(paths, fixedArgsLength: 50, maxCommandLine: 32000);
+
+        Assert.Single(chunks);
+        Assert.Equal(paths, chunks[0]);
+    }
+
+    [Fact]
+    public void ChunkScriptPaths_EmptyList_ReturnsNoChunks()
+    {
+        var chunks = ProcessArgumentBuilder.ChunkScriptPaths(new List<string>(), fixedArgsLength: 50, maxCommandLine: 200);
+
+        Assert.Empty(chunks);
+    }
+}

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
@@ -548,6 +548,17 @@ public partial class MarlinspikePanel : UserControl
             return;
         }
 
+        // Confirm the rename before touching any files (#2346). Filename rename used
+        // to run with no review step — a typo in the replacement text renamed files
+        // silently. Show the full old → new list and require explicit confirmation.
+        var confirmDialog = new RenameConfirmDialog(plans);
+        await confirmDialog.ShowDialog(_parentWindow);
+        if (!confirmDialog.Confirmed)
+        {
+            _viewModel.StatusText = "Rename cancelled.";
+            return;
+        }
+
         // Surface auto-suffix collision dialogs before proceeding.
         // Each plan whose validation triggered an auto-suffix must be confirmed.
         var confirmedPlans = new List<ResRefRenamePlan>();

--- a/Trebuchet/Trebuchet/Services/ProcessArgumentBuilder.cs
+++ b/Trebuchet/Trebuchet/Services/ProcessArgumentBuilder.cs
@@ -61,4 +61,54 @@ public static class ProcessArgumentBuilder
 
         return args;
     }
+
+    /// <summary>
+    /// Split <paramref name="scriptPaths"/> into chunks so each compiler invocation's
+    /// command line stays under <paramref name="maxCommandLine"/> characters (#2343).
+    ///
+    /// Windows caps a process command line at 32,767 chars; passing ~1100 absolute
+    /// paths as one <c>-c</c> invocation overflowed it and threw Win32 error 206
+    /// before the compiler started. Each path contributes its length plus one space
+    /// separator; <paramref name="fixedArgsLength"/> reserves room for the constant
+    /// flags (<c>-c -y -j N --root &lt;path&gt;</c>) shared by every chunk.
+    ///
+    /// A single path longer than the remaining budget still gets its own chunk —
+    /// it can't be split, and dropping it would silently skip a script.
+    /// </summary>
+    public static IReadOnlyList<IReadOnlyList<string>> ChunkScriptPaths(
+        IReadOnlyList<string> scriptPaths, int fixedArgsLength, int maxCommandLine)
+    {
+        var chunks = new List<IReadOnlyList<string>>();
+        if (scriptPaths.Count == 0)
+            return chunks;
+
+        var budget = maxCommandLine - fixedArgsLength;
+        if (budget < 1) budget = 1;
+
+        var current = new List<string>();
+        var currentLen = 0;
+
+        foreach (var path in scriptPaths)
+        {
+            var cost = path.Length + 1; // path + separating space
+
+            // Start a new chunk when adding this path would overflow the budget,
+            // unless the current chunk is empty (a lone oversize path must still
+            // be emitted rather than looping forever).
+            if (current.Count > 0 && currentLen + cost > budget)
+            {
+                chunks.Add(current);
+                current = new List<string>();
+                currentLen = 0;
+            }
+
+            current.Add(path);
+            currentLen += cost;
+        }
+
+        if (current.Count > 0)
+            chunks.Add(current);
+
+        return chunks;
+    }
 }

--- a/Trebuchet/Trebuchet/Services/ScriptCompilerService.cs
+++ b/Trebuchet/Trebuchet/Services/ScriptCompilerService.cs
@@ -504,11 +504,78 @@ public class ScriptCompilerService
         var includeRoot = (!string.IsNullOrEmpty(gamePath) && Directory.Exists(gamePath))
             ? gamePath
             : null;
-        var argList = ProcessArgumentBuilder.CompileArgs(
-            scriptPaths, includeRoot, continueOnError: true, threadCount: threadCount);
 
         // Use the directory of the first script as working directory
         var workingDir = Path.GetDirectoryName(scriptPaths[0]) ?? ".";
+
+        // Chunk the script list so each invocation stays under the OS command-line
+        // limit (#2343). Windows caps CreateProcess at 32,767 chars; ~1100 absolute
+        // paths overflowed it and threw error 206 before the compiler ran. Reserve
+        // a generous margin below the hard cap for safety across shells/OSes.
+        const int MaxCommandLine = 30000;
+        var fixedArgsLength = ProcessArgumentBuilder
+            .CompileArgs(System.Array.Empty<string>(), includeRoot, continueOnError: true, threadCount: threadCount)
+            .Sum(a => a.Length + 1);
+        var chunks = ProcessArgumentBuilder.ChunkScriptPaths(scriptPaths, fixedArgsLength, MaxCommandLine);
+
+        if (chunks.Count > 1)
+        {
+            UnifiedLogger.LogApplication(LogLevel.INFO,
+                $"Command line too long for one invocation — split {scriptPaths.Count} scripts into {chunks.Count} chunks.");
+        }
+
+        try
+        {
+            var compiledSoFar = 0;
+            foreach (var chunk in chunks)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var chunkOk = await CompileChunkAsync(
+                    chunk, includeRoot, threadCount, workingDir, batchResult,
+                    compiledSoFar, scriptPaths.Count, progress, cancellationToken);
+                compiledSoFar += chunk.Count;
+                if (!chunkOk && batchResult.ErrorMessage == "Compilation timed out")
+                    return batchResult; // hard stop on timeout, matching prior behavior
+            }
+
+            batchResult.Success = batchResult.FailedScripts.Count == 0
+                && string.IsNullOrEmpty(batchResult.ErrorMessage);
+
+            progress?.Invoke(scriptPaths.Count, scriptPaths.Count, "done");
+            UnifiedLogger.LogApplication(LogLevel.INFO,
+                $"Batch compilation complete: {batchResult.SuccessCount}/{batchResult.TotalScripts} succeeded");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            batchResult.ErrorMessage = ex.Message;
+            UnifiedLogger.LogApplication(LogLevel.ERROR, $"Batch compilation error: {ex.Message}");
+        }
+
+        return batchResult;
+    }
+
+    /// <summary>
+    /// Compile a single chunk of scripts (one compiler invocation) and append the
+    /// per-script results into <paramref name="batchResult"/>. Returns false if the
+    /// chunk timed out (caller stops the whole batch).
+    /// </summary>
+    private async Task<bool> CompileChunkAsync(
+        IReadOnlyList<string> scriptPaths,
+        string? includeRoot,
+        int threadCount,
+        string workingDir,
+        BatchCompilationResult batchResult,
+        int compiledSoFar,
+        int grandTotal,
+        Action<int, int, string>? progress,
+        CancellationToken cancellationToken)
+    {
+        var argList = ProcessArgumentBuilder.CompileArgs(
+            scriptPaths, includeRoot, continueOnError: true, threadCount: threadCount);
 
         var startInfo = new ProcessStartInfo
         {
@@ -527,7 +594,8 @@ public class ScriptCompilerService
         UnifiedLogger.LogApplication(LogLevel.INFO,
             $"Running: {Path.GetFileName(CompilerPath!)} -c [{scriptPaths.Count} files] -y -j (cwd: {workingDir})");
 
-        try
+        progress?.Invoke(compiledSoFar, grandTotal, $"compiling {scriptPaths.Count}...");
+
         {
             using var process = new Process { StartInfo = startInfo };
             var output = new StringBuilder();
@@ -555,7 +623,7 @@ public class ScriptCompilerService
                 try { process.Kill(); } catch (Exception) { }
                 batchResult.ErrorMessage = "Compilation timed out";
                 UnifiedLogger.LogApplication(LogLevel.ERROR, "Batch compilation timed out");
-                return batchResult;
+                return false;
             }
 
             // Wait again to ensure async output handlers finish
@@ -620,7 +688,9 @@ public class ScriptCompilerService
                 }
             }
 
-            // Build per-script results
+            // Build per-script results. Track failures THIS chunk added so the
+            // exit-code fallback below scopes to this invocation, not the whole batch.
+            var chunkFailedCount = 0;
             foreach (var scriptPath in scriptPaths)
             {
                 var scriptName = Path.GetFileName(scriptPath);
@@ -639,6 +709,7 @@ public class ScriptCompilerService
                     result.ErrorMessage = errors.FirstOrDefault() ?? "Compilation failed";
                     result.ErrorOutput = string.Join("\n", errors);
                     batchResult.FailedScripts.Add(scriptName);
+                    chunkFailedCount++;
                     UnifiedLogger.LogApplication(LogLevel.WARN, $"Failed: {scriptName}: {result.ErrorMessage}");
                 }
                 else
@@ -651,9 +722,9 @@ public class ScriptCompilerService
 
             // Exit code is the authoritative indicator of success.
             // If the compiler returned non-zero but our stderr parsing didn't identify
-            // specific failures, mark the whole batch as failed so we don't silently
-            // report success when scripts actually failed to compile.
-            if (exitCode != 0 && batchResult.FailedScripts.Count == 0)
+            // specific failures in THIS chunk, fall back to per-file heuristics so we
+            // don't silently report success when scripts actually failed to compile.
+            if (exitCode != 0 && chunkFailedCount == 0)
             {
                 UnifiedLogger.LogApplication(LogLevel.WARN,
                     $"Compiler exit code {exitCode} but no per-script errors parsed from stderr. Marking batch as failed.");
@@ -689,45 +760,32 @@ public class ScriptCompilerService
                     }
                 }
 
-                // If we still can't identify which scripts failed, mark all as failed
+                // If we still can't identify which scripts failed, mark every script
+                // in THIS chunk as failed (don't touch other chunks' results).
                 if (!anyIdentified)
                 {
                     UnifiedLogger.LogApplication(LogLevel.WARN,
-                        "Cannot identify specific failures — marking all scripts as failed");
-                    foreach (var result in batchResult.Results)
+                        "Cannot identify specific failures — marking this chunk's scripts as failed");
+                    foreach (var scriptPath in scriptPaths)
                     {
-                        result.Success = false;
+                        var result = batchResult.Results.First(r => r.ScriptPath == scriptPath);
+                        if (result.Success)
+                        {
+                            result.Success = false;
+                            batchResult.SuccessCount--;
+                            batchResult.FailedScripts.Add(Path.GetFileName(scriptPath)!);
+                        }
                         result.ExitCode = exitCode;
                         result.ErrorMessage = !string.IsNullOrWhiteSpace(errorText)
                             ? errorText.Trim()
                             : "Compilation failed (compiler returned non-zero exit code)";
                         result.ErrorOutput = errorText;
                     }
-                    batchResult.FailedScripts.Clear();
-                    batchResult.FailedScripts.AddRange(scriptPaths.Select(Path.GetFileName)!);
-                    batchResult.SuccessCount = 0;
                 }
             }
-
-            batchResult.Success = exitCode == 0 && batchResult.FailedScripts.Count == 0;
-
-            // Signal completion
-            progress?.Invoke(scriptPaths.Count, scriptPaths.Count, "done");
-
-            UnifiedLogger.LogApplication(LogLevel.INFO,
-                $"Batch compilation complete: {batchResult.SuccessCount}/{batchResult.TotalScripts} succeeded");
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            batchResult.ErrorMessage = ex.Message;
-            UnifiedLogger.LogApplication(LogLevel.ERROR, $"Batch compilation error: {ex.Message}");
         }
 
-        return batchResult;
+        return true;
     }
 
 }

--- a/Trebuchet/Trebuchet/Views/RenameConfirmDialog.axaml
+++ b/Trebuchet/Trebuchet/Views/RenameConfirmDialog.axaml
@@ -1,0 +1,63 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="RadoubLauncher.Views.RenameConfirmDialog"
+        Title="Confirm Rename"
+        SizeToContent="Height"
+        Width="560"
+        MinWidth="480"
+        MaxHeight="600"
+        WindowStartupLocation="CenterOwner"
+        CanResize="True"
+        ShowInTaskbar="False">
+
+    <Border Padding="16">
+        <DockPanel>
+            <!-- Header -->
+            <StackPanel DockPanel.Dock="Top" Spacing="6" Margin="0,0,0,12">
+                <TextBlock x:Name="HeaderText"
+                           FontSize="{DynamicResource FontSizeMedium}"
+                           FontWeight="SemiBold"
+                           TextWrapping="Wrap"/>
+                <TextBlock x:Name="DetailText"
+                           TextWrapping="Wrap"
+                           Opacity="0.85"
+                           Text="These files will be renamed and any references to them updated. This cannot be undone from the app (a backup is saved first)."/>
+            </StackPanel>
+
+            <!-- Buttons -->
+            <StackPanel DockPanel.Dock="Bottom"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        Spacing="8"
+                        Margin="0,12,0,0">
+                <Button Content="Rename"
+                        Click="OnConfirmClick"
+                        IsDefault="True"
+                        Padding="20,6"
+                        ToolTip.Tip="Proceed with the renames listed above."/>
+                <Button Content="Cancel"
+                        Click="OnCancelClick"
+                        IsCancel="True"
+                        Padding="20,6"
+                        ToolTip.Tip="Abort — no files are renamed."/>
+            </StackPanel>
+
+            <!-- Rename list -->
+            <Border BorderThickness="1"
+                    BorderBrush="{DynamicResource ThemeBorderMidBrush}"
+                    CornerRadius="4">
+                <ScrollViewer MaxHeight="420" Padding="8">
+                    <ItemsControl x:Name="RenameList">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Margin="0,2"
+                                           TextWrapping="NoWrap"
+                                           Text="{Binding}"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+            </Border>
+        </DockPanel>
+    </Border>
+</Window>

--- a/Trebuchet/Trebuchet/Views/RenameConfirmDialog.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/RenameConfirmDialog.axaml.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Radoub.Formats.Search.Rename;
+
+namespace RadoubLauncher.Views;
+
+/// <summary>
+/// Confirmation dialog shown before Marlinspike executes a filename/resref rename
+/// (#2346). Filename rename previously ran with no review step — only the
+/// auto-suffix collision dialog appeared, and only on a name collision. This
+/// surfaces the full old → new list so a typo in the replacement text can be
+/// caught before files are renamed and references rewritten.
+/// </summary>
+public partial class RenameConfirmDialog : Window
+{
+    /// <summary>True when the user confirmed the rename; false on cancel/close.</summary>
+    public bool Confirmed { get; private set; }
+
+    public RenameConfirmDialog()
+    {
+        InitializeComponent();
+    }
+
+    public RenameConfirmDialog(IReadOnlyList<ResRefRenamePlan> plans)
+        : this()
+    {
+        var count = plans.Count;
+        HeaderText.Text = count == 1
+            ? "Rename 1 file?"
+            : $"Rename {count} files?";
+
+        RenameList.ItemsSource = plans
+            .Select(p =>
+            {
+                var ext = Path.GetExtension(p.SourceFilePath);
+                return $"{p.OldName}{ext}  →  {p.NewName}{ext}";
+            })
+            .ToList();
+    }
+
+    private void OnConfirmClick(object? sender, RoutedEventArgs e)
+    {
+        Confirmed = true;
+        Close();
+    }
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e)
+    {
+        Confirmed = false;
+        Close();
+    }
+}

--- a/Trebuchet/Trebuchet/Views/ReplacePreviewWindow.axaml
+++ b/Trebuchet/Trebuchet/Views/ReplacePreviewWindow.axaml
@@ -6,7 +6,7 @@
         MinWidth="450" MinHeight="350"
         WindowStartupLocation="CenterOwner">
 
-    <Grid RowDefinitions="Auto,*,Auto,Auto">
+    <Grid RowDefinitions="Auto,Auto,*,Auto,Auto">
 
         <!-- Header -->
         <Border Grid.Row="0" Padding="12,8"
@@ -29,8 +29,19 @@
             </StackPanel>
         </Border>
 
+        <!-- .nss script notice (shown only when script-source content matches were skipped) -->
+        <Border x:Name="NssNotice" Grid.Row="1" Padding="12,8" IsVisible="False"
+                Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                BorderThickness="0,0,0,1">
+            <TextBlock x:Name="NssNoticeText"
+                       TextWrapping="Wrap"
+                       FontSize="{DynamicResource FontSizeSmall}"
+                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+        </Border>
+
         <!-- Change list -->
-        <TreeView x:Name="ChangeTree" Grid.Row="1" Margin="4">
+        <TreeView x:Name="ChangeTree" Grid.Row="2" Margin="4">
             <TreeView.Styles>
                 <Style Selector="TreeViewItem">
                     <Setter Property="IsExpanded" Value="True"/>
@@ -39,7 +50,7 @@
         </TreeView>
 
         <!-- Backup notice -->
-        <Border Grid.Row="2" Padding="8,4"
+        <Border Grid.Row="3" Padding="8,4"
                 Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
                 BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
                 BorderThickness="0,1,0,0">
@@ -49,7 +60,7 @@
         </Border>
 
         <!-- Buttons -->
-        <Border Grid.Row="3" Padding="12,8"
+        <Border Grid.Row="4" Padding="12,8"
                 Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                 BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
                 BorderThickness="0,1,0,0">

--- a/Trebuchet/Trebuchet/Views/ReplacePreviewWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/ReplacePreviewWindow.axaml.cs
@@ -35,6 +35,18 @@ public partial class ReplacePreviewWindow : Window
         _batchReplaceService = batchReplaceService;
 
         HeaderText.Text = $"Replacing \"{searchPattern}\" \u2192 \"{replaceText}\"";
+
+        // .nss script-source matches were found but can't be replaced here \u2014 tell the
+        // user instead of showing an unexplained empty/short preview (#2341).
+        if (preview.SkippedNssContentMatches > 0)
+        {
+            var n = preview.SkippedNssContentMatches;
+            NssNoticeText.Text =
+                $"\u26a0 {n} match{(n == 1 ? "" : "es")} in .nss script files {(n == 1 ? "is" : "are")} not shown \u2014 " +
+                "NWScript is plain text and isn't edited by Marlinspike. Open the script in your code editor to change it.";
+            NssNotice.IsVisible = true;
+        }
+
         BuildChangeTree(preview);
         UpdateSelectionCount();
     }

--- a/Trebuchet/Trebuchet/Views/ReplacePreviewWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/ReplacePreviewWindow.axaml.cs
@@ -43,7 +43,7 @@ public partial class ReplacePreviewWindow : Window
             var n = preview.SkippedNssContentMatches;
             NssNoticeText.Text =
                 $"\u26a0 {n} match{(n == 1 ? "" : "es")} in .nss script files {(n == 1 ? "is" : "are")} not shown \u2014 " +
-                "NWScript is plain text and isn't edited by Marlinspike. Open the script in your code editor to change it.";
+                "manage NSS files in your code editor.";
             NssNotice.IsVisible = true;
         }
 


### PR DESCRIPTION
## Summary

User-reported safety/UX bugs across Marlinspike, compile, and Relique:

- **#2341** — Marlinspike filename/resref rename ignored the file-type scope and silently renamed `.nss` scripts. Fix: honor scope for filename matches.
- **#2343** — Batch compile on large modules exceeds the Windows 32K command-line limit (error 206). Fix: chunk the file list per invocation.
- **#2346** — Filename rename ran with no preview/confirmation. Fix: confirmation dialog listing every old → new name.
- **#2347** — Relique item delete had no backup (unrecoverable). Fix: back up to `~/Radoub/Backups/` before deleting.
- **#2348** — Relique delete-confirm dialog clipped its buttons off-window (fixed height, not resizable). Fix: SizeToContent + resizable.

Also: Marlinspike now tells the user to edit `.nss` in a code editor when a script content match can't be replaced. Bootstrap doc now mandates backup before destructive file ops.

## Related Issues

- Closes #2341
- Closes #2343
- Closes #2346
- Closes #2347
- Closes #2348

## Tests

- #2341: FilenameSearchProvider scope tests; full Radoub.UI Search suite (146) pass
- #2343: 5 chunker tests; full Trebuchet.Tests (230) pass
- #2347: 2 deletion-service tests; full Relique suite (359) pass
- #2346 / #2348: UI dialogs — manual verification
- FlaUI (Trebuchet): 14 pass (captured)

## Manual Spot-Checks

- [ ] Marlinspike, only `.uti` ticked, resref search shared token → no `.nss` in results (#2341)
- [ ] Surgical mode: all file types unticked, filename search → still matches all types (#2341)
- [ ] Large module (LNS_DLG) compile → no error 206; log shows chunk split (#2343)
- [ ] Compile with one bad script → that script flagged failed, others compile (#2343)
- [ ] Filename rename → confirmation dialog lists old → new; Cancel renames nothing (#2346)
- [ ] Relique delete → file gone, backup present in ~/Radoub/Backups/{module}/{timestamp}/ (#2347)
- [ ] Relique delete-confirm dialog → Delete/Cancel buttons fully visible and clickable (#2348)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)