### PR TITLE
[Reliquary] feat: New-resource flow + bootstrap audit gaps (#2367)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Docs] - 2026-06-06
-**Branch**: `reliquary/issue-2367` | **PR**: #TBD
+**Branch**: `reliquary/issue-2367` | **PR**: #2371
 
 ### Bootstrap: require New-resource flow + audit gaps (post-Reliquary audit)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Docs] - 2026-06-06
+**Branch**: `reliquary/issue-2367` | **PR**: #TBD
+
+### Bootstrap: require New-resource flow + audit gaps (post-Reliquary audit)
+
+- `NEW_TOOL_BOOTSTRAP.md`: added a Day-1 requirement that every tool ship a `File → New` flow (Save-As-copy is not a substitute), plus verifiable Post-Implementation Audit rows for New-resource, Recent Files end-to-end, and no-dead-controls — gaps a 12/12 uniformity audit missed on Reliquary.
+- Reliquary `CLAUDE.md`: corrected stale Status (all 7 sprints done, v0.1.0-alpha) and linked open follow-ups (#2367–#2370, #2354, #2363).
+
+---
+
 ## [IntegrationTests 0.1.0-alpha] - 2026-06-06
 **Branch**: `radoub/sprint/flaui-coverage` | **PR**: #2365
 

--- a/Documentation/NEW_TOOL_BOOTSTRAP.md
+++ b/Documentation/NEW_TOOL_BOOTSTRAP.md
@@ -38,7 +38,7 @@ This guide holds the full checklist and detailed patterns for adding a new tool 
 
 ### Reference Implementation
 
-**Quartermaster is the canonical reference** for new Radoub tools. Study its structure before starting.
+**Quartermaster is the canonical reference** for new Radoub tools. Study its structure before starting. For the single-resource blueprint pattern specifically (one file = one editable resource), **Relique, Fence, and Quartermaster are the most feature-complete** — study all three for the full surface (new-resource flow, recent files, properties, preview, settings) before deciding what your tool needs.
 
 ### Pre-Coding Checklist
 
@@ -65,8 +65,8 @@ ToolName/
 │   │   ├── CommandLineService.cs     # --file, --safemode, --help
 │   │   └── SettingsService.cs        # Tool-specific settings + theme
 │   ├── Views/
-│   │   ├── MainWindow.axaml          # Standard menu structure
-│   │   └── Dialogs/                  # About, Settings windows
+│   │   ├── MainWindow.axaml          # Standard menu structure (incl. File → New)
+│   │   └── Dialogs/                  # About, Settings, New-resource flow
 │   ├── ViewModels/
 │   │   └── MainWindowViewModel.cs    # MVVM pattern
 │   └── Controls/                     # Custom controls
@@ -175,6 +175,8 @@ userDict.AddWord("Waterdeep");
 - [ ] **`AssemblyName` matches the tool name** in the `.csproj` (e.g. `<AssemblyName>Relique</AssemblyName>` for the Relique tool). `RootNamespace` can differ if a legacy internal name is preferred, but the built binary must ship as `ToolName.exe` / `ToolName` — Trebuchet's sibling discovery (`ToolLauncherService.RefreshPathsFromSiblingDirectory`) walks `ToolInfo.Name`, and the release workflow / cross-tool launchers all assume `Radoub/ToolName.exe`. Mismatch causes silent launch failures + a forced rename later with a settings-path migration (#2080).
 - [ ] **Override `IndexMetadataAsync` + `ReadSourceMetadataAsync`** on the file browser panel if the format has Name and/or Tag fields — see [File Browser Adoption](#file-browser-adoption-filebrowserpanelbase)
 - [ ] **Wire Undo/Redo via shared `UndoRedoManager`** — register Ctrl+Z / Ctrl+Y and route every user-initiated mutation through `IUndoableCommand` so the standard Undo/Redo menu items work from day one (#2231). Do **not** ship disabled Undo/Redo menu stubs — either wire them correctly or omit them.
+- [ ] **Ship a New-resource flow** (`File → New`, Ctrl+N) — the tool must let the user create a blank resource from scratch, not only edit existing files. A `SaveFilePicker`/`Save As`-into-module path that *copies* a base-game blueprint is **not** a substitute: it can't make a resource that isn't already in the game data. Match the lightest pattern that fits the format — Relique's New Item Wizard (base-item-type branching), Fence's simpler new-store, or a plain blank-document `File → New`. A tool that can only edit pre-existing files is incomplete. (Reliquary shipped without this — #2367 — because Save-As-copy masked the gap.)
+- [ ] **Wire Recent Files / MRU on BOTH ends** — see [Trebuchet Integration](#trebuchet-integration). Easy to get for free via `BaseToolSettingsService` + a `ToolRecentFilesService` case; easy to forget entirely (#2247, #2368).
 
 ### Trebuchet Integration
 
@@ -407,9 +409,14 @@ A `PaletteCache` is optional — wire it only when HAK/BIF extraction is expensi
 After a new tool's initial implementation is complete (before first release), run a UI uniformity audit against the checklist table above:
 
 - [ ] **Run UI uniformity audit** — verify all criteria in the UI Uniformity Checklist table pass
+- [ ] **Verify New-resource flow** — `File → New` creates a blank resource (NOT just Save-As-copy of an existing file). A tool that can only edit pre-existing files fails this check (#2367).
+- [ ] **Verify Recent Files end-to-end** — open a file, relaunch Trebuchet, confirm it appears under the tool's card. Empty dropdown = the #2247 regression (missing MRU persistence and/or `ToolRecentFilesService` registration).
+- [ ] **Verify no dead controls** — every menu item and button performs an action or is removed. An event-raised-but-unhandled control (handler-less `Click`, no `+=` subscription) is a no-op stub and violates #2231 (#2369).
 - [ ] **Run `run-tests.ps1 -Tool [ToolName]`** — confirm clean pass (privacy, tech-debt, unit tests)
 - [ ] **Verify Trebuchet integration** — tool registered in ToolLauncherService, `--file` argument works
 - [ ] **Add FlaUI smoke test** — basic launch/close test in `Radoub.IntegrationTests/[ToolName]/` (requires CI infrastructure from #1905)
+
+> These three audit rows exist because Reliquary passed a 12/12 UI-uniformity audit while missing the New-resource flow, Recent Files, and with two dead buttons — the checklist didn't catch what the prose required. Audit against behavior, not just the uniformity table.
 
 ### Versioning (NBGV)
 

--- a/Reliquary/CHANGELOG.md
+++ b/Reliquary/CHANGELOG.md
@@ -13,6 +13,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/); versioning via 
 
 - New Placeable flow: `File → New` (Ctrl+N) creates a blank, round-trippable placeable; first Save routes through Save As (#2367).
 - Recent Files: MRU now persists to `ReliquarySettings.json` with an Open Recent menu, and Reliquary is registered in Trebuchet's per-tool Recent Files dropdown (#2368).
+- Script sets: Save/Load Script Set now write and apply a reusable JSON preset of the 13 event slots (load is one undo step); previously the buttons did nothing (#2369).
+- Portrait Browse opens the shared PortraitBrowserWindow and sets PortraitId (undoable) with a live preview; previously stubbed (#2370).
 
 ---
 

--- a/Reliquary/CHANGELOG.md
+++ b/Reliquary/CHANGELOG.md
@@ -6,6 +6,16 @@ Format based on [Keep a Changelog](https://keepachangelog.com/); versioning via 
 
 ---
 
+## [0.6.0-alpha] - 2026-06-06
+**Branch**: `reliquary/issue-2367` | **PR**: #2371
+
+### Post-epic audit follow-ups
+
+- New Placeable flow: `File → New` (Ctrl+N) creates a blank, round-trippable placeable; first Save routes through Save As (#2367).
+- Recent Files: MRU now persists to `ReliquarySettings.json` with an Open Recent menu, and Reliquary is registered in Trebuchet's per-tool Recent Files dropdown (#2368).
+
+---
+
 ## [0.5.0-alpha] - 2026-06-06
 **Branch**: `radoub/sprint/flaui-coverage` | **PR**: #2365
 

--- a/Reliquary/CHANGELOG.md
+++ b/Reliquary/CHANGELOG.md
@@ -13,7 +13,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/); versioning via 
 
 - New Placeable flow: `File → New` (Ctrl+N) creates a blank, round-trippable placeable; first Save routes through Save As (#2367).
 - Recent Files: MRU now persists to `ReliquarySettings.json` with an Open Recent menu, and Reliquary is registered in Trebuchet's per-tool Recent Files dropdown (#2368).
-- Script sets: Save/Load Script Set now write and apply a reusable JSON preset of the 13 event slots (load is one undo step); previously the buttons did nothing (#2369).
+- Script sets: Save/Load Script Set now write and apply a reusable plain-text (`EventName=ResRef`) preset of the 13 event slots (load is one undo step); previously the buttons did nothing (#2369, #2374).
 - Portrait Browse opens the shared PortraitBrowserWindow and sets PortraitId (undoable) with a live preview; previously stubbed (#2370).
 
 ---

--- a/Reliquary/CLAUDE.md
+++ b/Reliquary/CLAUDE.md
@@ -32,12 +32,13 @@ Tool-specific guidance for Claude Code sessions working on Reliquary (PlaceableE
 | 6 | Text + Inventory panels, item palette caching, BrowserSaveNotifier | Done (#2358) |
 | 7 | Cross-tool dispatch (Conversation → Parley), FlaUI smoke, v0.1.0-alpha release | Done (#2364) |
 
-### Open follow-ups (post-epic audit 2026-06-06)
+### Post-epic audit follow-ups (2026-06-06)
 
-- #2367 — New Placeable flow (`File → New`; currently only Save-As-copy)
-- #2368 — Recent Files / MRU (persist + register in Trebuchet)
-- #2369 — Dead Save/Load Script Set buttons (wire or remove)
-- #2370 — Portrait Browse → shared `PortraitBrowserWindow`
+Resolved in PR #2371: #2367 (New Placeable flow), #2368 (Recent Files / MRU),
+#2369 (Save/Load Script Set wired), #2370 (Portrait Browse).
+
+Still open:
+
 - #2354 — Faction combo from module repute.fac
 - #2363 — Inventory column resize / palette gaps / non-resizable window
 

--- a/Reliquary/CLAUDE.md
+++ b/Reliquary/CLAUDE.md
@@ -23,14 +23,23 @@ Tool-specific guidance for Claude Code sessions working on Reliquary (PlaceableE
 
 ## Status
 
-**Sprint 4 (scaffolding) complete** — demoable skeleton only. Editor wiring lands in Sprints 5-7:
+**Epic #2289 complete** — all 7 sprints landed; shipped as v0.1.0-alpha. Full editor wired (IdentityCombat, Behavior, Text, Inventory), undo/redo, browser metadata, cross-tool dispatch, FlaUI coverage.
 
-| Sprint | Scope |
-|--------|-------|
-| 4 (done) | Project + services + browser panel + fixtures + Trebuchet registration |
-| 5 | IdentityCombat + Behavior panels wired with UndoRedoManager |
-| 6 | Text + Inventory panels, item palette caching, BrowserSaveNotifier |
-| 7 | Cross-tool dispatch (Conversation → Parley), FlaUI smoke, v0.1.0-alpha release |
+| Sprint | Scope | State |
+|--------|-------|-------|
+| 4 | Project + services + browser panel + fixtures + Trebuchet registration | Done (#2349) |
+| 5 | IdentityCombat + Behavior panels wired with UndoRedoManager | Done (#2352) |
+| 6 | Text + Inventory panels, item palette caching, BrowserSaveNotifier | Done (#2358) |
+| 7 | Cross-tool dispatch (Conversation → Parley), FlaUI smoke, v0.1.0-alpha release | Done (#2364) |
+
+### Open follow-ups (post-epic audit 2026-06-06)
+
+- #2367 — New Placeable flow (`File → New`; currently only Save-As-copy)
+- #2368 — Recent Files / MRU (persist + register in Trebuchet)
+- #2369 — Dead Save/Load Script Set buttons (wire or remove)
+- #2370 — Portrait Browse → shared `PortraitBrowserWindow`
+- #2354 — Faction combo from module repute.fac
+- #2363 — Inventory column resize / palette gaps / non-resizable window
 
 ---
 

--- a/Reliquary/Reliquary.Tests/Services/ReliquaryPortraitBrowserContextTests.cs
+++ b/Reliquary/Reliquary.Tests/Services/ReliquaryPortraitBrowserContextTests.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+using PlaceableEditor.Services;
+using Radoub.Formats.TwoDA;
+using Radoub.TestUtilities.Mocks;
+using Radoub.UI.Services;
+
+namespace PlaceableEditor.Tests.Services;
+
+/// <summary>
+/// ListPortraits padding-row filtering for Reliquary's portrait context (#2370), mirroring the
+/// Quartermaster coverage: real portraits.2da uses "****" for empty cells, custom/CEP content can
+/// use shorter asterisk runs, and any all-asterisk/blank BaseResRef must be skipped.
+/// </summary>
+public class ReliquaryPortraitBrowserContextTests
+{
+    private static ReliquaryPortraitBrowserContext BuildContext(MockGameDataService mock)
+        => new(mock, new ItemIconService(mock));
+
+    [Fact]
+    public void ListPortraits_SkipsAsteriskAndBlankBaseResRefs()
+    {
+        var mock = new MockGameDataService(includeSampleData: false);
+        var twoDA = new TwoDAFile { Columns = new() { "BaseResRef", "Race", "Sex" } };
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "hu_m_01_", "6", "0" } }); // real
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "****", "****", "****" } }); // pad
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "***", "****", "4" } });      // short pad
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "  ", "****", "4" } });       // whitespace
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "el_f_02_", "1", "1" } });    // real
+        mock.With2DA("portraits", twoDA);
+
+        var result = BuildContext(mock).ListPortraits().ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, p => Assert.DoesNotContain('*', p.ResRef));
+        Assert.Contains(result, p => p.ResRef == "hu_m_01_");
+        Assert.Contains(result, p => p.ResRef == "el_f_02_");
+    }
+}

--- a/Reliquary/Reliquary.Tests/Services/ScriptSetServiceTests.cs
+++ b/Reliquary/Reliquary.Tests/Services/ScriptSetServiceTests.cs
@@ -50,6 +50,29 @@ public class ScriptSetServiceTests
     }
 
     [Fact]
+    public void Serialize_WritesPlainTextKeyValueLines()
+    {
+        var vm = MakePlaceable();
+        SetSlot(vm, "OnOpen", "chest_open");
+
+        var text = System.Text.Encoding.UTF8.GetString(ScriptSetService.Serialize(vm.Scripts));
+
+        Assert.Contains("OnOpen=chest_open", text);
+        Assert.DoesNotContain("{", text); // not JSON
+    }
+
+    [Fact]
+    public void Parse_ToleratesBlankLinesAndComments()
+    {
+        var text = "# placeable script set\n\nOnOpen=chest_open\n  \nOnClosed = chest_close \n";
+        var map = ScriptSetService.Parse(System.Text.Encoding.UTF8.GetBytes(text));
+
+        Assert.Equal(2, map.Count);
+        Assert.Equal("chest_open", map["OnOpen"]);
+        Assert.Equal("chest_close", map["OnClosed"]); // trims whitespace around key + value
+    }
+
+    [Fact]
     public void Apply_IgnoresUnknownEventNames()
     {
         var target = MakePlaceable();

--- a/Reliquary/Reliquary.Tests/Services/ScriptSetServiceTests.cs
+++ b/Reliquary/Reliquary.Tests/Services/ScriptSetServiceTests.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Linq;
+using PlaceableEditor.Services;
+using PlaceableEditor.ViewModels;
+using Radoub.Formats.Utp;
+
+namespace PlaceableEditor.Tests.Services;
+
+/// <summary>
+/// Round-trip + apply behavior for the script-set preset (#2369): the 13 event slots
+/// serialize to JSON and reload onto another placeable's slots by stable EventName.
+/// </summary>
+public class ScriptSetServiceTests
+{
+    private static PlaceableViewModel MakePlaceable() => new(new UtpFile());
+
+    private static void SetSlot(PlaceableViewModel vm, string eventName, string resRef)
+        => vm.Scripts.First(s => s.EventName == eventName).ResRef = resRef;
+
+    [Fact]
+    public void Serialize_OnlyIncludesAssignedSlots()
+    {
+        var vm = MakePlaceable();
+        SetSlot(vm, "OnOpen", "chest_open");
+        SetSlot(vm, "OnClosed", "chest_close");
+
+        var map = ScriptSetService.Parse(ScriptSetService.Serialize(vm.Scripts));
+
+        Assert.Equal(2, map.Count);
+        Assert.Equal("chest_open", map["OnOpen"]);
+        Assert.Equal("chest_close", map["OnClosed"]);
+    }
+
+    [Fact]
+    public void RoundTrip_AppliesScriptsToAnotherPlaceable()
+    {
+        var source = MakePlaceable();
+        SetSlot(source, "OnOpen", "door_open");
+        SetSlot(source, "OnUsed", "door_used");
+
+        var bytes = ScriptSetService.Serialize(source.Scripts);
+        var map = ScriptSetService.Parse(bytes);
+
+        var target = MakePlaceable();
+        var applied = ScriptSetService.Apply(target.Scripts, map);
+
+        Assert.Equal(2, applied);
+        Assert.Equal("door_open", target.Scripts.First(s => s.EventName == "OnOpen").ResRef);
+        Assert.Equal("door_used", target.Scripts.First(s => s.EventName == "OnUsed").ResRef);
+    }
+
+    [Fact]
+    public void Apply_IgnoresUnknownEventNames()
+    {
+        var target = MakePlaceable();
+        var map = new Dictionary<string, string> { ["NotAnEvent"] = "x", ["OnOpen"] = "ok" };
+
+        var applied = ScriptSetService.Apply(target.Scripts, map);
+
+        Assert.Equal(1, applied); // only OnOpen matched a real slot
+        Assert.Equal("ok", target.Scripts.First(s => s.EventName == "OnOpen").ResRef);
+    }
+
+    [Fact]
+    public void Apply_ClearsSlotsAbsentFromPreset()
+    {
+        var target = MakePlaceable();
+        SetSlot(target, "OnDeath", "leftover");
+        var map = new Dictionary<string, string> { ["OnOpen"] = "fresh" };
+
+        ScriptSetService.Apply(target.Scripts, map);
+
+        // A preset is the full picture of the script set — slots it omits are cleared.
+        Assert.Equal("fresh", target.Scripts.First(s => s.EventName == "OnOpen").ResRef);
+        Assert.Equal(string.Empty, target.Scripts.First(s => s.EventName == "OnDeath").ResRef);
+    }
+}

--- a/Reliquary/Reliquary.Tests/ViewModels/PlaceableViewModelTests.cs
+++ b/Reliquary/Reliquary.Tests/ViewModels/PlaceableViewModelTests.cs
@@ -170,4 +170,33 @@ public class PlaceableViewModelTests
         vm.Conversation = "new_dlg";
         Assert.Equal("new_dlg", utp.Conversation);
     }
+
+    // --- New Placeable factory (#2367) ---
+
+    [Fact]
+    public void NewPlaceable_ProducesUseableEmptyPlaceable()
+    {
+        var vm = PlaceableViewModel.NewPlaceable();
+
+        Assert.Equal(string.Empty, vm.Name);
+        Assert.Equal(string.Empty, vm.Tag);
+        Assert.Equal(string.Empty, vm.TemplateResRef);
+        Assert.True(vm.Useable);        // a fresh placeable should be interactable by default
+        Assert.False(vm.HasInventory);  // no backpack until the user opts in
+        Assert.False(vm.Static);
+        Assert.False(vm.Plot);
+    }
+
+    [Fact]
+    public void NewPlaceable_RoundTripsThroughWriter()
+    {
+        var vm = PlaceableViewModel.NewPlaceable();
+
+        // A blank placeable must survive write→read so Save produces a valid .utp.
+        var bytes = UtpWriter.Write(vm.WriteToUtp());
+        var reread = UtpReader.Read(bytes);
+
+        Assert.Equal("UTP ", reread.FileType);
+        Assert.Equal(string.Empty, reread.Tag);
+    }
 }

--- a/Reliquary/Reliquary/Services/ReliquaryPortraitBrowserContext.cs
+++ b/Reliquary/Reliquary/Services/ReliquaryPortraitBrowserContext.cs
@@ -1,0 +1,110 @@
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Media.Imaging;
+using Radoub.Formats.Logging;
+using Radoub.Formats.Services;
+using Radoub.Formats.Settings;
+using Radoub.UI.Services;
+
+namespace PlaceableEditor.Services;
+
+/// <summary>
+/// Reliquary's implementation of <see cref="IPortraitBrowserContext"/> for the shared
+/// PortraitBrowserWindow (#2370). Sources portraits from portraits.2da and images from the shared
+/// <see cref="ItemIconService"/> — mirrors Quartermaster's context (placeables and creatures both
+/// use the same portrait table).
+/// </summary>
+public class ReliquaryPortraitBrowserContext : IPortraitBrowserContext
+{
+    private readonly IGameDataService _gameDataService;
+    private readonly ItemIconService _itemIconService;
+
+    public ReliquaryPortraitBrowserContext(IGameDataService gameDataService, ItemIconService itemIconService)
+    {
+        _gameDataService = gameDataService;
+        _itemIconService = itemIconService;
+    }
+
+    public string? CurrentFileDirectory => null;
+
+    public string? NeverwinterNightsPath => RadoubSettings.Instance.NeverwinterNightsPath;
+
+    public bool GameResourcesAvailable => _gameDataService?.IsConfigured ?? false;
+
+    public IEnumerable<PortraitEntry> ListPortraits()
+    {
+        var portraits = new List<PortraitEntry>();
+
+        int rowCount = _gameDataService.Get2DA("portraits")?.RowCount ?? 500;
+        for (int i = 0; i < rowCount; i++)
+        {
+            var baseResRef = _gameDataService.Get2DAValue("portraits", i, "BaseResRef");
+            if (IsEmptyCell(baseResRef))
+                continue;
+            baseResRef = baseResRef!.Trim();
+
+            var raceStr = _gameDataService.Get2DAValue("portraits", i, "Race");
+            var sexStr = _gameDataService.Get2DAValue("portraits", i, "Sex");
+
+            int race = -1;
+            int sex = -1;
+
+            if (!string.IsNullOrEmpty(raceStr) && raceStr != "****")
+                int.TryParse(raceStr, out race);
+
+            if (!string.IsNullOrEmpty(sexStr) && sexStr != "****")
+                int.TryParse(sexStr, out sex);
+
+            portraits.Add(new PortraitEntry
+            {
+                Id = (ushort)i,
+                ResRef = baseResRef,
+                Race = race,
+                Sex = sex
+            });
+        }
+
+        UnifiedLogger.LogApplication(LogLevel.INFO,
+            $"ReliquaryPortraitBrowserContext: Loaded {portraits.Count} portraits from portraits.2da");
+        return portraits;
+    }
+
+    /// <summary>
+    /// True for 2DA "empty" cells: null, blank/whitespace, or any all-asterisk run.
+    /// Aurora writes "****" but custom/CEP content uses shorter runs like "***".
+    /// </summary>
+    private static bool IsEmptyCell(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return true;
+        return value.Trim().All(c => c == '*');
+    }
+
+    public Bitmap? GetPortraitBitmap(string resRef) => _itemIconService.GetPortrait(resRef);
+
+    public string GetRaceName(int raceId)
+    {
+        if (raceId < 0)
+            return "Unknown";
+
+        var strRef = _gameDataService.Get2DAValue("racialtypes", raceId, "Name");
+        if (!string.IsNullOrEmpty(strRef) && strRef != "****" && uint.TryParse(strRef, out var tlkRef))
+        {
+            var name = _gameDataService.GetString(tlkRef);
+            if (!string.IsNullOrEmpty(name))
+                return name;
+        }
+
+        return raceId switch
+        {
+            0 => "Dwarf",
+            1 => "Elf",
+            2 => "Gnome",
+            3 => "Halfling",
+            4 => "Half-Elf",
+            5 => "Half-Orc",
+            6 => "Human",
+            _ => $"Race {raceId}"
+        };
+    }
+}

--- a/Reliquary/Reliquary/Services/ScriptSetService.cs
+++ b/Reliquary/Reliquary/Services/ScriptSetService.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using PlaceableEditor.ViewModels;
+
+namespace PlaceableEditor.Services;
+
+/// <summary>
+/// Reads/writes a placeable script set (#2369): the 13 event-handler ResRefs serialized to JSON,
+/// keyed by the slot's stable <see cref="ScriptSlotViewModel.EventName"/>. Lets a builder save a
+/// reusable set (e.g. a standard chest's open/close/disturbed scripts) and apply it to other
+/// placeables. Pure — no Avalonia, no disk — so the host owns the file picker and undo wrapping.
+/// </summary>
+public static class ScriptSetService
+{
+    private static readonly JsonSerializerOptions Options = new() { WriteIndented = true };
+
+    /// <summary>Serialize the assigned (non-empty) script slots to JSON bytes.</summary>
+    public static byte[] Serialize(IEnumerable<ScriptSlotViewModel> slots)
+    {
+        var map = slots
+            .Where(s => !string.IsNullOrWhiteSpace(s.ResRef))
+            .ToDictionary(s => s.EventName, s => s.ResRef);
+        return JsonSerializer.SerializeToUtf8Bytes(map, Options);
+    }
+
+    /// <summary>Parse a saved script set back into an event-name → ResRef map. Empty on malformed input.</summary>
+    public static IReadOnlyDictionary<string, string> Parse(byte[] bytes)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, string>>(bytes)
+                   ?? new Dictionary<string, string>();
+        }
+        catch (JsonException)
+        {
+            return new Dictionary<string, string>();
+        }
+    }
+
+    /// <summary>
+    /// Apply a parsed script set to the given slots, matching by EventName. A preset is the full
+    /// picture: every slot is set — to the preset's value if present, otherwise cleared — so loading
+    /// a set never leaves stale scripts from the previous placeable. Returns the number of slots that
+    /// received a non-empty value (used for the status message).
+    /// </summary>
+    public static int Apply(IEnumerable<ScriptSlotViewModel> slots, IReadOnlyDictionary<string, string> set)
+    {
+        int assigned = 0;
+        foreach (var slot in slots)
+        {
+            var value = set.TryGetValue(slot.EventName, out var resRef) ? resRef : string.Empty;
+            slot.ResRef = value;
+            if (!string.IsNullOrWhiteSpace(value)) assigned++;
+        }
+        return assigned;
+    }
+}

--- a/Reliquary/Reliquary/Services/ScriptSetService.cs
+++ b/Reliquary/Reliquary/Services/ScriptSetService.cs
@@ -1,41 +1,53 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json;
+using System.Text;
 using PlaceableEditor.ViewModels;
 
 namespace PlaceableEditor.Services;
 
 /// <summary>
-/// Reads/writes a placeable script set (#2369): the 13 event-handler ResRefs serialized to JSON,
-/// keyed by the slot's stable <see cref="ScriptSlotViewModel.EventName"/>. Lets a builder save a
-/// reusable set (e.g. a standard chest's open/close/disturbed scripts) and apply it to other
-/// placeables. Pure — no Avalonia, no disk — so the host owns the file picker and undo wrapping.
+/// Reads/writes a placeable script set (#2369, #2374): the 13 event-handler ResRefs as a plain-text
+/// `EventName=ResRef` file (one assigned slot per line), keyed by the slot's stable
+/// <see cref="ScriptSlotViewModel.EventName"/>. Lets a builder save a reusable set (e.g. a standard
+/// chest's open/close/disturbed scripts) and apply it to other placeables. Pure — no Avalonia, no
+/// disk — so the host owns the file picker and undo wrapping.
 /// </summary>
 public static class ScriptSetService
 {
-    private static readonly JsonSerializerOptions Options = new() { WriteIndented = true };
-
-    /// <summary>Serialize the assigned (non-empty) script slots to JSON bytes.</summary>
+    /// <summary>Serialize the assigned (non-empty) script slots to a plain-text `EventName=ResRef` file.</summary>
     public static byte[] Serialize(IEnumerable<ScriptSlotViewModel> slots)
     {
-        var map = slots
-            .Where(s => !string.IsNullOrWhiteSpace(s.ResRef))
-            .ToDictionary(s => s.EventName, s => s.ResRef);
-        return JsonSerializer.SerializeToUtf8Bytes(map, Options);
+        var sb = new StringBuilder();
+        sb.Append("# Reliquary placeable script set\n");
+        foreach (var slot in slots.Where(s => !string.IsNullOrWhiteSpace(s.ResRef)))
+            sb.Append(slot.EventName).Append('=').Append(slot.ResRef).Append('\n');
+        return Encoding.UTF8.GetBytes(sb.ToString());
     }
 
-    /// <summary>Parse a saved script set back into an event-name → ResRef map. Empty on malformed input.</summary>
+    /// <summary>
+    /// Parse a saved script set into an event-name → ResRef map. Tolerates blank lines, `#` comments,
+    /// CRLF/LF, and whitespace around the key/value. Lines without a single `=` are skipped.
+    /// </summary>
     public static IReadOnlyDictionary<string, string> Parse(byte[] bytes)
     {
-        try
+        var map = new Dictionary<string, string>();
+        var text = Encoding.UTF8.GetString(bytes);
+
+        foreach (var raw in text.Split('\n'))
         {
-            return JsonSerializer.Deserialize<Dictionary<string, string>>(bytes)
-                   ?? new Dictionary<string, string>();
+            var line = raw.Trim();
+            if (line.Length == 0 || line.StartsWith('#')) continue;
+
+            int eq = line.IndexOf('=');
+            if (eq <= 0) continue; // no key, or no separator
+
+            var key = line[..eq].Trim();
+            var value = line[(eq + 1)..].Trim();
+            if (key.Length > 0)
+                map[key] = value;
         }
-        catch (JsonException)
-        {
-            return new Dictionary<string, string>();
-        }
+
+        return map;
     }
 
     /// <summary>

--- a/Reliquary/Reliquary/ViewModels/PlaceableViewModel.cs
+++ b/Reliquary/Reliquary/ViewModels/PlaceableViewModel.cs
@@ -25,6 +25,15 @@ public sealed class PlaceableViewModel : INotifyPropertyChanged
         Scripts = BuildScriptSlots();
     }
 
+    /// <summary>
+    /// Create a blank placeable for File → New (#2367). Defaults to a useable, non-inventory,
+    /// non-static placeable — the most common starting point — with empty Name/Tag/ResRef the
+    /// user fills in. UtpFile's own defaults (FileType "UTP ", FileVersion "V3.2") make it
+    /// round-trip immediately, so Save produces a valid file with no further setup.
+    /// </summary>
+    public static PlaceableViewModel NewPlaceable()
+        => new(new UtpFile { Useable = true });
+
     /// <summary>The wrapped model. Returned by reference for preview/resolution callers.</summary>
     public UtpFile Utp => _utp;
 

--- a/Reliquary/Reliquary/Views/MainWindow.Editor.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.Editor.cs
@@ -374,11 +374,11 @@ public partial class MainWindow
         var file = await StorageProvider.SaveFilePickerAsync(new Avalonia.Platform.Storage.FilePickerSaveOptions
         {
             Title = "Save Script Set",
-            DefaultExtension = "json",
-            SuggestedFileName = "placeable-scripts.json",
+            DefaultExtension = "txt",
+            SuggestedFileName = "placeable-scripts.txt",
             FileTypeChoices = new[]
             {
-                new Avalonia.Platform.Storage.FilePickerFileType("Script Set") { Patterns = new[] { "*.json" } }
+                new Avalonia.Platform.Storage.FilePickerFileType("Script Set") { Patterns = new[] { "*.txt" } }
             }
         });
 
@@ -412,7 +412,7 @@ public partial class MainWindow
             AllowMultiple = false,
             FileTypeFilter = new[]
             {
-                new Avalonia.Platform.Storage.FilePickerFileType("Script Set") { Patterns = new[] { "*.json" } }
+                new Avalonia.Platform.Storage.FilePickerFileType("Script Set") { Patterns = new[] { "*.txt" } }
             }
         });
 

--- a/Reliquary/Reliquary/Views/MainWindow.Editor.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.Editor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -13,6 +14,7 @@ using Radoub.UI.Services.Search;
 using Radoub.UI.Undo;
 using Radoub.UI.ViewModels;
 using PlaceableEditor.Commands;
+using PlaceableEditor.Services;
 using PlaceableEditor.ViewModels;
 using PlaceableEditor.Views.Panels;
 
@@ -51,6 +53,8 @@ public partial class MainWindow
             behavior.Variables.DeleteRequested += OnVariableDeleteRequested;
             behavior.ScriptBrowseRequested += OnScriptBrowseRequested;
             behavior.ScriptEditRequested += OnScriptEditRequested;
+            behavior.SaveScriptSetRequested += OnSaveScriptSetRequested;
+            behavior.LoadScriptSetRequested += OnLoadScriptSetRequested;
             behavior.EditConversationRequested += OnEditConversationRequested;
         }
     }
