### PR TITLE
[Quartermaster] Sprint: Rendering Bug Cleanup (#2381)

### DIFF
--- a/.claude/scripts/New-AppearanceTestUtc.ps1
+++ b/.claude/scripts/New-AppearanceTestUtc.ps1
@@ -1,0 +1,56 @@
+# Build throwaway test creatures for QM model-preview verification (#2381).
+# Clones a base UTC (default Bucky.utc in LNS_DLG), swaps Appearance_Type, and
+# writes aN.utc files into the module so Quartermaster can open them quickly.
+# Uses the built Radoub.Formats.dll so the GFF round-trip matches QM.
+#
+# Requires PowerShell 7 (net assembly load); Windows PowerShell 5.1 cannot Add-Type a
+# net9.0 DLL. Use the full PS7 path, NOT the WindowsApps pwsh stub (Store launcher):
+#   & "C:\Program Files\PowerShell\7\pwsh.exe" -NoProfile -ExecutionPolicy Bypass `
+#       -File ".claude/scripts/New-AppearanceTestUtc.ps1" -Appearances a4=159,a5=3951
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string[]] $Appearances,
+
+    [string] $ModuleDir = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Neverwinter Nights\modules\LNS_DLG'),
+
+    [string] $BaseUtc = 'Bucky.utc'
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+$dll = Join-Path $repoRoot 'Radoub.Formats\Radoub.Formats\bin\Debug\net9.0\Radoub.Formats.dll'
+
+if (-not (Test-Path $dll)) {
+    throw "Radoub.Formats.dll not found at $dll - build Radoub.Formats first (dotnet build)."
+}
+Add-Type -Path $dll
+
+$basePath = Join-Path $ModuleDir $BaseUtc
+if (-not (Test-Path $basePath)) {
+    throw "Base UTC not found: $basePath"
+}
+
+foreach ($pair in ($Appearances -split ',')) {
+    $parts = $pair -split '='
+    if ($parts.Count -ne 2) { throw "Bad -Appearances entry '$pair'. Use file=row." }
+    $file = $parts[0].Trim()
+    $row = [uint16]($parts[1].Trim())
+
+    $utc = [Radoub.Formats.Utc.UtcReader]::Read($basePath)
+    $utc.AppearanceType = $row
+    $utc.TemplateResRef = $file
+    $utc.Tag = $file
+    $loc = New-Object Radoub.Formats.Gff.CExoLocString
+    $loc.SetString(0, "Test appearance $row ($file)")
+    $utc.FirstName = $loc
+
+    $outPath = Join-Path $ModuleDir ($file + '.utc')
+    [Radoub.Formats.Utc.UtcWriter]::Write($utc, $outPath)
+
+    $check = [Radoub.Formats.Utc.UtcReader]::Read($outPath)
+    if ($check.AppearanceType -ne $row) {
+        throw "Round-trip failed for $file - expected $row, got $($check.AppearanceType)"
+    }
+    Write-Host "Wrote $outPath  (Appearance_Type=$row)"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.3-alpha] - 2026-06-06
+**Branch**: `quartermaster/issue-2381` | **PR**: #2394
+
+### Model preview: PBR diffuse texture fallback (#1755)
+
+- Creature skins that reference a bare texture name now fall back to the NWN:EE PBR diffuse map (`<name>_d`) when the bare name is missing. Fixes white/untextured CEP3 creatures ported from NWN2 (e.g. Txpple beetles).
+
+---
+
 ## [Radoub.UI 0.2.2-alpha] - 2026-06-06
 **Branch**: `trebuchet/sprint/data-loss-marlinspike` | **PR**: #2387
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.4-alpha] - 2026-06-06
+**Branch**: `quartermaster/issue-2381` | **PR**: #2394
+
+### Model preview: softer lighting, less wash-out (#1762)
+
+- Lowered preview ambient (0.95→0.70) and the midtone gamma lift (1/1.6→1/1.1) so textures show their real color instead of bleached/faded. The PBR `_d` fallback (0.2.3) made the old over-bright lighting obvious on many creatures; this restores accurate tone across all models.
+
+---
+
 ## [Radoub.UI 0.2.3-alpha] - 2026-06-06
 **Branch**: `quartermaster/issue-2381` | **PR**: #2394
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.5-alpha] - 2026-06-07
+**Branch**: `quartermaster/issue-2381` | **PR**: #2394
+
+### Model preview: textures follow the model's source tier (#1758)
+
+- A creature model loaded from a HAK/Module now resolves its textures from the normal HAK-first chain instead of being forced to base-game BIF, so CEP-only skins (e.g. the green pixie `c_fairy`) render correctly instead of a stale 32×32 base stub. Base-game/Override models keep the BIF-preferred behavior (#1867 bat-wing fix). When a HAK creature's texture still falls back to a base-game stub, the preview now warns that it may be inaccurate. See follow-up refactor #2397.
+
+---
+
 ## [Radoub.UI 0.2.4-alpha] - 2026-06-06
 **Branch**: `quartermaster/issue-2381` | **PR**: #2394
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.6-alpha] - 2026-06-07
+**Branch**: `quartermaster/issue-2381` | **PR**: #2394
+
+### Model preview: graft full-body parts (robes) as a subtree (#1989)
+
+- A robe is a near-complete posed body (its own torso/limb hierarchy + coat/arms skin meshes), not a single part. The composer now grafts a robe's whole subtree preserving its internal transforms instead of splicing individual meshes onto skeleton bones (which collapsed/ballooned the arms). Skin meshes keep their `MdlSkinNode` type through cloning. Static-pose render now matches Aurora; per-variant residuals (Render=false limb meshes, cloak placement) tracked in #2398, animation in #2399.
+
+---
+
 ## [Radoub.UI 0.2.5-alpha] - 2026-06-07
 **Branch**: `quartermaster/issue-2381` | **PR**: #2394
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Project guidance for Claude Code sessions working with the Radoub multi-tool rep
 | **Quartermaster** | QM | Creature/inventory editor (`.utc`, `.bic` files) | `Quartermaster/CLAUDE.md` |
 | **Fence** | FEN | Merchant/store editor (`.utm` files) | `Fence/CLAUDE.md` |
 | **Relique** | REL | Item blueprint editor (`.uti` files) | `Relique/CLAUDE.md` |
+| **Reliquary** | RLQ | Placeable blueprint editor (`.utp` files; namespace `PlaceableEditor`) | `Reliquary/CLAUDE.md` |
 | **Trebuchet** | TRE | Radoub launcher/hub | `Trebuchet/CLAUDE.md` |
 | **Marlinspike** | MAR | Search & replace across files (lives in Trebuchet) | `Trebuchet/CLAUDE.md` |
 | **Radoub** | RAD | Repository-level / shared | This file |
@@ -27,11 +28,7 @@ Project guidance for Claude Code sessions working with the Radoub multi-tool rep
 
 ### Planned Tools
 
