### PR TITLE
[Parley] Sprint: Settings Migration & Drag-Drop Unification (#2382)

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Parley. One-line highlights per version; full details in 
 ---
 
 ## [0.1.174-alpha] - 2026-06-06
-**Branch**: `parley/issue-2382` | **PR**: #TBD
+**Branch**: `parley/issue-2382` | **PR**: #2388
 
 ### Sprint: Settings Migration & Drag-Drop Unification (#2382)
 

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Parley. One-line highlights per version; full details in 
 - Replace reflection-based DeleteNodeRecursive trampoline (#2324)
 - Migrate ExternalEditorPath/ManifestPath onto RadoubSettings (#2357)
 - Fix drag-drop onto expanded TreeView threads (header-height drop zone)
+- Fix data loss: stale property panel overwriting wrong node after drag-drop reparent
 
 ---
 

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Parley. One-line highlights per version; full details in 
 
 ---
 
+## [0.1.174-alpha] - 2026-06-06
+**Branch**: `parley/issue-2382` | **PR**: #TBD
+
+### Sprint: Settings Migration & Drag-Drop Unification (#2382)
+
+- Unify TreeView/FlowView drag-drop validation (#2109)
+- Replace reflection-based DeleteNodeRecursive trampoline (#2324)
+- Migrate ExternalEditorPath/ManifestPath onto RadoubSettings (#2357)
+
+---
+
 ## [0.1.173-alpha] - 2026-06-05
 **Branch**: `radoub/issue-2350` | **PR**: #2351
 

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Parley. One-line highlights per version; full details in 
 - Unify TreeView/FlowView drag-drop validation (#2109)
 - Replace reflection-based DeleteNodeRecursive trampoline (#2324)
 - Migrate ExternalEditorPath/ManifestPath onto RadoubSettings (#2357)
+- Fix drag-drop onto expanded TreeView threads (header-height drop zone)
 
 ---
 

--- a/Parley/Parley.Tests/CascadeDeleteStressTests.cs
+++ b/Parley/Parley.Tests/CascadeDeleteStressTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
 using Xunit;
 using Xunit.Abstractions;
 using DialogEditor.Models;
@@ -313,10 +312,7 @@ namespace Parley.Tests
             // Act
             var sw = Stopwatch.StartNew();
 
-            var deleteMethod = typeof(MainViewModel).GetMethod("DeleteNodeRecursive",
-                BindingFlags.NonPublic | BindingFlags.Instance);
-            Assert.NotNull(deleteMethod);
-            deleteMethod.Invoke(viewModel, new object?[] { firstEntry });
+            viewModel.DeleteNodeRecursive(firstEntry);
             dialog.RemoveNodeInternal(firstEntry, firstEntry.Type);
 
             // Remove start pointer
@@ -364,10 +360,7 @@ namespace Parley.Tests
             // Act
             var sw = Stopwatch.StartNew();
 
-            var deleteMethod = typeof(MainViewModel).GetMethod("DeleteNodeRecursive",
-                BindingFlags.NonPublic | BindingFlags.Instance);
-            Assert.NotNull(deleteMethod);
-            deleteMethod.Invoke(viewModel, new object?[] { firstEntry });
+            viewModel.DeleteNodeRecursive(firstEntry);
             dialog.RemoveNodeInternal(firstEntry, firstEntry.Type);
 
             var startToRemove = dialog.Starts.FirstOrDefault(s => s.Node == firstEntry);
@@ -417,9 +410,7 @@ namespace Parley.Tests
             _output.WriteLine($"Shared reply: '{sharedReply.Text?.GetDefault()}'");
 
             // Act: Delete the main chain (but NOT the external entry)
-            var deleteMethod = typeof(MainViewModel).GetMethod("DeleteNodeRecursive",
-                BindingFlags.NonPublic | BindingFlags.Instance);
-            deleteMethod?.Invoke(viewModel, new object[] { deleteTarget });
+            viewModel.DeleteNodeRecursive(deleteTarget);
             dialog.RemoveNodeInternal(deleteTarget, deleteTarget.Type);
 
             var startToRemove = dialog.Starts.FirstOrDefault(s => s.Node == deleteTarget);
@@ -461,9 +452,7 @@ namespace Parley.Tests
             // Act
             var sw = Stopwatch.StartNew();
 
-            var deleteMethod = typeof(MainViewModel).GetMethod("DeleteNodeRecursive",
-                BindingFlags.NonPublic | BindingFlags.Instance);
-            deleteMethod?.Invoke(viewModel, new object[] { firstEntry });
+            viewModel.DeleteNodeRecursive(firstEntry);
             dialog.RemoveNodeInternal(firstEntry, firstEntry.Type);
 
             var startToRemove = dialog.Starts.FirstOrDefault(s => s.Node == firstEntry);
@@ -526,9 +515,7 @@ namespace Parley.Tests
             var firstEntry = dialog.Entries.First();
 
             sw.Restart();
-            var deleteMethod = typeof(MainViewModel).GetMethod("DeleteNodeRecursive",
-                BindingFlags.NonPublic | BindingFlags.Instance);
-            deleteMethod?.Invoke(viewModel, new object[] { firstEntry });
+            viewModel.DeleteNodeRecursive(firstEntry);
             dialog.RemoveNodeInternal(firstEntry, firstEntry.Type);
             sw.Stop();
 
@@ -563,9 +550,7 @@ namespace Parley.Tests
             var firstEntry = dialog.Entries.First();
 
             sw.Restart();
-            var deleteMethod = typeof(MainViewModel).GetMethod("DeleteNodeRecursive",
-                BindingFlags.NonPublic | BindingFlags.Instance);
-            deleteMethod?.Invoke(viewModel, new object[] { firstEntry });
+            viewModel.DeleteNodeRecursive(firstEntry);
             dialog.RemoveNodeInternal(firstEntry, firstEntry.Type);
             sw.Stop();
 

--- a/Parley/Parley.Tests/DeleteDeepTreeTests.cs
+++ b/Parley/Parley.Tests/DeleteDeepTreeTests.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Xunit;
 using DialogEditor.Models;
 using DialogEditor.ViewModels;
-using System.Reflection;
 
 namespace Parley.Tests
 {
@@ -109,11 +108,8 @@ namespace Parley.Tests
             int initialReplies = dialog.Replies.Count;
 
             // Act - Delete the first entry (should cascade down the chain)
-            // Use reflection to call the private DeleteNodeRecursive method
-            var deleteMethod = typeof(MainViewModel).GetMethod("DeleteNodeRecursive",
-                BindingFlags.NonPublic | BindingFlags.Instance);
-            Assert.NotNull(deleteMethod);
-            deleteMethod.Invoke(viewModel, new object?[] { firstEntry });
+            // #2324: direct internal call (was reflection on a private trampoline)
+            viewModel.DeleteNodeRecursive(firstEntry!);
 
             dialog.RemoveNodeInternal(firstEntry!, firstEntry!.Type);
 
@@ -241,9 +237,7 @@ namespace Parley.Tests
             dialog.LinkRegistry.RegisterLink(ptr6);
 
             // Act - Delete entry1 (top of diamond)
-            var deleteMethod = typeof(MainViewModel).GetMethod("DeleteNodeRecursive",
-                BindingFlags.NonPublic | BindingFlags.Instance);
-            deleteMethod?.Invoke(viewModel, new object[] { entry1 });
+            viewModel.DeleteNodeRecursive(entry1);
             dialog.RemoveNodeInternal(entry1, entry1.Type);
 
             // Assert

--- a/Parley/Parley.Tests/DeleteOperationTests.cs
+++ b/Parley/Parley.Tests/DeleteOperationTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
 using DialogEditor.Services;
@@ -145,10 +144,8 @@ namespace Parley.Tests
                 dialog.Starts.Remove(startToRemove);
             }
 
-            // Use reflection to call the private DeleteNodeRecursive method
-            var deleteMethod = typeof(MainViewModel).GetMethod("DeleteNodeRecursive",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            deleteMethod?.Invoke(viewModel, new object[] { entry3 });
+            // #2324: direct internal call (was reflection on a private trampoline)
+            viewModel.DeleteNodeRecursive(entry3);
 
             // Remove from collection
             dialog.RemoveNodeInternal(entry3, entry3.Type);
@@ -379,10 +376,8 @@ namespace Parley.Tests
                 dialog.Starts.Remove(startToRemove);
             }
 
-            // Use reflection to call DeleteNodeRecursive
-            var deleteMethod = typeof(MainViewModel).GetMethod("DeleteNodeRecursive",
-                BindingFlags.NonPublic | BindingFlags.Instance);
-            deleteMethod?.Invoke(viewModel, new object[] { container });
+            // #2324: direct internal call (was reflection on a private trampoline)
+            viewModel.DeleteNodeRecursive(container);
 
             // Remove from collection
             dialog.RemoveNodeInternal(container, container.Type);

--- a/Parley/Parley.Tests/DialogDragDropTopologyTests.cs
+++ b/Parley/Parley.Tests/DialogDragDropTopologyTests.cs
@@ -1,0 +1,193 @@
+using DialogEditor.Models;
+using DialogEditor.Services;
+using Xunit;
+
+namespace Parley.Tests
+{
+    /// <summary>
+    /// Tests for the shared DialogNode-level topology helpers on DialogDragDropValidator
+    /// (#2109): parent resolution, sibling detection, and sibling-reorder index math.
+    /// These replace the per-view duplicates (TreeView's GetParentNodeForDialogNode /
+    /// GetSiblingIndexForDialogNode, FlowView's AreSiblings / ExecuteSiblingReorder).
+    /// </summary>
+    public class DialogDragDropTopologyTests
+    {
+        // entry (root start) -> reply -> childEntry
+        private static Dialog BuildChain(out DialogNode entry, out DialogNode reply, out DialogNode childEntry)
+        {
+            var dialog = new Dialog();
+
+            entry = dialog.CreateNode(DialogNodeType.Entry)!;
+            entry.Text.Add(0, "Entry");
+            dialog.AddNodeInternal(entry, entry.Type);
+            var start = dialog.CreatePtr()!;
+            start.Node = entry;
+            start.Type = DialogNodeType.Entry;
+            start.Index = 0;
+            start.IsStart = true;
+            dialog.Starts.Add(start);
+
+            reply = dialog.CreateNode(DialogNodeType.Reply)!;
+            reply.Text.Add(0, "Reply");
+            dialog.AddNodeInternal(reply, reply.Type);
+            var ptr = dialog.CreatePtr()!;
+            ptr.Node = reply;
+            ptr.Type = DialogNodeType.Reply;
+            ptr.Index = 0;
+            entry.Pointers.Add(ptr);
+
+            childEntry = dialog.CreateNode(DialogNodeType.Entry)!;
+            childEntry.Text.Add(0, "Child Entry");
+            dialog.AddNodeInternal(childEntry, childEntry.Type);
+            var ptr2 = dialog.CreatePtr()!;
+            ptr2.Node = childEntry;
+            ptr2.Type = DialogNodeType.Entry;
+            ptr2.Index = 0;
+            reply.Pointers.Add(ptr2);
+
+            return dialog;
+        }
+
+        private static DialogNode AddReplyChild(Dialog dialog, DialogNode parent, string text)
+        {
+            var node = dialog.CreateNode(DialogNodeType.Reply)!;
+            node.Text.Add(0, text);
+            dialog.AddNodeInternal(node, node.Type);
+            var ptr = dialog.CreatePtr()!;
+            ptr.Node = node;
+            ptr.Type = DialogNodeType.Reply;
+            ptr.Index = (uint)parent.Pointers.Count;
+            parent.Pointers.Add(ptr);
+            return node;
+        }
+
+        [Fact]
+        public void ResolveParent_RootEntry_ReturnsNull()
+        {
+            var dialog = BuildChain(out var entry, out _, out _);
+            Assert.Null(DialogDragDropValidator.ResolveParent(entry, dialog));
+        }
+
+        [Fact]
+        public void ResolveParent_Reply_ReturnsOwningEntry()
+        {
+            var dialog = BuildChain(out var entry, out var reply, out _);
+            Assert.Same(entry, DialogDragDropValidator.ResolveParent(reply, dialog));
+        }
+
+        [Fact]
+        public void ResolveParent_ChildEntry_ReturnsOwningReply()
+        {
+            var dialog = BuildChain(out _, out var reply, out var childEntry);
+            Assert.Same(reply, DialogDragDropValidator.ResolveParent(childEntry, dialog));
+        }
+
+        [Fact]
+        public void AreSiblings_TwoRootEntries_True()
+        {
+            var dialog = BuildChain(out var entry, out _, out _);
+            var entry2 = dialog.CreateNode(DialogNodeType.Entry)!;
+            entry2.Text.Add(0, "Entry2");
+            dialog.AddNodeInternal(entry2, entry2.Type);
+            var start = dialog.CreatePtr()!;
+            start.Node = entry2;
+            start.Type = DialogNodeType.Entry;
+            start.Index = 1;
+            start.IsStart = true;
+            dialog.Starts.Add(start);
+
+            Assert.True(DialogDragDropValidator.AreSiblings(entry, entry2, dialog));
+        }
+
+        [Fact]
+        public void AreSiblings_TwoRepliesUnderSameEntry_True()
+        {
+            var dialog = BuildChain(out var entry, out var reply, out _);
+            var reply2 = AddReplyChild(dialog, entry, "Reply2");
+            Assert.True(DialogDragDropValidator.AreSiblings(reply, reply2, dialog));
+        }
+
+        [Fact]
+        public void AreSiblings_NodesUnderDifferentParents_False()
+        {
+            var dialog = BuildChain(out var entry, out var reply, out var childEntry);
+            // reply is under entry; childEntry is under reply — not siblings
+            Assert.False(DialogDragDropValidator.AreSiblings(reply, childEntry, dialog));
+        }
+
+        [Fact]
+        public void AreSiblings_RootAndNonRoot_False()
+        {
+            var dialog = BuildChain(out var entry, out var reply, out _);
+            Assert.False(DialogDragDropValidator.AreSiblings(entry, reply, dialog));
+        }
+
+        [Fact]
+        public void ResolveSiblingReorder_RepliesUnderEntry_FindsParentAndIndices()
+        {
+            var dialog = BuildChain(out var entry, out var reply, out _);
+            var reply2 = AddReplyChild(dialog, entry, "Reply2");
+
+            var result = DialogDragDropValidator.ResolveSiblingReorder(reply, reply2, dialog);
+
+            Assert.True(result.Found);
+            Assert.Same(entry, result.Parent);
+            Assert.Equal(0, result.FromIndex);
+            Assert.Equal(1, result.ToIndex);
+        }
+
+        [Fact]
+        public void ResolveSiblingReorder_RootEntries_ParentNullIndicesFromStarts()
+        {
+            var dialog = BuildChain(out var entry, out _, out _);
+            var entry2 = dialog.CreateNode(DialogNodeType.Entry)!;
+            entry2.Text.Add(0, "Entry2");
+            dialog.AddNodeInternal(entry2, entry2.Type);
+            var start = dialog.CreatePtr()!;
+            start.Node = entry2;
+            start.Type = DialogNodeType.Entry;
+            start.Index = 1;
+            start.IsStart = true;
+            dialog.Starts.Add(start);
+
+            var result = DialogDragDropValidator.ResolveSiblingReorder(entry2, entry, dialog);
+
+            Assert.True(result.Found);
+            Assert.Null(result.Parent);
+            Assert.Equal(1, result.FromIndex);
+            Assert.Equal(0, result.ToIndex);
+        }
+
+        [Fact]
+        public void ResolveSiblingReorder_NotSiblings_NotFound()
+        {
+            var dialog = BuildChain(out _, out var reply, out var childEntry);
+            var result = DialogDragDropValidator.ResolveSiblingReorder(reply, childEntry, dialog);
+            Assert.False(result.Found);
+        }
+
+        [Fact]
+        public void GetSiblingInsertIndex_ChildBefore_ReturnsTargetIndex()
+        {
+            var dialog = BuildChain(out var entry, out var reply, out _);
+            var reply2 = AddReplyChild(dialog, entry, "Reply2"); // index 1 under entry
+            Assert.Equal(1, DialogDragDropValidator.GetSiblingInsertIndex(reply2, entry, dialog, insertAfter: false));
+        }
+
+        [Fact]
+        public void GetSiblingInsertIndex_ChildAfter_ReturnsTargetIndexPlusOne()
+        {
+            var dialog = BuildChain(out var entry, out var reply, out _);
+            AddReplyChild(dialog, entry, "Reply2");
+            Assert.Equal(1, DialogDragDropValidator.GetSiblingInsertIndex(reply, entry, dialog, insertAfter: true));
+        }
+
+        [Fact]
+        public void GetSiblingInsertIndex_RootLevel_UsesStartsIndex()
+        {
+            var dialog = BuildChain(out var entry, out _, out _);
+            Assert.Equal(0, DialogDragDropValidator.GetSiblingInsertIndex(entry, null, dialog, insertAfter: false));
+            Assert.Equal(1, DialogDragDropValidator.GetSiblingInsertIndex(entry, null, dialog, insertAfter: true));
+        }
+    }
+}

--- a/Parley/Parley.Tests/DragDropParityIntegrationTests.cs
+++ b/Parley/Parley.Tests/DragDropParityIntegrationTests.cs
@@ -117,5 +117,45 @@ namespace Parley.Tests
             Assert.True(treeViewDecision.IsValid);
             Assert.True(flowViewDecision.IsValid);
         }
+
+        // #2109: Sibling-reorder parity — both views resolve parent + indices through
+        // the same shared helpers, so a reorder produces identical (parent, from, to).
+
+        [Fact]
+        public void SiblingReorder_RepliesUnderEntry_ResolvesIdenticallyForBothViews()
+        {
+            // Arrange: entry with two reply children
+            var dialog = BuildDialog(out var entry, out var reply);
+            var reply2 = dialog.CreateNode(DialogNodeType.Reply)!;
+            reply2.Text.Add(0, "Reply2");
+            dialog.AddNodeInternal(reply2, reply2.Type);
+            var ptr = dialog.CreatePtr()!;
+            ptr.Node = reply2;
+            ptr.Type = DialogNodeType.Reply;
+            ptr.Index = 1;
+            entry.Pointers.Add(ptr);
+
+            // Both views call the same resolver — represent each view's call once.
+            var treeView = DialogDragDropValidator.ResolveSiblingReorder(reply, reply2, dialog);
+            var flowView = DialogDragDropValidator.ResolveSiblingReorder(reply, reply2, dialog);
+
+            Assert.True(treeView.Found);
+            Assert.True(DialogDragDropValidator.AreSiblings(reply, reply2, dialog));
+            Assert.Equal(treeView.Found, flowView.Found);
+            Assert.Same(treeView.Parent, flowView.Parent);
+            Assert.Equal(treeView.FromIndex, flowView.FromIndex);
+            Assert.Equal(treeView.ToIndex, flowView.ToIndex);
+            Assert.Same(entry, treeView.Parent);
+        }
+
+        [Fact]
+        public void NonSiblings_AreNotReordered_ForEitherView()
+        {
+            // Arrange: entry -> reply (parent/child, not siblings)
+            var dialog = BuildDialog(out var entry, out var reply);
+
+            Assert.False(DialogDragDropValidator.AreSiblings(entry, reply, dialog));
+            Assert.False(DialogDragDropValidator.ResolveSiblingReorder(entry, reply, dialog).Found);
+        }
     }
 }

--- a/Parley/Parley.Tests/DropZoneHeightTests.cs
+++ b/Parley/Parley.Tests/DropZoneHeightTests.cs
@@ -1,0 +1,63 @@
+using Avalonia;
+using DialogEditor.Services;
+using Xunit;
+
+namespace Parley.Tests
+{
+    /// <summary>
+    /// Regression tests for the expanded-TreeViewItem drop-zone bug (#2382 spot-check):
+    /// an expanded item's Bounds.Height includes its whole child subtree, so the header
+    /// row falls inside the top-20% "Before" sliver of a tall item and same-type Before
+    /// drops get rejected. The zone calc must run against the HEADER height, not the
+    /// full item height.
+    /// </summary>
+    public class DropZoneHeightTests
+    {
+        [Fact]
+        public void ResolveZoneHeight_HeaderSmallerThanItem_UsesHeader()
+        {
+            // Expanded item: full height 200 (header + children), header 24.
+            Assert.Equal(24, DropZoneHeightService.ResolveZoneHeight(fullItemHeight: 200, headerHeight: 24));
+        }
+
+        [Fact]
+        public void ResolveZoneHeight_NoHeaderMeasurement_FallsBackToItem()
+        {
+            Assert.Equal(200, DropZoneHeightService.ResolveZoneHeight(fullItemHeight: 200, headerHeight: null));
+        }
+
+        [Fact]
+        public void ResolveZoneHeight_HeaderZeroOrNegative_FallsBackToItem()
+        {
+            Assert.Equal(200, DropZoneHeightService.ResolveZoneHeight(fullItemHeight: 200, headerHeight: 0));
+            Assert.Equal(200, DropZoneHeightService.ResolveZoneHeight(fullItemHeight: 200, headerHeight: -5));
+        }
+
+        [Fact]
+        public void ResolveZoneHeight_HeaderEqualsItem_Collapsed_UsesHeader()
+        {
+            // Collapsed item: header == full height. Either is fine; use header.
+            Assert.Equal(24, DropZoneHeightService.ResolveZoneHeight(fullItemHeight: 24, headerHeight: 24));
+        }
+
+        [Fact]
+        public void HeaderRowMidpoint_OnExpandedItem_IsIntoZone_NotBefore()
+        {
+            // Pointer in the middle of a 24px header on a 200px expanded item.
+            var service = new TreeViewDragDropService();
+            var zoneHeight = DropZoneHeightService.ResolveZoneHeight(200, 24);
+            var pos = service.CalculateDropPosition(new Point(10, 12), new Rect(0, 0, 100, zoneHeight));
+            Assert.Equal(DropPosition.Into, pos);
+        }
+
+        [Fact]
+        public void HeaderRowMidpoint_WithBuggyFullHeight_WouldBeBefore()
+        {
+            // Documents the bug: using the full 200px height puts the header midpoint (12px)
+            // in the top-20% Before sliver (< 40px), which is what rejected same-type drops.
+            var service = new TreeViewDragDropService();
+            var pos = service.CalculateDropPosition(new Point(10, 12), new Rect(0, 0, 100, 200));
+            Assert.Equal(DropPosition.Before, pos);
+        }
+    }
+}

--- a/Parley/Parley.Tests/PropertyFlushGuardTests.cs
+++ b/Parley/Parley.Tests/PropertyFlushGuardTests.cs
@@ -1,0 +1,64 @@
+using DialogEditor.Models;
+using DialogEditor.Services;
+using Xunit;
+
+namespace Parley.Tests
+{
+    /// <summary>
+    /// Tests for the property-panel flush guard (#2382 data-loss bug).
+    ///
+    /// Repro: drag a reply thread between two conversations and back. After the move,
+    /// the TreeView restored selection to a sibling ("No") while the property panel still
+    /// displayed the dragged node ("Yes"). The next SaveCurrentNodeProperties flushed the
+    /// stale "Yes" TextBox onto the "No" DialogNode — overwriting No.Text with "Yes".
+    ///
+    /// Guard: only flush the panel back to the model when the panel was last populated FROM
+    /// the same DialogNode that is currently selected. If they diverge, the panel is stale
+    /// and a flush would corrupt the wrong node.
+    /// </summary>
+    public class PropertyFlushGuardTests
+    {
+        private static DialogNode MakeNode(Dialog dialog, DialogNodeType type, string text)
+        {
+            var n = dialog.CreateNode(type)!;
+            n.Text.Add(0, text);
+            dialog.AddNodeInternal(n, type);
+            return n;
+        }
+
+        [Fact]
+        public void ShouldFlush_SameNode_True()
+        {
+            var dialog = new Dialog();
+            var yes = MakeNode(dialog, DialogNodeType.Reply, "Yes");
+            Assert.True(PropertyFlushGuard.ShouldFlush(selectedNode: yes, lastPopulatedNode: yes));
+        }
+
+        [Fact]
+        public void ShouldFlush_DivergedNodes_False()
+        {
+            var dialog = new Dialog();
+            var yes = MakeNode(dialog, DialogNodeType.Reply, "Yes");
+            var no = MakeNode(dialog, DialogNodeType.Reply, "No");
+            // Panel shows Yes, selection is No → flushing would write Yes into No. Block it.
+            Assert.False(PropertyFlushGuard.ShouldFlush(selectedNode: no, lastPopulatedNode: yes));
+        }
+
+        [Fact]
+        public void ShouldFlush_NullSelected_False()
+        {
+            var dialog = new Dialog();
+            var yes = MakeNode(dialog, DialogNodeType.Reply, "Yes");
+            Assert.False(PropertyFlushGuard.ShouldFlush(selectedNode: null, lastPopulatedNode: yes));
+        }
+
+        [Fact]
+        public void ShouldFlush_NullLastPopulated_False()
+        {
+            var dialog = new Dialog();
+            var yes = MakeNode(dialog, DialogNodeType.Reply, "Yes");
+            // Panel never populated for this selection → nothing safe to flush.
+            Assert.False(PropertyFlushGuard.ShouldFlush(selectedNode: yes, lastPopulatedNode: null));
+        }
+    }
+}

--- a/Parley/Parley.Tests/SettingsPathMigrationTests.cs
+++ b/Parley/Parley.Tests/SettingsPathMigrationTests.cs
@@ -1,0 +1,56 @@
+using DialogEditor.Services;
+using Xunit;
+
+namespace DialogEditor.Tests
+{
+    /// <summary>
+    /// Tests for the one-time migration of Parley's local ExternalEditorPath/ManifestPath
+    /// values onto the shared RadoubSettings keys (#2357). The migration rule mirrors
+    /// Trebuchet's (#2295): adopt the legacy value only when the shared value is still empty,
+    /// so a value set elsewhere is never clobbered.
+    /// </summary>
+    public class SettingsPathMigrationTests
+    {
+        [Fact]
+        public void AdoptLegacyIfSharedEmpty_SharedEmpty_AdoptsLegacy()
+        {
+            var result = SettingsPathMigration.AdoptLegacyIfSharedEmpty("C:/legacy/editor.exe", "");
+            Assert.Equal("C:/legacy/editor.exe", result);
+        }
+
+        [Fact]
+        public void AdoptLegacyIfSharedEmpty_SharedSet_KeepsShared()
+        {
+            var result = SettingsPathMigration.AdoptLegacyIfSharedEmpty("C:/legacy/editor.exe", "C:/shared/editor.exe");
+            Assert.Equal("C:/shared/editor.exe", result);
+        }
+
+        [Fact]
+        public void AdoptLegacyIfSharedEmpty_BothEmpty_StaysEmpty()
+        {
+            var result = SettingsPathMigration.AdoptLegacyIfSharedEmpty("", "");
+            Assert.Equal("", result);
+        }
+
+        [Fact]
+        public void AdoptLegacyIfSharedEmpty_LegacyEmptySharedSet_KeepsShared()
+        {
+            var result = SettingsPathMigration.AdoptLegacyIfSharedEmpty("", "C:/shared/editor.exe");
+            Assert.Equal("C:/shared/editor.exe", result);
+        }
+
+        [Fact]
+        public void AdoptLegacyIfSharedEmpty_NullLegacy_TreatedAsEmpty()
+        {
+            var result = SettingsPathMigration.AdoptLegacyIfSharedEmpty(null, "");
+            Assert.Equal("", result);
+        }
+
+        [Fact]
+        public void AdoptLegacyIfSharedEmpty_NullShared_TreatedAsEmptyAndAdoptsLegacy()
+        {
+            var result = SettingsPathMigration.AdoptLegacyIfSharedEmpty("C:/legacy/editor.exe", null);
+            Assert.Equal("C:/legacy/editor.exe", result);
+        }
+    }
+}

--- a/Parley/Parley/Services/DialogDragDropValidator.cs
+++ b/Parley/Parley/Services/DialogDragDropValidator.cs
@@ -1,8 +1,23 @@
 using System.Collections.Generic;
+using System.Linq;
 using DialogEditor.Models;
 
 namespace DialogEditor.Services
 {
+    /// <summary>
+    /// Result of resolving a sibling-reorder between two nodes that share a parent (#2109).
+    /// </summary>
+    public readonly struct SiblingReorderResult
+    {
+        public bool Found { get; init; }
+        /// <summary>The shared parent node, or null when both siblings are root start points.</summary>
+        public DialogNode? Parent { get; init; }
+        public int FromIndex { get; init; }
+        public int ToIndex { get; init; }
+
+        public static SiblingReorderResult NotFound => new() { Found = false, FromIndex = -1, ToIndex = -1 };
+    }
+
     /// <summary>
     /// Classification of a drag-drop target.
     /// </summary>
@@ -32,10 +47,12 @@ namespace DialogEditor.Services
     /// Shared drag-drop validator for "drop as child of target" (Into) and
     /// "drop to root" (target == null) scenarios.
     ///
-    /// Both TreeView and FlowView delegate their parent-assignment validation
-    /// here so the two views can never disagree about which drops are legal (#2060).
-    /// Sibling-reorder (Before / After) remains in each view's own path pending
-    /// full unification (#2109).
+    /// Both TreeView and FlowView delegate their drag-drop logic here so the two
+    /// views can never disagree about which drops are legal or how reorders resolve.
+    /// The validator owns reparent validation (Into / Root), circular-reference
+    /// detection, NPC/PC placement rules, parent resolution, sibling detection, and
+    /// sibling-reorder index math (#2060, #2109). Views are thin adapters that map
+    /// their own node wrappers onto the shared DialogNode-level API.
     /// </summary>
     public static class DialogDragDropValidator
     {
@@ -116,10 +133,120 @@ namespace DialogEditor.Services
         }
 
         /// <summary>
-        /// True if <paramref name="possibleDescendant"/> is reachable from
-        /// <paramref name="source"/> via its pointer graph.
+        /// Resolves the parent DialogNode of <paramref name="node"/>, or null when the
+        /// node is a root-level start point. Shared by both views (#2109) — replaces
+        /// TreeView's GetParentNodeForDialogNode and FlowView's inline parent search.
         /// </summary>
-        private static bool IsDescendant(DialogNode source, DialogNode possibleDescendant)
+        public static DialogNode? ResolveParent(DialogNode node, Dialog dialog)
+        {
+            // Root-level start points have no parent node.
+            if (dialog.Starts.Any(s => s.Node == node))
+                return null;
+
+            foreach (var entry in dialog.Entries)
+            {
+                if (entry.Pointers.Any(p => p.Node == node))
+                    return entry;
+            }
+            foreach (var reply in dialog.Replies)
+            {
+                if (reply.Pointers.Any(p => p.Node == node))
+                    return reply;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// True if <paramref name="a"/> and <paramref name="b"/> share a parent — both
+        /// root start points, or both pointed to by the same node. Shared by both views
+        /// (#2109) — replaces FlowView's AreSiblings.
+        /// </summary>
+        public static bool AreSiblings(DialogNode a, DialogNode b, Dialog dialog)
+        {
+            if (a == b) return false;
+
+            bool aIsRoot = dialog.Starts.Any(s => s.Node == a);
+            bool bIsRoot = dialog.Starts.Any(s => s.Node == b);
+            if (aIsRoot || bIsRoot)
+                return aIsRoot && bIsRoot;
+
+            foreach (var parent in dialog.Entries.Concat(dialog.Replies))
+            {
+                bool hasA = parent.Pointers.Any(p => p.Node == a);
+                bool hasB = parent.Pointers.Any(p => p.Node == b);
+                if (hasA && hasB)
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Resolves the shared parent and the from/to indices for reordering
+        /// <paramref name="dragged"/> relative to <paramref name="target"/>. Returns
+        /// <see cref="SiblingReorderResult.NotFound"/> when the two are not siblings.
+        /// Shared by both views (#2109) — replaces the index math duplicated in
+        /// TreeView's GetSiblingIndexForDialogNode and FlowView's ExecuteSiblingReorder.
+        /// </summary>
+        public static SiblingReorderResult ResolveSiblingReorder(DialogNode dragged, DialogNode target, Dialog dialog)
+        {
+            // Root level: both must be in Starts.
+            int draggedStart = dialog.Starts.FindIndex(s => s.Node == dragged);
+            int targetStart = dialog.Starts.FindIndex(s => s.Node == target);
+            if (draggedStart >= 0 && targetStart >= 0)
+            {
+                return new SiblingReorderResult
+                {
+                    Found = true,
+                    Parent = null,
+                    FromIndex = draggedStart,
+                    ToIndex = targetStart
+                };
+            }
+            if (draggedStart >= 0 || targetStart >= 0)
+                return SiblingReorderResult.NotFound;
+
+            // Child level: find a parent that points to both.
+            foreach (var parent in dialog.Entries.Concat(dialog.Replies))
+            {
+                int from = parent.Pointers.FindIndex(p => p.Node == dragged);
+                int to = parent.Pointers.FindIndex(p => p.Node == target);
+                if (from >= 0 && to >= 0)
+                {
+                    return new SiblingReorderResult
+                    {
+                        Found = true,
+                        Parent = parent,
+                        FromIndex = from,
+                        ToIndex = to
+                    };
+                }
+            }
+
+            return SiblingReorderResult.NotFound;
+        }
+
+        /// <summary>
+        /// Index at which a node should be inserted relative to <paramref name="target"/>
+        /// among its siblings. <paramref name="parent"/> null means root level (Starts list).
+        /// Shared by both views (#2109) — replaces TreeView's GetSiblingIndex math.
+        /// </summary>
+        public static int GetSiblingInsertIndex(DialogNode target, DialogNode? parent, Dialog dialog, bool insertAfter)
+        {
+            int index = parent == null
+                ? dialog.Starts.FindIndex(s => s.Node == target)
+                : parent.Pointers.FindIndex(p => p.Node == target);
+
+            return insertAfter ? index + 1 : System.Math.Max(0, index);
+        }
+
+        /// <summary>
+        /// True if <paramref name="possibleDescendant"/> is reachable from
+        /// <paramref name="source"/> via its pointer graph. Public so both views can
+        /// run the same circular-reference check (#2109).
+        /// </summary>
+        public static bool IsDescendant(DialogNode source, DialogNode possibleDescendant)
         {
             var visited = new HashSet<DialogNode>();
             return IsReachable(source, possibleDescendant, visited);

--- a/Parley/Parley/Services/DropZoneHeightService.cs
+++ b/Parley/Parley/Services/DropZoneHeightService.cs
@@ -1,0 +1,26 @@
+namespace DialogEditor.Services
+{
+    /// <summary>
+    /// Resolves the height the TreeView drop-zone calculation should run against (#2382).
+    ///
+    /// An expanded TreeViewItem's Bounds.Height includes its entire child subtree, so the
+    /// header row ends up inside the top-20% "Before" zone of a tall item — which rejected
+    /// valid same-type Before/Into drops onto expanded threads. The zone math must use the
+    /// header-row height instead. This helper picks the header height when it is a sane
+    /// measurement and falls back to the full item height otherwise.
+    /// </summary>
+    public static class DropZoneHeightService
+    {
+        /// <summary>
+        /// Returns the height to use for drop-zone calculation: the header height when it is
+        /// a valid, non-larger measurement than the full item; otherwise the full item height.
+        /// </summary>
+        public static double ResolveZoneHeight(double fullItemHeight, double? headerHeight)
+        {
+            if (headerHeight is double h && h > 0 && h <= fullItemHeight)
+                return h;
+
+            return fullItemHeight;
+        }
+    }
+}

--- a/Parley/Parley/Services/EditorPreferencesService.cs
+++ b/Parley/Parley/Services/EditorPreferencesService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Radoub.Formats.Logging;
+using Radoub.Formats.Settings;
 
 namespace DialogEditor.Services
 {
@@ -31,11 +32,11 @@ namespace DialogEditor.Services
         private bool _simulatorShowWarnings = true;
 
         // Script editor settings
-        private string _externalEditorPath = "";
+        // #2357: ExternalEditorPath migrated to shared RadoubSettings.CodeEditorPath (no local field)
         private List<string> _scriptSearchPaths = new List<string>();
 
         // Radoub tool integration
-        private string _manifestPath = "";
+        // #2357: ManifestPath migrated to shared RadoubSettings.ManifestPath (no local field)
 
         // Parameter cache settings
         private bool _enableParameterCache = true;
@@ -85,10 +86,14 @@ namespace DialogEditor.Services
             _showDeleteConfirmation = showDeleteConfirmation;
             _simulatorShowWarnings = simulatorShowWarnings;
 
-            _externalEditorPath = externalEditorPath ?? "";
-            _scriptSearchPaths = scriptSearchPaths ?? new List<string>();
+            // #2357: One-time migration of legacy Parley path values onto shared RadoubSettings.
+            // Adopt the legacy value only if the shared value is still empty (mirrors #2295).
+            RadoubSettings.Instance.CodeEditorPath =
+                SettingsPathMigration.AdoptLegacyIfSharedEmpty(externalEditorPath, RadoubSettings.Instance.CodeEditorPath);
+            RadoubSettings.Instance.ManifestPath =
+                SettingsPathMigration.AdoptLegacyIfSharedEmpty(manifestPath, RadoubSettings.Instance.ManifestPath);
 
-            _manifestPath = manifestPath ?? "";
+            _scriptSearchPaths = scriptSearchPaths ?? new List<string>();
 
             _enableParameterCache = enableParameterCache;
             _maxCachedValuesPerParameter = Math.Max(5, Math.Min(50, maxCachedValuesPerParameter));
@@ -198,10 +203,17 @@ namespace DialogEditor.Services
         }
 
         // Script Editor Settings
+        // #2357: Passthrough to shared RadoubSettings.CodeEditorPath (single source of truth).
         public string ExternalEditorPath
         {
-            get => _externalEditorPath;
-            set { if (SetProperty(ref _externalEditorPath, value ?? "")) SettingsChanged?.Invoke(); }
+            get => RadoubSettings.Instance.CodeEditorPath;
+            set
+            {
+                if (RadoubSettings.Instance.CodeEditorPath == (value ?? "")) return;
+                RadoubSettings.Instance.CodeEditorPath = value ?? "";
+                OnPropertyChanged();
+                SettingsChanged?.Invoke();
+            }
         }
 
         public List<string> ScriptSearchPaths
@@ -221,10 +233,17 @@ namespace DialogEditor.Services
         internal List<string> ScriptSearchPathsInternal => _scriptSearchPaths;
 
         // Radoub Tool Integration
+        // #2357: Passthrough to shared RadoubSettings.ManifestPath (single source of truth).
         public string ManifestPath
         {
-            get => _manifestPath;
-            set { if (SetProperty(ref _manifestPath, value ?? "")) SettingsChanged?.Invoke(); }
+            get => RadoubSettings.Instance.ManifestPath;
+            set
+            {
+                if (RadoubSettings.Instance.ManifestPath == (value ?? "")) return;
+                RadoubSettings.Instance.ManifestPath = value ?? "";
+                OnPropertyChanged();
+                SettingsChanged?.Invoke();
+            }
         }
 
         // Parameter Cache Settings

--- a/Parley/Parley/Services/NodeOperationsManager.TreeHelpers.cs
+++ b/Parley/Parley/Services/NodeOperationsManager.TreeHelpers.cs
@@ -154,8 +154,9 @@ namespace DialogEditor.Services
         /// <summary>
         /// Recursively deletes a node and its children.
         /// Preserves nodes that have incoming links from elsewhere.
+        /// #2324: internal (was private) so MainViewModel + tests can call directly without reflection.
         /// </summary>
-        private void DeleteNodeRecursive(Dialog dialog, DialogNode node)
+        internal void DeleteNodeRecursive(Dialog dialog, DialogNode node)
         {
             // Recursively delete children, but only if they're not shared by other nodes
             if (node.Pointers != null && node.Pointers.Count > 0)

--- a/Parley/Parley/Services/PropertyFlushGuard.cs
+++ b/Parley/Parley/Services/PropertyFlushGuard.cs
@@ -1,0 +1,28 @@
+using DialogEditor.Models;
+
+namespace DialogEditor.Services
+{
+    /// <summary>
+    /// Guards the property-panel "flush to model" step against cross-node corruption (#2382).
+    ///
+    /// The property TextBoxes are populated FROM one DialogNode but flushed back on selection
+    /// change / file save. If selection moves to a different node (e.g. a drag-drop refresh
+    /// restores selection to a sibling) without the panel being repopulated, a flush would
+    /// write the displayed node's text onto the newly-selected node. This guard refuses to
+    /// flush unless the panel's source node is the same instance as the current selection.
+    /// </summary>
+    public static class PropertyFlushGuard
+    {
+        /// <summary>
+        /// True only when the panel may safely flush: a node is selected and the panel was
+        /// last populated from that exact same DialogNode instance.
+        /// </summary>
+        public static bool ShouldFlush(DialogNode? selectedNode, DialogNode? lastPopulatedNode)
+        {
+            if (selectedNode == null || lastPopulatedNode == null)
+                return false;
+
+            return ReferenceEquals(selectedNode, lastPopulatedNode);
+        }
+    }
+}

--- a/Parley/Parley/Services/SettingsPathMigration.cs
+++ b/Parley/Parley/Services/SettingsPathMigration.cs
@@ -1,0 +1,25 @@
+namespace DialogEditor.Services
+{
+    /// <summary>
+    /// One-time migration helpers for moving Parley-local path settings onto the shared
+    /// RadoubSettings keys (#2357). Mirrors Trebuchet's migration rule (#2295): adopt the
+    /// legacy value only when the shared value is still empty, so a value already set
+    /// elsewhere is never overwritten.
+    /// </summary>
+    public static class SettingsPathMigration
+    {
+        /// <summary>
+        /// Returns the value the shared setting should hold after migration:
+        /// the legacy value if (and only if) the shared value is currently empty,
+        /// otherwise the existing shared value. Null is treated as empty.
+        /// </summary>
+        public static string AdoptLegacyIfSharedEmpty(string? legacyValue, string? sharedValue)
+        {
+            var shared = sharedValue ?? "";
+            if (!string.IsNullOrEmpty(shared))
+                return shared;
+
+            return legacyValue ?? "";
+        }
+    }
+}

--- a/Parley/Parley/Services/SettingsService.cs
+++ b/Parley/Parley/Services/SettingsService.cs
@@ -693,8 +693,10 @@ namespace DialogEditor.Services
                     SoundBrowserIncludeBifFiles = SoundBrowserIncludeBifFiles,
                     SoundBrowserMonoOnly = SoundBrowserMonoOnly,
                     SpellCheckEnabled = SpellCheckEnabled,
-                    ManifestPath = SharedPathHelper.ContractPath(ManifestPath),
-                    ExternalEditorPath = SharedPathHelper.ContractPath(ExternalEditorPath),
+                    // #2357: ManifestPath/ExternalEditorPath now persist via shared RadoubSettings;
+                    // no longer written to Parley's local settings (cleared on first save after migration).
+                    ManifestPath = "",
+                    ExternalEditorPath = "",
                     ScriptSearchPaths = SharedPathHelper.ContractPaths(_editorPreferences.ScriptSearchPathsInternal),
                     RecentCreatureTags = _recentCreatureTags.ToList()
                 };

--- a/Parley/Parley/Services/TreeViewDragDropService.cs
+++ b/Parley/Parley/Services/TreeViewDragDropService.cs
@@ -219,7 +219,8 @@ namespace DialogEditor.Services
             }
 
             // Can't drop on descendant (would create circular reference)
-            if (IsDescendantOf(target, source))
+            // #2109: Shared graph-walk check (was a broken tree-walk that only caught self).
+            if (DialogDragDropValidator.IsDescendant(source.OriginalNode, target.OriginalNode))
             {
                 result.ErrorMessage = "Cannot drop node on its own descendant";
                 UnifiedLogger.LogApplication(LogLevel.DEBUG, $"TreeViewDragDrop.ValidateDrop: REJECTED - {result.ErrorMessage}");
@@ -322,225 +323,42 @@ namespace DialogEditor.Services
         }
 
         /// <summary>
-        /// Checks if target is a descendant of source (would create circular reference).
-        /// </summary>
-        private bool IsDescendantOf(TreeViewSafeNode target, TreeViewSafeNode source)
-        {
-            var current = target;
-            while (current != null)
-            {
-                if (current.OriginalNode == source.OriginalNode)
-                    return true;
-
-                // Walk up to parent - need to find parent in tree
-                current = FindParentTreeNode(current);
-            }
-            return false;
-        }
-
-        /// <summary>
         /// Gets the DialogNode parent of a TreeViewSafeNode.
         /// Returns null only if the node is at root level (child of ROOT container).
+        /// #2109: Delegates to the shared DialogDragDropValidator.ResolveParent so both
+        /// views resolve parents identically.
         /// </summary>
         private DialogNode? GetParentNode(TreeViewSafeNode node)
         {
-            UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                $"TreeViewDragDrop.GetParentNode: Finding parent for '{node.DisplayText}' (Type={node.OriginalNode.Type})");
-
             // TreeViewRootNode is the ROOT container - it has no parent
             if (node is TreeViewRootNode)
-            {
-                UnifiedLogger.LogApplication(LogLevel.DEBUG, "TreeViewDragDrop.GetParentNode: Node is TreeViewRootNode - returning null");
                 return null;
-            }
 
-            // The source pointer tells us where this node came from
-            var sourcePointer = node.SourcePointer;
             var dialog = node.OriginalNode.Parent;
-
             if (dialog == null)
             {
                 UnifiedLogger.LogApplication(LogLevel.WARN, "TreeViewDragDrop.GetParentNode: dialog is null - returning null");
                 return null;
             }
 
-            UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                $"TreeViewDragDrop.GetParentNode: sourcePointer={sourcePointer?.Node?.DisplayText ?? "null"}, dialog has {dialog.Entries.Count} entries, {dialog.Replies.Count} replies");
-
-            // Check if this node is a root-level entry (in Starts list)
-            // Root-level entries have no parent DialogNode (they're children of ROOT container)
-            foreach (var start in dialog.Starts)
-            {
-                if (start.Node == node.OriginalNode)
-                {
-                    // This is a root-level entry - no parent DialogNode
-                    UnifiedLogger.LogApplication(LogLevel.DEBUG, "TreeViewDragDrop.GetParentNode: Node is in Starts list - returning null (root level)");
-                    return null;
-                }
-            }
-
-            // For non-root nodes, find the parent by searching who has a pointer to this node
-            if (sourcePointer != null)
-            {
-                UnifiedLogger.LogApplication(LogLevel.DEBUG, "TreeViewDragDrop.GetParentNode: Searching by sourcePointer reference...");
-                // Search entries for the node containing this pointer
-                foreach (var entry in dialog.Entries)
-                {
-                    if (entry.Pointers.Contains(sourcePointer))
-                    {
-                        UnifiedLogger.LogApplication(LogLevel.DEBUG, $"TreeViewDragDrop.GetParentNode: Found parent Entry '{entry.DisplayText}' by sourcePointer");
-                        return entry;
-                    }
-                }
-                // Search replies for the node containing this pointer
-                foreach (var reply in dialog.Replies)
-                {
-                    if (reply.Pointers.Contains(sourcePointer))
-                    {
-                        UnifiedLogger.LogApplication(LogLevel.DEBUG, $"TreeViewDragDrop.GetParentNode: Found parent Reply '{reply.DisplayText}' by sourcePointer");
-                        return reply;
-                    }
-                }
-                UnifiedLogger.LogApplication(LogLevel.DEBUG, "TreeViewDragDrop.GetParentNode: sourcePointer not found in any node's Pointers list, trying fallback...");
-            }
-
-            // Fallback: Search all nodes for any pointer pointing to this node
-            // This handles cases where sourcePointer doesn't match (e.g., recreated pointers)
-            UnifiedLogger.LogApplication(LogLevel.DEBUG, "TreeViewDragDrop.GetParentNode: Fallback search by target node reference...");
-            var targetNode = node.OriginalNode;
-            foreach (var entry in dialog.Entries)
-            {
-                foreach (var ptr in entry.Pointers)
-                {
-                    if (ptr.Node == targetNode)
-                    {
-                        UnifiedLogger.LogApplication(LogLevel.DEBUG, $"TreeViewDragDrop.GetParentNode: Found parent Entry '{entry.DisplayText}' by fallback search");
-                        return entry;
-                    }
-                }
-            }
-            foreach (var reply in dialog.Replies)
-            {
-                foreach (var ptr in reply.Pointers)
-                {
-                    if (ptr.Node == targetNode)
-                    {
-                        UnifiedLogger.LogApplication(LogLevel.DEBUG, $"TreeViewDragDrop.GetParentNode: Found parent Reply '{reply.DisplayText}' by fallback search");
-                        return reply;
-                    }
-                }
-            }
-
-            // If we get here, the node is likely a root-level entry that wasn't in Starts
-            // (shouldn't happen in valid dialogs, but handle gracefully)
-            UnifiedLogger.LogApplication(LogLevel.WARN,
-                $"TreeViewDragDrop.GetParentNode: Could not find parent for node '{node.DisplayText}' - treating as root level");
-            return null;
-        }
-
-        /// <summary>
-        /// Gets the DialogNode parent of a DialogNode (for grandparent lookups).
-        /// Similar to GetParentNode but works directly with DialogNode.
-        /// </summary>
-        private DialogNode? GetParentNodeForDialogNode(DialogNode node)
-        {
-            var dialog = node.Parent;
-            if (dialog == null)
-                return null;
-
-            // Check if this is a root-level entry
-            foreach (var start in dialog.Starts)
-            {
-                if (start.Node == node)
-                    return null; // Root level
-            }
-
-            // Search for parent by finding who has a pointer to this node
-            foreach (var entry in dialog.Entries)
-            {
-                foreach (var ptr in entry.Pointers)
-                {
-                    if (ptr.Node == node)
-                        return entry;
-                }
-            }
-            foreach (var reply in dialog.Replies)
-            {
-                foreach (var ptr in reply.Pointers)
-                {
-                    if (ptr.Node == node)
-                        return reply;
-                }
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Gets sibling index for a DialogNode relative to its parent.
-        /// Used when we need to insert relative to a DialogNode (not TreeViewSafeNode).
-        /// </summary>
-        private int GetSiblingIndexForDialogNode(DialogNode? sibling, DialogNode? parent, bool insertAfter)
-        {
-            if (sibling == null)
-                return 0;
-
-            if (parent == null)
-            {
-                // Root level - index in Starts list
-                var dialog = sibling.Parent;
-                if (dialog != null)
-                {
-                    var index = dialog.Starts.FindIndex(s => s.Node == sibling);
-                    return insertAfter ? index + 1 : Math.Max(0, index);
-                }
-                return 0;
-            }
-
-            // Find index in parent's pointers
-            var pointerIndex = parent.Pointers.FindIndex(p => p.Node == sibling);
-            return insertAfter ? pointerIndex + 1 : Math.Max(0, pointerIndex);
+            return DialogDragDropValidator.ResolveParent(node.OriginalNode, dialog);
         }
 
         /// <summary>
         /// Gets the index where a node should be inserted relative to target.
+        /// #2109: Delegates to the shared DialogDragDropValidator.GetSiblingInsertIndex.
         /// </summary>
         private int GetSiblingIndex(TreeViewSafeNode target, DialogNode? parent, bool insertAfter)
         {
-            if (parent == null)
+            var dialog = target.OriginalNode.Parent;
+            if (dialog == null)
             {
-                // Root level - index in Starts list
-                var dialog = target.OriginalNode.Parent;
-                if (dialog != null)
-                {
-                    var index = dialog.Starts.FindIndex(s => s.Node == target.OriginalNode);
-                    UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                        $"TreeViewDragDrop.GetSiblingIndex: ROOT level, target='{target.OriginalNode.DisplayText}', " +
-                        $"index={index}, insertAfter={insertAfter}, result={( insertAfter ? index + 1 : index )}");
-                    return insertAfter ? index + 1 : index;
-                }
                 UnifiedLogger.LogApplication(LogLevel.WARN,
-                    $"TreeViewDragDrop.GetSiblingIndex: ROOT level but dialog is NULL for target='{target.OriginalNode.DisplayText}'");
+                    $"TreeViewDragDrop.GetSiblingIndex: dialog is NULL for target='{target.OriginalNode.DisplayText}'");
                 return 0;
             }
 
-            // Find index in parent's pointers - use Node property which references the actual DialogNode
-            var pointerIndex = parent.Pointers.FindIndex(p => p.Node == target.OriginalNode);
-            UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                $"TreeViewDragDrop.GetSiblingIndex: Parent='{parent.DisplayText}', target='{target.OriginalNode.DisplayText}', " +
-                $"pointerIndex={pointerIndex}, insertAfter={insertAfter}, result={( insertAfter ? pointerIndex + 1 : Math.Max(0, pointerIndex) )}");
-
-            return insertAfter ? pointerIndex + 1 : Math.Max(0, pointerIndex);
-        }
-
-        /// <summary>
-        /// Finds the parent TreeViewSafeNode for a given node.
-        /// </summary>
-        private TreeViewSafeNode? FindParentTreeNode(TreeViewSafeNode node)
-        {
-            // This would need access to the tree structure
-            // For now, return null - full implementation requires tree traversal
-            return null;
+            return DialogDragDropValidator.GetSiblingInsertIndex(target.OriginalNode, parent, dialog, insertAfter);
         }
 
         /// <summary>

--- a/Parley/Parley/ViewModels/MainViewModel.NodeOperations.cs
+++ b/Parley/Parley/ViewModels/MainViewModel.NodeOperations.cs
@@ -200,20 +200,13 @@ namespace DialogEditor.ViewModels
             }
         }
 
-        // COMPATIBILITY: Kept for existing tests that use reflection to access this method
-        // TODO (#2324): Update tests to use public DeleteNode API and remove this trampoline
-        #pragma warning disable IDE0051 // Remove unused private members
-        private void DeleteNodeRecursive(DialogNode node)
+        // #2324: Test seam for the recursive-delete behavior that bypasses the full DeleteNode
+        // flow (no orphan cleanup). internal + typed delegation — no reflection.
+        internal void DeleteNodeRecursive(DialogNode node)
         {
             if (CurrentDialog == null) return;
-
-            // Delegate to NodeOperationsManager's internal implementation via reflection
-            var managerType = _nodeOpsManager.GetType();
-            var deleteMethod = managerType.GetMethod("DeleteNodeRecursive",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            deleteMethod?.Invoke(_nodeOpsManager, new object[] { CurrentDialog, node });
+            _nodeOpsManager.DeleteNodeRecursive(CurrentDialog, node);
         }
-        #pragma warning restore IDE0051
 
         // Phase 2a: Node Reordering
         public void MoveNodeUp(TreeViewSafeNode nodeToMove)

--- a/Parley/Parley/Views/FlowchartPanel.axaml.cs
+++ b/Parley/Parley/Views/FlowchartPanel.axaml.cs
@@ -824,42 +824,22 @@ namespace DialogEditor.Views
 
         /// <summary>
         /// Checks if two FlowchartNodes are siblings (share the same parent in the dialog structure).
+        /// #2109: Delegates to the shared DialogDragDropValidator so FlowView and TreeView agree.
         /// </summary>
         private bool AreSiblings(FlowchartNode a, FlowchartNode b)
         {
             if (a.OriginalNode == null || b.OriginalNode == null) return false;
 
-            var graph = _viewModel.FlowchartGraph;
-            if (graph == null) return false;
-
-            // Check if both are root-level (in Dialog.Starts)
             var dialog = _viewModel.CurrentDialog;
             if (dialog == null) return false;
 
-            bool aIsRoot = dialog.Starts.Any(s => s.Node == a.OriginalNode);
-            bool bIsRoot = dialog.Starts.Any(s => s.Node == b.OriginalNode);
-            if (aIsRoot && bIsRoot) return true;
-
-            // Check if they share a parent
-            foreach (var entry in dialog.Entries)
-            {
-                bool hasA = entry.Pointers.Any(p => p.Node == a.OriginalNode);
-                bool hasB = entry.Pointers.Any(p => p.Node == b.OriginalNode);
-                if (hasA && hasB) return true;
-            }
-            foreach (var reply in dialog.Replies)
-            {
-                bool hasA = reply.Pointers.Any(p => p.Node == a.OriginalNode);
-                bool hasB = reply.Pointers.Any(p => p.Node == b.OriginalNode);
-                if (hasA && hasB) return true;
-            }
-
-            return false;
+            return DialogDragDropValidator.AreSiblings(a.OriginalNode, b.OriginalNode, dialog);
         }
 
         /// <summary>
         /// Resolves sibling indices and raises SiblingReorderRequested event (#240).
         /// MainWindow handles undo state + actual reorder execution.
+        /// #2109: Index/parent resolution delegated to the shared DialogDragDropValidator.
         /// </summary>
         private void ExecuteSiblingReorder(FlowchartNode draggedNode, FlowchartNode targetNode, Point dropPoint)
         {
@@ -868,43 +848,12 @@ namespace DialogEditor.Views
             var dialog = _viewModel.CurrentDialog;
             if (dialog == null) return;
 
-            // Find shared parent and indices
-            DialogNode? parent = null;
-            int fromIndex = -1;
-            int toIndex = -1;
-
-            // Check root level
-            bool draggedIsRoot = false;
-            for (int i = 0; i < dialog.Starts.Count; i++)
-            {
-                if (dialog.Starts[i].Node == draggedNode.OriginalNode) { fromIndex = i; draggedIsRoot = true; }
-                if (dialog.Starts[i].Node == targetNode.OriginalNode) toIndex = i;
-            }
-
-            if (!draggedIsRoot)
-            {
-                // Find parent node
-                foreach (var entry in dialog.Entries.Concat(dialog.Replies))
-                {
-                    fromIndex = -1;
-                    toIndex = -1;
-                    for (int i = 0; i < entry.Pointers.Count; i++)
-                    {
-                        if (entry.Pointers[i].Node == draggedNode.OriginalNode) fromIndex = i;
-                        if (entry.Pointers[i].Node == targetNode.OriginalNode) toIndex = i;
-                    }
-                    if (fromIndex >= 0 && toIndex >= 0)
-                    {
-                        parent = entry;
-                        break;
-                    }
-                }
-            }
-
-            if (fromIndex < 0 || toIndex < 0) return;
+            var reorder = DialogDragDropValidator.ResolveSiblingReorder(
+                draggedNode.OriginalNode, targetNode.OriginalNode, dialog);
+            if (!reorder.Found) return;
 
             // Raise event for MainWindow to handle undo + execution
-            SiblingReorderRequested?.Invoke(draggedNode.OriginalNode, parent, fromIndex, toIndex);
+            SiblingReorderRequested?.Invoke(draggedNode.OriginalNode, reorder.Parent, reorder.FromIndex, reorder.ToIndex);
         }
 
         /// <summary>

--- a/Parley/Parley/Views/Helpers/TreeViewUIController.cs
+++ b/Parley/Parley/Views/Helpers/TreeViewUIController.cs
@@ -192,7 +192,11 @@ namespace Parley.Views.Helpers
                 // GetPosition(targetItem) returns position relative to targetItem, so Y starts at 0
                 // We need bounds relative to self (starting at 0,0) for correct zone calculation
                 var pointerPos = e.GetPosition(targetItem);
-                var itemBounds = new Rect(0, 0, targetItem.Bounds.Width, targetItem.Bounds.Height);
+                // #2382: An expanded item's Bounds.Height includes its child subtree, which
+                // would push the header row into the top-20% "Before" zone. Use header height.
+                var zoneHeight = DropZoneHeightService.ResolveZoneHeight(
+                    targetItem.Bounds.Height, GetHeaderHeight(targetItem));
+                var itemBounds = new Rect(0, 0, targetItem.Bounds.Width, zoneHeight);
                 var dropPosition = _dragDropService.CalculateDropPosition(pointerPos, itemBounds);
 
                 // Validate the drop
@@ -242,8 +246,11 @@ namespace Parley.Views.Helpers
 
             if (targetItem?.DataContext is TreeViewSafeNode targetNode)
             {
-                // Use 0,0-based bounds - GetPosition returns relative coordinates
-                var itemBounds = new Rect(0, 0, targetItem.Bounds.Width, targetItem.Bounds.Height);
+                // Use 0,0-based bounds - GetPosition returns relative coordinates.
+                // #2382: Use header height, not full bounds (expanded items include children).
+                var zoneHeight = DropZoneHeightService.ResolveZoneHeight(
+                    targetItem.Bounds.Height, GetHeaderHeight(targetItem));
+                var itemBounds = new Rect(0, 0, targetItem.Bounds.Width, zoneHeight);
                 var dropPosition = _dragDropService.CalculateDropPosition(e.GetPosition(targetItem), itemBounds);
 
                 var validation = _dragDropService.ValidateDrop(draggedNode, targetNode, dropPosition);
@@ -299,6 +306,29 @@ namespace Parley.Views.Helpers
             // Walk up from the source to find a TreeViewItem
             var source = e.Source as Control;
             return source?.FindAncestorOfType<TreeViewItem>();
+        }
+
+        /// <summary>
+        /// #2382: Returns the height of a TreeViewItem's header row (the PART_LayoutRoot
+        /// Border in the default template), excluding any expanded child subtree. Returns
+        /// null when the part can't be found so callers fall back to the full item height.
+        /// </summary>
+        private static double? GetHeaderHeight(TreeViewItem item)
+        {
+            // The item's own header Border, not a child item's: take the first PART_LayoutRoot
+            // that has no intervening TreeViewItem between it and this item (expanded items
+            // nest child TreeViewItems, each with their own PART_LayoutRoot).
+            foreach (var border in item.GetVisualDescendants().OfType<Border>())
+            {
+                if (border.Name != "PART_LayoutRoot")
+                    continue;
+
+                var ancestorItem = border.FindAncestorOfType<TreeViewItem>();
+                if (ReferenceEquals(ancestorItem, item))
+                    return border.Bounds.Height;
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/Parley/Parley/Views/MainWindow.Properties.cs
+++ b/Parley/Parley/Views/MainWindow.Properties.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using DialogEditor.Models;
+using DialogEditor.Services;
 
 using Radoub.Formats.Logging;
 using DialogEditor.ViewModels;
@@ -33,6 +34,18 @@ namespace DialogEditor.Views
             }
 
             var dialogNode = _selectedNode.OriginalNode;
+
+            // #2382: Refuse to flush when the panel is out of sync with the selection.
+            // After a drag-drop refresh the TreeView can restore selection to a sibling
+            // while the panel still shows the dragged node — flushing here would write the
+            // displayed node's text onto the newly-selected node (data loss).
+            if (!PropertyFlushGuard.ShouldFlush(dialogNode, _lastPopulatedNode))
+            {
+                UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                    $"SaveCurrentNodeProperties: skipped — panel ('{_lastPopulatedNode?.Text?.GetDefault()}') " +
+                    $"out of sync with selection ('{dialogNode.Text?.GetDefault()}')");
+                return;
+            }
 
             // Issue #342: Use SafeControlFinder for cleaner null-safe control access
             // Update Speaker (only if editable)
@@ -137,6 +150,10 @@ namespace DialogEditor.Views
             }
 
             var dialogNode = node.OriginalNode;
+
+            // #2382: Record the node the panel is now populated from, so a later flush
+            // can verify it still matches the current selection before writing back.
+            _lastPopulatedNode = dialogNode;
 
             // Debug: Log node type for Issue #12 investigation
             UnifiedLogger.LogApplication(LogLevel.DEBUG,

--- a/Parley/Parley/Views/MainWindow.axaml.cs
+++ b/Parley/Parley/Views/MainWindow.axaml.cs
@@ -65,6 +65,12 @@ namespace DialogEditor.Views
         // Node selection state (shared across partial files)
         private TreeViewSafeNode? _selectedNode;
 
+        // #2382: The DialogNode the property panel was last populated FROM. Guards
+        // SaveCurrentNodeProperties against flushing stale TextBox values onto a
+        // different node when selection changes without a repopulate (e.g. drag-drop
+        // refresh restoring selection to a sibling).
+        private DialogNode? _lastPopulatedNode;
+
         public MainWindow(IServiceProvider serviceProvider)
         {
             InitializeComponent();

--- a/Parley/Parley/Views/QuestBrowserWindow.axaml.cs
+++ b/Parley/Parley/Views/QuestBrowserWindow.axaml.cs
@@ -362,21 +362,15 @@ namespace DialogEditor.Views
         /// </summary>
         private string? FindManifestPath()
         {
-            // First: Check shared Radoub settings (set by Manifest when it runs)
-            var sharedPath = Radoub.Formats.Settings.RadoubSettings.Instance.ManifestPath;
+            // First: Check shared Radoub settings (set by Manifest when it runs).
+            // #2357: _settings.ManifestPath is now a passthrough to this same value.
+            var sharedPath = _settings.ManifestPath;
             if (!string.IsNullOrEmpty(sharedPath) && File.Exists(sharedPath))
             {
                 return sharedPath;
             }
 
-            // Second: Check Parley-specific settings (legacy or manual override)
-            var settingsPath = _settings.ManifestPath;
-            if (!string.IsNullOrEmpty(settingsPath) && File.Exists(settingsPath))
-            {
-                return settingsPath;
-            }
-
-            // Third: Auto-detect common locations
+            // Second: Auto-detect common locations
             var parleyDir = AppDomain.CurrentDomain.BaseDirectory;
             var manifestPaths = new[]
             {


### PR DESCRIPTION
## Summary

Internal Parley hardening sprint plus two spot-check fixes found during verification.

## Work Items

- [x] #2357 — Migrate ExternalEditorPath/ManifestPath onto shared RadoubSettings
- [x] #2324 — Replace reflection-based DeleteNodeRecursive trampoline
- [x] #2109 — Unify TreeView/FlowView drag-drop validation
- [x] Spot-check fix: drag-drop onto expanded TreeView threads (header-height drop zone)
- [x] Spot-check fix: data loss — stale property panel overwriting wrong node after reparent

## Related Issues

- Closes #2382, #2109, #2324, #2357

## Tests

- Parley unit: 900 passed
- Parley FlaUI: 26/27 (1 failure: `CreaturePicker_LoadsCreaturesFromTestModule` — pre-existing flake, unrelated to diff; failed at a different step on re-run. Follow-up to be filed.)

## Follow-up

- #2392 — after reparent, selection restores to sibling instead of moved node (UX; data-loss already guarded)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)