### PR TITLE
[Reliquary] Sprint: Epic #2289 placeable-editor follow-ups

### DIFF
--- a/.github/workflows/reliquary-pr-build.yml
+++ b/.github/workflows/reliquary-pr-build.yml
@@ -1,0 +1,48 @@
+name: Reliquary PR Build Check
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'Reliquary/**'
+      - 'Radoub.Formats/**'
+      - 'Radoub.UI/**'
+      - '.github/workflows/reliquary-pr-build.yml'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0  # NBGV needs full history
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '9.0.x'
+
+    - name: Restore dependencies
+      run: dotnet restore Reliquary/Reliquary/Reliquary.csproj
+
+    - name: Build Reliquary
+      id: build
+      run: dotnet build Reliquary/Reliquary/Reliquary.csproj --configuration Release --no-restore
+      continue-on-error: true
+
+    - name: Report status
+      if: always()
+      shell: bash
+      run: |
+        if [ "${{ steps.build.outcome }}" = "success" ]; then
+          echo "✅ Reliquary build successful (${{ matrix.os }})"
+        else
+          echo "❌ Reliquary build failed (${{ matrix.os }})"
+          exit 1
+        fi

--- a/.github/workflows/reliquary-pr-tests.yml
+++ b/.github/workflows/reliquary-pr-tests.yml
@@ -1,0 +1,77 @@
+name: Reliquary PR Tests
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'Reliquary/**'
+      - 'Radoub.Formats/**'
+      - 'Radoub.UI/**'
+      - '.github/workflows/reliquary-pr-tests.yml'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0  # NBGV needs full history
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '9.0.x'
+
+    - name: Restore and build
+      run: dotnet build Reliquary/Reliquary.Tests/Reliquary.Tests.csproj --configuration Release
+
+    - name: Run Reliquary.Tests
+      id: reliquary-tests
+      shell: bash
+      run: |
+        dotnet test Reliquary/Reliquary.Tests/Reliquary.Tests.csproj \
+          --configuration Release \
+          --no-build \
+          --verbosity normal \
+          --logger "trx;LogFileName=reliquary-results.trx" \
+          --collect:"XPlat Code Coverage" \
+          --results-directory ./TestResults/Reliquary
+      continue-on-error: true
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: reliquary-test-results-${{ matrix.os }}
+        path: ./TestResults
+        retention-days: 30
+
+    - name: Test Report
+      uses: dorny/test-reporter@v3
+      if: always()
+      with:
+        name: Reliquary Test Results (${{ matrix.os }})
+        path: './TestResults/Reliquary/reliquary-results.trx'
+        reporter: dotnet-trx
+        fail-on-error: false
+
+    - name: Report test results
+      if: always()
+      shell: bash
+      run: |
+        if [ "${{ steps.reliquary-tests.outcome }}" = "success" ]; then
+          echo "✅ Reliquary tests passed (${{ matrix.os }})"
+        else
+          echo "❌ Reliquary tests failed (${{ matrix.os }})"
+          exit 1
+        fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.1-alpha] - 2026-06-06
+**Branch**: `reliquary/sprint/epic-2289-followups` | **PR**: #2377
+
+### Cross-tool dispatch: resolve target tool from settings
+
+- `ToolDispatchService` now looks up the target tool's path from shared `RadoubSettings` (written when that tool runs) before falling back to relative-directory discovery. Fixes cross-tool "open in X" launches failing in dev/portable layouts where tools live in separate bin trees.
+
+---
+
 ## [Docs] - 2026-06-06
 **Branch**: `reliquary/issue-2367` | **PR**: #2371
 

--- a/Radoub.UI/Radoub.UI/Services/Search/ToolDispatchService.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/ToolDispatchService.cs
@@ -104,10 +104,42 @@ public class ToolDispatchService
     }
 
     /// <summary>