@@ -355,6 +359,89 @@ public partial class MainWindow
         var moduleDir = GetModuleWorkingDirectory();
         if (!ExternalEditorService.OpenScript(slot.ResRef, fileDir, moduleDir))
             UpdateStatus($"Could not open {slot.ResRef}.nss — not found near the placeable or module.");
+    }
+
+    // --- Script sets (save/load a reusable preset, #2369) ---
+
+    private async void OnSaveScriptSetRequested(object? sender, EventArgs e)
+    {
+        if (_placeable is null)
+        {
+            UpdateStatus("Open or create a placeable before saving a script set.");
+            return;
+        }
+
+        var file = await StorageProvider.SaveFilePickerAsync(new Avalonia.Platform.Storage.FilePickerSaveOptions
+        {
+            Title = "Save Script Set",
+            DefaultExtension = "json",
+            SuggestedFileName = "placeable-scripts.json",
+            FileTypeChoices = new[]
+            {
+                new Avalonia.Platform.Storage.FilePickerFileType("Script Set") { Patterns = new[] { "*.json" } }
+            }
+        });
+
+        var path = file?.Path.LocalPath;
+        if (string.IsNullOrEmpty(path)) return;
+
+        try
+        {
+            File.WriteAllBytes(path, ScriptSetService.Serialize(_placeable.Scripts));
+            UpdateStatus($"Saved script set to {Path.GetFileName(path)}");
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"Reliquary: script-set save failed for {UnifiedLogger.SanitizePath(path)}: {ex.Message}");
+            UpdateStatus($"Could not save script set: {ex.Message}");
+        }
+    }
+
+    private async void OnLoadScriptSetRequested(object? sender, EventArgs e)
+    {
+        if (_placeable is null)
+        {
+            UpdateStatus("Open or create a placeable before loading a script set.");
+            return;
+        }
+
+        var files = await StorageProvider.OpenFilePickerAsync(new Avalonia.Platform.Storage.FilePickerOpenOptions
+        {
+            Title = "Load Script Set",
+            AllowMultiple = false,
+            FileTypeFilter = new[]
+            {
+                new Avalonia.Platform.Storage.FilePickerFileType("Script Set") { Patterns = new[] { "*.json" } }
+            }
+        });
+
+        var path = files.Count > 0 ? files[0].Path.LocalPath : null;
+        if (string.IsNullOrEmpty(path)) return;
+
+        IReadOnlyDictionary<string, string> set;
+        try
+        {
+            set = ScriptSetService.Parse(File.ReadAllBytes(path));
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"Reliquary: script-set load failed for {UnifiedLogger.SanitizePath(path)}: {ex.Message}");
+            UpdateStatus($"Could not load script set: {ex.Message}");
+            return;
+        }
+
+        // Snapshot the current 13 slots so the whole apply is a single undo step.
+        var before = _placeable.Scripts.ToDictionary(s => s.EventName, s => s.ResRef);
+        var slots = _placeable.Scripts;
+
+        _undo.Execute(new RelayUndoableCommand(
+            () => { ScriptSetService.Apply(slots, set); },
+            () => { ScriptSetService.Apply(slots, before); },
+            "load script set"));
+
+        UpdateStatus($"Loaded script set from {Path.GetFileName(path)}");
     }
 
     // --- Conversation (cross-tool dispatch to Parley, Sprint 7 #2297) ---

