### PR TITLE
[Trebuchet] Sprint: Critical Data Loss + Marlinspike Polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Radoub.UI 0.2.2-alpha] - 2026-06-06
 **Branch**: `trebuchet/sprint/data-loss-marlinspike` | **PR**: #2387
 
-### Batch-replace preview value (#2224)
+### Batch-replace preview value (#2224) + warning-color converter (#2182)
 
 - `PendingChange.ComputedNewFieldValue` exposes the post-replace field value (literal substring substitution, no case folding) so replace previews can show the real result instead of the bare replacement term.
+- New `BoolToWarningBrushConverter` — binds status text to the theme warning color so validator rejections are visible.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.Formats 0.2.65-alpha] - 2026-06-06
+**Branch**: `trebuchet/sprint/data-loss-marlinspike` | **PR**: #2387
+
+### ResRefValidator: clearer rejection messages (#2182)
+
+- Length error now suggests a 16-char truncation; the invalid-character error names the offending characters instead of only restating the rule.
+
+---
+
+## [Radoub.UI 0.2.2-alpha] - 2026-06-06
+**Branch**: `trebuchet/sprint/data-loss-marlinspike` | **PR**: #2387
+
+### Batch-replace preview value (#2224)
+
+- `PendingChange.ComputedNewFieldValue` exposes the post-replace field value (literal substring substitution, no case folding) so replace previews can show the real result instead of the bare replacement term.
+
+---
+
 ## [Radoub.UI 0.2.1-alpha] - 2026-06-06
 **Branch**: `reliquary/sprint/epic-2289-followups` | **PR**: #2377
 

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefValidatorTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Rename/ResRefValidatorTests.cs
@@ -55,6 +55,32 @@ public class ResRefValidatorTests
         Assert.Contains("lowercase letters, digits, and underscores", result.Error);
     }
 
+    // #2182 — length error should suggest a 16-char truncation the user can use.
+    [Fact]
+    public void Validate_TooLong_ErrorSuggestsTruncatedName()
+    {
+        var validator = new ResRefValidator();
+        var result = validator.Validate("longitem_blueprint_extra", new HashSet<string>(), ".uti");
+        Assert.False(result.IsValid);
+        Assert.NotNull(result.Error);
+        // Suggests the first 16 characters of the normalized name.
+        Assert.Contains("longitem_bluepri", result.Error);
+    }
+
+    // #2182 — char error should name the offending characters, not just the rule.
+    [Theory]
+    [InlineData("louis-roumain", "'-'")]
+    [InlineData("louis roumain", "space")]
+    [InlineData("louis@home", "'@'")]
+    public void Validate_InvalidCharacters_ErrorNamesTheBadChars(string input, string badCharText)
+    {
+        var validator = new ResRefValidator();
+        var result = validator.Validate(input, new HashSet<string>(), ".dlg");
+        Assert.False(result.IsValid);
+        Assert.NotNull(result.Error);
+        Assert.Contains(badCharText, result.Error);
+    }
+
     [Fact]
     public void Validate_StartsWithDigit_ReturnsOkWithWarning()
     {

--- a/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefValidator.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefValidator.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace Radoub.Formats.Search.Rename;
 
 /// <summary>
@@ -37,11 +39,19 @@ public class ResRefValidator
 
         if (normalized.Length > MaxLength)
             return ResRefValidationResult.Fail(
-                $"ResRef '{normalized}' is {normalized.Length} characters ({MaxLength} max)");
+                $"ResRef '{normalized}' is {normalized.Length} characters ({MaxLength} max). " +
+                $"Try '{normalized[..MaxLength]}'.");
 
         if (!System.Text.RegularExpressions.Regex.IsMatch(normalized, @"^[a-z0-9_]+$"))
+        {
+            var badChars = normalized
+                .Where(c => !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_'))
+                .Distinct()
+                .Select(c => c == ' ' ? "space" : $"'{c}'");
             return ResRefValidationResult.Fail(
-                "ResRef can only contain lowercase letters, digits, and underscores");
+                $"ResRef can only contain lowercase letters, digits, and underscores. " +
+                $"Remove: {string.Join(", ", badChars)}");
+        }
 
         string? warning = null;
         if (char.IsDigit(normalized[0]))