-    /// Try to discover a tool executable relative to the executing assembly.
+    /// Map a dispatchable tool to the shared RadoubSettings path it registers when it runs.
+    /// Mirrors Parley's FindManifestPath: settings written by a tool on launch are the authoritative
+    /// way one tool finds another in dev + portable layouts (where tools are NOT siblings on disk).
+    /// </summary>
+    private static string? GetRegisteredToolPath(string toolName)
+    {
+        var settings = Radoub.Formats.Settings.RadoubSettings.Instance;
+        return toolName switch
+        {
+            "Parley" => settings.ParleyPath,
+            "Manifest" => settings.ManifestPath,
+            "Quartermaster" => settings.QuartermasterPath,
+            "Fence" => settings.FencePath,
+            "Relique" => settings.ReliquePath,
+            "Reliquary" => settings.ReliquaryPath,
+            "Trebuchet" => settings.TrebuchetPath,
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Try to discover a tool executable: first the path the tool registered in shared settings when
+    /// it last ran, then locations relative to the executing assembly (sibling deployment layouts).
     /// </summary>
     private static void DiscoverTool(DispatchableToolInfo info)
     {
+        // Settings-first: the tool writes its own path to RadoubSettings on launch. This is how
+        // cross-tool dispatch works in dev (separate bin trees) — relative discovery only finds
+        // siblings in a packaged deployment.
+        var registered = GetRegisteredToolPath(info.ToolName);
+        if (!string.IsNullOrEmpty(registered) && File.Exists(registered))
+        {
+            info.ExecutablePath = registered;
+            return;
+        }
+
         var baseDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
         if (baseDir == null) return;
 

--- a/Reliquary/CHANGELOG.md
+++ b/Reliquary/CHANGELOG.md
@@ -6,6 +6,20 @@ Format based on [Keep a Changelog](https://keepachangelog.com/); versioning via 
 
 ---
 
+## [0.7.0-alpha] - 2026-06-06
+**Branch**: `reliquary/sprint/epic-2289-followups` | **PR**: #TBD
+
+### Sprint: Epic #2289 placeable-editor follow-ups
+
+- Faction combo populated from the module's `repute.fac`; selection is undoable (#2354).
+- Inventory column resize, palette panel gaps, and non-resizable MainWindow fixed for large-font support (#2363).
+- ResRef/Tag auto-sync with name (Relique-style linked checkbox) (#2372).
+- Conversation field gains a Browse button to the shared DialogBrowserWindow (undoable) (#2373).
+- 3D model preview now fits its allotted area in the IdentityCombat panel (#2375).
+- Initial State edited as a named dropdown of placeable animation states instead of a raw number (#2376).
+
+---
+
 ## [0.6.0-alpha] - 2026-06-06
 **Branch**: `reliquary/issue-2367` | **PR**: #2371
 

--- a/Reliquary/CHANGELOG.md
+++ b/Reliquary/CHANGELOG.md
@@ -7,7 +7,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/); versioning via 
 ---
 
 ## [0.7.0-alpha] - 2026-06-06
-**Branch**: `reliquary/sprint/epic-2289-followups` | **PR**: #TBD
+**Branch**: `reliquary/sprint/epic-2289-followups` | **PR**: #2377
 
 ### Sprint: Epic #2289 placeable-editor follow-ups
 

--- a/Reliquary/Reliquary.Tests/Services/FactionServiceTests.cs
+++ b/Reliquary/Reliquary.Tests/Services/FactionServiceTests.cs
@@ -1,0 +1,91 @@
+using System.IO;
+using System.Linq;
+using Radoub.Formats.Fac;
+using PlaceableEditor.Services;
+
+namespace PlaceableEditor.Tests.Services;
+
+/// <summary>
+/// FactionService (#2354) loads the module's repute.fac into (Id, Name) pairs for the Behavior
+/// panel's Faction combo, falling back to the five standard NWN factions when no module / no
+/// repute.fac. No hardcoded faction data when a module file is present — mirrors Quartermaster's
+/// AppearanceService.GetAllFactions.
+/// </summary>
+public class FactionServiceTests
+{
+    [Fact]
+    public void Load_NullModuleDir_ReturnsStandardFallback()
+    {
+        var factions = FactionService.Load(null);
+
+        Assert.Equal(5, factions.Count);
+        Assert.Equal((ushort)0, factions[0].Id);
+        Assert.Equal("PC", factions[0].Name);
+        Assert.Equal("Hostile", factions[1].Name);
+    }
+
+    [Fact]
+    public void Load_ModuleDirWithoutReputeFac_ReturnsStandardFallback()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var factions = FactionService.Load(dir);
+            Assert.Equal(5, factions.Count);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Load_ReputeFacPresent_ReturnsFactionsInIndexOrder()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var fac = new FacFile();
+            fac.FactionList.Add(new Faction { FactionName = "PC" });
+            fac.FactionList.Add(new Faction { FactionName = "Hostile" });
+            fac.FactionList.Add(new Faction { FactionName = "Townsfolk" });
+            fac.FactionList.Add(new Faction { FactionName = "Bandits" });
+            FacWriter.Write(fac, Path.Combine(dir, "repute.fac"));
+
+            var factions = FactionService.Load(dir);
+
+            Assert.Equal(4, factions.Count);
+            Assert.Equal((ushort)2, factions[2].Id);
+            Assert.Equal("Townsfolk", factions[2].Name);
+            Assert.Equal("Bandits", factions[3].Name);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Load_EmptyFactionName_FallsBackToIndexedLabel()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var fac = new FacFile();
+            fac.FactionList.Add(new Faction { FactionName = "PC" });
+            fac.FactionList.Add(new Faction { FactionName = "" });
+            FacWriter.Write(fac, Path.Combine(dir, "repute.fac"));
+
+            var factions = FactionService.Load(dir);
+
+            Assert.Equal("Faction 1", factions[1].Name);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/Reliquary/Reliquary.Tests/Services/PlaceableNamingServiceTests.cs
+++ b/Reliquary/Reliquary.Tests/Services/PlaceableNamingServiceTests.cs
@@ -1,0 +1,48 @@
+using PlaceableEditor.Services;
+
+namespace PlaceableEditor.Tests.Services;
+
+/// <summary>
+/// PlaceableNamingService (#2372) mirrors Relique's ItemNamingService: derive a NWN Tag (UPPERCASE,
+/// ≤32) and ResRef (lowercase, ≤16) from a display name. Used by the Identity panel's "sync with
+/// name" checkboxes so naming a placeable doesn't require typing Tag/ResRef by hand.
+/// </summary>
+public class PlaceableNamingServiceTests
+{
+    [Theory]
+    [InlineData("Treasure Chest", "TREASURE_CHEST")]
+    [InlineData("oak door!!!", "OAK_DOOR")]
+    [InlineData("  spaced  out  ", "SPACED_OUT")]
+    [InlineData("", "")]
+    public void GenerateTag_UppercasesSanitizesAndUnderscores(string name, string expected)
+        => Assert.Equal(expected, PlaceableNamingService.GenerateTag(name));
+
+    [Theory]
+    [InlineData("Treasure Chest", "treasure_chest")]
+    [InlineData("oak door!!!", "oak_door")]
+    [InlineData("", "")]
+    public void GenerateResRef_LowercasesSanitizesAndUnderscores(string name, string expected)
+        => Assert.Equal(expected, PlaceableNamingService.GenerateResRef(name));
+
+    [Fact]
+    public void GenerateResRef_TruncatesTo16Chars()
+    {
+        var resRef = PlaceableNamingService.GenerateResRef("A Very Long Placeable Name Indeed");
+        Assert.True(resRef.Length <= 16, $"ResRef '{resRef}' exceeds 16 chars");
+    }
+
+    [Fact]
+    public void GenerateTag_TruncatesTo32Chars()
+    {
+        var tag = PlaceableNamingService.GenerateTag("A Very Long Placeable Name That Exceeds Thirty Two Characters");
+        Assert.True(tag.Length <= 32, $"Tag '{tag}' exceeds 32 chars");
+    }
+
+    [Fact]
+    public void Generate_TrimsTrailingUnderscoreAfterTruncation()
+    {
+        // 16-char boundary landing on a space would otherwise leave a trailing underscore.
+        var resRef = PlaceableNamingService.GenerateResRef("abcdefghijklmno pqr");
+        Assert.False(resRef.EndsWith("_"), $"ResRef '{resRef}' has a trailing underscore");
+    }
+}

--- a/Reliquary/Reliquary.Tests/ViewModels/PlaceableAnimationStateTests.cs
+++ b/Reliquary/Reliquary.Tests/ViewModels/PlaceableAnimationStateTests.cs
@@ -1,0 +1,42 @@
+using System.Linq;
+using PlaceableEditor.ViewModels;
+
+namespace PlaceableEditor.Tests.ViewModels;
+
+/// <summary>
+/// The Initial State combo (#2376) lists the engine-fixed placeable animation states from
+/// BioWare's Door/Placeable GFF spec Table 4.1.2 (default/open/closed/destroyed/activated/
+/// deactivated = 0..5). These values are engine-internal, not 2DA/module data, so a static
+/// catalog is authoritative rather than hardcoded game data.
+/// </summary>
+public class PlaceableAnimationStateTests
+{
+    [Fact]
+    public void Catalog_HasSixStatesInValueOrder()
+    {
+        var states = PlaceableAnimationState.All;
+
+        Assert.Equal(6, states.Count);
+        Assert.Equal(new byte[] { 0, 1, 2, 3, 4, 5 }, states.Select(s => s.Value).ToArray());
+    }
+
+    [Theory]
+    [InlineData(0, "Default")]
+    [InlineData(1, "Open")]
+    [InlineData(2, "Closed")]
+    [InlineData(3, "Destroyed")]
+    [InlineData(4, "Activated")]
+    [InlineData(5, "Deactivated")]
+    public void Catalog_MapsValueToFriendlyName(byte value, string expectedName)
+    {
+        var state = PlaceableAnimationState.All.Single(s => s.Value == value);
+        Assert.Equal(expectedName, state.Name);
+    }
+
+    [Fact]
+    public void Display_CombinesNameAndValue()
+    {
+        var open = PlaceableAnimationState.All.Single(s => s.Value == 1);
+        Assert.Equal("Open (1)", open.Display);
+    }
+}

--- a/Reliquary/Reliquary/Services/FactionService.cs
+++ b/Reliquary/Reliquary/Services/FactionService.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Radoub.Formats.Fac;
+using Radoub.Formats.Logging;
+
+namespace PlaceableEditor.Services;
+
+/// <summary>
+/// Loads the module's faction list (repute.fac) for the Behavior panel's Faction combo (#2354).
+/// Mirrors Quartermaster's AppearanceService.GetAllFactions: real factions from the module when
+/// available, the five standard NWN factions as a graceful fallback. No hardcoded faction data
+/// when a repute.fac is present — the faction id is the list index, the engine convention.
+/// </summary>
+public static class FactionService
+{
+    /// <summary>
+    /// Load (Id, Name) pairs from <paramref name="moduleDirectory"/>/repute.fac. Returns the
+    /// standard NWN factions when the directory is null/missing, repute.fac is absent or unreadable,
+    /// or the file lists no factions.
+    /// </summary>
+    public static List<(ushort Id, string Name)> Load(string? moduleDirectory)
+    {
+        if (!string.IsNullOrEmpty(moduleDirectory))
+        {
+            try
+            {
+                var facPath = Path.Combine(moduleDirectory, "repute.fac");
+                if (File.Exists(facPath))
+                {
+                    var fac = FacReader.Read(facPath);
+                    if (fac.FactionList.Count > 0)
+                    {
+                        var factions = new List<(ushort Id, string Name)>(fac.FactionList.Count);
+                        for (int i = 0; i < fac.FactionList.Count; i++)
+                        {
+                            var name = fac.FactionList[i].FactionName;
+                            factions.Add(((ushort)i,
+                                string.IsNullOrEmpty(name) ? $"Faction {i}" : name));
+                        }
+                        return factions;
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is IOException or InvalidOperationException or FormatException)
+            {
+                UnifiedLogger.LogApplication(LogLevel.WARN,
+                    $"Reliquary: could not load repute.fac: {ex.Message}. Using default factions.");
+            }
+        }
+
+        return StandardFactions();
+    }
+
+    /// <summary>The five standard NWN factions (id = index), used when no module repute.fac applies.</summary>
+    private static List<(ushort Id, string Name)> StandardFactions() => new()
+    {
+        (0, "PC"),
+        (1, "Hostile"),
+        (2, "Commoner"),
+        (3, "Merchant"),
+        (4, "Defender"),
+    };
+}

--- a/Reliquary/Reliquary/Services/PlaceableNamingService.cs
+++ b/Reliquary/Reliquary/Services/PlaceableNamingService.cs
@@ -1,0 +1,50 @@
+using System.Text.RegularExpressions;
+
+namespace PlaceableEditor.Services;
+
+/// <summary>
+/// Tag/ResRef generation from a display name (#2372), mirroring Relique's ItemNamingService.
+/// ResRef: filename-like (16 char max, lowercase, [a-z0-9_]). Tag: script identifier (32 char max,
+/// UPPERCASE, [a-zA-Z0-9_]). Used by the Identity panel's "sync with name" checkboxes.
+/// </summary>
+public static partial class PlaceableNamingService
+{
+    private const int MaxResRefLength = 16;
+    private const int MaxTagLength = 32;
+
+    [GeneratedRegex(@"[^a-zA-Z0-9 ]")]
+    private static partial Regex NonAlphanumericOrSpaceRegex();
+
+    [GeneratedRegex(@" +")]
+    private static partial Regex MultiSpaceRegex();
+
+    /// <summary>Tag from a name: sanitize, '_' for spaces, UPPERCASE, ≤32, trim trailing '_'.</summary>
+    public static string GenerateTag(string name)
+    {
+        var sanitized = Sanitize(name);
+        return sanitized.Length == 0 ? string.Empty
+            : TruncateAndTrim(sanitized.ToUpperInvariant(), MaxTagLength);
+    }
+
+    /// <summary>ResRef from a name: sanitize, '_' for spaces, lowercase, ≤16, trim trailing '_'.</summary>
+    public static string GenerateResRef(string name)
+    {
+        var sanitized = Sanitize(name);
+        return sanitized.Length == 0 ? string.Empty
+            : TruncateAndTrim(sanitized.ToLowerInvariant(), MaxResRefLength);
+    }
+
+    private static string Sanitize(string name)
+    {
+        var stripped = NonAlphanumericOrSpaceRegex().Replace(name, string.Empty);
+        var collapsed = MultiSpaceRegex().Replace(stripped, " ");
+        return collapsed.Trim().Replace(' ', '_');
+    }
+
+    private static string TruncateAndTrim(string value, int maxLength)
+    {
+        if (value.Length > maxLength)
+            value = value[..maxLength];
+        return value.TrimEnd('_');
+    }
+}

--- a/Reliquary/Reliquary/ViewModels/PlaceableAnimationState.cs
+++ b/Reliquary/Reliquary/ViewModels/PlaceableAnimationState.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace PlaceableEditor.ViewModels;
+
+/// <summary>
+/// One named placeable animation state for the Initial State combo (#2376). The byte value is
+/// written straight to <see cref="Radoub.Formats.Utp.UtpFile.AnimationState"/>.
+/// </summary>
+public sealed record PlaceableAnimationState(byte Value, string Name)
+{
+    /// <summary>Combo label, e.g. "Open (1)".</summary>
+    public string Display => $"{Name} ({Value})";
+
+    /// <summary>
+    /// The engine-fixed set of placeable animation states, in value order. Source: BioWare
+    /// Door/Placeable GFF spec, Table 4.1.2. These are engine-internal enum values (not 2DA or
+    /// module data), so the catalog is authoritative rather than hardcoded game data — a model's
+    /// MDL must actually contain the matching animation for a state to render, but the stored byte
+    /// is always one of these six.
+    /// </summary>
+    public static IReadOnlyList<PlaceableAnimationState> All { get; } = new[]
+    {
+        new PlaceableAnimationState(0, "Default"),
+        new PlaceableAnimationState(1, "Open"),
+        new PlaceableAnimationState(2, "Closed"),
+        new PlaceableAnimationState(3, "Destroyed"),
+        new PlaceableAnimationState(4, "Activated"),
+        new PlaceableAnimationState(5, "Deactivated"),
+    };
+}

--- a/Reliquary/Reliquary/ViewModels/PlaceableViewModel.cs
+++ b/Reliquary/Reliquary/ViewModels/PlaceableViewModel.cs
@@ -182,6 +182,9 @@ public sealed class PlaceableViewModel : INotifyPropertyChanged
         set { if (_utp.AnimationState == value) return; _utp.AnimationState = value; OnPropertyChanged(); }
     }
 
+    /// <summary>Named animation states for the Initial State combo (#2376). Engine-fixed catalog.</summary>
+    public IReadOnlyList<PlaceableAnimationState> AnimationStates => PlaceableAnimationState.All;
+
     /// <summary>Body-bag index (design "Treasure Model").</summary>
     public byte TreasureModel
     {

--- a/Reliquary/Reliquary/Views/MainWindow.Editor.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.Editor.cs
@@ -56,6 +56,8 @@ public partial class MainWindow
             behavior.SaveScriptSetRequested += OnSaveScriptSetRequested;
             behavior.LoadScriptSetRequested += OnLoadScriptSetRequested;
             behavior.EditConversationRequested += OnEditConversationRequested;
+            behavior.ConversationBrowseRequested += OnConversationBrowseRequested;
+            behavior.FactionChanged += OnFactionSelected;
         }
     }
 
@@ -149,6 +151,7 @@ public partial class MainWindow
         }
 
         PopulateAppearanceAndPreview(); // appearance combo + 3D model (when game data configured)
+        PopulateFactionCombo();         // faction combo from the module's repute.fac (#2354)
         RefreshInventory();             // backpack + palette (visible only when Has Inventory)
 
         TrackPlaceableEdits(_placeable); // any field/variable/inventory edit marks the document dirty
@@ -473,5 +476,22 @@ public partial class MainWindow
             UpdateStatus($"Could not launch Parley for {resRef}.dlg — Parley may not be installed alongside Reliquary.");
         else
             UpdateStatus($"Opening {resRef}.dlg in Parley…");
+    }
+
+    /// <summary>
+    /// Open the shared DialogBrowserWindow and set the Conversation ResRef from the selection (#2373).
+    /// Routes the change through undo (SetFieldCommand), mirroring the script-slot browse.
+    /// </summary>
+    private async void OnConversationBrowseRequested(object? sender, EventArgs e)
+    {
+        if (_placeable is null) return;
+
+        var context = new PlaceableEditor.Services.ReliquaryScriptBrowserContext(_currentFilePath, _gameData);
+        var browser = new Radoub.UI.Views.DialogBrowserWindow(context);
+        var result = await browser.ShowDialog<string?>(this);
+        if (string.IsNullOrEmpty(result)) return;
+
+        _undo.Execute(new SetFieldCommand<string>(
+            () => _placeable.Conversation, v => _placeable.Conversation = v, result, "set conversation"));
     }
 }

--- a/Reliquary/Reliquary/Views/MainWindow.Lifecycle.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.Lifecycle.cs
@@ -35,12 +35,23 @@ public partial class MainWindow
             browser.ModulePath = moduleDir;
     }
 
-    /// <summary>Collapse/expand the browser sidebar by zeroing its width and hiding the splitter.</summary>
+    /// <summary>
+    /// Collapse/expand the browser sidebar. Zeroes the browser + splitter *columns* (not just the
+    /// panel width) and hides both controls, so the editor reclaims the full row — mirroring Relique's
+    /// SetItemBrowserPanelVisible. Zeroing only the panel width left the Auto column occupying a blank
+    /// gap (#2363 follow-up).
+    /// </summary>
     private void SetBrowserCollapsed(bool collapsed)
     {
         var browser = this.FindControl<PlaceableBrowserPanel>("PlaceableBrowserPanel");
         var splitter = this.FindControl<GridSplitter>("BrowserSplitter");
-        if (browser != null) browser.Width = collapsed ? 0 : 260;
+        var grid = this.FindControl<Grid>("OuterContentGrid");
+        if (grid != null)
+        {
+            grid.ColumnDefinitions[0].Width = new Avalonia.Controls.GridLength(collapsed ? 0 : 260, Avalonia.Controls.GridUnitType.Pixel);
+            grid.ColumnDefinitions[1].Width = new Avalonia.Controls.GridLength(collapsed ? 0 : 4, Avalonia.Controls.GridUnitType.Pixel);
+        }
+        if (browser != null) browser.IsVisible = !collapsed;
         if (splitter != null) splitter.IsVisible = !collapsed;
     }
 

--- a/Reliquary/Reliquary/Views/MainWindow.Services.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.Services.cs
@@ -142,6 +142,25 @@ public partial class MainWindow
         UpdateModelPreview(appearanceId);
     }
 
+    /// <summary>Populate the Behavior panel's Faction combo from the module's repute.fac (#2354).</summary>
+    private void PopulateFactionCombo()
+    {
+        if (_placeable is null) return;
+        var behavior = this.FindControl<PlaceableEditor.Views.Panels.BehaviorPanel>("BehaviorPanel");
+        if (behavior is null) return;
+
+        var factions = PlaceableEditor.Services.FactionService.Load(GetModuleWorkingDirectory());
+        behavior.PopulateFactions(factions, _placeable.Faction);
+    }
+
+    /// <summary>Route a faction pick through undo (host owns the repute.fac list + undo wrapping).</summary>
+    private void OnFactionSelected(object? sender, uint factionId)
+    {
+        if (_placeable is null) return;
+        _undo.Execute(new Radoub.UI.Undo.SetFieldCommand<uint>(
+            () => _placeable.Faction, v => _placeable.Faction = v, factionId, "change faction"));
+    }
+
     private async void OnPortraitBrowseRequested(object? sender, EventArgs e)
     {
         if (_placeable is null) return;

--- a/Reliquary/Reliquary/Views/MainWindow.axaml
+++ b/Reliquary/Reliquary/Views/MainWindow.axaml
@@ -39,10 +39,9 @@
                        Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
         </Border>
 
-        <Grid x:Name="OuterContentGrid" ColumnDefinitions="Auto,Auto,*">
+        <Grid x:Name="OuterContentGrid" ColumnDefinitions="260,4,*">
             <panels:PlaceableBrowserPanel x:Name="PlaceableBrowserPanel"
-                                          Grid.Column="0"
-                                          Width="260"/>
+                                          Grid.Column="0"/>
             <GridSplitter x:Name="BrowserSplitter" Grid.Column="1" Width="4"
                           Background="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <ScrollViewer Grid.Column="2">

--- a/Reliquary/Reliquary/Views/MainWindow.axaml
+++ b/Reliquary/Reliquary/Views/MainWindow.axaml
@@ -7,6 +7,7 @@
         x:Class="PlaceableEditor.Views.MainWindow"
         Title="Reliquary"
         Width="1000" Height="700"
+        MinWidth="800" MinHeight="600"
         WindowStartupLocation="CenterScreen"
         KeyDown="OnWindowKeyDown">
 

--- a/Reliquary/Reliquary/Views/Panels/BehaviorPanel.axaml
+++ b/Reliquary/Reliquary/Views/Panels/BehaviorPanel.axaml
@@ -93,6 +93,9 @@
                                AutomationProperties.AutomationId="Reliquary_Numeric_TreasureModel"/>
             </Grid>
             <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,2,0,0">
+                <Button Content="Browse…" Click="OnBrowseConversationClick"
+                        ToolTip.Tip="Browse module/HAK dialogs and set the Conversation ResRef."
+                        AutomationProperties.AutomationId="Reliquary_Button_BrowseConversation"/>
                 <Button Content="Edit → Parley" Click="OnEditConversationClick"
                         ToolTip.Tip="Open this conversation's .dlg in Parley."
                         AutomationProperties.AutomationId="Reliquary_Button_EditConversation"/>

--- a/Reliquary/Reliquary/Views/Panels/BehaviorPanel.axaml
+++ b/Reliquary/Reliquary/Views/Panels/BehaviorPanel.axaml
@@ -74,10 +74,12 @@
                           AutomationProperties.AutomationId="Reliquary_Combo_Faction"/>
 
                 <TextBlock Grid.Row="0" Grid.Column="3" Text="Initial State" VerticalAlignment="Center"/>
-                <NumericUpDown Grid.Row="0" Grid.Column="4" Minimum="0" Maximum="255" Increment="1"
-                               FormatString="0" MinWidth="120"
-                               Value="{Binding InitialState, Mode=TwoWay}"
-                               AutomationProperties.AutomationId="Reliquary_Numeric_InitialState"/>
+                <ComboBox Grid.Row="0" Grid.Column="4" MinWidth="120"
+                          ItemsSource="{Binding AnimationStates}"
+                          SelectedValue="{Binding InitialState, Mode=TwoWay}"
+                          SelectedValueBinding="{Binding Value}"
+                          DisplayMemberBinding="{Binding Display}"
+                          AutomationProperties.AutomationId="Reliquary_Combo_InitialState"/>
 
                 <TextBlock Grid.Row="1" Grid.Column="0" Text="Conversation" VerticalAlignment="Center"/>
                 <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Conversation, Mode=TwoWay}"

--- a/Reliquary/Reliquary/Views/Panels/BehaviorPanel.axaml.cs
+++ b/Reliquary/Reliquary/Views/Panels/BehaviorPanel.axaml.cs
@@ -95,9 +95,11 @@ public partial class BehaviorPanel : UserControl
         => ConversationBrowseRequested?.Invoke(this, EventArgs.Empty);
 
     /// <summary>
-    /// Fill the Faction combo from the host-provided list (loaded from the module's repute.fac) and
-    /// preselect <paramref name="selectedId"/>. The host owns the list + undo wrapping; the combo
-    /// only raises <see cref="FactionChanged"/> on user edits, never during this populate.
+    /// Fill the Faction combo from the host-provided list (loaded from the module's repute.fac). The
+    /// combo intentionally starts with no selection (per #2354 follow-up): the user opens the dropdown
+    /// to assign a faction, rather than the combo asserting a faction the placeable may not have meant.
+    /// The stored faction value is untouched until the user picks. The host owns the list + undo
+    /// wrapping; the combo only raises <see cref="FactionChanged"/> on user edits, never on populate.
     /// </summary>
     public void PopulateFactions(System.Collections.Generic.IReadOnlyList<(ushort Id, string Name)> factions, uint selectedId)
     {
@@ -107,9 +109,8 @@ public partial class BehaviorPanel : UserControl
         _suppressFactionEvent = true;
         try
         {
-            var items = factions.Select(f => new FactionItem(f.Id, f.Name)).ToList();
-            combo.ItemsSource = items;
-            combo.SelectedItem = items.FirstOrDefault(i => i.Id == selectedId);
+            combo.ItemsSource = factions.Select(f => new FactionItem(f.Id, f.Name)).ToList();
+            combo.SelectedItem = null; // start blank; user pulls down to choose (#2354 follow-up)
         }
         finally
         {

--- a/Reliquary/Reliquary/Views/Panels/BehaviorPanel.axaml.cs
+++ b/Reliquary/Reliquary/Views/Panels/BehaviorPanel.axaml.cs
@@ -34,6 +34,15 @@ public partial class BehaviorPanel : UserControl
     /// <summary>Raised when the conversation Edit→Parley button is clicked (Sprint 7 dispatch).</summary>
     public event EventHandler? EditConversationRequested;
 
+    /// <summary>Raised when the conversation Browse… button is clicked (#2373; host opens the shared DialogBrowser).</summary>
+    public event EventHandler? ConversationBrowseRequested;
+
+    /// <summary>Raised when the user picks a faction (carries the faction id) for the host to wrap in undo.</summary>
+    public event EventHandler<uint>? FactionChanged;
+
+    /// <summary>Suppresses <see cref="FactionChanged"/> while the host populates/preselects the combo.</summary>
+    private bool _suppressFactionEvent;
+
     public BehaviorPanel()
     {
         InitializeComponent();
@@ -82,8 +91,42 @@ public partial class BehaviorPanel : UserControl
     private void OnEditConversationClick(object? sender, RoutedEventArgs e)
         => EditConversationRequested?.Invoke(this, EventArgs.Empty);
 
+    private void OnBrowseConversationClick(object? sender, RoutedEventArgs e)
+        => ConversationBrowseRequested?.Invoke(this, EventArgs.Empty);
+
+    /// <summary>
+    /// Fill the Faction combo from the host-provided list (loaded from the module's repute.fac) and
+    /// preselect <paramref name="selectedId"/>. The host owns the list + undo wrapping; the combo
+    /// only raises <see cref="FactionChanged"/> on user edits, never during this populate.
+    /// </summary>
+    public void PopulateFactions(System.Collections.Generic.IReadOnlyList<(ushort Id, string Name)> factions, uint selectedId)
+    {
+        var combo = this.FindControl<ComboBox>("FactionCombo");
+        if (combo is null) return;
+
+        _suppressFactionEvent = true;
+        try
+        {
+            var items = factions.Select(f => new FactionItem(f.Id, f.Name)).ToList();
+            combo.ItemsSource = items;
+            combo.SelectedItem = items.FirstOrDefault(i => i.Id == selectedId);
+        }
+        finally
+        {
+            _suppressFactionEvent = false;
+        }
+    }
+
     private void OnFactionChanged(object? sender, SelectionChangedEventArgs e)
     {
-        // Faction binding flows through the host, which owns the repute.fac list + undo wrapping.
+        if (_suppressFactionEvent) return;
+        if (sender is ComboBox { SelectedItem: FactionItem item })
+            FactionChanged?.Invoke(this, item.Id);
+    }
+
+    /// <summary>Display item for the Faction combo: shows the name, carries the faction id.</summary>
+    private sealed record FactionItem(ushort Id, string Name)
+    {
+        public override string ToString() => Name;
     }
 }

--- a/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml
+++ b/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml
@@ -48,22 +48,19 @@
                                  Text="{Binding Tag, Mode=TwoWay}"
                                  MaxLength="32"
                                  AutomationProperties.AutomationId="Reliquary_Field_Tag"/>
-                        <CheckBox Grid.Row="1" Grid.Column="2" x:Name="SyncTagCheck" Content="= Name"
-                                  Margin="6,0,0,0" VerticalAlignment="Center"
-                                  ToolTip.Tip="Keep Tag in sync with the Name (uppercased)."
-                                  IsCheckedChanged="OnSyncTagChanged"
-                                  AutomationProperties.AutomationId="Reliquary_Check_SyncTag"/>
+                        <!-- One checkbox drives both Tag + ResRef sync (#2354 follow-up). Spans the Tag
+                             and ResRef rows so it reads as governing both fields. -->
+                        <CheckBox Grid.Row="1" Grid.RowSpan="2" Grid.Column="2" x:Name="SyncNameCheck"
+                                  Content="= Name" Margin="6,0,0,0" VerticalAlignment="Center"
+                                  ToolTip.Tip="Keep Tag (UPPERCASE) and ResRef (lowercase, ≤16) in sync with the Name."
+                                  IsCheckedChanged="OnSyncNameChanged"
+                                  AutomationProperties.AutomationId="Reliquary_Check_SyncName"/>
 
                         <TextBlock Grid.Row="2" Grid.Column="0" Text="ResRef" VerticalAlignment="Center"/>
                         <TextBox Grid.Row="2" Grid.Column="1" x:Name="ResRefTextBox"
                                  Text="{Binding TemplateResRef, Mode=TwoWay}"
                                  MaxLength="16"
                                  AutomationProperties.AutomationId="Reliquary_Field_ResRef"/>
-                        <CheckBox Grid.Row="2" Grid.Column="2" x:Name="SyncResRefCheck" Content="= Name"
-                                  Margin="6,0,0,0" VerticalAlignment="Center"
-                                  ToolTip.Tip="Keep ResRef in sync with the Name (lowercased, ≤16 chars)."
-                                  IsCheckedChanged="OnSyncResRefChanged"
-                                  AutomationProperties.AutomationId="Reliquary_Check_SyncResRef"/>
 
                         <TextBlock Grid.Row="3" Grid.Column="0" Text="Appearance" VerticalAlignment="Center"/>
                         <ComboBox Grid.Row="3" Grid.Column="1"

--- a/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml
+++ b/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml
@@ -39,24 +39,31 @@
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
                         <TextBlock Grid.Row="0" Grid.Column="0" Text="Name" VerticalAlignment="Center"/>
-                        <TextBox Grid.Row="0" Grid.Column="1"
+                        <TextBox Grid.Row="0" Grid.Column="1" x:Name="NameTextBox"
                                  Text="{Binding Name, Mode=TwoWay}"
                                  AutomationProperties.AutomationId="Reliquary_Field_Name"/>
 
                         <TextBlock Grid.Row="1" Grid.Column="0" Text="Tag" VerticalAlignment="Center"/>
-                        <TextBox Grid.Row="1" Grid.Column="1"
+                        <TextBox Grid.Row="1" Grid.Column="1" x:Name="TagTextBox"
                                  Text="{Binding Tag, Mode=TwoWay}"
                                  MaxLength="32"
                                  AutomationProperties.AutomationId="Reliquary_Field_Tag"/>
+                        <CheckBox Grid.Row="1" Grid.Column="2" x:Name="SyncTagCheck" Content="= Name"
+                                  Margin="6,0,0,0" VerticalAlignment="Center"
+                                  ToolTip.Tip="Keep Tag in sync with the Name (uppercased)."
+                                  IsCheckedChanged="OnSyncTagChanged"
+                                  AutomationProperties.AutomationId="Reliquary_Check_SyncTag"/>
 
                         <TextBlock Grid.Row="2" Grid.Column="0" Text="ResRef" VerticalAlignment="Center"/>
-                        <TextBox Grid.Row="2" Grid.Column="1"
+                        <TextBox Grid.Row="2" Grid.Column="1" x:Name="ResRefTextBox"
                                  Text="{Binding TemplateResRef, Mode=TwoWay}"
                                  MaxLength="16"
                                  AutomationProperties.AutomationId="Reliquary_Field_ResRef"/>
-                        <TextBlock Grid.Row="2" Grid.Column="2" Text="(16 ch)" Margin="6,0,0,0"
-                                   VerticalAlignment="Center"
-                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <CheckBox Grid.Row="2" Grid.Column="2" x:Name="SyncResRefCheck" Content="= Name"
+                                  Margin="6,0,0,0" VerticalAlignment="Center"
+                                  ToolTip.Tip="Keep ResRef in sync with the Name (lowercased, ≤16 chars)."
+                                  IsCheckedChanged="OnSyncResRefChanged"
+                                  AutomationProperties.AutomationId="Reliquary_Check_SyncResRef"/>
 
                         <TextBlock Grid.Row="3" Grid.Column="0" Text="Appearance" VerticalAlignment="Center"/>
                         <ComboBox Grid.Row="3" Grid.Column="1"
@@ -132,12 +139,18 @@
                 <GridSplitter Grid.Column="3" Width="4"
                               Background="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
 
-                <!-- 3D preview -->
-                <Border Grid.Column="4"
+                <!-- 3D preview. Square (260x260) so the model fits at a 1:1 aspect; the panel root is
+                     a StackPanel, so an explicit Height (not just MinHeight) is required to give the GL
+                     control real bounds to render/camera-fit into (#2375). The control stretches to
+                     fill the Border, matching Quartermaster's AppearancePanel preview. -->
+                <Border Grid.Column="4" VerticalAlignment="Top"
+                        Height="260"
                         Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
                         BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
-                        BorderThickness="1" MinHeight="200">
+                        BorderThickness="1">
                     <ctrl:ModelPreviewGLControl x:Name="ModelPreview"
+                                                HorizontalAlignment="Stretch"
+                                                VerticalAlignment="Stretch"
                                                 AutomationProperties.AutomationId="Reliquary_ModelPreview"/>
                 </Border>
             </Grid>

--- a/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml.cs
+++ b/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml.cs
@@ -32,35 +32,27 @@ public partial class IdentityCombatPanel : UserControl
         if (name != null) name.TextChanged += OnNameChanged;
     }
 
-    // --- Tag/ResRef sync with name (#2372), mirroring Relique's NewItem naming UX ---
+    // --- Tag/ResRef sync with name (#2372), mirroring Relique's NewItem naming UX. One checkbox
+    //     drives both fields (#2354 follow-up): checked → Tag/ResRef track the name and lock. ---
 
     private void OnNameChanged(object? sender, TextChangedEventArgs e) => ApplyNameSync();
 
-    private void OnSyncTagChanged(object? sender, RoutedEventArgs e)
+    private void OnSyncNameChanged(object? sender, RoutedEventArgs e)
     {
+        var on = this.FindControl<CheckBox>("SyncNameCheck")?.IsChecked == true;
         var tag = this.FindControl<TextBox>("TagTextBox");
-        var check = this.FindControl<CheckBox>("SyncTagCheck");
-        if (tag is null || check is null) return;
-        tag.IsReadOnly = check.IsChecked == true;
-        if (check.IsChecked == true) tag.Text = PlaceableNamingService.GenerateTag(CurrentName);
-    }
-
-    private void OnSyncResRefChanged(object? sender, RoutedEventArgs e)
-    {
         var resRef = this.FindControl<TextBox>("ResRefTextBox");
-        var check = this.FindControl<CheckBox>("SyncResRefCheck");
-        if (resRef is null || check is null) return;
-        resRef.IsReadOnly = check.IsChecked == true;
-        if (check.IsChecked == true) resRef.Text = PlaceableNamingService.GenerateResRef(CurrentName);
+        if (tag != null) tag.IsReadOnly = on;
+        if (resRef != null) resRef.IsReadOnly = on;
+        if (on) ApplyNameSync();
     }
 
-    /// <summary>Re-derive Tag/ResRef from the current name for whichever sync checkboxes are on.</summary>
+    /// <summary>Re-derive Tag + ResRef from the current name while the sync checkbox is on.</summary>
     private void ApplyNameSync()
     {
-        if (this.FindControl<CheckBox>("SyncTagCheck")?.IsChecked == true)
-            this.FindControl<TextBox>("TagTextBox")!.Text = PlaceableNamingService.GenerateTag(CurrentName);
-        if (this.FindControl<CheckBox>("SyncResRefCheck")?.IsChecked == true)
-            this.FindControl<TextBox>("ResRefTextBox")!.Text = PlaceableNamingService.GenerateResRef(CurrentName);
+        if (this.FindControl<CheckBox>("SyncNameCheck")?.IsChecked != true) return;
+        this.FindControl<TextBox>("TagTextBox")!.Text = PlaceableNamingService.GenerateTag(CurrentName);
+        this.FindControl<TextBox>("ResRefTextBox")!.Text = PlaceableNamingService.GenerateResRef(CurrentName);
     }
 
     private string CurrentName => this.FindControl<TextBox>("NameTextBox")?.Text ?? string.Empty;

--- a/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml.cs
+++ b/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml.cs
@@ -1,9 +1,11 @@
 using System;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media.Imaging;
 using Radoub.Formats.Services;
 using Radoub.UI.Controls;
+using PlaceableEditor.Services;
 
 namespace PlaceableEditor.Views.Panels;
 
@@ -26,7 +28,42 @@ public partial class IdentityCombatPanel : UserControl
     public IdentityCombatPanel()
     {
         InitializeComponent();
+        var name = this.FindControl<TextBox>("NameTextBox");
+        if (name != null) name.TextChanged += OnNameChanged;
     }
+
+    // --- Tag/ResRef sync with name (#2372), mirroring Relique's NewItem naming UX ---
+
+    private void OnNameChanged(object? sender, TextChangedEventArgs e) => ApplyNameSync();
+
+    private void OnSyncTagChanged(object? sender, RoutedEventArgs e)
+    {
+        var tag = this.FindControl<TextBox>("TagTextBox");
+        var check = this.FindControl<CheckBox>("SyncTagCheck");
+        if (tag is null || check is null) return;
+        tag.IsReadOnly = check.IsChecked == true;
+        if (check.IsChecked == true) tag.Text = PlaceableNamingService.GenerateTag(CurrentName);
+    }
+
+    private void OnSyncResRefChanged(object? sender, RoutedEventArgs e)
+    {
+        var resRef = this.FindControl<TextBox>("ResRefTextBox");
+        var check = this.FindControl<CheckBox>("SyncResRefCheck");
+        if (resRef is null || check is null) return;
+        resRef.IsReadOnly = check.IsChecked == true;
+        if (check.IsChecked == true) resRef.Text = PlaceableNamingService.GenerateResRef(CurrentName);
+    }
+
+    /// <summary>Re-derive Tag/ResRef from the current name for whichever sync checkboxes are on.</summary>
+    private void ApplyNameSync()
+    {
+        if (this.FindControl<CheckBox>("SyncTagCheck")?.IsChecked == true)
+            this.FindControl<TextBox>("TagTextBox")!.Text = PlaceableNamingService.GenerateTag(CurrentName);
+        if (this.FindControl<CheckBox>("SyncResRefCheck")?.IsChecked == true)
+            this.FindControl<TextBox>("ResRefTextBox")!.Text = PlaceableNamingService.GenerateResRef(CurrentName);
+    }
+
+    private string CurrentName => this.FindControl<TextBox>("NameTextBox")?.Text ?? string.Empty;
 
     private void InitializeComponent()
     {

--- a/Reliquary/Reliquary/Views/Panels/InventoryPanel.axaml
+++ b/Reliquary/Reliquary/Views/Panels/InventoryPanel.axaml
@@ -19,12 +19,15 @@
             <!-- Backpack LEFT | UTI palette MIDDLE | details RIGHT (design §5.4, 3 splitters).
                  Adventurer-backpack model: flat list, no body slots. -->
             <Grid x:Name="InventoryGrid" MinHeight="320">
+                <!-- All three content columns are proportional (star) so the two GridSplitters
+                     redistribute space cleanly without leaving empty gaps; MinWidth floors keep
+                     each pane usable at large fonts (#2363). -->
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="300" MinWidth="200"/>
+                    <ColumnDefinition Width="3*" MinWidth="200"/>
                     <ColumnDefinition Width="5"/>
-                    <ColumnDefinition Width="*" MinWidth="240"/>
+                    <ColumnDefinition Width="4*" MinWidth="240"/>
                     <ColumnDefinition Width="5"/>
-                    <ColumnDefinition Width="260" MinWidth="200"/>
+                    <ColumnDefinition Width="3*" MinWidth="200"/>
                 </Grid.ColumnDefinitions>
 
                 <!-- Placeable Contents (backpack) -->


### PR DESCRIPTION
## Summary

Sprint bundling six follow-up issues from the Reliquary placeable-editor epic (#2289), surfaced by manual testing of PR #2371, plus manual-test follow-ups and CI/shared-lib fixes.

## Items

- Closes #2354 — Faction combo from module `repute.fac` (starts blank; undoable)
- Closes #2363 — Inventory pane gaps + resizable window (MinWidth/Height, star columns); browser F4 collapse reclaims full row
- Closes #2372 — Tag/ResRef sync with name (single "= Name" checkbox)
- Closes #2373 — Conversation Browse button (shared DialogBrowserWindow)
- Closes #2375 — 3D model preview fits its allotted area
- Closes #2376 — Initial State as named dropdown (BioWare animation-state catalog)

## Also in this PR

- Shared: `ToolDispatchService` resolves target tool path from `RadoubSettings` before relative discovery — fixes cross-tool "Edit → Parley" in dev layouts (root CHANGELOG, Radoub.UI 0.2.1-alpha).
- CI: added dedicated `reliquary-pr-build.yml` + `reliquary-pr-tests.yml` (Reliquary had none).
- Filed #2378 (QM needs an "Edit → Parley" button).

## Tests

- Unit: Reliquary 101, Radoub.Formats 1328, Radoub.UI 937, Radoub.Dictionary 75 — all pass.
- FlaUI: Reliquary integration 7/7 pass.
- CI: all checks green (Windows + Linux).
- New unit tests: PlaceableAnimationState (4), FactionService (4), PlaceableNamingService (10).

## Manual verification (confirmed in app)

- ✅ Edit → Parley launches; F4 browser collapse clean; faction dropdown works.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)