--- a/Reliquary/Reliquary/Views/MainWindow.Editor.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.Editor.cs
@@ -55,6 +55,25 @@ public partial class MainWindow
         }
     }
 
+    /// <summary>File → New (#2367): prompt to discard, then bind a blank placeable as an unsaved document.</summary>
+    private async void OnNewClick(object? sender, RoutedEventArgs e)
+    {
+        if (!await ConfirmDiscardAsync()) return;
+        try
+        {
+            _isLoading = true; // suppress dirty marking while panels rebind to the new VM
+            _currentFilePath = null;          // unsaved — first Save routes through Save As
+            _documentState.IsReadOnly = false;
+            BindPlaceable(PlaceableViewModel.NewPlaceable());
+            UpdateTitle(); // BindPlaceable's ClearDirty is a no-op when already clean, so refresh the title
+            UpdateStatus("New placeable — fill in name/tag, then Save.");
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
     /// <summary>Load a UTP file into the editor, wrap it in a VM, and bind the panels.</summary>
     private void LoadPlaceable(string filePath)
     {
@@ -66,6 +85,7 @@ public partial class MainWindow
             _documentState.IsReadOnly = false;
             BindPlaceable(new PlaceableViewModel(utp));
             UpdateTitle(); // BindPlaceable's ClearDirty is a no-op when already clean, so refresh the title explicitly
+            AddRecentFile(filePath);
             UpdateStatus($"Loaded {Path.GetFileName(filePath)}");
         }
         catch (Exception ex) when (ex is IOException or InvalidDataException)
@@ -202,6 +222,7 @@ public partial class MainWindow
         {
             UtpWriter.Write(_placeable.WriteToUtp(), path);
             _documentState.ClearDirty();
+            AddRecentFile(path);
 
             // Refresh the browser row's Tag/Name without a full reindex (design §5.5).
             var browser = this.FindControl<PlaceableBrowserPanel>("PlaceableBrowserPanel");
@@ -217,6 +238,45 @@ public partial class MainWindow
                 $"Reliquary: save failed for {UnifiedLogger.SanitizePath(path)}: {ex.Message}");
             UpdateStatus($"Save failed: {ex.Message}");
             return false;
+        }
+    }
+
+    // --- Recent Files (MRU) ---
+    // Persistence is inherited from BaseToolSettingsService (RecentFiles / AddRecentFile);
+    // Trebuchet reads ~/Radoub/Reliquary/ReliquarySettings.json via ToolRecentFilesService (#2368).
+
+    /// <summary>Record a file in the MRU and refresh the Open Recent submenu.</summary>
+    private void AddRecentFile(string filePath)
+    {
+        PlaceableEditor.Services.SettingsService.Instance.AddRecentFile(filePath);
+        PopulateRecentFiles();
+    }
+
+    /// <summary>Rebuild the Open Recent submenu from the persisted MRU list.</summary>
+    private void PopulateRecentFiles()
+    {
+        var menu = this.FindControl<MenuItem>("RecentFilesMenu");
+        if (menu == null) return;
+
+        menu.Items.Clear();
+        var recent = PlaceableEditor.Services.SettingsService.Instance.RecentFiles;
+
+        if (recent.Count == 0)
+        {
+            menu.Items.Add(new MenuItem { Header = "(none)", IsEnabled = false });
+            return;
+        }
+
+        foreach (var path in recent)
+        {
+            var item = new MenuItem { Header = Path.GetFileName(path), Tag = path };
+            ToolTip.SetTip(item, UnifiedLogger.SanitizePath(path));
+            item.Click += async (_, _) =>
+            {
+                if (!await ConfirmDiscardAsync()) return;
+                LoadPlaceable((string)item.Tag!);
+            };
+            menu.Items.Add(item);
         }
     }
 