-| Tool | Description | Status |
-|------|-------------|--------|
-| **Reliquary** | (TBD — placeholder for future tool) | Planned; bootstrap FlaUI infra tracked in [#2304](https://github.com/LordOfMyatar/Radoub/issues/2304) |
-
-Future tools land as subdirectories with their own README, CLAUDE.md, and development infrastructure. Bootstrap follows the [New Tool Bootstrap guide](Documentation/NEW_TOOL_BOOTSTRAP.md).
+None currently. Future tools land as subdirectories with their own README, CLAUDE.md, and development infrastructure. Bootstrap follows the [New Tool Bootstrap guide](Documentation/NEW_TOOL_BOOTSTRAP.md).
 
 ---
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -11,7 +11,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ### Sprint: Rendering Bug Cleanup (#2381)
 
 - Fire/stag/bombardier beetle (Txpple) and giant/glow spider (CEP `una`) now render textured, not white (#1755, #1760) — PBR diffuse fallback in shared Radoub.UI 0.2.3-alpha (see root CHANGELOG)
-- Fey/pixy, dire rat model rendering fixes (#1758, #1762)
+- Dire rat (CEP `una`) now renders textured; softer preview lighting so models aren't washed out (#1762) — shared Radoub.UI 0.2.4-alpha (see root CHANGELOG)
+- Fey/pixy model rendering fix (#1758)
 - Robe armor rendering gaps / missing lower body parts (#1989)
 - Snake preview floating fangs + flat pose (#2126)
 - Level-by-level stats history tracking in comments (#875)

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -13,9 +13,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 - Fire/stag/bombardier beetle (Txpple) and giant/glow spider (CEP `una`) now render textured, not white (#1755, #1760) — PBR diffuse fallback in shared Radoub.UI 0.2.3-alpha (see root CHANGELOG)
 - Dire rat (CEP `una`) now renders textured; softer preview lighting so models aren't washed out (#1762) — shared Radoub.UI 0.2.4-alpha (see root CHANGELOG)
 - Fey/pixy (`c_fairy`) and other CEP creatures render their own pack's textures, not a base-game stub (#1758) — preview textures follow the model's source tier (shared Radoub.UI 0.2.5-alpha, see root CHANGELOG)
-- Robe armor rendering gaps / missing lower body parts (#1989)
+- Robe armor renders as a proper combined body — no more back-gaps/missing-legs/ballooned arms; suppresses the body parts the robe replaces and grafts the robe's own posed subtree (#1989) — shared Radoub.UI 0.2.6-alpha (see root CHANGELOG). Per-variant residuals tracked in #2398/#2399.
 - Snake preview floating fangs + flat pose (#2126)
-- Level-by-level stats history tracking in comments (#875)
 
 ---
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -10,7 +10,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ### Sprint: Rendering Bug Cleanup (#2381)
 
-- Fire beetle, fey/pixy, dire rat, giant spider model rendering fixes (#1755, #1758, #1762, #1760)
+- Fire/stag/bombardier beetle (Txpple) now render textured, not white (#1755) — PBR diffuse fallback in shared Radoub.UI 0.2.3-alpha (see root CHANGELOG)
+- Fey/pixy, dire rat, giant spider model rendering fixes (#1758, #1762, #1760)
 - Robe armor rendering gaps / missing lower body parts (#1989)
 - Snake preview floating fangs + flat pose (#2126)
 - Level-by-level stats history tracking in comments (#875)

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -14,7 +14,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 - Dire rat (CEP `una`) now renders textured; softer preview lighting so models aren't washed out (#1762) — shared Radoub.UI 0.2.4-alpha (see root CHANGELOG)
 - Fey/pixy (`c_fairy`) and other CEP creatures render their own pack's textures, not a base-game stub (#1758) — preview textures follow the model's source tier (shared Radoub.UI 0.2.5-alpha, see root CHANGELOG)
 - Robe armor renders as a proper combined body — no more back-gaps/missing-legs/ballooned arms; suppresses the body parts the robe replaces and grafts the robe's own posed subtree (#1989) — shared Radoub.UI 0.2.6-alpha (see root CHANGELOG). Per-variant residuals tracked in #2398/#2399.
-- Snake preview floating fangs + flat pose (#2126)
+- Snake floating fangs + flat pose (#2126) — root-caused as the un-applied skin-mesh deformation; deferred to skinning epic #2400 (not fixable without the shared renderer's bone-weight deformation work)
+- Removed the disabled "Not yet implemented" Undo/Redo/Cut/Copy/Paste Edit-menu stubs (#2250) per the #2231 UI-uniformity rule
 
 ---
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.117-alpha] - 2026-06-06
-**Branch**: `quartermaster/issue-2381` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2381` | **PR**: #2394
 
 ### Sprint: Rendering Bug Cleanup (#2381)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.117-alpha] - 2026-06-06
+**Branch**: `quartermaster/issue-2381` | **PR**: #TBD
+
+### Sprint: Rendering Bug Cleanup (#2381)
+
+- Fire beetle, fey/pixy, dire rat, giant spider model rendering fixes (#1755, #1758, #1762, #1760)
+- Robe armor rendering gaps / missing lower body parts (#1989)
+- Snake preview floating fangs + flat pose (#2126)
+- Level-by-level stats history tracking in comments (#875)
+
+---
+
 ## [0.2.116-alpha] - 2026-06-05
 **Branch**: `radoub/issue-2350` | **PR**: #2351
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -10,8 +10,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ### Sprint: Rendering Bug Cleanup (#2381)
 
-- Fire/stag/bombardier beetle (Txpple) now render textured, not white (#1755) — PBR diffuse fallback in shared Radoub.UI 0.2.3-alpha (see root CHANGELOG)
-- Fey/pixy, dire rat, giant spider model rendering fixes (#1758, #1762, #1760)
+- Fire/stag/bombardier beetle (Txpple) and giant/glow spider (CEP `una`) now render textured, not white (#1755, #1760) — PBR diffuse fallback in shared Radoub.UI 0.2.3-alpha (see root CHANGELOG)
+- Fey/pixy, dire rat model rendering fixes (#1758, #1762)
 - Robe armor rendering gaps / missing lower body parts (#1989)
 - Snake preview floating fangs + flat pose (#2126)
 - Level-by-level stats history tracking in comments (#875)

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -12,7 +12,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 - Fire/stag/bombardier beetle (Txpple) and giant/glow spider (CEP `una`) now render textured, not white (#1755, #1760) — PBR diffuse fallback in shared Radoub.UI 0.2.3-alpha (see root CHANGELOG)
 - Dire rat (CEP `una`) now renders textured; softer preview lighting so models aren't washed out (#1762) — shared Radoub.UI 0.2.4-alpha (see root CHANGELOG)
-- Fey/pixy model rendering fix (#1758)
+- Fey/pixy (`c_fairy`) and other CEP creatures render their own pack's textures, not a base-game stub (#1758) — preview textures follow the model's source tier (shared Radoub.UI 0.2.5-alpha, see root CHANGELOG)
 - Robe armor rendering gaps / missing lower body parts (#1989)
 - Snake preview floating fangs + flat pose (#2126)
 - Level-by-level stats history tracking in comments (#875)

--- a/Quartermaster/CLAUDE.md
+++ b/Quartermaster/CLAUDE.md
@@ -129,9 +129,8 @@ Quartermaster/
 │   │       ├── QuickBarPanel.axaml(.cs) - Quick access bar
 │   │       └── PlaceholderPanel.axaml(.cs) - Placeholder
 │   └── Assets/
-└── Quartermaster.Tests/ (unit tests)
-    ├── CommandLineServiceTests.cs
-    └── SettingsServiceTests.cs
+└── Quartermaster.Tests/ (43 unit-test files — services, wizard logic, round-trip,
+                          appearance/HAK-merge, feat/skill/spell, level history)
 ```
 
 ---
@@ -291,6 +290,26 @@ Items are resolved in this order:
 
 ---
 
+## Model Preview & Textures
+
+The 3D appearance preview lives in shared `Radoub.UI` (`ModelPreviewGLControl`,
+`TextureService`, `MeshSkipHeuristic` — all in `Radoub.UI/Controls` + `Radoub.UI/Services`),
+not in Quartermaster. Edit there for rendering bugs.
+
+**PBR texture resolution (#1755, #1760)**: NWN:EE creature skins resolve textures two
+ways — (1) an `.mtr` material file named by the mesh's `materialname`, or (2) a fixed
+suffix convention where the bare `<name>` has companion maps `<name>_d` (diffuse),
+`_n` (normal), `_r` (roughness), `_i` (illum). MDL meshes reference the bare name;
+`TextureService.LoadTextureWithKind` falls back to `<name>_d` when the bare name misses.
+CEP3 creatures ported from NWN2 (Txpple beetles, CEP `una` spiders) rely on this — without
+the fallback they render **white**.
+
+**Known gap**: the binary MDL reader declares `MaterialName` but never reads it, and `.mtr`
+files (resource type 3007) are not parsed. MTR-driven creatures whose diffuse has a non-`_d`
+name still render white. If a white-model bug isn't explained by the `_d` convention, suspect MTR.
+
+---
+
 ## Testing
 
 ### Unit Tests
@@ -299,14 +318,15 @@ Items are resolved in this order:
 dotnet test Quartermaster/Quartermaster.Tests
 ```
 
-35+ test files covering:
-- AbilityPointBuyService, AlignmentRestriction, Appearance (3 variants)
+43 test files covering:
+- AbilityPointBuyService, AlignmentRestriction, Appearance (analysis/filter/service/HAK-merge)
 - CharacterCreation, CharacterSheet, ClassAlignment, ClassDomain, Combat
-- CreatureDisplay, Domain, FeatCache, FeatService (4 variants)
+- CreatureDisplay, Domain, FeatCache, FeatService (4 variants + prereq-override + subtype)
 - LevelHistory, LevelUpApplication, LevelUpSkillDisplay, Metamagic
-- ModelService (2 variants), NcwHardening, PaletteColor
-- PrestigePrerequisite, RoundTripValidation, ScriptBrowserContext
-- ScriptTemplate, SkillService, SpellService, CommandLineService, SettingsService
+- ModelNameConstruction, NcwHardening, PaletteColor, PltColorIndices
+- PrestigePrerequisite, RoundTripValidation, ScriptBrowserContext, PortraitBrowserContext
+- ScriptTemplate, SkillService, SpellService, CommandLineService, SettingsService (+ bool persistence)
+- WizardDisplayItem, PathSafety, GameDataWarnOnce
 
 ### Integration Tests
 
@@ -315,6 +335,19 @@ FlaUI smoke tests in `Radoub.IntegrationTests/Quartermaster/`:
 ```bash
 dotnet test Radoub.IntegrationTests --filter "Category=Smoke&FullyQualifiedName~Quartermaster"
 ```
+
+### Manual Model-Preview Fixtures
+
+To eyeball a specific appearance, clone Bucky.utc with a swapped `Appearance_Type` into
+LNS_DLG (PS7 required — loads the net9.0 Radoub.Formats.dll; do NOT use Windows PowerShell 5.1
+or the WindowsApps `pwsh` stub):
+
+```bash
+& "C:\Program Files\PowerShell\7\pwsh.exe" -NoProfile -ExecutionPolicy Bypass `
+  -File ".claude/scripts/New-AppearanceTestUtc.ps1" -Appearances a4=159,a5=3951
+```
+
+Open the generated `aN.utc` in QM → Appearance panel to verify rendering.
 
 ---
 

--- a/Quartermaster/Quartermaster.Tests/RobePartSuppressionTests.cs
+++ b/Quartermaster/Quartermaster.Tests/RobePartSuppressionTests.cs
@@ -1,0 +1,56 @@
+using Quartermaster.Services;
+using Xunit;
+
+namespace Quartermaster.Tests;
+
+/// <summary>
+/// Tests for robe body-part suppression (#1989). NWN robe models are a single combined
+/// mesh covering torso + pelvis + upper legs (and, for long-sleeve robes like CEP Robe
+/// #186, shoulders + biceps). The composer must skip those individual parts when a robe
+/// is equipped, or they z-fight / leave gaps. Extremities (head, neck, forearms, hands,
+/// shins, feet) and the belt continue to load.
+/// </summary>
+public class RobePartSuppressionTests
+{
+    // Robe #186 supplies its own torso/pelvis/biceps/thighs/forearms/shins/hands geometry.
+    [Theory]
+    [InlineData("chest")]
+    [InlineData("pelvis")]
+    [InlineData("legl")]
+    [InlineData("legr")]
+    [InlineData("shol")]
+    [InlineData("shor")]
+    [InlineData("bicepl")]
+    [InlineData("bicepr")]
+    [InlineData("forel")]
+    [InlineData("forer")]
+    [InlineData("handl")]
+    [InlineData("handr")]
+    [InlineData("shinl")]
+    [InlineData("shinr")]
+    public void RobeActive_SuppressesCoveredParts(string partType)
+        => Assert.True(RobePartSuppression.IsSuppressedByRobe(partType, robeActive: true));
+
+    // The robe has no head/neck/foot geometry — those still load. Belt is kept (separate cinch).
+    [Theory]
+    [InlineData("head")]
+    [InlineData("neck")]
+    [InlineData("robe")]
+    [InlineData("belt")]
+    [InlineData("footl")]
+    [InlineData("footr")]
+    public void RobeActive_PreservesHeadNeckFeet(string partType)
+        => Assert.False(RobePartSuppression.IsSuppressedByRobe(partType, robeActive: true));
+
+    [Theory]
+    [InlineData("chest")]
+    [InlineData("pelvis")]
+    [InlineData("legl")]
+    [InlineData("shol")]
+    public void NoRobe_SuppressesNothing(string partType)
+        => Assert.False(RobePartSuppression.IsSuppressedByRobe(partType, robeActive: false));
+
+    [Fact]
+    public void IsCaseInsensitive()
+        => Assert.True(RobePartSuppression.IsSuppressedByRobe("CHEST", robeActive: true));
+}

--- a/Quartermaster/Quartermaster/Services/ModelService.cs
+++ b/Quartermaster/Quartermaster/Services/ModelService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Radoub.Formats.Common;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Mdl;
+using Radoub.Formats.Resolver;
 using Radoub.Formats.Services;
 using Radoub.Formats.Utc;
 using Radoub.Formats.Uti;
@@ -21,7 +22,17 @@ public class ModelService
     private readonly IGameDataService _gameDataService;
     private readonly MdlReader _mdlReader = new();
     private readonly Dictionary<string, MdlModel?> _modelCache = new();
+    private readonly Dictionary<string, ResourceSource> _modelSourceCache = new();
     private readonly MdlPartComposer _composer;
+
+    /// <summary>
+    /// Source of the most recent model resolved by <see cref="LoadModel"/>. Drives the
+    /// preview's texture-source policy (#1758): a HAK/Module creature should use its own
+    /// pack's textures, a base/Override creature keeps the #1867 BIF-prefer behavior.
+    /// Defaults to <see cref="ResourceSource.Bif"/> so part-based player bodies (composed
+    /// from base parts) keep BIF-preferred textures.
+    /// </summary>
+    public ResourceSource LastLoadedModelSource { get; private set; } = ResourceSource.Bif;
 
     public ModelService(IGameDataService gameDataService)
     {
@@ -76,7 +87,11 @@ public class ModelService
                         $"LoadCreatureModel: No armor overrides (naked creature or no chest armor)");
                 }
 
-                return LoadPartBasedCreatureModel(creature, armorOverrides);
+                var partModel = LoadPartBasedCreatureModel(creature, armorOverrides);
+                // Part-based player/creature bodies are composed from base-game parts;
+                // keep BIF-preferred textures (#1867) regardless of which part loaded last.
+                LastLoadedModelSource = ResourceSource.Bif;
+                return partModel;
             }
 
             return LoadModelForAppearance(appearanceId, gender, phenotype);
@@ -305,6 +320,8 @@ public class ModelService
         if (_modelCache.TryGetValue(resRef, out var cached))
         {
             UnifiedLogger.LogApplication(LogLevel.DEBUG, $"LoadModel: '{resRef}' from cache, hasModel={cached != null}");
+            if (_modelSourceCache.TryGetValue(resRef, out var cachedSource))
+                LastLoadedModelSource = cachedSource;
             return cached;
         }
 
@@ -316,6 +333,8 @@ public class ModelService
             return null;
         }
 
+        LastLoadedModelSource = resourceResult.Source;
+        _modelSourceCache[resRef] = resourceResult.Source;
         var modelData = resourceResult.Data;
         var sourceFile = System.IO.Path.GetFileName(resourceResult.SourcePath);
         UnifiedLogger.LogApplication(LogLevel.INFO, $"LoadModel: '{resRef}' from {resourceResult.Source} ({sourceFile}), {modelData.Length} bytes");

--- a/Quartermaster/Quartermaster/Services/ModelService.cs
+++ b/Quartermaster/Quartermaster/Services/ModelService.cs
@@ -201,35 +201,57 @@ public class ModelService
 
         var parts = new List<(string PartType, string ResRef)>();
 
-        // Head — special, uses AppearanceHead, never overridden by armor
-        AppendPart(parts, basePrefix, "head", creature.AppearanceHead);
-
-        AppendPart(parts, basePrefix, "neck", GetPartNumber("Neck", creature.BodyPart_Neck));
-        AppendPart(parts, basePrefix, "chest", GetPartNumber("Torso", creature.BodyPart_Torso));
-
-        // Robe is armor-only (no creature body part); only added if armor has a robe override
+        // Robe is armor-only (no creature body part); only added if armor has a robe override.
         var robePartNumber = (armorOverrides != null && armorOverrides.TryGetValue("Robe", out var robeValue) && robeValue > 0)
             ? robeValue : (byte)0;
-        AppendPart(parts, basePrefix, "robe", robePartNumber);
 
-        AppendPart(parts, basePrefix, "pelvis", GetPartNumber("Pelvis", creature.BodyPart_Pelvis));
-        AppendPart(parts, basePrefix, "belt", GetPartNumber("Belt", creature.BodyPart_Belt));
+        // #1989: load the robe FIRST and only suppress the body parts it covers if it actually
+        // resolved. Otherwise (robe model missing for this mannequin) we'd strip the torso/arms/
+        // legs AND have no robe to replace them — an empty render (the dana/pmo0 case).
+        if (robePartNumber > 0)
+            AppendPart(parts, basePrefix, "robe", robePartNumber);
+        bool robeActive = parts.Any(p => p.PartType.Equals("robe", System.StringComparison.OrdinalIgnoreCase));
+        if (robePartNumber > 0 && !robeActive)
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"LoadPartBasedCreatureModel: robe #{robePartNumber} did not resolve — keeping body parts (no suppression)");
 
-        AppendPart(parts, basePrefix, "shol", GetPartNumber("LShoul", creature.BodyPart_LShoul));
-        AppendPart(parts, basePrefix, "shor", GetPartNumber("RShoul", creature.BodyPart_RShoul));
-        AppendPart(parts, basePrefix, "bicepl", GetPartNumber("LBicep", creature.BodyPart_LBicep));
-        AppendPart(parts, basePrefix, "bicepr", GetPartNumber("RBicep", creature.BodyPart_RBicep));
-        AppendPart(parts, basePrefix, "forel", GetPartNumber("LFArm", creature.BodyPart_LFArm));
-        AppendPart(parts, basePrefix, "forer", GetPartNumber("RFArm", creature.BodyPart_RFArm));
-        AppendPart(parts, basePrefix, "handl", GetPartNumber("LHand", creature.BodyPart_LHand));
-        AppendPart(parts, basePrefix, "handr", GetPartNumber("RHand", creature.BodyPart_RHand));
+        // A robe is a near-complete posed body covering torso/pelvis/limbs; skip those individual
+        // parts when a robe actually loaded — loading them additively causes z-fighting and gaps.
+        void AddPart(string partType, byte partNumber)
+        {
+            if (RobePartSuppression.IsSuppressedByRobe(partType, robeActive))
+            {
+                UnifiedLogger.LogApplication(LogLevel.INFO,
+                    $"LoadPartBasedCreatureModel: skipping '{partType}' (covered by robe #{robePartNumber})");
+                return;
+            }
+            AppendPart(parts, basePrefix, partType, partNumber);
+        }
 
-        AppendPart(parts, basePrefix, "legl", GetPartNumber("LThigh", creature.BodyPart_LThigh));
-        AppendPart(parts, basePrefix, "legr", GetPartNumber("RThigh", creature.BodyPart_RThigh));
-        AppendPart(parts, basePrefix, "shinl", GetPartNumber("LShin", creature.BodyPart_LShin));
-        AppendPart(parts, basePrefix, "shinr", GetPartNumber("RShin", creature.BodyPart_RShin));
-        AppendPart(parts, basePrefix, "footl", GetPartNumber("LFoot", creature.BodyPart_LFoot));
-        AppendPart(parts, basePrefix, "footr", GetPartNumber("RFoot", creature.BodyPart_RFoot));
+        // Head — special, uses AppearanceHead, never overridden by armor
+        AddPart("head", creature.AppearanceHead);
+
+        AddPart("neck", GetPartNumber("Neck", creature.BodyPart_Neck));
+        AddPart("chest", GetPartNumber("Torso", creature.BodyPart_Torso));
+
+        AddPart("pelvis", GetPartNumber("Pelvis", creature.BodyPart_Pelvis));
+        AddPart("belt", GetPartNumber("Belt", creature.BodyPart_Belt));
+
+        AddPart("shol", GetPartNumber("LShoul", creature.BodyPart_LShoul));
+        AddPart("shor", GetPartNumber("RShoul", creature.BodyPart_RShoul));
+        AddPart("bicepl", GetPartNumber("LBicep", creature.BodyPart_LBicep));
+        AddPart("bicepr", GetPartNumber("RBicep", creature.BodyPart_RBicep));
+        AddPart("forel", GetPartNumber("LFArm", creature.BodyPart_LFArm));
+        AddPart("forer", GetPartNumber("RFArm", creature.BodyPart_RFArm));
+        AddPart("handl", GetPartNumber("LHand", creature.BodyPart_LHand));
+        AddPart("handr", GetPartNumber("RHand", creature.BodyPart_RHand));
+
+        AddPart("legl", GetPartNumber("LThigh", creature.BodyPart_LThigh));
+        AddPart("legr", GetPartNumber("RThigh", creature.BodyPart_RThigh));
+        AddPart("shinl", GetPartNumber("LShin", creature.BodyPart_LShin));
+        AddPart("shinr", GetPartNumber("RShin", creature.BodyPart_RShin));
+        AddPart("footl", GetPartNumber("LFoot", creature.BodyPart_LFoot));
+        AddPart("footr", GetPartNumber("RFoot", creature.BodyPart_RFoot));
 
         return _composer.Compose(basePrefix, parts);
     }

--- a/Quartermaster/Quartermaster/Services/RobePartSuppression.cs
+++ b/Quartermaster/Quartermaster/Services/RobePartSuppression.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace Quartermaster.Services;
+
+/// <summary>
+/// Decides which body parts a robe model replaces (#1989). An NWN robe model is a near-total
+/// body: inspection of CEP Robe #186 (`pmh0_robe186`, supermodel `pmh0`) shows it supplies its
+/// own geometry for torso, pelvis, biceps, thighs, forearms, shins, and hands — everything
+/// except head, neck, and feet. Loading the individual body parts alongside it duplicates that
+/// geometry at slightly-off transforms (the floating forearms/hands seen in the bug) and leaves
+/// gaps where the robe expects to be the only mesh.
+///
+/// So when a robe is equipped, suppress every covered part and keep only head, neck, and feet
+/// (the robe has no foot geometry). Belt is kept (a separately-cinched belt is common). Rare
+/// short-sleeve / half-robe variants would over-suppress under this fixed list; if one is found
+/// to regress it needs a data-driven signal (tracked separately) rather than a hardcoded set.
+/// </summary>
+public static class RobePartSuppression
+{
+    private static readonly HashSet<string> RobeCoveredParts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "chest", "pelvis", "legl", "legr", "shol", "shor", "bicepl", "bicepr",
+        "forel", "forer", "handl", "handr", "shinl", "shinr",
+    };
+
+    public static bool IsSuppressedByRobe(string partType, bool robeActive) =>
+        robeActive && !string.IsNullOrEmpty(partType) && RobeCoveredParts.Contains(partType);
+}

--- a/Quartermaster/Quartermaster/Views/MainWindow.axaml
+++ b/Quartermaster/Quartermaster/Views/MainWindow.axaml
@@ -80,12 +80,8 @@
                 <MenuItem Header="E_xit" Click="OnExitClick" InputGesture="Alt+F4"/>
             </MenuItem>
             <MenuItem Header="_Edit">
-                <MenuItem Header="_Undo" InputGesture="Ctrl+Z" IsEnabled="False" ToolTip.Tip="Not yet implemented"/>
-                <MenuItem Header="_Redo" InputGesture="Ctrl+Y" IsEnabled="False" ToolTip.Tip="Not yet implemented"/>
-                <Separator/>
-                <MenuItem Header="Cu_t" InputGesture="Ctrl+X" IsEnabled="False" ToolTip.Tip="Not yet implemented"/>
-                <MenuItem Header="_Copy" InputGesture="Ctrl+C" IsEnabled="False" ToolTip.Tip="Not yet implemented"/>
-                <MenuItem Header="_Paste" InputGesture="Ctrl+V" IsEnabled="False" ToolTip.Tip="Not yet implemented"/>
+                <!-- Undo/Redo/Cut/Copy/Paste removed (#2250): disabled "Not yet implemented"
+                     stubs violate the #2231 UI-uniformity rule. Re-add only when wired. -->
                 <MenuItem Header="_Delete" Click="OnDeleteClick" InputGesture="Delete" IsEnabled="{Binding HasSelection, ElementName=MainWindowInstance}"/>
                 <Separator/>
                 <MenuItem Header="_Find..." Click="OnFindClick" InputGesture="Ctrl+F" IsEnabled="{Binding HasFile, ElementName=MainWindowInstance}"/>

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.DataLoading.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.DataLoading.cs
@@ -184,11 +184,13 @@ public partial class AppearancePanel
                     armorColors.Value.leather1, armorColors.Value.leather2);
             }
 
-            // Prefer BIF textures for creature models to avoid CEP texture
-            // incompatibilities (e.g., reversed bat wings from CEP texture) (#1867)
-            _modelPreviewGL.PreferBifTextures = true;
-
+            // Texture-source policy (#1758): load the model first, then prefer BIF
+            // textures only when the model itself came from base game/Override (#1867
+            // bat-wing fix). HAK/Module creatures (CEP) use their own pack's textures
+            // so CEP-only skins like c_fairy resolve correctly instead of a base stub.
             var model = _modelService.LoadCreatureModel(_currentCreature);
+            _modelPreviewGL.PreferBifTextures =
+                TextureSourcePolicy.PreferBif(_modelService.LastLoadedModelSource);
             _modelPreviewGL.Model = model;
             RefreshAnimationList(model);
         }

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
@@ -80,6 +80,7 @@ public partial class AppearancePanel
         {
             _modelPreviewGL.PreviewStateChanged += OnPreviewStateChanged;
             _modelPreviewGL.MeshInfoChanged += OnMeshInfoChanged;
+            _modelPreviewGL.TextureSourceChanged += OnTextureSourceChanged;
         }
 
         // 3D Preview button events
@@ -389,6 +390,7 @@ public partial class AppearancePanel
         {
             _modelPreviewGL.PreviewStateChanged -= OnPreviewStateChanged;
             _modelPreviewGL.MeshInfoChanged -= OnMeshInfoChanged;
+            _modelPreviewGL.TextureSourceChanged -= OnTextureSourceChanged;
         }
 
         if (_rotateLeftButton != null)
@@ -643,6 +645,25 @@ public partial class AppearancePanel
             default:
                 _previewStateOverlay.IsVisible = false;
                 break;
+        }
+    }
+
+    private void OnTextureSourceChanged(object? sender, bool usedBaseFallback)
+    {
+        // #1758: a CEP creature whose own pack lacked the texture fell back to a
+        // base-game stub — warn that the preview skin may not match the asset.
+        if (_textureSourceStatusText == null) return;
+
+        if (usedBaseFallback)
+        {
+            _textureSourceStatusText.Text =
+                "⚠ Preview may be inaccurate — using base-game textures (model's pack has no matching texture)";
+            _textureSourceStatusText.Foreground = BrushManager.GetWarningBrush(this);
+            _textureSourceStatusText.IsVisible = true;
+        }
+        else
+        {
+            _textureSourceStatusText.IsVisible = false;
         }
     }
 

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
@@ -328,11 +328,18 @@
                         </Grid>
                     </Border>
 
-                    <!-- Model Info Status Line (#1873) -->
-                    <TextBlock Grid.Row="2" x:Name="ModelInfoStatusText"
-                               FontSize="{DynamicResource FontSizeSmall}" Padding="10,4"
-                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
-                               IsVisible="False"/>
+                    <!-- Model Info Status Lines (#1873 mesh info, #1758 texture-source warning) -->
+                    <StackPanel Grid.Row="2" Orientation="Vertical">
+                        <TextBlock x:Name="ModelInfoStatusText"
+                                   FontSize="{DynamicResource FontSizeSmall}" Padding="10,4"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                   TextWrapping="Wrap"
+                                   IsVisible="False"/>
+                        <TextBlock x:Name="TextureSourceStatusText"
+                                   FontSize="{DynamicResource FontSizeSmall}" Padding="10,0,10,4"
+                                   TextWrapping="Wrap"
+                                   IsVisible="False"/>
+                    </StackPanel>
 
                     <!-- Preview Controls -->
                     <Border Grid.Row="3" Padding="10"

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
@@ -72,6 +72,7 @@ public partial class AppearancePanel : UserControl
     private Border? _previewStateOverlay;
     private TextBlock? _previewStateText;
     private TextBlock? _modelInfoStatusText;
+    private TextBlock? _textureSourceStatusText;
     private Button? _rotateLeftButton;
     private Button? _rotateRightButton;
     private Button? _resetViewButton;
@@ -176,6 +177,7 @@ public partial class AppearancePanel : UserControl
         _previewStateOverlay = this.FindControl<Border>("PreviewStateOverlay");
         _previewStateText = this.FindControl<TextBlock>("PreviewStateText");
         _modelInfoStatusText = this.FindControl<TextBlock>("ModelInfoStatusText");
+        _textureSourceStatusText = this.FindControl<TextBlock>("TextureSourceStatusText");
         _rotateLeftButton = this.FindControl<Button>("RotateLeftButton");
         _rotateRightButton = this.FindControl<Button>("RotateRightButton");
         _resetViewButton = this.FindControl<Button>("ResetViewButton");

--- a/Radoub.UI/Radoub.UI.Tests/MdlPartComposerRobeTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/MdlPartComposerRobeTests.cs
@@ -1,0 +1,100 @@
+using System.Numerics;
+using Radoub.Formats.Mdl;
+using Radoub.TestUtilities.Mocks;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Tests the robe subtree-graft path in MdlPartComposer (#1989). A robe model is a near-complete
+/// posed body with its own nested bone hierarchy; the composer must graft that subtree preserving
+/// each mesh's local transform (so limbs keep their authored positions) rather than splicing
+/// individual meshes onto the skeleton's bones (which collapsed the arms onto the torso).
+/// </summary>
+public class MdlPartComposerRobeTests
+{
+    private static MdlTrimeshNode Mesh(string name, Vector3 pos, int verts, bool skin = false)
+    {
+        var n = skin ? new MdlSkinNode() : new MdlTrimeshNode();
+        n.Name = name;
+        n.Position = pos;
+        n.Orientation = Quaternion.Identity;
+        n.Scale = 1.0f;
+        n.Vertices = new Vector3[verts];
+        n.Faces = new MdlFace[1];
+        return n;
+    }
+
+    private static MdlNode Bone(string name, Vector3 pos)
+        => new() { Name = name, Position = pos, Orientation = Quaternion.Identity, Scale = 1.0f };
+
+    /// <summary>Skeleton: rootdummy → torso_g → Rbicep_g → rforearm_g.</summary>
+    private static MdlModel BuildSkeleton()
+    {
+        var root = Bone("rootdummy", new Vector3(0, 0, 1.2f));
+        var torso = Bone("torso_g", new Vector3(0, 0, 0));
+        var bicep = Bone("Rbicep_g", new Vector3(0.2f, 0, 0.35f));
+        var fore = Bone("rforearm_g", new Vector3(0.04f, 0, -0.30f));
+        bicep.Children.Add(fore); fore.Parent = bicep;
+        torso.Children.Add(bicep); bicep.Parent = torso;
+        root.Children.Add(torso); torso.Parent = root;
+        return new MdlModel { Name = "pmh0", GeometryRoot = root };
+    }
+
+    /// <summary>Robe: rootdummy → torso_g → rbicep_g → rforearm_g, plus a 'coat' skin child.</summary>
+    private static MdlModel BuildRobe()
+    {
+        var root = Bone("rootdummy", new Vector3(0, 0, 1.2f));
+        var torso = Mesh("torso_g", new Vector3(0, 0, 0), 27);
+        var bicep = Mesh("rbicep_g", new Vector3(0.2f, 0, 0.35f), 33);
+        var fore = Mesh("rforearm_g", new Vector3(0.04f, 0, -0.30f), 27);
+        bicep.Children.Add(fore); fore.Parent = bicep;
+        torso.Children.Add(bicep); bicep.Parent = torso;
+        var coat = Mesh("coat", new Vector3(0, 0, 1.21f), 324, skin: true);
+        root.Children.Add(torso); torso.Parent = root;
+        root.Children.Add(coat); coat.Parent = root;
+        return new MdlModel { Name = "pmh0_robe186", GeometryRoot = root };
+    }
+
+    private static MdlPartComposer MakeComposer(MdlModel skeleton, MdlModel robe)
+    {
+        var mock = new MockGameDataService(includeSampleData: false);
+        return new MdlPartComposer(mock, (resRef, _) => resRef switch
+        {
+            "pmh0" => skeleton,
+            "pmh0_robe186" => robe,
+            _ => null,
+        });
+    }
+
+    [Fact]
+    public void Robe_GraftsForearmAtItsOwnChainPosition_NotCollapsedToTorso()
+    {
+        var composer = MakeComposer(BuildSkeleton(), BuildRobe());
+
+        var composite = composer.Compose("pmh0", new[] { ("robe", "pmh0_robe186") }, adjustSeams: false);
+
+        Assert.NotNull(composite);
+        var fore = MdlPartComposer.FindBoneByName(composite!.GeometryRoot!, "rforearm_g");
+        Assert.NotNull(fore);
+
+        // World Z of the robe forearm via its own chain: root(1.2) + torso(0) + bicep(0.35) + fore(-0.30)
+        var world = MdlPartComposer.GetMeshWorldTransform(fore!);
+        Assert.True(Matrix4x4.Decompose(world, out _, out _, out var t));
+        Assert.Equal(1.25f, t.Z, 3); // 1.2 + 0 + 0.35 - 0.30
+        // If it had been collapsed onto the torso bone (the old bug) Z would be ~1.2, not 1.25.
+    }
+
+    [Fact]
+    public void Robe_PreservesCoatAsSkinMesh()
+    {
+        var composer = MakeComposer(BuildSkeleton(), BuildRobe());
+
+        var composite = composer.Compose("pmh0", new[] { ("robe", "pmh0_robe186") }, adjustSeams: false);
+
+        var coat = MdlPartComposer.FindBoneByName(composite!.GeometryRoot!, "coat");
+        Assert.NotNull(coat);
+        Assert.IsType<MdlSkinNode>(coat); // clone preserves skin type (#1989)
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/TextureServiceHelperTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/TextureServiceHelperTests.cs
@@ -101,6 +101,25 @@ public class TextureServiceHelperTests
         Assert.Equal(10, result[PltLayers.Tattoo2]);
     }
 
+    [Theory]
+    [InlineData("cre_017_t_b01", "cre_017_t_b01_d")] // #1755 CEP3 PBR beetle texture
+    [InlineData("c_dragon_red", "c_dragon_red_d")]
+    public void PbrDiffuseFallbackName_AppendsDSuffix(string baseName, string expected)
+    {
+        // #1755: NWN:EE PBR textures are stored as <name>_d (diffuse), _n, _r, _i.
+        // MDL meshes reference the bare <name>; when bare lookups miss we must try _d.
+        Assert.Equal(expected, TextureService.PbrDiffuseFallbackName(baseName));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("cre_017_t_b01_d")] // already a diffuse map — don't double-suffix
+    public void PbrDiffuseFallbackName_NoFallbackWhenInapplicable(string? baseName)
+    {
+        Assert.Null(TextureService.PbrDiffuseFallbackName(baseName));
+    }
+
     [Fact]
     public void ConvertBiowareDdsToStandard_TooShort_ReturnsNull()
     {

--- a/Radoub.UI/Radoub.UI.Tests/TextureServiceHelperTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/TextureServiceHelperTests.cs
@@ -103,6 +103,8 @@ public class TextureServiceHelperTests
 
     [Theory]
     [InlineData("cre_017_t_b01", "cre_017_t_b01_d")] // #1755 CEP3 PBR beetle texture
+    [InlineData("c2_spidgi_b01", "c2_spidgi_b01_d")] // #1760 CEP spider (giant)
+    [InlineData("c2_spidgl_b01", "c2_spidgl_b01_d")] // #1760 CEP spider (glow)
     [InlineData("c_dragon_red", "c_dragon_red_d")]
     public void PbrDiffuseFallbackName_AppendsDSuffix(string baseName, string expected)
     {

--- a/Radoub.UI/Radoub.UI.Tests/TextureSourcePolicyTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/TextureSourcePolicyTests.cs
@@ -1,0 +1,31 @@
+using Radoub.Formats.Resolver;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Tests for TextureSourcePolicy — chooses whether the model preview should prefer
+/// base-game (BIF) textures based on where the model itself was resolved (#1758).
+/// Base/Override models keep the #1867 BIF-prefer behavior (avoids reversed CEP
+/// textures); HAK/Module models use the normal HAK-first chain so CEP-only creature
+/// textures (e.g. c_fairy) resolve correctly instead of a stale BIF stub.
+/// </summary>
+public class TextureSourcePolicyTests
+{
+    [Fact]
+    public void PreferBif_BifSource_ReturnsTrue()
+        => Assert.True(TextureSourcePolicy.PreferBif(ResourceSource.Bif));
+
+    [Fact]
+    public void PreferBif_OverrideSource_ReturnsTrue()
+        => Assert.True(TextureSourcePolicy.PreferBif(ResourceSource.Override));
+
+    [Fact]
+    public void PreferBif_HakSource_ReturnsFalse() // #1758 c_fairy case
+        => Assert.False(TextureSourcePolicy.PreferBif(ResourceSource.Hak));
+
+    [Fact]
+    public void PreferBif_ModuleSource_ReturnsFalse()
+        => Assert.False(TextureSourcePolicy.PreferBif(ResourceSource.Module));
+}

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
@@ -129,6 +129,13 @@ public class ModelPreviewGLControl : OpenGlControlBase
     public event EventHandler<ModelMeshInfo>? MeshInfoChanged;
 
     /// <summary>
+    /// Raised on the UI thread after textures load. The bool is true when a non-base
+    /// model (HAK/Module) had at least one texture fall back to a base-game (BIF) stub,
+    /// so the preview skin may not match the intended asset (#1758).
+    /// </summary>
+    public event EventHandler<bool>? TextureSourceChanged;
+
+    /// <summary>
     /// The model to render.
     /// </summary>
     public MdlModel? Model
@@ -1396,6 +1403,10 @@ public class ModelPreviewGLControl : OpenGlControlBase
             $"metal1={_colorIndices.Metal1}, metal2={_colorIndices.Metal2}, cloth1={_colorIndices.Cloth1}, cloth2={_colorIndices.Cloth2}");
 
         var failedTextures = new List<string>();
+        // #1758: for a non-base model (PreferBifTextures=false), note when a texture
+        // resolves from base-game BIF instead of the model's own pack — the preview skin
+        // may then not match the intended asset.
+        bool usedBaseFallback = false;
         foreach (var texName in textureNames)
         {
             if (_textureCache.ContainsKey(texName))
@@ -1419,6 +1430,8 @@ public class ModelPreviewGLControl : OpenGlControlBase
                 {
                     _textureCache[texName] = texId;
                     if (isPlt) _pltTextureNames.Add(texName);
+                    if (!_preferBifTextures && _textureService.ResolvesFromBase(texName))
+                        usedBaseFallback = true;
                     UnifiedLogger.LogApplication(LogLevel.DEBUG, $"  Loaded texture '{texName}' ({width}x{height}) -> texId={texId}, isPlt={isPlt}");
                 }
             }
@@ -1448,6 +1461,8 @@ public class ModelPreviewGLControl : OpenGlControlBase
                     {
                         _textureCache[modelTexture] = fallbackId;
                         if (isPlt) _pltTextureNames.Add(modelTexture);
+                        if (!_preferBifTextures && _textureService.ResolvesFromBase(modelTexture))
+                            usedBaseFallback = true;
                         UnifiedLogger.LogApplication(LogLevel.DEBUG,
                             $"  Loaded model fallback texture '{modelTexture}' ({w}x{h}) -> texId={fallbackId}, isPlt={isPlt}");
                     }
@@ -1465,6 +1480,13 @@ public class ModelPreviewGLControl : OpenGlControlBase
                 }
             }
         }
+
+        // #1758: notify the host so it can warn that a CEP creature is showing
+        // base-game textures (preview may not match the intended asset).
+        if (Dispatcher.UIThread.CheckAccess())
+            TextureSourceChanged?.Invoke(this, usedBaseFallback);
+        else
+            Dispatcher.UIThread.Post(() => TextureSourceChanged?.Invoke(this, usedBaseFallback));
     }
 
     private uint UploadTexture(int width, int height, byte[] rgba)

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
@@ -913,8 +913,8 @@ public class ModelPreviewGLControl : OpenGlControlBase
         // surface cues.
         var lightDir = Vector3.Normalize(new Vector3(0.3f, -0.5f, 0.8f));
         _shaderManager!.SetUniformVec3("lightDir", lightDir);
-        _shaderManager!.SetUniformVec3("lightColor", new Vector3(0.15f, 0.15f, 0.15f));
-        _shaderManager!.SetUniformVec3("ambientColor", new Vector3(0.95f, 0.95f, 0.95f));
+        _shaderManager!.SetUniformVec3("lightColor", new Vector3(0.25f, 0.25f, 0.25f));
+        _shaderManager!.SetUniformVec3("ambientColor", new Vector3(0.70f, 0.70f, 0.70f));
         _shaderManager!.SetUniformInt("debugMode", _debugMode);
 
         // Bind VAO and draw

--- a/Radoub.UI/Radoub.UI/Controls/OpenGLShaderManager.cs
+++ b/Radoub.UI/Radoub.UI/Controls/OpenGLShaderManager.cs
@@ -129,8 +129,10 @@ void main()
 
     vec3 result = (ambient + diffuse) * baseColor;
 
-    // Gamma correction: NWN textures are sRGB; brighten midtones to match toolset look
-    result = pow(result, vec3(1.0 / 1.6));
+    // Gamma correction: NWN textures are sRGB; a mild midtone lift matches the
+    // toolset look. 1/1.6 over-brightened and washed out textures (esp. NWN2-ported
+    // PBR _d diffuse maps); 1/1.1 keeps only a slight lift without bleaching (#1762).
+    result = pow(result, vec3(1.0 / 1.1));
 
     FragColor = vec4(result, 1.0);
 }

--- a/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
+++ b/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
@@ -205,6 +205,20 @@ public sealed class MdlPartComposer
                 return;
             }
 
+            EnsureCompositeRoot(compositeModel);
+
+            // #1989: a robe is not a single body part — it is a near-complete posed body that
+            // ships its own nested bone hierarchy (torso_g→rbicep_g→rforearm_g→rhand_g, etc.)
+            // plus skin meshes (coat, arms). Splicing its individual meshes onto the skeleton's
+            // bones discards the robe's internal local transforms and balloons the arms/legs.
+            // Instead graft the robe's whole subtree, preserving its hierarchy, so each mesh keeps
+            // the exact world transform Aurora computes from the robe's own node chain.
+            if (IsFullBodyPart(partType, partModel))
+            {
+                GraftPartSubtree(compositeModel, partModel, partType, partResRef, meshPartTypes);
+                return;
+            }
+
             // Bone lookup targets the composite's OWN (cloned) skeleton root — never the cached
             // skeleton model. Attaching to / nudging the cached skeleton would corrupt it for the
             // next render (#1735).
@@ -213,8 +227,6 @@ public sealed class MdlPartComposer
                 ? FindBoneByName(compositeModel.GeometryRoot, boneName)
                 : null;
 
-            // Compute a fallback world position for parts whose bones can't be found.
-            // (The skeleton lookup may miss in synthetic test models or partial skeletons.)
             var fallbackPosition = Vector3.Zero;
             if (bone != null)
             {
@@ -228,8 +240,7 @@ public sealed class MdlPartComposer
                 if (node is not MdlTrimeshNode sourceTrimesh) continue;
 
                 // Clone the part mesh before attaching — the source is a cached MdlModel shared
-                // across renders; we set Bitmap/Position/Parent on the CLONE only (#1735). Geometry
-                // arrays (vertices, normals, faces, UVs) are immutable here, so they're shared.
+                // across renders; we set Bitmap/Position/Parent on the CLONE only (#1735).
                 var trimesh = CloneTrimeshShallow(sourceTrimesh);
 
                 // Body part MDL files have geometry at local origin. Body part bitmap fields
@@ -237,31 +248,17 @@ public sealed class MdlPartComposer
                 // name from the part ResRef instead.
                 trimesh.Bitmap = partResRef;
 
-                if (compositeModel.GeometryRoot == null)
-                {
-                    compositeModel.GeometryRoot = new MdlNode
-                    {
-                        Name = "composite_root",
-                        Orientation = Quaternion.Identity,
-                        Scale = 1.0f,
-                    };
-                }
-
                 if (bone != null)
                 {
-                    // Parent under the bone — its bind position carries the world transform,
-                    // so zero out the mesh's own offset to avoid double-application.
                     trimesh.Position = Vector3.Zero;
                     trimesh.Parent = bone;
                     bone.Children.Add(trimesh);
                 }
                 else
                 {
-                    // Fallback: skeleton bone missing, attach at the bone's would-be world
-                    // position under the composite root.
                     trimesh.Position = fallbackPosition;
                     trimesh.Parent = compositeModel.GeometryRoot;
-                    compositeModel.GeometryRoot.Children.Add(trimesh);
+                    compositeModel.GeometryRoot!.Children.Add(trimesh);
                 }
 
                 meshPartTypes[trimesh.Name] = partType;
@@ -272,6 +269,72 @@ public sealed class MdlPartComposer
             UnifiedLogger.LogApplication(LogLevel.WARN,
                 $"MdlPartComposer.TryAddBodyPart: failed to add '{partType}' from '{partResRef}': {ex.GetType().Name}: {ex.Message}");
         }
+    }
+
+    private static void EnsureCompositeRoot(MdlModel compositeModel)
+    {
+        if (compositeModel.GeometryRoot == null)
+        {
+            compositeModel.GeometryRoot = new MdlNode
+            {
+                Name = "composite_root",
+                Orientation = Quaternion.Identity,
+                Scale = 1.0f,
+            };
+        }
+    }
+
+    /// <summary>
+    /// A "full body" part carries its own multi-node body hierarchy rather than a single mesh
+    /// at the origin. Robes are the case that matters (#1989); detect by part type.
+    /// </summary>
+    private static bool IsFullBodyPart(string partType, MdlModel partModel) =>
+        partType.Equals("robe", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Graft a full-body part's entire node subtree under the composite root, preserving its
+    /// internal hierarchy and per-node local transforms. The part's root dummy aligns with the
+    /// skeleton root (both at the same world origin), so its children attach directly under the
+    /// composite root and reproduce the part's own world transforms (#1989).
+    /// </summary>
+    private void GraftPartSubtree(
+        MdlModel compositeModel,
+        MdlModel partModel,
+        string partType,
+        string partResRef,
+        Dictionary<string, string> meshPartTypes)
+    {
+        if (partModel.GeometryRoot == null)
+            return;
+
+        EnsureCompositeRoot(compositeModel);
+        var root = compositeModel.GeometryRoot!;
+
+        // Graft the part root's CHILDREN (skip the part's own root dummy, whose translation
+        // duplicates the skeleton root's). Each child subtree is cloned with hierarchy intact.
+        int grafted = 0;
+        foreach (var child in partModel.GeometryRoot.Children)
+        {
+            var clone = CloneNode(child, root);
+            ApplyPartBitmap(clone, partResRef, partType, meshPartTypes);
+            root.Children.Add(clone);
+            grafted++;
+        }
+
+        UnifiedLogger.LogApplication(LogLevel.INFO,
+            $"MdlPartComposer: grafted full-body part '{partType}' ({partResRef}) — {grafted} subtree(s)");
+    }
+
+    /// <summary>Set the texture name + record the part type on every mesh in a grafted subtree.</summary>
+    private static void ApplyPartBitmap(MdlNode node, string partResRef, string partType, Dictionary<string, string> meshPartTypes)
+    {
+        if (node is MdlTrimeshNode mesh && mesh.Vertices.Length > 0)
+        {
+            mesh.Bitmap = partResRef;
+            meshPartTypes[mesh.Name] = partType;
+        }
+        foreach (var child in node.Children)
+            ApplyPartBitmap(child, partResRef, partType, meshPartTypes);
     }
 
     /// <summary>
@@ -314,43 +377,58 @@ public sealed class MdlPartComposer
     /// mutates Position / Bitmap / Parent on the clone, so sharing geometry is safe and cheap.
     /// Children are NOT copied here (CloneNode handles hierarchy).
     /// </summary>
-    private static MdlTrimeshNode CloneTrimeshShallow(MdlTrimeshNode s) => new()
+    private static MdlTrimeshNode CloneTrimeshShallow(MdlTrimeshNode s)
     {
-        NodeType = s.NodeType,
-        Name = s.Name,
-        Position = s.Position,
-        Orientation = s.Orientation,
-        Scale = s.Scale,
-        Wirecolor = s.Wirecolor,
-        InheritColor = s.InheritColor,
-        PositionTimes = s.PositionTimes,
-        PositionValues = s.PositionValues,
-        OrientationTimes = s.OrientationTimes,
-        OrientationValues = s.OrientationValues,
-        ScaleTimes = s.ScaleTimes,
-        ScaleValues = s.ScaleValues,
-        Vertices = s.Vertices,
-        Normals = s.Normals,
-        TextureCoords = s.TextureCoords,
-        VertexColors = s.VertexColors,
-        Faces = s.Faces,
-        Bitmap = s.Bitmap,
-        Bitmap2 = s.Bitmap2,
-        MaterialName = s.MaterialName,
-        Ambient = s.Ambient,
-        Diffuse = s.Diffuse,
-        Specular = s.Specular,
-        Shininess = s.Shininess,
-        Alpha = s.Alpha,
-        SelfIllumColor = s.SelfIllumColor,
-        Render = s.Render,
-        Shadow = s.Shadow,
-        Beaming = s.Beaming,
-        RotateTexture = s.RotateTexture,
-        TransparencyHint = s.TransparencyHint,
-        Tilefade = s.Tilefade,
-        RenderOrder = s.RenderOrder,
-    };
+        // Preserve the runtime type so a skin mesh stays an MdlSkinNode (#1989): the
+        // tiny-trimesh skip heuristic and mesh-info counts key on `is MdlSkinNode`, and a
+        // robe's coat/arms are skins. Bone arrays are shared (immutable during composition).
+        MdlTrimeshNode clone = s is MdlSkinNode sk
+            ? new MdlSkinNode
+            {
+                BoneWeights = sk.BoneWeights,
+                BoneNodeNames = sk.BoneNodeNames,
+                BoneQuaternions = sk.BoneQuaternions,
+                BoneTranslations = sk.BoneTranslations,
+                NodeToBoneMap = sk.NodeToBoneMap,
+            }
+            : new MdlTrimeshNode();
+
+        clone.NodeType = s.NodeType;
+        clone.Name = s.Name;
+        clone.Position = s.Position;
+        clone.Orientation = s.Orientation;
+        clone.Scale = s.Scale;
+        clone.Wirecolor = s.Wirecolor;
+        clone.InheritColor = s.InheritColor;
+        clone.PositionTimes = s.PositionTimes;
+        clone.PositionValues = s.PositionValues;
+        clone.OrientationTimes = s.OrientationTimes;
+        clone.OrientationValues = s.OrientationValues;
+        clone.ScaleTimes = s.ScaleTimes;
+        clone.ScaleValues = s.ScaleValues;
+        clone.Vertices = s.Vertices;
+        clone.Normals = s.Normals;
+        clone.TextureCoords = s.TextureCoords;
+        clone.VertexColors = s.VertexColors;
+        clone.Faces = s.Faces;
+        clone.Bitmap = s.Bitmap;
+        clone.Bitmap2 = s.Bitmap2;
+        clone.MaterialName = s.MaterialName;
+        clone.Ambient = s.Ambient;
+        clone.Diffuse = s.Diffuse;
+        clone.Specular = s.Specular;
+        clone.Shininess = s.Shininess;
+        clone.Alpha = s.Alpha;
+        clone.SelfIllumColor = s.SelfIllumColor;
+        clone.Render = s.Render;
+        clone.Shadow = s.Shadow;
+        clone.Beaming = s.Beaming;
+        clone.RotateTexture = s.RotateTexture;
+        clone.TransparencyHint = s.TransparencyHint;
+        clone.Tilefade = s.Tilefade;
+        clone.RenderOrder = s.RenderOrder;
+        return clone;
+    }
 
     /// <summary>
     /// Find a node in the bone hierarchy by name (case-insensitive).

--- a/Radoub.UI/Radoub.UI/Services/TextureService.cs
+++ b/Radoub.UI/Radoub.UI/Services/TextureService.cs
@@ -560,6 +560,21 @@ public class TextureService
         if (ddsResult.HasValue)
             return (ddsResult.Value.width, ddsResult.Value.height, ddsResult.Value.pixels, false);
 
+        // #1755: NWN:EE PBR materials store the diffuse map as <name>_d (with _n/_r/_i
+        // companions). MDL meshes reference the bare <name>; when that misses, try the
+        // PBR diffuse variant — this is how Aurora resolves CEP3 (Txpple) creature skins.
+        var pbrName = PbrDiffuseFallbackName(resRef);
+        if (pbrName != null)
+        {
+            var pbrTga = LoadTgaTexture(pbrName);
+            if (pbrTga.HasValue)
+                return (pbrTga.Value.width, pbrTga.Value.height, pbrTga.Value.pixels, false);
+
+            var pbrDds = LoadDdsTexture(pbrName);
+            if (pbrDds.HasValue)
+                return (pbrDds.Value.width, pbrDds.Value.height, pbrDds.Value.pixels, false);
+        }
+
         // If race-specific texture not found, try human fallback
         // e.g., pme0_head001 -> pmh0_head001
         if (resRef.Length > 4 && (resRef.StartsWith("pm") || resRef.StartsWith("pf")))
@@ -639,6 +654,28 @@ public class TextureService
     {
         _paletteCache.Clear();
         _renderedTextureCache.Clear();
+    }
+
+    /// <summary>
+    /// NWN:EE PBR materials store their maps with channel suffixes: <c>_d</c> (diffuse),
+    /// <c>_n</c> (normal), <c>_r</c> (roughness), <c>_i</c> (illumination). MDL meshes
+    /// reference the bare base name; the renderer resolves the visible color from the
+    /// <c>_d</c> diffuse map. Returns the diffuse-variant resref to try when the bare
+    /// name is not found, or null when no fallback applies (empty, or already a map). (#1755)
+    /// </summary>
+    internal static string? PbrDiffuseFallbackName(string? baseName)
+    {
+        if (string.IsNullOrEmpty(baseName))
+            return null;
+
+        // Already a PBR channel map — don't append another suffix.
+        if (baseName.EndsWith("_d", StringComparison.OrdinalIgnoreCase)
+            || baseName.EndsWith("_n", StringComparison.OrdinalIgnoreCase)
+            || baseName.EndsWith("_r", StringComparison.OrdinalIgnoreCase)
+            || baseName.EndsWith("_i", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        return baseName + "_d";
     }
 
     /// <summary>

--- a/Radoub.UI/Radoub.UI/Services/TextureService.cs
+++ b/Radoub.UI/Radoub.UI/Services/TextureService.cs
@@ -538,6 +538,34 @@ public class TextureService
     /// a PLT (color-index-dependent) source. Callers can use this to cache non-PLT
     /// textures across color changes.
     /// </summary>
+    /// <summary>
+    /// Reports whether the texture <paramref name="resRef"/> resolves from base-game
+    /// BIF rather than a HAK/Module/Override. Used by the preview to warn when a CEP
+    /// creature's texture fell back to a base-game stub (#1758) — its own pack did not
+    /// supply the texture, so the rendered skin may not match the intended asset.
+    /// Considers the same candidate names the loader tries (bare + PBR <name>_d).
+    /// </summary>
+    public bool ResolvesFromBase(string resRef)
+    {
+        if (string.IsNullOrEmpty(resRef))
+            return false;
+
+        var name = resRef.ToLowerInvariant();
+        var candidates = new List<string> { name };
+        var pbr = PbrDiffuseFallbackName(name);
+        if (pbr != null) candidates.Add(pbr);
+
+        ushort[] types = { ResourceTypes.Plt, ResourceTypes.Tga, ResourceTypes.Dds };
+        foreach (var cand in candidates)
+            foreach (var t in types)
+            {
+                var res = _gameDataService.FindResourceWithSource(cand, t);
+                if (res != null && res.Data.Length > 0)
+                    return res.Source == Radoub.Formats.Resolver.ResourceSource.Bif;
+            }
+        return false;
+    }
+
     public (int width, int height, byte[] pixels, bool isPlt)? LoadTextureWithKind(
         string resRef,
         PltColorIndices? colorIndices = null)

--- a/Radoub.UI/Radoub.UI/Services/TextureSourcePolicy.cs
+++ b/Radoub.UI/Radoub.UI/Services/TextureSourcePolicy.cs
@@ -1,0 +1,18 @@
+using Radoub.Formats.Resolver;
+
+namespace Radoub.UI.Services;
+
+/// <summary>
+/// Decides whether the model preview should prefer base-game (BIF) textures, based on
+/// where the model itself was resolved from (#1758).
+///
+/// Base-game and Override models keep the #1867 BIF-prefer behavior so a base creature
+/// does not pick up an incompatible CEP texture (e.g. reversed bat wings). HAK and Module
+/// models use the normal HAK-first chain so CEP-only creature textures resolve from their
+/// own pack instead of a stale base-game stub (the c_fairy 32x32 case).
+/// </summary>
+public static class TextureSourcePolicy
+{
+    public static bool PreferBif(ResourceSource modelSource) =>
+        modelSource is ResourceSource.Bif or ResourceSource.Override;
+}


### PR DESCRIPTION
## Summary

Sprint #2381 — Quartermaster 3D model-preview rendering cleanup. Cleared a cluster of CEP/custom-content rendering bugs and a UI-uniformity violation.

## Work Items

- [x] #1755 — Fire/stag/bombardier beetle (Txpple) render textured — PBR `_d` diffuse fallback
- [x] #1760 — Giant/glow spider (CEP `una`) — fixed by #1755 + regression test
- [x] #1762 — Dire rat textured; softer preview lighting (de-bleach)
- [x] #1758 — Fey/pixy (`c_fairy`) + CEP creatures use their own pack's textures (source-tier policy) + base-fallback warning
- [x] #1989 — Robe armor renders as a combined body (suppression + subtree graft)
- [~] #2126 — Snake: root-caused as un-applied skin deformation → deferred to skinning epic #2400
- [x] #2250 — Removed disabled Edit-menu stubs (replaces dropped #875)

## Follow-ups filed

#2395 (emitters), #2396 (wings/tails), #2397 (resolver source-tier refactor), #2398 (robe variant residuals), #2399 (robe animation), #2400 (skinning epic).

## Pre-Merge Checklist

### Tests
| Check | Status |
|-------|--------|
| Privacy scan | ✅ No hardcoded paths |
| Tech debt | ⚠️ ModelPreviewGLControl.cs 1367 lines — tracked in #2127 |
| Unit tests (local, Windows) | ✅ 3613 passed, 0 failed (Formats/UI/Dictionary/QM) |
| UI tests (FlaUI) | ✅ 12 passed, 0 failed |
| CI checks (incl. Linux) | ✅ All pass (ubuntu + windows build + unit) |

### Validation
| Check | Status |
|-------|--------|
| CHANGELOG | ✅ QM 0.2.117 + root Radoub.UI 0.2.3–0.2.6, PR #2394 |
| [Unreleased] | ✅ Empty |
| Wiki | ✅ Current (2026-06-03) |

### Notes
- Theme scan WARN: 21 hardcoded theme values (mostly pre-existing, e.g. TokenSelectorWindow); not introduced by this PR's logic.

Closes #1755, #1760, #1762, #1758, #1989, #2250

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)