### PR TITLE
[Parley] Fix: Drag-drop reparent selects sibling instead of moved node (#2392)

### DIFF
--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Parley. One-line highlights per version; full details in 
 
 ---
 
+## [0.1.175-alpha] - 2026-06-06
+**Branch**: `parley/issue-2392` | **PR**: #TBD
+
+### Fix: Drag-drop reparent selects sibling instead of moved node (#2392)
+
+---
+
 ## [0.1.174-alpha] - 2026-06-06
 **Branch**: `parley/issue-2382` | **PR**: #2388
 

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Parley. One-line highlights per version; full details in 
 ---
 
 ## [0.1.175-alpha] - 2026-06-06
-**Branch**: `parley/issue-2392` | **PR**: #TBD
+**Branch**: `parley/issue-2392` | **PR**: #2393
 
 ### Fix: Drag-drop reparent selects sibling instead of moved node (#2392)
 

--- a/Parley/Parley.Tests/TreeRefreshCoordinatorTests.cs
+++ b/Parley/Parley.Tests/TreeRefreshCoordinatorTests.cs
@@ -253,6 +253,61 @@ namespace DialogEditor.Tests
         }
 
         [Fact]
+        public void RefreshAndSelectNode_MovedNodeUnderCollapsedParent_SelectsMovedNode()
+        {
+            // #2392: After a drag-drop reparent, the moved node lands under a
+            // collapsed parent whose children are still lazy (placeholder only).
+            // FindNodeByKey must populate-and-descend to find the moved node
+            // instead of falling back to a sibling at NodeIndex-1.
+            var dialog = new Dialog();
+
+            // Two replies in the global Replies list: a sibling at index 0 and
+            // the moved node at index 1.
+            var siblingReply = new DialogNode { Type = DialogNodeType.Reply };
+            var movedReply = new DialogNode { Type = DialogNodeType.Reply };
+            dialog.Replies.Add(siblingReply); // index 0
+            dialog.Replies.Add(movedReply);   // index 1
+
+            // Parent entry that owns the moved reply via a real (non-link) pointer.
+            var parentEntry = new DialogNode { Type = DialogNodeType.Entry };
+            parentEntry.Pointers.Add(new DialogPtr
+            {
+                Type = DialogNodeType.Reply,
+                Index = 1,
+                Node = movedReply,
+                IsLink = false
+            });
+            dialog.Entries.Add(parentEntry);
+
+            // Rebuilt tree: root → parentEntry (collapsed: children are lazy,
+            // so only a placeholder exists; movedReply is NOT yet materialized).
+            var rootNode = new TreeViewRootNode(new Dialog());
+            var parentSafe = new TreeViewSafeNode(parentEntry);
+            rootNode.Children!.Add(parentSafe);
+            var treeNodes = new ObservableCollection<TreeViewSafeNode> { rootNode };
+
+            TreeViewSafeNode? restoredNode = null;
+
+            _coordinator = new TreeRefreshCoordinator(
+                populateDialogNodes: (skip) => { },
+                saveExpansionState: () => new HashSet<DialogNode>(),
+                restoreExpansionState: (nodes, refs) => { },
+                getDialogNodes: () => treeNodes,
+                getCurrentDialog: () => dialog,
+                getSelectedNode: () => null,
+                setSelectedNode: (node) => restoredNode = node,
+                getFocusedFieldInfo: () => (null, null),
+                restoreFocusedField: (name, pos) => { },
+                publishDialogRefreshed: (source) => { },
+                scheduleDeferred: action => action());
+
+            _coordinator.RefreshAndSelectNode(movedReply);
+
+            Assert.NotNull(restoredNode);
+            Assert.Same(movedReply, restoredNode!.OriginalNode);
+        }
+
+        [Fact]
         public void RefreshToRoot_DoesNotCallSetSelectedNode()
         {
             bool setSelectedCalled = false;

--- a/Parley/Parley/Services/TreeRefreshCoordinator.cs
+++ b/Parley/Parley/Services/TreeRefreshCoordinator.cs
@@ -275,6 +275,11 @@ namespace DialogEditor.Services
             if (parent.OriginalNode == target)
                 return parent;
 
+            // #2392: Tree children are lazy-loaded (#82) — a node reparented under
+            // a collapsed ancestor is not yet materialized, so force-populate at each
+            // level before descending. Mirrors the search-navigation fix (#1842).
+            parent.PopulateChildren();
+
             if (parent.Children != null)
             {
                 foreach (var child in parent.Children)


### PR DESCRIPTION
## Summary

After a drag-drop reparent, the TreeView restored selection to a *sibling* of the moved node instead of the moved node itself.

**Root cause**: `TreeRefreshCoordinator.FindTreeViewNodeRecursive` searched only materialized tree children, but children are lazy-loaded (#82). A node reparented under a collapsed ancestor was not yet built, so `FindFallbackNode` selected the previous sibling. Fix forces `PopulateChildren()` at each level before descending, mirroring the search-navigation fix (#1842).

## Related Issues

- Closes #2392
- Relates to #2388 (data-loss guard that masked the corruption)

## Tests

- New regression test: reparent under collapsed parent → moved node is selected (not sibling)
- Parley unit: 901/901 ✅
- Parley FlaUI: 27/27 ✅ (one creature-picker flake on first pass, passed on retry — unrelated module-load timing)

## Checklist

- [x] Implementation complete
- [x] Regression test added
- [x] CHANGELOG updated with date + PR number
- [x] Unit + FlaUI verified

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)