--- a/Reliquary/Reliquary/Views/MainWindow.Services.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.Services.cs
@@ -23,6 +23,7 @@ public partial class MainWindow
     private IPlaceableAppearanceService? _appearances;
     private PlaceableModelLoader? _modelLoader;
     private TextureService? _textureService;
+    private ItemIconService? _itemIconService;
     private bool _servicesInitialized;
 
     private void WireServices()
@@ -47,6 +48,7 @@ public partial class MainWindow
                 _appearances = new PlaceableAppearanceService(_gameData);
                 _modelLoader = new PlaceableModelLoader(_gameData, _appearances);
                 _textureService = new TextureService(_gameData);
+                _itemIconService = new ItemIconService(_gameData);
                 _itemFactory = new Radoub.UI.ViewModels.ItemViewModelFactory(_gameData);
                 UnifiedLogger.LogApplication(LogLevel.INFO, "Reliquary: GameDataService configured.");
             }
@@ -121,6 +123,7 @@ public partial class MainWindow
             identity.PopulateAppearances(_appearances, _placeable.Appearance);
 
         UpdateModelPreview(_placeable.Appearance);
+        RefreshPortraitPreview();
     }
 
     private void UpdateModelPreview(uint appearanceId)
@@ -139,12 +142,44 @@ public partial class MainWindow
         UpdateModelPreview(appearanceId);
     }
 