--- a/Radoub.UI/Radoub.UI.Tests/BoolToWarningBrushConverterTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/BoolToWarningBrushConverterTests.cs
@@ -1,0 +1,39 @@
+using Avalonia;
+using Avalonia.Media;
+using Radoub.UI.Converters;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// #2182: status-text warning color. True → a concrete warning brush; non-warning
+/// → no override (UnsetValue or a resolved default), never the warning brush.
+/// </summary>
+public class BoolToWarningBrushConverterTests
+{
+    private readonly BoolToWarningBrushConverter _converter = new();
+
+    [Fact]
+    public void Convert_True_ReturnsBrush()
+    {
+        var result = _converter.Convert(true, typeof(IBrush), null, null!);
+        Assert.IsAssignableFrom<IBrush>(result);
+    }
+
+    [Fact]
+    public void Convert_False_DoesNotReturnWarningBrush()
+    {
+        // No app/theme in the test host → resource lookup misses → UnsetValue.
+        // The key guarantee: false never yields a warning brush.
+        var warning = _converter.Convert(true, typeof(IBrush), null, null!);
+        var notWarning = _converter.Convert(false, typeof(IBrush), null, null!);
+        Assert.NotEqual(warning, notWarning);
+    }
+
+    [Fact]
+    public void Convert_NonBool_DoesNotReturnWarningBrush()
+    {
+        var result = _converter.Convert("not a bool", typeof(IBrush), null, null!);
+        Assert.Equal(AvaloniaProperty.UnsetValue, result);
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/Services/Search/PendingChangeComputedValueTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/Search/PendingChangeComputedValueTests.cs
@@ -1,0 +1,87 @@
+using Radoub.Formats.Search;
+using Radoub.UI.Services.Search;
+using Xunit;
+
+namespace Radoub.UI.Tests.Services.Search;
+
+/// <summary>
+/// #2224: ReplacePreviewWindow showed the bare replacement term instead of the
+/// substring-substituted field value. PendingChange.ComputedNewFieldValue produces
+/// the same result the write path produces (literal substitution at the match
+/// offset) so the preview matches reality. No lowercasing — the write path
+/// (SearchProviderBase.ReplaceInString) does not lowercase.
+/// </summary>
+public class PendingChangeComputedValueTests
+{
+    private static FieldDefinition Field(SearchFieldType type = SearchFieldType.Text) =>
+        new()
+        {
+            Name = "FirstName",
+            GffPath = "FirstName",
+            FieldType = type,
+            Category = SearchFieldCategory.Content
+        };
+
+    private static PendingChange Change(string fullValue, int offset, int length, string replacement,
+        SearchFieldType type = SearchFieldType.Text) =>
+        new()
+        {
+            Match = new SearchMatch
+            {
+                Field = Field(type),
+                MatchedText = fullValue.Substring(offset, length),
+                FullFieldValue = fullValue,
+                MatchOffset = offset,
+                MatchLength = length
+            },
+            ReplacementText = replacement,
+            FilePath = "x.utc"
+        };
+
+    [Fact]
+    public void Substitutes_match_within_field_not_whole_field()
+    {
+        // "Louis Romain", match "Louis" (0..5) -> "lewie"
+        var change = Change("Louis Romain", 0, 5, "lewie");
+        Assert.Equal("lewie Romain", change.ComputedNewFieldValue);
+    }
+
+    [Fact]
+    public void Substitutes_match_in_middle_of_field()
+    {
+        // "There is also Louis. The locals..." match "Louis" at 14
+        var full = "There is also Louis. The locals tell me...";
+        var change = Change(full, 14, 5, "lewie");
+        Assert.Equal("There is also lewie. The locals tell me...", change.ComputedNewFieldValue);
+    }
+
+    [Fact]
+    public void Substitutes_match_with_trailing_text_no_space()
+    {
+        // "LouisROMAIN" match "Louis" -> "lewieROMAIN"
+        var change = Change("LouisROMAIN", 0, 5, "lewie");
+        Assert.Equal("lewieROMAIN", change.ComputedNewFieldValue);
+    }
+
+    [Fact]
+    public void Whole_field_match_replaces_entire_value()
+    {
+        var change = Change("Louis", 0, 5, "lewie");
+        Assert.Equal("lewie", change.ComputedNewFieldValue);
+    }
+
+    [Fact]
+    public void Preserves_case_does_not_lowercase()
+    {
+        // Write path does not lowercase; preview must match reality.
+        var change = Change("Louis Romain", 0, 5, "Lewie");
+        Assert.Equal("Lewie Romain", change.ComputedNewFieldValue);
+    }
+
+    [Fact]
+    public void Empty_replacement_deletes_the_match()
+    {
+        var change = Change("Louis Romain", 0, 6, "");
+        Assert.Equal("Romain", change.ComputedNewFieldValue);
+    }
+}

--- a/Radoub.UI/Radoub.UI/Converters/BoolToWarningBrushConverter.cs
+++ b/Radoub.UI/Radoub.UI/Converters/BoolToWarningBrushConverter.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using Radoub.UI.Services;
+
+namespace Radoub.UI.Converters;
+
+/// <summary>
+/// Converts a bool to a foreground brush for status text. True = theme warning
+/// brush (so validator rejections stand out, #2182); False = the normal
+/// medium-emphasis foreground. ConverterParameter optionally overrides the
+/// "normal" theme resource key (default SystemControlForegroundBaseMediumBrush).
+/// Uses BrushManager / theme resources so the color follows the active theme.
+/// </summary>
+public class BoolToWarningBrushConverter : IValueConverter
+{
+    public static readonly BoolToWarningBrushConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is bool isWarning && isWarning)
+            return BrushManager.GetWarningBrush();
+
+        var normalKey = parameter as string ?? "SystemControlForegroundBaseMediumBrush";
+        if (Application.Current?.Resources.TryGetResource(normalKey, Application.Current.ActualThemeVariant, out var res) == true
+            && res is IBrush brush)
+            return brush;
+        return AvaloniaProperty.UnsetValue;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Radoub.UI/Radoub.UI/Services/Search/Models/BatchReplaceModels.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/Models/BatchReplaceModels.cs
@@ -18,6 +18,28 @@ public class PendingChange
 
     /// <summary>User can toggle individual changes on/off</summary>
     public bool IsSelected { get; set; } = true;
+
+    /// <summary>
+    /// The full field value after the replacement is applied — the same literal
+    /// substring substitution the write path performs
+    /// (SearchProviderBase.ReplaceInString): splice ReplacementText in at the match
+    /// offset, leaving the rest of the field intact. Used by the Replace Preview so
+    /// it shows the real post-replace value, not the bare replacement term (#2224).
+    /// No case folding: the write path does not lowercase, so neither does the preview.
+    /// </summary>
+    public string ComputedNewFieldValue
+    {
+        get
+        {
+            var full = Match.FullFieldValue;
+            var start = Match.MatchOffset;
+            var end = Match.MatchOffset + Match.MatchLength;
+            // Defensive: a malformed match offset/length must not throw in the UI.
+            if (start < 0 || end > full.Length || start > end)
+                return ReplacementText;
+            return full[..start] + ReplacementText + full[end..];
+        }
+    }
 }
 
 /// <summary>

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.36.9-alpha] - 2026-06-06
+**Branch**: `trebuchet/sprint/data-loss-marlinspike` | **PR**: #TBD
+
+### Sprint: Critical Data Loss + Marlinspike Polish
+
+- Investigating script-loss after Relique delete + Trebuchet save (#2344, deferred).
+- Marlinspike replace-preview now shows the substituted value, not raw replacement text (#2224).
+- Marlinspike results support multi-select with checkboxes for rename scope (#2179).
+- Clearer Marlinspike validator error wording (#2182).
+
+---
+
 ## [1.36.8-alpha] - 2026-06-04
 **Branch**: `trebuchet/sprint/compile-marlinspike-scope` | **PR**: #2345
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [1.36.9-alpha] - 2026-06-06
-**Branch**: `trebuchet/sprint/data-loss-marlinspike` | **PR**: #TBD
+**Branch**: `trebuchet/sprint/data-loss-marlinspike` | **PR**: #2387
 
 ### Sprint: Critical Data Loss + Marlinspike Polish
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -11,10 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Sprint: Critical Data Loss + Marlinspike Polish
 
-- Investigating script-loss after Relique delete + Trebuchet save (#2344, deferred).
-- Marlinspike replace-preview now shows the substituted value, not raw replacement text (#2224).
-- Marlinspike results support multi-select with checkboxes for rename scope (#2179).
-- Clearer Marlinspike validator error wording (#2182).
+- Marlinspike replace-preview now shows the substituted field value, not the raw replacement term (#2224).
+- Marlinspike results gained checkbox-per-row rename scope with tri-state group cascade (#2179).
+- Clearer Marlinspike validator error wording — suggested truncation and named invalid characters (#2182).
+- Script-loss after Relique delete + Trebuchet save (#2344): investigated, deferred (likely a stale external working directory; left open for in-the-act capture).
 
 ---
 

--- a/Trebuchet/Trebuchet.Tests/MarlinspikePanelViewModelTests.cs
+++ b/Trebuchet/Trebuchet.Tests/MarlinspikePanelViewModelTests.cs
@@ -44,6 +44,30 @@ public class MarlinspikePanelViewModelTests
         Assert.Equal("All Fields", vm.SelectedCategory);
         Assert.False(vm.IsSearching);
         Assert.Equal("Ready", vm.StatusText);
+        Assert.False(vm.StatusIsWarning);
+    }
+
+    // #2182 — validator-rejection status must render in the warning color so it's
+    // visible. SetWarningStatus flags it; any later plain StatusText set clears it.
+    [Fact]
+    public void SetWarningStatus_SetsTextAndWarningFlag()
+    {
+        var vm = new MarlinspikePanelViewModel();
+        vm.SetWarningStatus("Rename skipped — 'foo' has invalid char '-'");
+
+        Assert.Equal("Rename skipped — 'foo' has invalid char '-'", vm.StatusText);
+        Assert.True(vm.StatusIsWarning);
+    }
+
+    [Fact]
+    public void PlainStatusText_ClearsWarningFlag()
+    {
+        var vm = new MarlinspikePanelViewModel();
+        vm.SetWarningStatus("bad");
+        Assert.True(vm.StatusIsWarning);
+
+        vm.StatusText = "Ready";
+        Assert.False(vm.StatusIsWarning);
     }
 
     [Fact]

--- a/Trebuchet/Trebuchet.Tests/RenameDispatchHelpersTests.cs
+++ b/Trebuchet/Trebuchet.Tests/RenameDispatchHelpersTests.cs
@@ -132,6 +132,39 @@ public class RenameDispatchHelpersTests : IDisposable
         Assert.Empty(plans);  // validator rejects > 16 chars; plan skipped
     }
 
+    // #2182 — rejected entries report the specific validator reason so the UI can
+    // show actionable text instead of "validator rejected all proposed names".
+    [Fact]
+    public void BuildRenamePlansFromPreview_CapturesRejectionReasons()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "valid_name.dlg"), "x");
+
+        var preview = new BatchReplacePreview();
+        preview.Changes.Add(new PendingChange
+        {
+            Match = new SearchMatch
+            {
+                Field = FilenameSearchProvider.FilenameField,
+                MatchedText = "valid_name",
+                FullFieldValue = "valid_name",
+                MatchOffset = 0,
+                MatchLength = "valid_name".Length,
+                Location = "test"
+            },
+            ReplacementText = "bad-name",  // hyphen → invalid chars
+            FilePath = Path.Combine(_tempDir, "valid_name.dlg")
+        });
+
+        var reasons = new List<string>();
+        var plans = RenameDispatchHelpers.BuildRenamePlansFromPreview(
+            preview, _tempDir, new ResRefValidator(), reasons);
+
+        Assert.Empty(plans);
+        Assert.Single(reasons);
+        Assert.Contains("'-'", reasons[0]);            // names the bad char (#2182)
+        Assert.Contains("bad-name", reasons[0]);       // names the offending file/name
+    }
+
     [Fact]
     public void BuildRenamePlansFromPreview_BuildsValidPlanForSimpleRename()
     {

--- a/Trebuchet/Trebuchet.Tests/RenameScopeSelectionTests.cs
+++ b/Trebuchet/Trebuchet.Tests/RenameScopeSelectionTests.cs
@@ -1,0 +1,122 @@
+using RadoubLauncher.Services;
+using Xunit;
+
+namespace Trebuchet.Tests;
+
+/// <summary>
+/// #2179: checkbox-per-row rename scope. RenameScopeSelection is the pure model
+/// behind the Marlinspike results-tree checkboxes — tri-state group cascade and the
+/// checked-file set that feeds the rename selectionFilter. Tested without FlaUI.
+/// </summary>
+public class RenameScopeSelectionTests
+{
+    private static RenameScopeSelection TwoGroups()
+    {
+        var sel = new RenameScopeSelection();
+        sel.AddFile("uti", "a.uti");
+        sel.AddFile("uti", "b.uti");
+        sel.AddFile("utc", "c.utc");
+        return sel;
+    }
+
+    [Fact]
+    public void Files_start_checked_by_default()
+    {
+        var sel = TwoGroups();
+        Assert.True(sel.IsFileChecked("a.uti"));
+        Assert.Equal(3, sel.SelectedFilePaths.Count);
+        Assert.True(sel.HasSelection);
+    }
+
+    [Fact]
+    public void Can_add_file_unchecked()
+    {
+        var sel = new RenameScopeSelection();
+        sel.AddFile("uti", "a.uti", isChecked: false);
+        Assert.False(sel.IsFileChecked("a.uti"));
+        Assert.Empty(sel.SelectedFilePaths);
+        Assert.False(sel.HasSelection);
+    }
+
+    [Fact]
+    public void Unchecking_one_file_drops_it_from_selection()
+    {
+        var sel = TwoGroups();
+        sel.SetFileChecked("b.uti", false);
+        Assert.False(sel.SelectedFilePaths.Contains("b.uti"));
+        Assert.Contains("a.uti", sel.SelectedFilePaths);
+        Assert.Contains("c.utc", sel.SelectedFilePaths);
+    }
+
+    [Fact]
+    public void Group_all_checked_when_every_child_checked()
+    {
+        var sel = TwoGroups();
+        Assert.Equal(GroupCheckState.All, sel.GetGroupState("uti"));
+    }
+
+    [Fact]
+    public void Group_partial_when_some_children_checked()
+    {
+        var sel = TwoGroups();
+        sel.SetFileChecked("a.uti", false);
+        Assert.Equal(GroupCheckState.Partial, sel.GetGroupState("uti"));
+    }
+
+    [Fact]
+    public void Group_none_when_no_children_checked()
+    {
+        var sel = TwoGroups();
+        sel.SetFileChecked("a.uti", false);
+        sel.SetFileChecked("b.uti", false);
+        Assert.Equal(GroupCheckState.None, sel.GetGroupState("uti"));
+    }
+
+    [Fact]
+    public void Group_cascade_unchecks_all_children()
+    {
+        var sel = TwoGroups();
+        sel.SetGroupChecked("uti", false);
+        Assert.False(sel.IsFileChecked("a.uti"));
+        Assert.False(sel.IsFileChecked("b.uti"));
+        Assert.True(sel.IsFileChecked("c.utc")); // other group untouched
+        Assert.Equal(GroupCheckState.None, sel.GetGroupState("uti"));
+    }
+
+    [Fact]
+    public void Group_cascade_rechecks_all_children()
+    {
+        var sel = TwoGroups();
+        sel.SetGroupChecked("uti", false);
+        sel.SetGroupChecked("uti", true);
+        Assert.Equal(GroupCheckState.All, sel.GetGroupState("uti"));
+    }
+
+    [Fact]
+    public void SetAll_toggles_every_group()
+    {
+        var sel = TwoGroups();
+        sel.SetAllChecked(false);
+        Assert.Empty(sel.SelectedFilePaths);
+        Assert.False(sel.HasSelection);
+        sel.SetAllChecked(true);
+        Assert.Equal(3, sel.SelectedFilePaths.Count);
+    }
+
+    [Fact]
+    public void Selection_is_case_insensitive_for_file_paths()
+    {
+        var sel = new RenameScopeSelection();
+        sel.AddFile("uti", "Item.uti");
+        sel.SetFileChecked("ITEM.UTI", false);
+        Assert.False(sel.IsFileChecked("item.uti"));
+        Assert.Empty(sel.SelectedFilePaths);
+    }
+
+    [Fact]
+    public void Unknown_group_state_is_none()
+    {
+        var sel = TwoGroups();
+        Assert.Equal(GroupCheckState.None, sel.GetGroupState("dlg"));
+    }
+}

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml
@@ -1,8 +1,13 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:RadoubLauncher.ViewModels"
+             xmlns:conv="using:Radoub.UI.Converters"
              x:Class="RadoubLauncher.Controls.MarlinspikePanel"
              x:DataType="vm:MarlinspikePanelViewModel">
+
+    <UserControl.Resources>
+        <conv:BoolToWarningBrushConverter x:Key="WarningBrushConverter"/>
+    </UserControl.Resources>
 
     <Grid RowDefinitions="Auto,Auto,*,Auto">
 
@@ -114,7 +119,7 @@
                              IsVisible="{Binding ShowProgress}"/>
                 <TextBlock Text="{Binding StatusText}"
                            VerticalAlignment="Center"
-                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                           Foreground="{Binding StatusIsWarning, Converter={StaticResource WarningBrushConverter}}"/>
             </DockPanel>
         </Border>
 

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
@@ -609,11 +609,16 @@ public partial class MarlinspikePanel : UserControl
         }
 
         var validator = new ResRefValidator();
-        var plans = RenameDispatchHelpers.BuildRenamePlansFromPreview(preview, moduleDir, validator);
+        var rejected = new List<string>();
+        var plans = RenameDispatchHelpers.BuildRenamePlansFromPreview(preview, moduleDir, validator, rejected);
 
         if (plans.Count == 0)
         {
-            _viewModel.StatusText = "Rename skipped — no valid filename targets (validator rejected all proposed names).";
+            // Surface the specific validator reason (suggested truncation / named bad
+            // chars) instead of a generic "all rejected" line (#2182).
+            _viewModel.StatusText = rejected.Count > 0
+                ? $"Rename skipped — {rejected[0]}"
+                : "Rename skipped — no valid filename targets.";
             return;
         }
 

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
@@ -212,7 +212,7 @@ public partial class MarlinspikePanel : UserControl
         var validationError = criteria.Validate();
         if (validationError != null)
         {
-            _viewModel.StatusText = $"Invalid pattern: {validationError}";
+            _viewModel.SetWarningStatus($"Invalid pattern: {validationError}");
             return;
         }
 
@@ -615,10 +615,10 @@ public partial class MarlinspikePanel : UserControl
         if (plans.Count == 0)
         {
             // Surface the specific validator reason (suggested truncation / named bad
-            // chars) instead of a generic "all rejected" line (#2182).
-            _viewModel.StatusText = rejected.Count > 0
+            // chars) in the warning color so it's visible (#2182).
+            _viewModel.SetWarningStatus(rejected.Count > 0
                 ? $"Rename skipped — {rejected[0]}"
-                : "Rename skipped — no valid filename targets.";
+                : "Rename skipped — no valid filename targets.");
             return;
         }
 

--- a/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/MarlinspikePanel.axaml.cs
@@ -34,6 +34,13 @@ public partial class MarlinspikePanel : UserControl
     private DateTime? _indexedModuleDirMtime;
     private string? _indexedModuleDirPath;
 
+    // #2179 — checkbox-per-row rename scope. The pure model owns the tri-state /
+    // cascade rules; these lists let us sync the visual checkbox controls when a
+    // group cascade or a child toggle changes derived state.
+    private readonly RenameScopeSelection _scopeSelection = new();
+    private readonly List<(CheckBox Box, string GroupKey)> _groupCheckBoxes = new();
+    private readonly List<(CheckBox Box, string FilePath, string GroupKey)> _fileCheckBoxes = new();
+
     /// <summary>Maps resource types to Trebuchet tool names for launch dispatch.</summary>
     private static readonly Dictionary<ushort, string> ResourceTypeToToolName = new()
     {
@@ -261,25 +268,52 @@ public partial class MarlinspikePanel : UserControl
             return;
         }
 
+        // Reset the rename-scope model + checkbox tracking for this fresh result set.
+        ResetScopeSelection();
+
         var treeItems = new List<TreeViewItem>();
         var grouped = results.GroupByExtension();
 
         foreach (var (extension, files) in grouped.OrderBy(g => g.Key))
         {
             var totalMatches = files.Sum(f => f.MatchCount);
+
+            // Group-row checkbox: tri-state, cascades to all file rows under it (#2179).
+            var groupCheckBox = new CheckBox
+            {
+                Content = $"{GetFileTypeLabel(extension)} (.{extension}) \u2014 {files.Count} file{(files.Count != 1 ? "s" : "")}, {totalMatches} match{(totalMatches != 1 ? "es" : "")}",
+                IsChecked = true,
+                IsThreeState = true,
+                Tag = extension
+            };
+            groupCheckBox.IsCheckedChanged += OnGroupCheckChanged;
+            _groupCheckBoxes.Add((groupCheckBox, extension));
+
             var groupNode = new TreeViewItem
             {
-                Header = $"{GetFileTypeLabel(extension)} (.{extension}) \u2014 {files.Count} file{(files.Count != 1 ? "s" : "")}, {totalMatches} match{(totalMatches != 1 ? "es" : "")}",
+                Header = groupCheckBox,
                 IsExpanded = true
             };
 
             foreach (var fileResult in files.OrderBy(f => f.FileName))
             {
-                var fileNode = new TreeViewItem
+                // File-row checkbox: drives the scope model; default checked.
+                _scopeSelection.AddFile(extension, fileResult.FilePath, isChecked: true);
+
+                var fileCheckBox = new CheckBox
                 {
-                    Header = fileResult.HadParseError
+                    Content = fileResult.HadParseError
                         ? $"{fileResult.FileName} \u2014 \u26a0 {fileResult.ParseError}"
                         : $"{fileResult.FileName} \u2014 {fileResult.MatchCount} match{(fileResult.MatchCount != 1 ? "es" : "")}",
+                    IsChecked = true,
+                    Tag = fileResult
+                };
+                fileCheckBox.IsCheckedChanged += OnFileCheckChanged;
+                _fileCheckBoxes.Add((fileCheckBox, fileResult.FilePath, extension));
+
+                var fileNode = new TreeViewItem
+                {
+                    Header = fileCheckBox,
                     Tag = fileResult,
                     IsExpanded = true
                 };
@@ -319,6 +353,73 @@ public partial class MarlinspikePanel : UserControl
         }
 
         ResultsTree.ItemsSource = treeItems;
+    }
+
+    private void ResetScopeSelection()
+    {
+        foreach (var (box, _) in _groupCheckBoxes)
+            box.IsCheckedChanged -= OnGroupCheckChanged;
+        foreach (var (box, _, _) in _fileCheckBoxes)
+            box.IsCheckedChanged -= OnFileCheckChanged;
+        _groupCheckBoxes.Clear();
+        _fileCheckBoxes.Clear();
+        _scopeSelection.Clear();
+    }
+
+    // File-row checkbox toggled → update model, then re-derive the parent group's
+    // tri-state so the group checkbox reflects partial/all/none (#2179).
+    private void OnFileCheckChanged(object? sender, RoutedEventArgs e)
+    {
+        if (sender is not CheckBox box || box.Tag is not FileSearchResult fileResult)
+            return;
+
+        _scopeSelection.SetFileChecked(fileResult.FilePath, box.IsChecked == true);
+
+        var entry = _fileCheckBoxes.FirstOrDefault(f => ReferenceEquals(f.Box, box));
+        if (entry.GroupKey != null)
+            SyncGroupCheckBox(entry.GroupKey);
+    }
+
+    // Group-row checkbox toggled by the user → cascade to every child file row.
+    // Tri-state (null) is a display-only state the user can't set directly: a click
+    // moves null→checked, so treat anything non-false as "check all".
+    private void OnGroupCheckChanged(object? sender, RoutedEventArgs e)
+    {
+        if (sender is not CheckBox box || box.Tag is not string groupKey)
+            return;
+
+        // Ignore programmatic tri-state updates we push from SyncGroupCheckBox.
+        if (box.IsChecked == null) return;
+
+        var check = box.IsChecked == true;
+        _scopeSelection.SetGroupChecked(groupKey, check);
+
+        foreach (var (childBox, _, childGroup) in _fileCheckBoxes)
+        {
+            if (childGroup != groupKey) continue;
+            childBox.IsCheckedChanged -= OnFileCheckChanged;
+            childBox.IsChecked = check;
+            childBox.IsCheckedChanged += OnFileCheckChanged;
+        }
+    }
+
+    // Push the model's derived tri-state onto the group checkbox without retriggering
+    // the cascade handler.
+    private void SyncGroupCheckBox(string groupKey)
+    {
+        var entry = _groupCheckBoxes.FirstOrDefault(g => g.GroupKey == groupKey);
+        if (entry.Box == null) return;
+
+        bool? state = _scopeSelection.GetGroupState(groupKey) switch
+        {
+            GroupCheckState.All => true,
+            GroupCheckState.None => false,
+            _ => null
+        };
+
+        entry.Box.IsCheckedChanged -= OnGroupCheckChanged;
+        entry.Box.IsChecked = state;
+        entry.Box.IsCheckedChanged += OnGroupCheckChanged;
     }
 
     private void OnResultDoubleTapped(object? sender, TappedEventArgs e)
@@ -431,7 +532,7 @@ public partial class MarlinspikePanel : UserControl
         {
             if (_viewModel != null)
                 _viewModel.StatusText =
-                    "Select a row first (click a file, match, or group), then click Replace Selected. Or use Replace All.";
+                    "Check at least one file (or a group) in the results, then click Replace Selected. Or use Replace All.";
             return;
         }
 
@@ -439,45 +540,13 @@ public partial class MarlinspikePanel : UserControl
     }
 
     /// <summary>
-    /// Get file paths for the user's tree selection. The tree is populated
-    /// programmatically with raw TreeViewItem instances that carry their row
-    /// data in the .Tag property (FileSearchResult, MatchInfo, or null for
-    /// group nodes). Inherited DataContext is the panel VM, so we read .Tag
-    /// directly — same pattern OnResultDoubleTapped uses.
-    ///
-    /// Selecting a file row → that file.
-    /// Selecting a match row → its parent file.
-    /// Selecting a group row → every file under that group.
+    /// File paths the user checked for "Replace Selected" (#2179). The checked set
+    /// is authoritative — tree highlight drives navigation (double-click to open),
+    /// not rename scope. Group-row checkboxes cascade to their files via the scope
+    /// model, so checking a group is equivalent to checking each of its files.
     /// </summary>
-    private HashSet<string> GetSelectedFilePaths()
-    {
-        var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        if (ResultsTree.SelectedItem is not Avalonia.Controls.TreeViewItem item)
-            return paths;
-
-        switch (item.Tag)
-        {
-            case MatchInfo matchInfo:
-                paths.Add(matchInfo.FilePath);
-                break;
-            case FileSearchResult fileResult:
-                paths.Add(fileResult.FilePath);
-                break;
-            default:
-                // Group node (no Tag) — walk its child file-result items.
-                foreach (var child in item.Items)
-                {
-                    if (child is Avalonia.Controls.TreeViewItem childItem
-                        && childItem.Tag is FileSearchResult childFile)
-                    {
-                        paths.Add(childFile.FilePath);
-                    }
-                }
-                break;
-        }
-        return paths;
-    }
+    private HashSet<string> GetSelectedFilePaths() =>
+        _scopeSelection.SelectedFilePaths.ToHashSet(StringComparer.OrdinalIgnoreCase);
 
     private async Task OpenReplacePreviewAsync(IReadOnlySet<string>? selectionFilter)
     {
@@ -688,6 +757,7 @@ public partial class MarlinspikePanel : UserControl
         {
             _viewModel.StatusText = $"Replaced {result.ReplacementsMade} matches in {result.FilesModified} files. Backup created.";
             _viewModel.ClearResults();
+            ResetScopeSelection();
             ResultsTree.ItemsSource = null;
         }
         else
@@ -706,6 +776,7 @@ public partial class MarlinspikePanel : UserControl
         _indexedModuleDirMtime = null;
         _indexedModuleDirPath = null;
         _viewModel?.ClearResults();
+        ResetScopeSelection();
         ResultsTree.ItemsSource = null;
         DurationText.Text = "";
         ModulePathText.Text = "";

--- a/Trebuchet/Trebuchet/Services/RenameDispatchHelpers.cs
+++ b/Trebuchet/Trebuchet/Services/RenameDispatchHelpers.cs
@@ -36,8 +36,14 @@ public static class RenameDispatchHelpers
     /// Skips entries whose validator result is invalid. Caller is responsible
     /// for surfacing skipped entries to the user (e.g., via status bar).
     /// </summary>
+    /// <param name="rejectedReasons">
+    /// Optional sink: each skipped entry appends a user-facing reason ("name" — error)
+    /// so the caller can show the specific validator message instead of a generic
+    /// "all rejected" line (#2182).
+    /// </param>
     public static IReadOnlyList<ResRefRenamePlan> BuildRenamePlansFromPreview(
-        BatchReplacePreview preview, string moduleDir, ResRefValidator validator)
+        BatchReplacePreview preview, string moduleDir, ResRefValidator validator,
+        ICollection<string>? rejectedReasons = null)
     {
         if (preview == null) return Array.Empty<ResRefRenamePlan>();
         if (string.IsNullOrEmpty(moduleDir)) return Array.Empty<ResRefRenamePlan>();
@@ -73,7 +79,8 @@ public static class RenameDispatchHelpers
             if (!validation.IsValid)
             {
                 // Skip invalid entries — caller may inspect plans count vs preview filename count
-                // to surface a status message.
+                // to surface a status message. Capture the specific reason for #2182.
+                rejectedReasons?.Add($"\"{proposedNewName}\" — {validation.Error}");
                 continue;
             }
 

--- a/Trebuchet/Trebuchet/Services/RenameScopeSelection.cs
+++ b/Trebuchet/Trebuchet/Services/RenameScopeSelection.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RadoubLauncher.Services;
+
+/// <summary>
+/// Tri-state for a group (extension) checkbox in the Marlinspike results tree (#2179).
+/// </summary>
+public enum GroupCheckState
+{
+    /// <summary>No files under the group are checked.</summary>
+    None,
+    /// <summary>Some but not all files under the group are checked.</summary>
+    Partial,
+    /// <summary>All files under the group are checked.</summary>
+    All
+}
+
+/// <summary>
+/// Pure selection model for the Marlinspike results tree's checkbox-per-row rename
+/// scope (#2179). The view binds checkboxes to this model and reads
+/// <see cref="SelectedFilePaths"/> when the user clicks "Replace Selected" — no
+/// dependence on tree highlight. Kept free of any Avalonia type so the cascade and
+/// tri-state rules are unit-testable without FlaUI.
+///
+/// Files are grouped by an arbitrary group key (the file extension in the UI). Each
+/// file path is unique within the model; checking a group checks every file under it,
+/// and the group's tri-state is derived from its files.
+/// </summary>
+public sealed class RenameScopeSelection
+{
+    // group key -> file paths (insertion order preserved for stable UI).
+    private readonly Dictionary<string, List<string>> _groups = new();
+    // file path -> checked. Case-insensitive to match Aurora filename handling.
+    private readonly Dictionary<string, bool> _checked = new(StringComparer.OrdinalIgnoreCase);
+    // file path -> group key, for fast group lookup on a per-file toggle.
+    private readonly Dictionary<string, string> _fileGroup = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Register a file under a group. Default checked state is true (every result
+    /// starts selected, matching the prior "Replace All by default" expectation).
+    /// Re-adding the same path is a no-op for grouping but resets its checked state.
+    /// </summary>
+    public void AddFile(string groupKey, string filePath, bool isChecked = true)
+    {
+        if (string.IsNullOrEmpty(groupKey)) throw new ArgumentException("groupKey required", nameof(groupKey));
+        if (string.IsNullOrEmpty(filePath)) throw new ArgumentException("filePath required", nameof(filePath));
+
+        if (!_groups.TryGetValue(groupKey, out var list))
+        {
+            list = new List<string>();
+            _groups[groupKey] = list;
+        }
+        if (!_fileGroup.ContainsKey(filePath))
+        {
+            list.Add(filePath);
+            _fileGroup[filePath] = groupKey;
+        }
+        _checked[filePath] = isChecked;
+    }
+
+    /// <summary>Set the checked state of a single file row.</summary>
+    public void SetFileChecked(string filePath, bool isChecked)
+    {
+        if (_checked.ContainsKey(filePath))
+            _checked[filePath] = isChecked;
+    }
+
+    /// <summary>Check/uncheck every file under a group (group-checkbox cascade).</summary>
+    public void SetGroupChecked(string groupKey, bool isChecked)
+    {
+        if (!_groups.TryGetValue(groupKey, out var list)) return;
+        foreach (var path in list)
+            _checked[path] = isChecked;
+    }
+
+    /// <summary>Check/uncheck every file in every group (select-all / deselect-all).</summary>
+    public void SetAllChecked(bool isChecked)
+    {
+        foreach (var path in _checked.Keys.ToList())
+            _checked[path] = isChecked;
+    }
+
+    /// <summary>Current checked state of one file (false if unknown).</summary>
+    public bool IsFileChecked(string filePath) =>
+        _checked.TryGetValue(filePath, out var v) && v;
+
+    /// <summary>Derived tri-state for a group's checkbox.</summary>
+    public GroupCheckState GetGroupState(string groupKey)
+    {
+        if (!_groups.TryGetValue(groupKey, out var list) || list.Count == 0)
+            return GroupCheckState.None;
+
+        var checkedCount = list.Count(p => _checked.TryGetValue(p, out var v) && v);
+        if (checkedCount == 0) return GroupCheckState.None;
+        if (checkedCount == list.Count) return GroupCheckState.All;
+        return GroupCheckState.Partial;
+    }
+
+    /// <summary>
+    /// The set of checked file paths — the rename scope. Feeds the existing
+    /// selectionFilter consumed by OpenReplacePreviewAsync / RenameDispatchHelpers.
+    /// </summary>
+    public IReadOnlySet<string> SelectedFilePaths =>
+        _checked.Where(kv => kv.Value)
+                .Select(kv => kv.Key)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>True when at least one file is checked.</summary>
+    public bool HasSelection => _checked.Values.Any(v => v);
+
+    /// <summary>Drop all groups and files (called when the results tree is rebuilt).</summary>
+    public void Clear()
+    {
+        _groups.Clear();
+        _checked.Clear();
+        _fileGroup.Clear();
+    }
+}

--- a/Trebuchet/Trebuchet/ViewModels/MarlinspikePanelViewModel.cs
+++ b/Trebuchet/Trebuchet/ViewModels/MarlinspikePanelViewModel.cs
@@ -56,6 +56,33 @@ public partial class MarlinspikePanelViewModel : ObservableObject
     [ObservableProperty]
     private string _statusText = "Ready";
 
+    /// <summary>
+    /// True when StatusText is a warning the user must notice (e.g. a validator
+    /// rejection). The view binds the status foreground to the theme warning color
+    /// when set (#2182). Auto-cleared whenever StatusText is set by any other path.
+    /// </summary>
+    [ObservableProperty]
+    private bool _statusIsWarning;
+
+    // Guards the auto-clear so SetWarningStatus can set the text then the flag
+    // without OnStatusTextChanged immediately resetting it.
+    private bool _settingWarningStatus;
+
+    partial void OnStatusTextChanged(string value)
+    {
+        if (!_settingWarningStatus)
+            StatusIsWarning = false;
+    }
+
+    /// <summary>Set a warning-colored status message (#2182).</summary>
+    public void SetWarningStatus(string text)
+    {
+        _settingWarningStatus = true;
+        StatusText = text;
+        _settingWarningStatus = false;
+        StatusIsWarning = true;
+    }
+
     [ObservableProperty]
     private string _progressText = "";
 

--- a/Trebuchet/Trebuchet/Views/ReplacePreviewWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/ReplacePreviewWindow.axaml.cs
@@ -77,9 +77,12 @@ public partial class ReplacePreviewWindow : Window
                 var oldText = change.Match.FullFieldValue.Length > 50
                     ? change.Match.FullFieldValue[..50] + "..."
                     : change.Match.FullFieldValue;
-                var newText = change.ReplacementText.Length > 50
-                    ? change.ReplacementText[..50] + "..."
-                    : change.ReplacementText;
+                // Show the computed post-replace field value (substring substitution),
+                // not the bare replacement term (#2224).
+                var computed = change.ComputedNewFieldValue;
+                var newText = computed.Length > 50
+                    ? computed[..50] + "..."
+                    : computed;
 
                 var location = change.Match.Location?.ToString() ?? change.Match.Field.Name;
 


### PR DESCRIPTION
## Summary

Sprint #2384: Marlinspike polish + investigation of the deferred script-loss data-loss bug.

## Work Items

- #2224 — Replace Preview now shows the substituted field value, not the raw replacement term (pure UI fix).
- #2179 — Checkbox-per-row rename scope with tri-state group cascade; "Replace Selected" reads the checked set.
- #2182 — Clearer validator wording (suggested truncation, named invalid chars) rendered in the theme warning color.
- #2344 — Investigated, **deferred**: no `_`-specific code path exists; likely a stale external (Aurora Toolset) working directory packed over the .mod. Left open for in-the-act capture.

## Related Issues

- Closes #2384
- Relates to #2344 (deferred, left open)

## Tests

- Unit: Radoub.Formats 1332 ✅, Radoub.UI 946 ✅, Trebuchet.Tests 250 ✅, Radoub.Dictionary 75 ✅
- New: 6 (preview) + 11 (rename scope) + 4 (validator/dispatch) + 5 (warning color/converter)
- FlaUI (Trebuchet Workspace): 8/9 — the 1 failure (`LaunchTab_HasBuildStatusSection`) is a pre-existing scroll-timing flake in the Build & Test tab (untouched by this branch); passes on isolated re-run.
- Privacy scan ✅, tech-debt scan ✅ (no files >800 lines).

## Manual Spot-Checks

- [ ] Checkbox per file row + tri-state group row; group toggle cascades to children
- [ ] "Replace Selected" acts on checked files only; double-click still opens the editor
- [ ] Preview shows `"Louis Romain" → "lewie Romain"` (substituted), not `→ "lewie"`
- [ ] Rename to `bad-name` → warning-colored status naming `'-'`; >16-char name suggests truncation

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)