-    private void OnPortraitBrowseRequested(object? sender, EventArgs e)
+    private async void OnPortraitBrowseRequested(object? sender, EventArgs e)
     {
-        // The shared PortraitBrowserWindow needs an IPortraitBrowserContext (portraits.2da +
-        // bitmap loading) that currently lives only in Quartermaster. Sharing that context is
-        // tracked as follow-up; until then the button surfaces a status hint rather than a
-        // half-built portrait service. PortraitId still round-trips via the model.
-        UpdateStatus("Portrait browser pending shared IPortraitBrowserContext extract (follow-up).");
+        if (_placeable is null) return;
+        if (_gameData is null || !_gameData.IsConfigured || _itemIconService is null)
+        {
+            UpdateStatus("Portrait browser needs a configured game install (set paths in Trebuchet).");
+            return;
+        }
+
+        var context = new PlaceableEditor.Services.ReliquaryPortraitBrowserContext(_gameData, _itemIconService);
+        var browser = Radoub.UI.Views.PortraitBrowserWindow.Create(context);
+        var result = await browser.ShowDialog<ushort?>(this);
+        if (result is not { } portraitId) return; // cancelled
+
+        // Route the change through undo, then refresh the preview image.
+        _undo.Execute(new Radoub.UI.Undo.SetFieldCommand<ushort>(
+            () => _placeable.PortraitId, v => _placeable.PortraitId = v, portraitId, "change portrait"));
+
+        RefreshPortraitPreview();
+    }
+
+    /// <summary>Resolve the placeable's PortraitId to a bitmap and push it into the identity panel.</summary>
+    private void RefreshPortraitPreview()
+    {
+        if (_placeable is null || _gameData is null || _itemIconService is null) return;
+        var identity = this.FindControl<IdentityCombatPanel>("IdentityCombatPanel");
+        if (identity is null) return;
+
+        var resRef = _gameData.Get2DAValue("portraits", _placeable.PortraitId, "BaseResRef");
+        if (string.IsNullOrWhiteSpace(resRef) || resRef.Trim().Trim('*').Length == 0)
+        {
+            identity.SetPortrait(null);
+            return;
+        }
+
+        // GetPortraitBitmap takes the base ResRef and resolves the size suffix internally
+        // (same path the browser thumbnails use).
+        var context = new PlaceableEditor.Services.ReliquaryPortraitBrowserContext(_gameData, _itemIconService);
+        identity.SetPortrait(context.GetPortraitBitmap(resRef.Trim()));
     }
 }

--- a/Reliquary/Reliquary/Views/MainWindow.axaml
+++ b/Reliquary/Reliquary/Views/MainWindow.axaml
@@ -13,7 +13,9 @@
     <DockPanel>
         <Menu DockPanel.Dock="Top">
             <MenuItem Header="_File">
+                <MenuItem Header="_New" Click="OnNewClick" InputGesture="Ctrl+N"/>
                 <MenuItem Header="_Open..." Click="OnOpenClick" InputGesture="Ctrl+O"/>
+                <MenuItem x:Name="RecentFilesMenu" Header="Open _Recent"/>
                 <MenuItem Header="_Save" Click="OnSaveClick" InputGesture="Ctrl+S"/>
                 <MenuItem Header="Save _As..." Click="OnSaveAsClick" InputGesture="Ctrl+Shift+S"/>
                 <Separator/>

--- a/Reliquary/Reliquary/Views/MainWindow.axaml.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.axaml.cs
@@ -47,6 +47,7 @@ public partial class MainWindow : Window
         WireEditor();
         WireServices();
         WireInventory();
+        PopulateRecentFiles(); // show persisted MRU at launch (#2368)
 
         // Tunnel so F4 reaches us before a focused child (ComboBox etc.) can consume it.
         AddHandler(KeyDownEvent, OnWindowKeyDownTunnel, Avalonia.Interactivity.RoutingStrategies.Tunnel);
@@ -100,6 +101,11 @@ public partial class MainWindow : Window
                     OnSaveAsClick(sender, e);
                 else
                     OnSaveClick(sender, e);
+                e.Handled = true;
+                break;
+            case Key.N:
+                if (e.KeyModifiers.HasFlag(KeyModifiers.Shift)) break;
+                OnNewClick(sender, e);
                 e.Handled = true;
                 break;
             case Key.O:

--- a/Trebuchet/Trebuchet.Tests/ToolRecentFilesServiceTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ToolRecentFilesServiceTests.cs
@@ -17,6 +17,7 @@ public class ToolRecentFilesServiceTests
     [InlineData("Manifest", "/fake/radoub/Manifest/ManifestSettings.json")]
     [InlineData("Fence", "/fake/radoub/Fence/FenceSettings.json")]
     [InlineData("Relique", "/fake/radoub/Relique/ReliqueSettings.json")]
+    [InlineData("Reliquary", "/fake/radoub/Reliquary/ReliquarySettings.json")]
     public void GetSettingsPath_KnownTool_ReturnsExpectedPath(string toolName, string expectedSuffix)
     {
         var actual = ToolRecentFilesService.GetSettingsPathFor(FakeRadoubDir, toolName);
@@ -32,6 +33,16 @@ public class ToolRecentFilesServiceTests
         // Regression: #2247 - "Relique" case was missing from the switch,
         // causing GetRecentFiles("Relique") to return an empty list always.
         var path = ToolRecentFilesService.GetSettingsPathFor(FakeRadoubDir, "Relique");
+
+        Assert.NotNull(path);
+    }
+
+    [Fact]
+    public void GetSettingsPath_Reliquary_IsNotNull()
+    {
+        // #2368 - same regression shape as #2247: Reliquary shipped without an MRU
+        // registration, so its tool-card dropdown was permanently empty.
+        var path = ToolRecentFilesService.GetSettingsPathFor(FakeRadoubDir, "Reliquary");
 
         Assert.NotNull(path);
     }

--- a/Trebuchet/Trebuchet/Services/ToolRecentFilesService.cs
+++ b/Trebuchet/Trebuchet/Services/ToolRecentFilesService.cs
@@ -154,6 +154,7 @@ public class ToolRecentFilesService
             "Manifest" => "ManifestSettings.json",
             "Fence" => "FenceSettings.json",
             "Relique" => "ReliqueSettings.json",
+            "Reliquary" => "ReliquarySettings.json",
             _ => null
         };
 


### PR DESCRIPTION
## Summary

Post-epic audit of Reliquary (#2289, all 7 sprints closed) surfaced gaps a passing 12/12 UI-uniformity audit didn't catch. This PR fixes the docs side; the Reliquary code fixes (#2367-#2370) land on this same branch next.

**Bootstrap (`NEW_TOOL_BOOTSTRAP.md`):**
- New Day-1 requirement: every tool must ship a `File → New` flow. Save-As-copy of a base-game blueprint is not a substitute — it can't create a resource that isn't already in game data.
- Three new Post-Implementation Audit rows (verifiable, behavior-based): New-resource flow, Recent Files end-to-end, no dead controls. These are the exact holes that slipped past Reliquary's uniformity audit.
- Note that Relique/Fence/QM are the most feature-complete single-resource references.

**Reliquary `CLAUDE.md`:** Status section was stale (claimed "Sprint 4 complete, 5-7 pending"). Corrected to all-7-done / v0.1.0-alpha and linked open follow-ups.

## Related Issues

- Lead: #2367 (New Placeable flow — the HIGH gap that motivated the bootstrap change)
- Audit follow-ups also filed: #2368 (MRU), #2369 (dead script-set buttons), #2370 (portrait)
- Relates to epic #2289

## Checklist

- [x] Bootstrap doc updated
- [x] Reliquary CLAUDE.md status corrected
- [x] CHANGELOG updated
- [ ] Reliquary code fixes (#2367-#2370) — follow on this branch

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
