### PR TITLE
[Relique] Sprint: Cost & UX (#2385)

### DIFF
--- a/.claude/scripts/New-CostTestUti.ps1
+++ b/.claude/scripts/New-CostTestUti.ps1
@@ -1,0 +1,114 @@
+# Build throwaway test items for Relique item-cost verification (#2235).
+# Creates .uti blueprints with a chosen base item + item-property list so the cost
+# formula can be validated against the Aurora toolset: open each file in the toolset
+# to read its computed Cost, then open the same file in Relique (--file) and read the
+# [CostCalc] log lines to compare.
+#
+# Uses the built Radoub.Formats.dll so the GFF round-trip matches Relique.
+#
+# Requires PowerShell 7 (net assembly load); Windows PowerShell 5.1 cannot Add-Type a
+# net9.0 DLL. Use the full PS7 path, NOT the WindowsApps pwsh stub (Store launcher):
+#   & "C:\Program Files\PowerShell\7\pwsh.exe" -NoProfile -ExecutionPolicy Bypass `
+#       -File ".claude/scripts/New-CostTestUti.ps1" `
+#       -Items "cost_ac2=16:torso=4:prop=1,2,9;cost_kama_eb3=40:prop=6,3,1"
+#
+# -Items format: semicolon-separated item specs. Each spec is colon-separated fields:
+#   name = <resref/tag/filename, <=16 chars>          (required, first field)
+#   <baseItemIndex>                                    (required, second field, integer)
+#   torso=<n>                                          (optional, armor torso part for base AC)
+#   addcost=<n>                                        (optional, AddCost gold)
+#   prop=<propName>,<costValue>,<costTable>[,<subtype>][,<param>,<paramValue>]
+#       (repeatable — one property per prop= field)
+#
+# Example specs:
+#   cost_ac2=16:torso=4:prop=1,2,9           studded-leather-like, +2 AC (prop 1, costtbl 9)
+#   cost_eb3=40:prop=6,3,2                    longsword, +3 enhancement (prop 6, costtbl 2)
+#   cost_multi=40:prop=6,2,2:prop=16,5,4     two props (enhancement + damage)
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $Items,
+
+    [string] $ModuleDir = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Neverwinter Nights\modules\LNS_DLG')
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+$dll = Join-Path $repoRoot 'Radoub.Formats\Radoub.Formats\bin\Debug\net9.0\Radoub.Formats.dll'
+
+if (-not (Test-Path $dll)) {
+    throw "Radoub.Formats.dll not found at $dll - build Radoub.Formats first (dotnet build)."
+}
+Add-Type -Path $dll
+
+if (-not (Test-Path $ModuleDir)) {
+    throw "Module directory not found: $ModuleDir"
+}
+
+function New-Prop([string] $spec) {
+    # prop value fields: propName,costValue,costTable[,subtype[,param,paramValue]]
+    $f = $spec -split ','
+    if ($f.Count -lt 3) { throw "Bad prop '$spec'. Need propName,costValue,costTable[,subtype[,param,paramValue]]." }
+    $p = New-Object Radoub.Formats.Uti.ItemProperty
+    $p.PropertyName = [uint16]$f[0].Trim()
+    $p.CostValue    = [uint16]$f[1].Trim()
+    $p.CostTable    = [byte]$f[2].Trim()
+    $p.Subtype      = if ($f.Count -ge 4 -and $f[3].Trim() -ne '') { [uint16]$f[3].Trim() } else { [uint16]0 }
+    if ($f.Count -ge 6) {
+        $p.Param1      = [byte]$f[4].Trim()
+        $p.Param1Value = [byte]$f[5].Trim()
+    } else {
+        $p.Param1 = [byte]255  # 0xFF = no param
+    }
+    $p.ChanceAppear = [byte]100
+    return $p
+}
+
+$created = @()
+
+foreach ($itemSpec in ($Items -split ';')) {
+    $itemSpec = $itemSpec.Trim()
+    if ($itemSpec -eq '') { continue }
+
+    $fields = $itemSpec -split ':'
+    $name = $fields[0].Trim()
+    if ($name.Length -gt 16) { throw "Item name '$name' exceeds 16 chars (Aurora limit)." }
+    $baseItem = [int]$fields[1].Trim()
+
+    $uti = New-Object Radoub.Formats.Uti.UtiFile
+    $uti.BaseItem = $baseItem
+    $uti.TemplateResRef = $name.ToLowerInvariant()
+    $uti.Tag = $name
+    $loc = New-Object Radoub.Formats.Gff.CExoLocString
+    $loc.SetString(0, "Cost test $name")
+    $uti.LocalizedName = $loc
+    $uti.Identified = $true
+    $uti.StackSize = [uint16]1
+
+    for ($i = 2; $i -lt $fields.Count; $i++) {
+        $field = $fields[$i].Trim()
+        if ($field -eq '') { continue }
+        $kv = $field -split '=', 2
+        $key = $kv[0].Trim().ToLowerInvariant()
+        $val = if ($kv.Count -gt 1) { $kv[1].Trim() } else { '' }
+
+        switch ($key) {
+            'torso'   { $uti.ArmorParts['Torso'] = [byte]$val }
+            'addcost' { $uti.AddCost = [uint32]$val }
+            'prop'    { $uti.Properties.Add((New-Prop $val)) }
+            default   { throw "Unknown field '$key' in '$itemSpec'." }
+        }
+    }
+
+    $outPath = Join-Path $ModuleDir ($name.ToLowerInvariant() + '.uti')
+    [Radoub.Formats.Uti.UtiWriter]::Write($uti, $outPath)
+    $created += $outPath
+    Write-Host "Wrote $outPath (baseItem=$baseItem, props=$($uti.Properties.Count))"
+}
+
+Write-Host ""
+Write-Host "Created $($created.Count) test item(s) in $ModuleDir"
+Write-Host "Open each in the Aurora toolset to read its Cost, then in Relique:"
+foreach ($p in $created) {
+    Write-Host "  dotnet run --project Relique/Relique/Relique.csproj -- --file `"$p`""
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -753,6 +753,37 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".\.claude\scripts\Searc
 
 ---
 
+## Mutual Workflow Testing (Claude + Human Loop)
+
+For verifying computed/derived values against the real game (e.g. item cost vs the Aurora
+toolset, model preview vs in-game), Claude and the human split the loop:
+
+**Claude can:**
+1. **Generate fixture files** with known inputs (e.g. `.claude/scripts/New-CostTestUti.ps1`,
+   `New-AppearanceTestUtc.ps1`) written into a test module (`LNS_DLG`). These use the built
+   `Radoub.Formats.dll` via PS7 so the GFF round-trip matches the tool.
+2. **Launch the tool directed at a fixture** — `dotnet run --project <Tool>/<Tool>/<Tool>.csproj
+   -- --mod <Module> --file <file>` (a GUI launch; run with `run_in_background`).
+3. **Read the tool's own logs** to capture computed values — add temporary `[Tag]` diagnostic
+   log lines (e.g. `[CostCalc]`) to the code under test, then
+   `grep` the newest `~/Radoub/{Tool}/Logs/Session_*/` for that tag.
+4. **Stop the app** between fixtures: `Get-Process <Tool> | Stop-Process -Force` (PowerShell tool).
+
+**Human verifies** the same fixture in the authoritative source — open it in the Aurora toolset
+to read the ground-truth value, or run UAT for behavior Claude can't observe from logs.
+
+**Loop**: Claude generates fixtures + collects tool values → human reads Aurora/UAT values →
+Claude compares, fixes, regenerates. Remove the temporary diagnostic logging before committing.
+
+**Notes**:
+- App launch is a real GUI process (not FlaUI) — fine to launch for log capture; still stop it
+  when done so it doesn't lock the build output (`Relique.exe` is locked while running).
+- This is distinct from FlaUI integration tests (which drive the UI and take over the desktop —
+  never run without explicit user request).
+- Keep generated fixtures in the test module; they are throwaway, not committed.
+
+---
+
 ## Agent Skills (obra/superpowers)
 
 Installed skills in `.agents/skills/` provide structured methodologies. Claude **must** follow these skills when their trigger conditions are met — no user invocation needed, no skipping without explicit user override.

--- a/Documentation/NEW_TOOL_BOOTSTRAP.md
+++ b/Documentation/NEW_TOOL_BOOTSTRAP.md
@@ -177,6 +177,7 @@ userDict.AddWord("Waterdeep");
 - [ ] **Wire Undo/Redo via shared `UndoRedoManager`** — register Ctrl+Z / Ctrl+Y and route every user-initiated mutation through `IUndoableCommand` so the standard Undo/Redo menu items work from day one (#2231). Do **not** ship disabled Undo/Redo menu stubs — either wire them correctly or omit them.
 - [ ] **Ship a New-resource flow** (`File → New`, Ctrl+N) — the tool must let the user create a blank resource from scratch, not only edit existing files. A `SaveFilePicker`/`Save As`-into-module path that *copies* a base-game blueprint is **not** a substitute: it can't make a resource that isn't already in the game data. Match the lightest pattern that fits the format — Relique's New Item Wizard (base-item-type branching), Fence's simpler new-store, or a plain blank-document `File → New`. A tool that can only edit pre-existing files is incomplete. (Reliquary shipped without this — #2367 — because Save-As-copy masked the gap.)
 - [ ] **Wire Recent Files / MRU on BOTH ends** — see [Trebuchet Integration](#trebuchet-integration). Easy to get for free via `BaseToolSettingsService` + a `ToolRecentFilesService` case; easy to forget entirely (#2247, #2368).
+- [ ] **Wire a Find feature (`Ctrl+F`)** — every tool must let the user locate things inside the open resource via a standard `Ctrl+F` shortcut (#2401). What "find" searches is format-specific: dialog text/nodes in Parley, item/property rows in Relique, inventory/stat fields in Quartermaster, store entries in Fence, placeable fields in Reliquary. Register the `Ctrl+F` `KeyGesture` and an `Edit → Find` menu item that opens (or focuses) the tool's find affordance — a search box that filters/highlights the relevant list or jumps to matches. This is a baseline expectation, not optional: a tool with no in-editor Find is incomplete. Do **not** ship a disabled "Find" menu stub — wire it or omit the menu entry until it is wired.
 
 ### Trebuchet Integration
 
@@ -227,6 +228,7 @@ The `[Edit → OtherTool]` launch pattern (one tool opening a resource in anothe
 | **Token Picker** | Right-click "All Tokens..." must open `Radoub.UI.Views.TokenSelectorWindow` (4 tabs: Standard / Highlight / Custom Tokens / Custom Colors). Route through `TokenInsertionHelper.OpenTokenWindow` — do NOT instantiate the older `TokenInsertionWindow` directly; it lacks the Custom Tokens tab (#2075). | Manifest.PropertyPanel, Relique post-#2075 |
 | **Variables Grid** | Use shared `Radoub.UI.Controls.VariablesPanel` *(Sprint 3)* — do NOT fork `VariableViewModel`. | (shared control) |
 | **Undo/Redo** | Wire shared `UndoRedoManager` + Ctrl+Z / Ctrl+Y; route mutating actions through `IUndoableCommand`. No disabled "Not yet implemented" menu stubs (#2231). | (TBD — pending epic #2231 reference impl) |
+| **Find** | Wire `Ctrl+F` + `Edit → Find` to locate things in the open resource (format-specific: nodes, rows, fields). Baseline expectation; no disabled stubs (#2401). | (TBD — first tool to ship Find sets the pattern) |
 
 **Resource Browsers** (use shared implementations from Radoub.UI):
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A collection of cross-platform tools for creating and editing Neverwinter Nights
 | Quartermaster | `.utc`, `.bic` | Creature/inventory editor |
 | Fence | `.utm` | Merchant/store editor |
 | Relique | `.uti` | Item blueprint editor |
+| Reliquary | `.utp` | Placeable blueprint editor |
 | Trebuchet | — | Launcher/hub (manages `.mod` modules) |
 
 ### Ready for Preview
@@ -112,6 +113,23 @@ Cross-platform item blueprint editor for Neverwinter Nights `.uti` files.
 
 **Learn more**: [Relique/README.md](Relique/README.md) | [Wiki](https://github.com/LordOfMyatar/Radoub/wiki/Relique)
 
+#### Reliquary - Placeable Blueprint Editor
+
+Cross-platform placeable blueprint editor for Neverwinter Nights `.utp` files (chests, doors, statues, containers).
+
+**Status**: User Preview (Alpha)
+**Platforms**: Windows, Linux, macOS (experimental)
+**Key Features**:
+- Placeable blueprint editing (identity, combat, behavior, text, appearance, scripts)
+- Visual appearance preview with OpenGL 3D rendering
+- Inventory editing for placeables that hold items (UTI palette, undoable add/remove)
+- 13 event script slots with Browse/Edit and reusable script-set presets
+- Faction editor sourced from the module's `repute.fac`
+- Portrait browser, named animation-state dropdown, ResRef/Tag auto-sync
+- New Placeable flow, recent files, full undo/redo
+
+**Learn more**: [Reliquary/README.md](Reliquary/README.md) | [Wiki](https://github.com/LordOfMyatar/Radoub/wiki/Reliquary)
+
 #### Trebuchet - Tool Launcher & Module Hub
 
 Central launcher and module management hub for the Radoub toolset.
@@ -139,7 +157,7 @@ Central launcher and module management hub for the Radoub toolset.
 
 Aurora Engine file format parsers used by all tools.
 
-**Supported Formats**: GFF, KEY, BIF, TLK, 2DA, ERF, DLG, JRL, UTC, UTI, UTM, BIC, IFO, SSF
+**Supported Formats**: GFF, KEY, BIF, TLK, 2DA, ERF, DLG, JRL, UTC, UTI, UTM, UTP, BIC, IFO, SSF
 
 #### Radoub.UI
 
@@ -223,6 +241,7 @@ dotnet build Manifest/Manifest/Manifest.csproj
 dotnet build Quartermaster/Quartermaster/Quartermaster.csproj
 dotnet build Fence/Fence/Fence.csproj
 dotnet build Relique/Relique/Relique.csproj
+dotnet build Reliquary/Reliquary/Reliquary.csproj
 dotnet build Trebuchet/Trebuchet/Trebuchet.csproj
 ```
 

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.10.24-alpha] - 2026-06-07
-**Branch**: `relique/issue-2385` | **PR**: #TBD
+**Branch**: `relique/issue-2385` | **PR**: #2402
 
 ### Sprint: Cost, UX & SafeMode (#2385)
 

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.10.24-alpha] - 2026-06-07
+**Branch**: `relique/issue-2385` | **PR**: #TBD
+
+### Sprint: Cost, UX & SafeMode (#2385)
+
+- SafeMode support (`--safemode` flag) for bootstrap parity (#2011)
+- Rationalize Add vs Add Checked buttons (#2234)
+- Compute base Cost from properties + base AC, replacing static stored value (#2235)
+- Mannequin idle pose — relaxed stance for armor preview (#2232)
+
+---
+
 ## [0.10.23-alpha] - 2026-06-06
 **Branch**: `relique/issue-2258` | **PR**: #2379
 

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -9,12 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [0.10.24-alpha] - 2026-06-07
 **Branch**: `relique/issue-2385` | **PR**: #2402
 
-### Sprint: Cost, UX & SafeMode (#2385)
+### Sprint: Cost & UX (#2385)
 
-- SafeMode support (`--safemode` flag) for bootstrap parity (#2011)
 - Rationalize Add vs Add Checked buttons (#2234)
 - Compute base Cost from properties + base AC, replacing static stored value (#2235)
 - Mannequin idle pose — relaxed stance for armor preview (#2232)
+- Docs: refresh root README (Reliquary listed) + add Ctrl+F Find to NEW_TOOL_BOOTSTRAP (#2401)
 
 ---
 

--- a/Relique/Relique.Tests/Services/ItemCostCalculatorTests.cs
+++ b/Relique/Relique.Tests/Services/ItemCostCalculatorTests.cs
@@ -42,6 +42,17 @@ public class ItemCostCalculatorTests
         mock.Set2DAValue("baseitems", 41, "ItemMultiplier", "1");
         mock.Set2DAValue("baseitems", 41, "ModelType", "0");
 
+        // 1 = longsword (BaseCost 15), 0 = dagger (BaseCost 10) — verified against the toolset.
+        // Weapons have ItemMultiplier 2 (the toolset doubles the bracket for them).
+        mock.Set2DAValue("baseitems", 1, "BaseCost", "15");
+        mock.Set2DAValue("baseitems", 1, "Stacking", "1");
+        mock.Set2DAValue("baseitems", 1, "ItemMultiplier", "2");
+        mock.Set2DAValue("baseitems", 1, "ModelType", "0");
+        mock.Set2DAValue("baseitems", 0, "BaseCost", "10");
+        mock.Set2DAValue("baseitems", 0, "Stacking", "1");
+        mock.Set2DAValue("baseitems", 0, "ItemMultiplier", "2");
+        mock.Set2DAValue("baseitems", 0, "ModelType", "0");
+
         // armor.2da: row = base AC, COST column
         mock.Set2DAValue("armor", 0, "COST", "0");
         mock.Set2DAValue("armor", 5, "COST", "400");   // AC 5 armor base cost 400
@@ -67,11 +78,30 @@ public class ItemCostCalculatorTests
         mock.Set2DAValue("itempropdef", 30, "Cost", "0");
         mock.Set2DAValue("itempropdef", 30, "SubTypeResRef", "****");
         mock.Set2DAValue("itempropdef", 30, "CostTableResRef", "5");
+        //  1 = AC Bonus: nonzero PropertyCost (0.9) acts as a MULTIPLIER on CostValue (NWN:EE),
+        //      not an additive term. Matches the real studded-leather +2 AC case.
+        mock.Set2DAValue("itempropdef", 1, "Cost", "0.9");
+        mock.Set2DAValue("itempropdef", 1, "SubTypeResRef", "****");
+        mock.Set2DAValue("itempropdef", 1, "CostTableResRef", "9");
+        // 16 = Damage Bonus: real PropertyCost 3.5 multiplier, CostTable 4 (verified vs toolset).
+        mock.Set2DAValue("itempropdef", 16, "Cost", "3.5");
+        mock.Set2DAValue("itempropdef", 16, "SubTypeResRef", "****");
+        mock.Set2DAValue("itempropdef", 16, "CostTableResRef", "4");
 
         // iprp_costtable.2da: index → cost 2da name
         mock.Set2DAValue("iprp_costtable", 2, "Name", "iprp_bonuscost");
         mock.Set2DAValue("iprp_costtable", 3, "Name", "iprp_spellcost");
+        mock.Set2DAValue("iprp_costtable", 4, "Name", "iprp_damagecost");
         mock.Set2DAValue("iprp_costtable", 5, "Name", "iprp_negcost");
+        mock.Set2DAValue("iprp_costtable", 9, "Name", "iprp_armorcost");
+
+        // iprp_armorcost.2da: AC bonus magnitudes
+        mock.Set2DAValue("iprp_armorcost", 2, "Cost", "1.9");  // +2 AC → 1.9
+
+        // iprp_bonuscost.2da: enhancement +5 → 4.9, +2 → 1.9 (verified vs toolset)
+        mock.Set2DAValue("iprp_bonuscost", 5, "Cost", "4.9");
+        // iprp_damagecost.2da: damage value 5 → magnitude 1.0
+        mock.Set2DAValue("iprp_damagecost", 5, "Cost", "1");
 
         // iprp_bonuscost.2da: CostValue row → Cost column
         mock.Set2DAValue("iprp_bonuscost", 1, "Cost", "1");   // +1 → cost 1
@@ -194,6 +224,48 @@ public class ItemCostCalculatorTests
         // [10 + 1000*(0) + 20] * 1 * 1 = 30
         var uti = Uti(40, 0, Prop(15, costValue: 2, costTable: 3, subtype: 0));
         Assert.Equal(30u, calc.Calculate(uti));
+    }
+
+    [Fact]
+    public void Calculate_AcBonus_PropertyCostMultipliesCostValue_MatchesAuroraToolset()
+    {
+        var mock = CreateMock();
+        // Reproduce the real studded-leather +2 AC case verified against the Aurora toolset:
+        // armor base item 16, torso → AC 3 → armor.2da[3].COST = 15.
+        mock.Set2DAValue("parts_chest", 4, "ACBONUS", "3");
+        mock.Set2DAValue("armor", 3, "COST", "15");
+        var calc = new ItemCostCalculator(mock);
+
+        var uti = Uti(16, 0, Prop(1, costValue: 2, costTable: 9));
+        uti.ArmorParts["Torso"] = 4;
+
+        // PropertyCost 0.9 × CostValue 1.9 = 1.71 → [15 + 1000*(1.71^2)] = 15 + 2924 = 2939.
+        Assert.Equal(2939u, calc.Calculate(uti));
+    }
+
+    [Fact]
+    public void Calculate_WeaponEnhancement5_MatchesAuroraToolset()
+    {
+        var calc = new ItemCostCalculator(CreateMock());
+        // Longsword (base item 1, BaseCost 15) + Enhancement +5 (prop 6, costVal 5 → 4.9).
+        // PropertyCost 1 × 4.9 = 4.9 → [15 + 1000*4.9²] = 15 + 24010 = 48050 (toolset-verified).
+        var uti = Uti(1, 0, Prop(6, costValue: 5, costTable: 2));
+        Assert.Equal(48050u, calc.Calculate(uti));
+    }
+
+    [Fact]
+    public void Calculate_MultipleProperties_SumThenSquare_MatchesAuroraToolset()
+    {
+        var mock = CreateMock();
+        // Real enhancement +2 magnitude is 1.9 (the base mock uses round 2 elsewhere).
+        mock.Set2DAValue("iprp_bonuscost", 2, "Cost", "1.9");
+        var calc = new ItemCostCalculator(mock);
+        // Dagger (base item 0, BaseCost 10, ItemMultiplier 2) + Enhancement +2 (1×1.9=1.9)
+        // + Damage 5 (3.5×1.0=3.5). Mult = 5.4 → [10 + 1000*5.4²]*2 = 29170*2 = 58340 (toolset).
+        var uti = Uti(0, 0,
+            Prop(6, costValue: 2, costTable: 2),
+            Prop(16, costValue: 5, costTable: 4));
+        Assert.Equal(58340u, calc.Calculate(uti));
     }
 
     [Fact]

--- a/Relique/Relique.Tests/Services/ItemCostCalculatorTests.cs
+++ b/Relique/Relique.Tests/Services/ItemCostCalculatorTests.cs
@@ -1,0 +1,212 @@
+using System.Collections.Generic;
+using ItemEditor.Services;
+using Radoub.Formats.Uti;
+using Radoub.TestUtilities.Mocks;
+using Xunit;
+
+namespace ItemEditor.Tests.Services;
+
+/// <summary>
+/// Tests for the Aurora item cost formula (wiki Ch4 §4.4):
+///   ItemCost = [BaseCost + 1000*(Mult^2 - NegMult^2) + SpellCosts] * MaxStack * BaseMult + AddCost
+/// </summary>
+public class ItemCostCalculatorTests
+{
+    // ---- Mock setup ---------------------------------------------------------
+
+    /// <summary>
+    /// Builds a mock with one non-armor base item (index 40, a longsword-like)
+    /// and one armor base item (index 16). Property cost tables are wired so that
+    /// individual tests can assert specific contributions.
+    /// </summary>
+    private static MockGameDataService CreateMock()
+    {
+        var mock = new MockGameDataService(includeSampleData: false);
+
+        // baseitems.2da
+        // 40 = non-armor: BaseCost 10, Stacking 1, ItemMultiplier 1, ModelType 0
+        mock.Set2DAValue("baseitems", 40, "BaseCost", "10");
+        mock.Set2DAValue("baseitems", 40, "Stacking", "1");
+        mock.Set2DAValue("baseitems", 40, "ItemMultiplier", "1");
+        mock.Set2DAValue("baseitems", 40, "ModelType", "0");
+
+        // 16 = armor: BaseCost column ignored for armor, Stacking 1, ItemMultiplier 1, ModelType 3
+        mock.Set2DAValue("baseitems", 16, "BaseCost", "0");
+        mock.Set2DAValue("baseitems", 16, "Stacking", "1");
+        mock.Set2DAValue("baseitems", 16, "ItemMultiplier", "1");
+        mock.Set2DAValue("baseitems", 16, "ModelType", "3");
+
+        // 41 = stackable non-armor: BaseCost 5, Stacking 99, ItemMultiplier 1, ModelType 0
+        mock.Set2DAValue("baseitems", 41, "BaseCost", "5");
+        mock.Set2DAValue("baseitems", 41, "Stacking", "99");
+        mock.Set2DAValue("baseitems", 41, "ItemMultiplier", "1");
+        mock.Set2DAValue("baseitems", 41, "ModelType", "0");
+
+        // armor.2da: row = base AC, COST column
+        mock.Set2DAValue("armor", 0, "COST", "0");
+        mock.Set2DAValue("armor", 5, "COST", "400");   // AC 5 armor base cost 400
+
+        // parts_chest.2da: row = torso part, ACBONUS column
+        mock.Set2DAValue("parts_chest", 0, "ACBONUS", "0");
+        mock.Set2DAValue("parts_chest", 7, "ACBONUS", "5");  // torso part 7 → AC 5
+
+        // itempropdef.2da
+        //  6  = Enhancement Bonus: PropertyCost 0, CostTable 2 (bonuscost)
+        mock.Set2DAValue("itempropdef", 6, "Cost", "0");
+        mock.Set2DAValue("itempropdef", 6, "SubTypeResRef", "****");
+        mock.Set2DAValue("itempropdef", 6, "CostTableResRef", "2");
+        //  0  = Ability Bonus: PropertyCost 0, has subtype iprp_abilities, CostTable 2
+        mock.Set2DAValue("itempropdef", 0, "Cost", "0");
+        mock.Set2DAValue("itempropdef", 0, "SubTypeResRef", "iprp_abilities");
+        mock.Set2DAValue("itempropdef", 0, "CostTableResRef", "2");
+        // 15  = Cast Spell: PropertyCost 0, subtype iprp_spells, CostTable 3
+        mock.Set2DAValue("itempropdef", 15, "Cost", "0");
+        mock.Set2DAValue("itempropdef", 15, "SubTypeResRef", "iprp_spells");
+        mock.Set2DAValue("itempropdef", 15, "CostTableResRef", "3");
+        // 30 = a property with a non-zero PropertyCost and a negative cost value
+        mock.Set2DAValue("itempropdef", 30, "Cost", "0");
+        mock.Set2DAValue("itempropdef", 30, "SubTypeResRef", "****");
+        mock.Set2DAValue("itempropdef", 30, "CostTableResRef", "5");
+
+        // iprp_costtable.2da: index → cost 2da name
+        mock.Set2DAValue("iprp_costtable", 2, "Name", "iprp_bonuscost");
+        mock.Set2DAValue("iprp_costtable", 3, "Name", "iprp_spellcost");
+        mock.Set2DAValue("iprp_costtable", 5, "Name", "iprp_negcost");
+
+        // iprp_bonuscost.2da: CostValue row → Cost column
+        mock.Set2DAValue("iprp_bonuscost", 1, "Cost", "1");   // +1 → cost 1
+        mock.Set2DAValue("iprp_bonuscost", 2, "Cost", "2");   // +2 → cost 2
+        mock.Set2DAValue("iprp_bonuscost", 3, "Cost", "3");   // +3 → cost 3
+
+        // iprp_abilities.2da: subtype rows have a Cost column (SubtypeCost)
+        mock.Set2DAValue("iprp_abilities", 0, "Cost", "0");
+
+        // iprp_spells.2da: subtype rows have a Cost column (SubtypeCost for Cast Spell)
+        mock.Set2DAValue("iprp_spells", 0, "Cost", "1");
+
+        // iprp_spellcost.2da: spell cost values
+        mock.Set2DAValue("iprp_spellcost", 1, "Cost", "10");
+        mock.Set2DAValue("iprp_spellcost", 2, "Cost", "20");
+
+        // iprp_negcost.2da: negative cost values
+        mock.Set2DAValue("iprp_negcost", 1, "Cost", "-2");
+
+        return mock;
+    }
+
+    private static ItemProperty Prop(ushort name, ushort costValue, byte costTable, ushort subtype = 0) =>
+        new() { PropertyName = name, CostValue = costValue, CostTable = costTable, Subtype = subtype, Param1 = 0xFF };
+
+    private static UtiFile Uti(int baseItem, uint addCost = 0, params ItemProperty[] props)
+    {
+        var uti = new UtiFile { BaseItem = baseItem, AddCost = addCost };
+        foreach (var p in props) uti.Properties.Add(p);
+        return uti;
+    }
+
+    // ---- Tests --------------------------------------------------------------
+
+    [Fact]
+    public void Calculate_Unconfigured_ReturnsNull()
+    {
+        var calc = new ItemCostCalculator(new MockGameDataService(includeSampleData: false).AsUnconfigured());
+        Assert.Null(calc.Calculate(Uti(40)));
+    }
+
+    [Fact]
+    public void Calculate_NonArmorNoProperties_IsBaseCostTimesStackTimesMult_PlusAddCost()
+    {
+        var calc = new ItemCostCalculator(CreateMock());
+        // BaseCost 10, no props, Stacking 1, Mult 1, AddCost 0 → 10
+        Assert.Equal(10u, calc.Calculate(Uti(40)));
+    }
+
+    [Fact]
+    public void Calculate_AddCost_IsAddedOutsideTheBracket()
+    {
+        var calc = new ItemCostCalculator(CreateMock());
+        // (10) * 1 * 1 + 25 = 35
+        Assert.Equal(35u, calc.Calculate(Uti(40, addCost: 25)));
+    }
+
+    [Fact]
+    public void Calculate_StackableItem_MultipliesByStacking()
+    {
+        var calc = new ItemCostCalculator(CreateMock());
+        // BaseCost 5 * Stacking 99 * Mult 1 = 495
+        Assert.Equal(495u, calc.Calculate(Uti(41)));
+    }
+
+    [Fact]
+    public void Calculate_SinglePositiveProperty_SquaresMultiplierTimes1000()
+    {
+        var calc = new ItemCostCalculator(CreateMock());
+        // Enhancement +2 → property cost 2 (positive). Mult=2, NegMult=0.
+        // [10 + 1000*(2^2 - 0)] * 1 * 1 = 10 + 4000 = 4010
+        var uti = Uti(40, 0, Prop(6, costValue: 2, costTable: 2));
+        Assert.Equal(4010u, calc.Calculate(uti));
+    }
+
+    [Fact]
+    public void Calculate_TwoPositiveProperties_SumThenSquare()
+    {
+        var calc = new ItemCostCalculator(CreateMock());
+        // Two enhancement-style props: cost 1 and cost 3 → Mult = 4.
+        // [10 + 1000*(4^2)] = 10 + 16000 = 16010
+        var uti = Uti(40, 0,
+            Prop(6, costValue: 1, costTable: 2),
+            Prop(6, costValue: 3, costTable: 2));
+        Assert.Equal(16010u, calc.Calculate(uti));
+    }
+
+    [Fact]
+    public void Calculate_NegativeProperty_SubtractsSquaredNegMultiplier()
+    {
+        var calc = new ItemCostCalculator(CreateMock());
+        // One positive cost 3 (Mult=3) and one negative cost -2 (NegMult=2).
+        // [10 + 1000*(3^2 - 2^2)] = 10 + 1000*5 = 5010
+        var uti = Uti(40, 0,
+            Prop(6, costValue: 3, costTable: 2),
+            Prop(30, costValue: 1, costTable: 5));
+        Assert.Equal(5010u, calc.Calculate(uti));
+    }
+
+    [Fact]
+    public void Calculate_Armor_UsesArmorTableBaseCostFromTorsoAc()
+    {
+        var calc = new ItemCostCalculator(CreateMock());
+        // Armor base item 16, torso part 7 → AC 5 → armor.2da[5].COST = 400.
+        // No props → [400] * 1 * 1 = 400
+        var uti = Uti(16);
+        uti.ArmorParts["Torso"] = 7;
+        Assert.Equal(400u, calc.Calculate(uti));
+    }
+
+    [Fact]
+    public void Calculate_CastSpell_ExcludedFromMultiplierAndAddedAsSpellCost()
+    {
+        var calc = new ItemCostCalculator(CreateMock());
+        // Single Cast Spell property (prop 15), subtype 0 (iprp_spells Cost = 1),
+        // CostValue 2 → iprp_spellcost[2].Cost = 20.
+        // PropertyCost 0 → SubtypeCost path: subtype cost = 1.
+        // CastSpellCost = (PropertyCost 0 + CostValue 20) * SubtypeCost 1 = 20.
+        // Single spell → most-expensive tier *100% = 20.
+        // [10 + 1000*(0) + 20] * 1 * 1 = 30
+        var uti = Uti(40, 0, Prop(15, costValue: 2, costTable: 3, subtype: 0));
+        Assert.Equal(30u, calc.Calculate(uti));
+    }
+
+    [Fact]
+    public void Calculate_SubtypeCostUsedWhenPropertyCostIsZero()
+    {
+        var mock = CreateMock();
+        // Ability bonus (prop 0): PropertyCost 0 → fall back to subtype cost.
+        // iprp_abilities row 2 Cost = 4 (SubtypeCost). CostValue from bonuscost.
+        mock.Set2DAValue("iprp_abilities", 2, "Cost", "4");
+        var calc = new ItemCostCalculator(mock);
+        // prop 0, subtype 2 (subtypecost 4), costValue 1 (bonuscost 1) → property cost 4 + 1 = 5
+        // [10 + 1000*(5^2)] = 10 + 25000 = 25010
+        var uti = Uti(40, 0, Prop(0, costValue: 1, costTable: 2, subtype: 2));
+        Assert.Equal(25010u, calc.Calculate(uti));
+    }
+}

--- a/Relique/Relique.Tests/Services/MannequinPoseAdjusterTests.cs
+++ b/Relique/Relique.Tests/Services/MannequinPoseAdjusterTests.cs
@@ -1,0 +1,127 @@
+using System.Numerics;
+using ItemEditor.Services;
+using Radoub.Formats.Mdl;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace ItemEditor.Tests.Services;
+
+public class MannequinPoseAdjusterTests
+{
+    private static MdlModel BuildSkeleton()
+    {
+        // root → torso_g → {lbicep_g→lforearm_g, rbicep_g}, pelvis_g → {lthigh_g, rthigh_g}
+        var lforearm = new MdlNode { Name = "lforearm_g", Orientation = Quaternion.Identity };
+        var lbicep = new MdlNode { Name = "lbicep_g", Orientation = Quaternion.Identity };
+        lbicep.Children.Add(lforearm); lforearm.Parent = lbicep;
+        var rbicep = new MdlNode { Name = "rbicep_g", Orientation = Quaternion.Identity };
+
+        var torso = new MdlNode { Name = "torso_g", Orientation = Quaternion.Identity };
+        torso.Children.Add(lbicep); lbicep.Parent = torso;
+        torso.Children.Add(rbicep); rbicep.Parent = torso;
+
+        var lthigh = new MdlNode { Name = "lthigh_g", Orientation = Quaternion.Identity };
+        var rthigh = new MdlNode { Name = "rthigh_g", Orientation = Quaternion.Identity };
+        var pelvis = new MdlNode { Name = "pelvis_g", Orientation = Quaternion.Identity };
+        pelvis.Children.Add(lthigh); lthigh.Parent = pelvis;
+        pelvis.Children.Add(rthigh); rthigh.Parent = pelvis;
+
+        var root = new MdlNode { Name = "root", Orientation = Quaternion.Identity };
+        root.Children.Add(torso); torso.Parent = root;
+        root.Children.Add(pelvis); pelvis.Parent = root;
+
+        return new MdlModel { Name = "pmh0", GeometryRoot = root };
+    }
+
+    private static MdlNode Find(MdlModel m, string name) =>
+        MdlPartComposer.FindBoneByName(m.GeometryRoot!, name)!;
+
+    [Fact]
+    public void ApplyRelaxedPose_RotatesBicepBones()
+    {
+        var model = BuildSkeleton();
+        MannequinPoseAdjuster.ApplyRelaxedPose(model);
+
+        Assert.NotEqual(Quaternion.Identity, Find(model, "lbicep_g").Orientation);
+        Assert.NotEqual(Quaternion.Identity, Find(model, "rbicep_g").Orientation);
+    }
+
+    [Fact]
+    public void ApplyRelaxedPose_RotatesThighBones()
+    {
+        var model = BuildSkeleton();
+        MannequinPoseAdjuster.ApplyRelaxedPose(model);
+
+        Assert.NotEqual(Quaternion.Identity, Find(model, "lthigh_g").Orientation);
+        Assert.NotEqual(Quaternion.Identity, Find(model, "rthigh_g").Orientation);
+    }
+
+    [Fact]
+    public void ApplyRelaxedPose_LeftAndRightAreMirrored()
+    {
+        var model = BuildSkeleton();
+        MannequinPoseAdjuster.ApplyRelaxedPose(model);
+
+        var l = Find(model, "lbicep_g").Orientation;
+        var r = Find(model, "rbicep_g").Orientation;
+
+        // Mirrored: the right rotation is the conjugate (opposite angle about the same axis)
+        // of the left, so combining left with right yields (near) identity.
+        var combined = Quaternion.Normalize(l * r);
+        Assert.True(QuaternionsApproximatelyEqual(combined, Quaternion.Identity),
+            $"expected mirrored rotations to cancel, got {combined}");
+    }
+
+    [Fact]
+    public void ApplyRelaxedPose_DoesNotRotateUnrelatedBones()
+    {
+        var model = BuildSkeleton();
+        MannequinPoseAdjuster.ApplyRelaxedPose(model);
+
+        // torso, pelvis, forearm, root are not adjusted directly.
+        Assert.Equal(Quaternion.Identity, Find(model, "torso_g").Orientation);
+        Assert.Equal(Quaternion.Identity, Find(model, "pelvis_g").Orientation);
+        Assert.Equal(Quaternion.Identity, Find(model, "lforearm_g").Orientation);
+        Assert.Equal(Quaternion.Identity, Find(model, "root").Orientation);
+    }
+
+    [Fact]
+    public void ApplyRelaxedPose_AbductsByConfiguredAngle()
+    {
+        var model = BuildSkeleton();
+        MannequinPoseAdjuster.ApplyRelaxedPose(model);
+
+        var expected = Quaternion.CreateFromAxisAngle(
+            Vector3.UnitY, MannequinPoseAdjuster.ArmAbductionDegrees * (float)System.Math.PI / 180f);
+        var actual = Find(model, "lbicep_g").Orientation;
+
+        Assert.True(QuaternionsApproximatelyEqual(actual, Quaternion.Normalize(expected)),
+            $"expected {expected}, got {actual}");
+    }
+
+    [Fact]
+    public void ApplyRelaxedPose_NullModel_DoesNotThrow()
+    {
+        MannequinPoseAdjuster.ApplyRelaxedPose(null);
+        MannequinPoseAdjuster.ApplyRelaxedPose(new MdlModel { GeometryRoot = null });
+    }
+
+    [Fact]
+    public void ApplyRelaxedPose_MissingBones_SkippedSilently()
+    {
+        // Skeleton with only a root — none of the target bones exist.
+        var model = new MdlModel { GeometryRoot = new MdlNode { Name = "root" } };
+        MannequinPoseAdjuster.ApplyRelaxedPose(model);
+        Assert.Equal(Quaternion.Identity, model.GeometryRoot!.Orientation);
+    }
+
+    private static bool QuaternionsApproximatelyEqual(Quaternion a, Quaternion b, float tol = 1e-4f)
+    {
+        // q and -q represent the same rotation.
+        bool same = System.MathF.Abs(a.X - b.X) < tol && System.MathF.Abs(a.Y - b.Y) < tol
+                 && System.MathF.Abs(a.Z - b.Z) < tol && System.MathF.Abs(a.W - b.W) < tol;
+        bool neg = System.MathF.Abs(a.X + b.X) < tol && System.MathF.Abs(a.Y + b.Y) < tol
+                 && System.MathF.Abs(a.Z + b.Z) < tol && System.MathF.Abs(a.W + b.W) < tol;
+        return same || neg;
+    }
+}

--- a/Relique/Relique.Tests/Services/MannequinPoseAdjusterTests.cs
+++ b/Relique/Relique.Tests/Services/MannequinPoseAdjusterTests.cs
@@ -10,18 +10,25 @@ public class MannequinPoseAdjusterTests
 {
     private static MdlModel BuildSkeleton()
     {
-        // root → torso_g → {lbicep_g→lforearm_g, rbicep_g}, pelvis_g → {lthigh_g, rthigh_g}
+        // root → torso_g → {lbicep_g→lforearm_g, rbicep_g→rforearm_g},
+        //         pelvis_g → {lthigh_g→lshin_g, rthigh_g→rshin_g}
         var lforearm = new MdlNode { Name = "lforearm_g", Orientation = Quaternion.Identity };
         var lbicep = new MdlNode { Name = "lbicep_g", Orientation = Quaternion.Identity };
         lbicep.Children.Add(lforearm); lforearm.Parent = lbicep;
+        var rforearm = new MdlNode { Name = "rforearm_g", Orientation = Quaternion.Identity };
         var rbicep = new MdlNode { Name = "rbicep_g", Orientation = Quaternion.Identity };
+        rbicep.Children.Add(rforearm); rforearm.Parent = rbicep;
 
         var torso = new MdlNode { Name = "torso_g", Orientation = Quaternion.Identity };
         torso.Children.Add(lbicep); lbicep.Parent = torso;
         torso.Children.Add(rbicep); rbicep.Parent = torso;
 
+        var lshin = new MdlNode { Name = "lshin_g", Orientation = Quaternion.Identity };
         var lthigh = new MdlNode { Name = "lthigh_g", Orientation = Quaternion.Identity };
+        lthigh.Children.Add(lshin); lshin.Parent = lthigh;
+        var rshin = new MdlNode { Name = "rshin_g", Orientation = Quaternion.Identity };
         var rthigh = new MdlNode { Name = "rthigh_g", Orientation = Quaternion.Identity };
+        rthigh.Children.Add(rshin); rshin.Parent = rthigh;
         var pelvis = new MdlNode { Name = "pelvis_g", Orientation = Quaternion.Identity };
         pelvis.Children.Add(lthigh); lthigh.Parent = pelvis;
         pelvis.Children.Add(rthigh); rthigh.Parent = pelvis;
@@ -78,11 +85,22 @@ public class MannequinPoseAdjusterTests
         var model = BuildSkeleton();
         MannequinPoseAdjuster.ApplyRelaxedPose(model);
 
-        // torso, pelvis, forearm, root are not adjusted directly.
+        // torso, pelvis, root are not adjusted directly.
         Assert.Equal(Quaternion.Identity, Find(model, "torso_g").Orientation);
         Assert.Equal(Quaternion.Identity, Find(model, "pelvis_g").Orientation);
-        Assert.Equal(Quaternion.Identity, Find(model, "lforearm_g").Orientation);
         Assert.Equal(Quaternion.Identity, Find(model, "root").Orientation);
+    }
+
+    [Fact]
+    public void ApplyRelaxedPose_FlexesForearmAndShinBones()
+    {
+        var model = BuildSkeleton();
+        MannequinPoseAdjuster.ApplyRelaxedPose(model);
+
+        Assert.NotEqual(Quaternion.Identity, Find(model, "lforearm_g").Orientation);
+        Assert.NotEqual(Quaternion.Identity, Find(model, "rforearm_g").Orientation);
+        Assert.NotEqual(Quaternion.Identity, Find(model, "lshin_g").Orientation);
+        Assert.NotEqual(Quaternion.Identity, Find(model, "rshin_g").Orientation);
     }
 
     [Fact]

--- a/Relique/Relique/Services/ItemCostCalculator.cs
+++ b/Relique/Relique/Services/ItemCostCalculator.cs
@@ -78,7 +78,6 @@ public class ItemCostCalculator
             + spellTotal;
 
         double total = bracket * maxStack * baseMult + uti.AddCost;
-
         if (total < 0) total = 0;
         return (uint)Math.Round(total, MidpointRounding.AwayFromZero);
     }
@@ -98,15 +97,26 @@ public class ItemCostCalculator
     }
 
     /// <summary>
-    /// Per-property cost (non-spell) = PropertyCost + SubtypeCost + CostValue.
-    /// SubtypeCost only applies when PropertyCost is 0 (§4.4.2).
+    /// Per-property cost. The BioWare doc (§4.4.2) describes this additively
+    /// (PropertyCost + SubtypeCost + CostValue), but NWN:EE actually treats the
+    /// itempropdef.2da <c>Cost</c> column as a <b>multiplier</b> on the property's
+    /// magnitude, not an additive term. Verified against the Aurora toolset:
+    /// studded leather +2 AC → PropertyCost 0.9 × CostValue 1.9 = 1.71, and
+    /// 15 + 1000·1.71² = 2939 (matches the toolset; the additive reading gave 7855).
+    ///
+    /// Model: magnitude = CostValue (+ SubtypeCost only when there is no PropertyCost
+    /// multiplier); cost = PropertyCost × magnitude, treating a missing/zero
+    /// PropertyCost as a multiplier of 1 so magnitude-only properties still count.
     /// </summary>
     private double CalculatePropertyCost(ItemProperty prop)
     {
         double propertyCost = GetPropertyCost(prop.PropertyName);
-        double subtypeCost = propertyCost == 0 ? GetSubtypeCost(prop) : 0;
         double costValue = GetCostValue(prop);
-        return propertyCost + subtypeCost + costValue;
+        double subtypeCost = propertyCost == 0 ? GetSubtypeCost(prop) : 0;
+
+        double magnitude = costValue + subtypeCost;
+        double multiplier = propertyCost == 0 ? 1.0 : propertyCost;
+        return multiplier * magnitude;
     }
 
     /// <summary>

--- a/Relique/Relique/Services/ItemCostCalculator.cs
+++ b/Relique/Relique/Services/ItemCostCalculator.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Radoub.Formats.Services;
+using Radoub.Formats.Uti;
+
+namespace ItemEditor.Services;
+
+/// <summary>
+/// Computes an item's gold cost using the Aurora engine formula (wiki Ch4 §4.4):
+///
+///   ItemCost = [BaseCost + 1000*(Multiplier^2 - NegMultiplier^2) + SpellCosts]
+///              * MaxStack * BaseMult + AddCost
+///
+/// The engine recomputes Cost on load, so the stored UTI value is advisory only.
+/// This calculator reproduces the engine result so the editor can display and save
+/// the value the game will actually use. Returns null when game data is unavailable,
+/// in which case the caller should keep the stored value (#2235).
+/// </summary>
+public class ItemCostCalculator
+{
+    private const int CastSpellPropertyName = 15;
+
+    private readonly IGameDataService _gameData;
+
+    public ItemCostCalculator(IGameDataService gameData)
+    {
+        _gameData = gameData ?? throw new ArgumentNullException(nameof(gameData));
+    }
+
+    /// <summary>
+    /// Compute the item cost. Returns null if game data is not configured or the
+    /// base item row is missing, so the caller can fall back to the stored value.
+    /// </summary>
+    public uint? Calculate(UtiFile uti)
+    {
+        if (uti == null) throw new ArgumentNullException(nameof(uti));
+        if (!_gameData.IsConfigured) return null;
+
+        var baseItems = _gameData.Get2DA("baseitems");
+        if (baseItems == null || uti.BaseItem < 0 || uti.BaseItem >= baseItems.RowCount)
+            return null;
+
+        var modelType = GetInt(baseItems.GetValue(uti.BaseItem, "ModelType"), 0);
+        var isArmor = modelType == 3;
+
+        double baseCost = isArmor
+            ? ResolveArmorBaseCost(uti)
+            : GetDouble(baseItems.GetValue(uti.BaseItem, "BaseCost"), 0);
+
+        double maxStack = GetDouble(baseItems.GetValue(uti.BaseItem, "Stacking"), 1);
+        if (maxStack < 1) maxStack = 1;
+        double baseMult = GetDouble(baseItems.GetValue(uti.BaseItem, "ItemMultiplier"), 1);
+        if (baseMult <= 0) baseMult = 1;
+
+        double multiplier = 0;     // sum of positive non-spell property costs
+        double negMultiplier = 0;  // sum of |negative| non-spell property costs
+        var spellCosts = new List<double>();
+
+        foreach (var prop in uti.Properties)
+        {
+            if (prop.PropertyName == CastSpellPropertyName)
+            {
+                spellCosts.Add(CalculateCastSpellCost(prop));
+                continue;
+            }
+
+            double cost = CalculatePropertyCost(prop);
+            if (cost > 0) multiplier += cost;
+            else if (cost < 0) negMultiplier += -cost;
+        }
+
+        double spellTotal = AggregateSpellCosts(spellCosts);
+
+        double bracket = baseCost
+            + 1000.0 * (multiplier * multiplier - negMultiplier * negMultiplier)
+            + spellTotal;
+
+        double total = bracket * maxStack * baseMult + uti.AddCost;
+
+        if (total < 0) total = 0;
+        return (uint)Math.Round(total, MidpointRounding.AwayFromZero);
+    }
+
+    /// <summary>
+    /// Armor BaseCost = armor.2da[baseAC].COST, where baseAC = parts_chest.2da[Torso].ACBONUS.
+    /// </summary>
+    private double ResolveArmorBaseCost(UtiFile uti)
+    {
+        var torsoPart = uti.ArmorParts.TryGetValue("Torso", out var t) ? t : (byte)0;
+
+        var acBonusStr = _gameData.Get2DAValue("parts_chest", torsoPart, "ACBONUS");
+        var baseAc = GetInt(acBonusStr, 0);
+
+        var costStr = _gameData.Get2DAValue("armor", baseAc, "COST");
+        return GetDouble(costStr, 0);
+    }
+
+    /// <summary>
+    /// Per-property cost (non-spell) = PropertyCost + SubtypeCost + CostValue.
+    /// SubtypeCost only applies when PropertyCost is 0 (§4.4.2).
+    /// </summary>
+    private double CalculatePropertyCost(ItemProperty prop)
+    {
+        double propertyCost = GetPropertyCost(prop.PropertyName);
+        double subtypeCost = propertyCost == 0 ? GetSubtypeCost(prop) : 0;
+        double costValue = GetCostValue(prop);
+        return propertyCost + subtypeCost + costValue;
+    }
+
+    /// <summary>
+    /// Cast Spell cost = (PropertyCost + CostValue) * SubtypeCost (§4.4.3).
+    /// </summary>
+    private double CalculateCastSpellCost(ItemProperty prop)
+    {
+        double propertyCost = GetPropertyCost(prop.PropertyName);
+        double subtypeCost = GetSubtypeCost(prop);
+        double costValue = GetCostValue(prop);
+        return (propertyCost + costValue) * subtypeCost;
+    }
+
+    /// <summary>
+    /// Tier the accumulated cast-spell costs: most expensive 100%, second 75%, rest 50%.
+    /// </summary>
+    private static double AggregateSpellCosts(List<double> spellCosts)
+    {
+        if (spellCosts.Count == 0) return 0;
+
+        var ordered = spellCosts.OrderByDescending(c => c).ToList();
+        double total = 0;
+        for (int i = 0; i < ordered.Count; i++)
+        {
+            double factor = i == 0 ? 1.0 : i == 1 ? 0.75 : 0.5;
+            total += ordered[i] * factor;
+        }
+        return total;
+    }
+
+    /// <summary>PropertyCost: itempropdef.2da[PropertyName].Cost (**** → 0).</summary>
+    private double GetPropertyCost(int propertyName)
+    {
+        var propDef = _gameData.Get2DA("itempropdef");
+        if (propDef == null || propertyName < 0 || propertyName >= propDef.RowCount)
+            return 0;
+        return GetDouble(propDef.GetValue(propertyName, "Cost"), 0);
+    }
+
+    /// <summary>SubtypeCost: subtype 2da[Subtype].Cost via itempropdef SubTypeResRef.</summary>
+    private double GetSubtypeCost(ItemProperty prop)
+    {
+        var propDef = _gameData.Get2DA("itempropdef");
+        if (propDef == null || prop.PropertyName >= propDef.RowCount)
+            return 0;
+
+        var subtypeResRef = propDef.GetValue(prop.PropertyName, "SubTypeResRef");
+        if (!IsValid(subtypeResRef))
+            return 0;
+
+        return GetDouble(_gameData.Get2DAValue(subtypeResRef!, prop.Subtype, "Cost"), 0);
+    }
+
+    /// <summary>
+    /// CostValue: iprp_costtable.2da[CostTable].Name → cost 2da[CostValue].Cost.
+    /// </summary>
+    private double GetCostValue(ItemProperty prop)
+    {
+        var costTableResRef = _gameData.Get2DAValue("iprp_costtable", prop.CostTable, "Name");
+        if (!IsValid(costTableResRef))
+            return 0;
+
+        return GetDouble(_gameData.Get2DAValue(costTableResRef!, prop.CostValue, "Cost"), 0);
+    }
+
+    private static bool IsValid(string? value) => !string.IsNullOrEmpty(value) && value != "****";
+
+    private static int GetInt(string? value, int fallback)
+    {
+        if (!IsValid(value)) return fallback;
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var r) ? r : fallback;
+    }
+
+    private static double GetDouble(string? value, double fallback)
+    {
+        if (!IsValid(value)) return fallback;
+        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var r) ? r : fallback;
+    }
+}

--- a/Relique/Relique/Services/ItemPreviewController.cs
+++ b/Relique/Relique/Services/ItemPreviewController.cs
@@ -160,6 +160,12 @@ public sealed class ItemPreviewController
                 return;
             }
 
+            // Relax the armor mannequin's stance so limb parts (hands, forearms, boots) are
+            // visible from the default camera (#2232). Armor only — the skeleton composition
+            // path is the mannequin; flat composites (weapons) have no skeleton.
+            if (resolution.HasArmorParts)
+                MannequinPoseAdjuster.ApplyRelaxedPose(composed);
+
             ApplyTrophyRotationIfHeldWeapon(uti, composed);
 
             _renderer.SetModel(composed);

--- a/Relique/Relique/Services/MannequinPoseAdjuster.cs
+++ b/Relique/Relique/Services/MannequinPoseAdjuster.cs
@@ -29,6 +29,12 @@ public static class MannequinPoseAdjuster
     /// <summary>Thigh separation angle (degrees) — opens the stance to hip width.</summary>
     public const float LegSeparationDegrees = 9f;
 
+    /// <summary>Elbow flexion (degrees) — slight forearm bend so arms aren't locked straight.</summary>
+    public const float ElbowFlexionDegrees = 5f;
+
+    /// <summary>Knee flexion (degrees) — slight shin bend so legs aren't locked straight.</summary>
+    public const float KneeFlexionDegrees = 4f;
+
     /// <summary>
     /// Local rotation axis for arm abduction. NWN bicep bones run down the limb; rotating
     /// about the forward (Y) axis swings the arm in the frontal (X-Z) plane — out to the side.
@@ -38,6 +44,12 @@ public static class MannequinPoseAdjuster
     /// <summary>Local rotation axis for thigh separation (same frontal-plane swing).</summary>
     private static readonly Vector3 LegSeparationAxis = Vector3.UnitY;
 
+    /// <summary>
+    /// Local rotation axis for elbow/knee flexion. Rotating about the side (X) axis bends the
+    /// limb in the sagittal plane — forearm forward, shin back — for a relaxed, non-locked pose.
+    /// </summary>
+    private static readonly Vector3 FlexionAxis = Vector3.UnitX;
+
     private static readonly (string Bone, Vector3 Axis, float Degrees)[] Adjustments =
     {
         // Left/right mirrored: opposite signs so both limbs swing outward symmetrically.
@@ -45,6 +57,12 @@ public static class MannequinPoseAdjuster
         ("rbicep_g", ArmAbductionAxis, -ArmAbductionDegrees),
         ("lthigh_g", LegSeparationAxis,  LegSeparationDegrees),
         ("rthigh_g", LegSeparationAxis, -LegSeparationDegrees),
+
+        // Slight elbow/knee bend so limbs aren't locked straight (same sign both sides).
+        ("lforearm_g", FlexionAxis, ElbowFlexionDegrees),
+        ("rforearm_g", FlexionAxis, ElbowFlexionDegrees),
+        ("lshin_g", FlexionAxis, -KneeFlexionDegrees),
+        ("rshin_g", FlexionAxis, -KneeFlexionDegrees),
     };
 
     /// <summary>

--- a/Relique/Relique/Services/MannequinPoseAdjuster.cs
+++ b/Relique/Relique/Services/MannequinPoseAdjuster.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Numerics;
+using Radoub.Formats.Mdl;
+using Radoub.UI.Services;
+
+namespace ItemEditor.Services;
+
+/// <summary>
+/// Relaxes the armor-preview mannequin's static bind pose so limb armor parts are visible
+/// from the default front camera (#2232). The stock skeleton stands "at attention" — arms
+/// straight down (hands/forearms occluded by the hips) and legs together. This adjuster
+/// abducts the upper arms slightly outward and separates the thighs to roughly hip width,
+/// without going to a T-pose.
+///
+/// Applied only to the Relique armor mannequin — it mutates the composite model's cloned
+/// bone hierarchy after composition, so the shared <see cref="MdlPartComposer"/> and other
+/// consumers (e.g. Quartermaster creature preview) are unaffected.
+///
+/// Each adjustment premultiplies a delta rotation in the bone's local frame
+/// (<c>orientation = orientation * delta</c>), so meshes attached to the bone and every
+/// child bone (forearm, hand; shin, foot) follow the rotation automatically. Angles are
+/// intentionally conservative and live here as named constants for easy visual tuning.
+/// </summary>
+public static class MannequinPoseAdjuster
+{
+    /// <summary>Upper-arm abduction angle (degrees) — swings arms out from the torso.</summary>
+    public const float ArmAbductionDegrees = 18f;
+
+    /// <summary>Thigh separation angle (degrees) — opens the stance to hip width.</summary>
+    public const float LegSeparationDegrees = 9f;
+
+    /// <summary>
+    /// Local rotation axis for arm abduction. NWN bicep bones run down the limb; rotating
+    /// about the forward (Y) axis swings the arm in the frontal (X-Z) plane — out to the side.
+    /// </summary>
+    private static readonly Vector3 ArmAbductionAxis = Vector3.UnitY;
+
+    /// <summary>Local rotation axis for thigh separation (same frontal-plane swing).</summary>
+    private static readonly Vector3 LegSeparationAxis = Vector3.UnitY;
+
+    private static readonly (string Bone, Vector3 Axis, float Degrees)[] Adjustments =
+    {
+        // Left/right mirrored: opposite signs so both limbs swing outward symmetrically.
+        ("lbicep_g", ArmAbductionAxis,  ArmAbductionDegrees),
+        ("rbicep_g", ArmAbductionAxis, -ArmAbductionDegrees),
+        ("lthigh_g", LegSeparationAxis,  LegSeparationDegrees),
+        ("rthigh_g", LegSeparationAxis, -LegSeparationDegrees),
+    };
+
+    /// <summary>
+    /// Apply the relaxed stance in place. No-op if the model has no skeleton root. Bones that
+    /// aren't present in this skeleton are skipped silently.
+    /// </summary>
+    public static void ApplyRelaxedPose(MdlModel? model)
+    {
+        var root = model?.GeometryRoot;
+        if (root == null) return;
+
+        foreach (var (boneName, axis, degrees) in Adjustments)
+        {
+            var bone = MdlPartComposer.FindBoneByName(root, boneName);
+            if (bone == null) continue;
+
+            var delta = Quaternion.CreateFromAxisAngle(
+                Vector3.Normalize(axis),
+                degrees * (float)System.Math.PI / 180f);
+
+            // Premultiply in the bone's local frame so children inherit the rotation.
+            bone.Orientation = Quaternion.Normalize(bone.Orientation * delta);
+        }
+    }
+}

--- a/Relique/Relique/Views/MainWindow.EditorPopulation.cs
+++ b/Relique/Relique/Views/MainWindow.EditorPopulation.cs
@@ -36,7 +36,6 @@ public partial class MainWindow
             _selectedPropertyType = null;
             _editingPropertyIndex = -1;
             AddPropertyButton.IsEnabled = false;
-            AddCheckedButton.IsEnabled = false;
             EditPropertyButton.IsEnabled = false;
             RemovePropertyButton.IsEnabled = false;
             ClearAllPropertiesButton.IsEnabled = false;

--- a/Relique/Relique/Views/MainWindow.EditorPopulation.cs
+++ b/Relique/Relique/Views/MainWindow.EditorPopulation.cs
@@ -166,22 +166,29 @@ public partial class MainWindow
 
     private void SelectPaletteCategoryInComboBox(byte paletteId)
     {
-        for (int i = 0; i < PaletteCategoryComboBox.Items.Count; i++)
-        {
-            if (PaletteCategoryComboBox.Items[i] is ComboBoxItem item && item.Tag is byte id && id == paletteId)
-            {
-                _isLoading = true;
-                PaletteCategoryComboBox.SelectedIndex = i;
-                _isLoading = false;
-                return;
-            }
-        }
-        // Not found — select first item if available
-        if (PaletteCategoryComboBox.Items.Count > 0)
+        // Save/restore the loading flag rather than forcing it false. This runs *inside*
+        // PopulateEditor, which the file-open path wraps in _isLoading=true. Forcing false
+        // here un-guarded everything later in PopulateEditor (e.g. the Cost recompute),
+        // which then marked the freshly-loaded document dirty (#2385 spot-check).
+        var wasLoading = _isLoading;
+        try
         {
             _isLoading = true;
-            PaletteCategoryComboBox.SelectedIndex = 0;
-            _isLoading = false;
+            for (int i = 0; i < PaletteCategoryComboBox.Items.Count; i++)
+            {
+                if (PaletteCategoryComboBox.Items[i] is ComboBoxItem item && item.Tag is byte id && id == paletteId)
+                {
+                    PaletteCategoryComboBox.SelectedIndex = i;
+                    return;
+                }
+            }
+            // Not found — select first item if available
+            if (PaletteCategoryComboBox.Items.Count > 0)
+                PaletteCategoryComboBox.SelectedIndex = 0;
+        }
+        finally
+        {
+            _isLoading = wasLoading;
         }
     }
 

--- a/Relique/Relique/Views/MainWindow.EditorPopulation.cs
+++ b/Relique/Relique/Views/MainWindow.EditorPopulation.cs
@@ -130,6 +130,9 @@ public partial class MainWindow
         }
 
         ArmorClassText.Text = acBonus;
+
+        // Base AC feeds armor BaseCost, so a torso-part change shifts the computed Cost (#2235).
+        RecomputeCost();
     }
 
     private void DisplayBaseItemType(int baseItemIndex)
@@ -153,6 +156,7 @@ public partial class MainWindow
             DisplayBaseItemType(picker.SelectedBaseItemIndex.Value);
             UpdateConditionalFields(picker.SelectedBaseItemIndex.Value);
             PopulateAvailableProperties(PropertySearchBox.Text); // Refresh for new base item type (#1972)
+            RecomputeCost(); // Base item drives BaseCost/MaxStack/ItemMultiplier (#2235)
         }
     }
 

--- a/Relique/Relique/Views/MainWindow.ItemProperties.cs
+++ b/Relique/Relique/Views/MainWindow.ItemProperties.cs
@@ -858,6 +858,27 @@ public partial class MainWindow
 
         ItemStatisticsText.Text = stats;
         ItemStatisticsPanel.IsVisible = true;
+
+        RecomputeCost();
+    }
+
+    /// <summary>
+    /// Recompute the engine-derived item Cost (wiki Ch4 §4.4) and push it to the
+    /// view model so the read-only Cost field reflects the value the game will use.
+    /// Falls back to the stored value when game data is unavailable (#2235).
+    /// </summary>
+    private void RecomputeCost()
+    {
+        if (_itemViewModel == null || _currentItem == null || _itemCostCalculator == null)
+            return;
+
+        // Don't mutate read-only archive items — their Cost display stays as stored.
+        if (_documentState.IsReadOnly)
+            return;
+
+        var computed = _itemCostCalculator.Calculate(_currentItem);
+        if (computed.HasValue)
+            _itemViewModel.Cost = computed.Value;
     }
 
     /// <summary>

--- a/Relique/Relique/Views/MainWindow.ItemProperties.cs
+++ b/Relique/Relique/Views/MainWindow.ItemProperties.cs
@@ -65,7 +65,7 @@ public partial class MainWindow
 
         AvailablePropertiesTree.Items.Clear();
         _checkedPropertyIndices.Clear();
-        UpdateAddCheckedButton();
+        UpdateAddButtonState();
 
         if (_itemPropertyService == null)
             return;
@@ -111,7 +111,7 @@ public partial class MainWindow
                     _checkedPropertyIndices.Add(capturedType.PropertyIndex);
                 else
                     _checkedPropertyIndices.Remove(capturedType.PropertyIndex);
-                UpdateAddCheckedButton();
+                UpdateAddButtonState();
             };
 
             var node = new TreeViewItem
@@ -175,9 +175,16 @@ public partial class MainWindow
         return TreeExpansionTracker.Capture(expanded);
     }
 
-    private void UpdateAddCheckedButton()
+    /// <summary>
+    /// The single Add button (#2234) is enabled when the document is editable and there
+    /// is something to add — either checked properties (bulk path) or a selected property
+    /// (configured path).
+    /// </summary>
+    private void UpdateAddButtonState()
     {
-        AddCheckedButton.IsEnabled = _checkedPropertyIndices.Count > 0 && _currentItem != null && !_documentState.IsReadOnly;
+        AddPropertyButton.IsEnabled = _currentItem != null
+            && !_documentState.IsReadOnly
+            && (_checkedPropertyIndices.Count > 0 || _selectedPropertyType != null);
     }
 
     /// <summary>
@@ -195,7 +202,6 @@ public partial class MainWindow
         if (ro)
         {
             AddPropertyButton.IsEnabled = false;
-            AddCheckedButton.IsEnabled = false;
             EditPropertyButton.IsEnabled = false;
             RemovePropertyButton.IsEnabled = false;
             ClearAllPropertiesButton.IsEnabled = false;
@@ -293,7 +299,7 @@ public partial class MainWindow
             {
                 _selectedPropertyType = propertyType;
                 UpdatePropertyConfigPanel(propertyType);
-                AddPropertyButton.IsEnabled = _currentItem != null && !_documentState.IsReadOnly;
+                UpdateAddButtonState();
 
                 // If a subtype child node was selected, pre-select it in the dropdown
                 if (selectedNode.Tag is TwoDAEntry subtypeEntry && SubtypeComboBox.IsVisible)
@@ -313,7 +319,7 @@ public partial class MainWindow
         {
             _selectedPropertyType = null;
             PropertyConfigPanel.IsVisible = false;
-            AddPropertyButton.IsEnabled = false;
+            UpdateAddButtonState();
         }
     }
 
@@ -408,7 +414,23 @@ public partial class MainWindow
         }
     }
 
+    /// <summary>
+    /// Single Add button (#2234). If any properties are checked in the tree, bulk-add
+    /// them with default values; otherwise add the selected property using the configured
+    /// values from the PropertyConfigPanel. One button, behavior follows the active state.
+    /// </summary>
     private void OnAddPropertyClick(object? sender, RoutedEventArgs e)
+    {
+        if (_currentItem == null || _itemPropertyService == null) return;
+        if (_documentState.IsReadOnly) return;
+
+        if (_checkedPropertyIndices.Count > 0)
+            AddCheckedProperties();
+        else
+            AddConfiguredProperty();
+    }
+
+    private void AddConfiguredProperty()
     {
         if (_currentItem == null || _itemPropertyService == null || _selectedPropertyType == null)
             return;
@@ -429,7 +451,7 @@ public partial class MainWindow
         TryAddProperty(_selectedPropertyType, subtypeIndex, costValueIndex, paramValueIndex);
     }
 
-    private void OnAddCheckedClick(object? sender, RoutedEventArgs e)
+    private void AddCheckedProperties()
     {
         if (_currentItem == null || _itemPropertyService == null || _checkedPropertyIndices.Count == 0)
             return;

--- a/Relique/Relique/Views/MainWindow.Lifecycle.cs
+++ b/Relique/Relique/Views/MainWindow.Lifecycle.cs
@@ -105,6 +105,7 @@ public partial class MainWindow
             _baseItemTypes = baseItemTypes;
             _itemPropertyService = itemPropertyService;
             _itemStatisticsService = itemStatisticsService;
+            _itemCostCalculator = new ItemCostCalculator(gameDataService); // #2235
             _itemIconService = itemIconService;
             _paletteColorService = paletteColorService;
             _armorPartCatalog = new ArmorPartCatalogService(gameDataService); // #2164

--- a/Relique/Relique/Views/MainWindow.axaml
+++ b/Relique/Relique/Views/MainWindow.axaml
@@ -640,15 +640,7 @@
                                             HorizontalContentAlignment="Center"
                                             Margin="0,0,0,8"
                                             IsEnabled="False"
-                                            ToolTip.Tip="Add selected property with configured values"/>
-                                    <Button x:Name="AddCheckedButton"
-                                            Content="Add Checked &gt;"
-                                            Click="OnAddCheckedClick"
-                                            Width="100"
-                                            HorizontalContentAlignment="Center"
-                                            Margin="0,0,0,8"
-                                            IsEnabled="False"
-                                            ToolTip.Tip="Add all checked properties with default values"/>
+                                            ToolTip.Tip="Add checked properties (defaults), or the selected property with configured values if none are checked"/>
                                     <Button x:Name="EditPropertyButton"
                                             Content="Edit"
                                             Click="OnEditPropertyClick"

--- a/Relique/Relique/Views/MainWindow.axaml
+++ b/Relique/Relique/Views/MainWindow.axaml
@@ -185,17 +185,17 @@
                                          Watermark="(set from filename)"/>
                                 <TextBlock Grid.Row="1" Grid.Column="3" Text="Cost" Classes="label"/>
                                 <StackPanel Grid.Row="1" Grid.Column="4" Orientation="Horizontal" Margin="0,0,0,8">
-                                    <!-- Cost is calculated by the engine from base AC + iprp_*.Cost rows; making
-                                         it editable is misleading since it gets recomputed on load. Show as
-                                         read-only display; AddCost is the user-adjustable adjustment.
-                                         Real computation engine tracked in #2235. -->
+                                    <!-- Cost is recomputed live from the Aurora formula (wiki Ch4 §4.4):
+                                         base cost (armor.2da[AC] or baseitems.BaseCost) + property cost
+                                         multipliers + spell costs, scaled by stack/ItemMultiplier (#2235).
+                                         Read-only; AddCost is the user-adjustable adjustment. -->
                                     <TextBox x:Name="CostDisplay"
                                              Text="{Binding Cost, Mode=OneWay}"
                                              IsReadOnly="True"
                                              Width="140"
                                              Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
-                                             ToolTip.Tip="Calculated base cost (engine-derived). Edit Additional to adjust the final price."
-                                             Watermark="(calculated)"/>
+                                             ToolTip.Tip="Computed base cost (Aurora formula). Edit Additional to adjust the final price."
+                                             Watermark="(computed)"/>
                                     <TextBlock Text="Additional" VerticalAlignment="Center" Margin="10,0,8,0"/>
                                     <NumericUpDown x:Name="AddCostUpDown"
                                                    Value="{Binding AddCost, Mode=TwoWay}"

--- a/Relique/Relique/Views/MainWindow.axaml.cs
+++ b/Relique/Relique/Views/MainWindow.axaml.cs
@@ -29,6 +29,7 @@ public partial class MainWindow : Window, INotifyPropertyChanged
     private ItemPropertyService? _itemPropertyService;
     private readonly PropertyCategoryService _categoryService = new();
     private ItemStatisticsService? _itemStatisticsService;
+    private ItemCostCalculator? _itemCostCalculator;
     private PropertyTypeInfo? _selectedPropertyType;
     private int _editingPropertyIndex = -1; // -1 = add mode, >= 0 = editing that index
     private bool _suppressAutoApply; // true while combos are being repopulated programmatically (#2226)


### PR DESCRIPTION
## Summary

Sprint #2385 — Relique Cost, UX & mannequin preview.

- **#2235 Cost** — Compute item Cost from the full Aurora formula. `itempropdef.2da` Cost is a *multiplier* on property magnitude (not additive); weapons apply `ItemMultiplier`. Validated against the Aurora toolset on 7 fixtures (AC sweep + magic properties — all exact). Also fixed a load false-dirty bug (`_isLoading` clobbered mid-populate caused spurious save prompts).
- **#2234 UX** — Collapse Add / Add Checked into a single Add button (checked items use defaults; selected uses configured values).
- **#2232 Preview** — Relaxed mannequin pose for armor preview: arm abduction + leg separation + slight elbow/knee bend so limb armor is visible from the front.
- **#2401 Docs** — README lists Reliquary; NEW_TOOL_BOOTSTRAP gains a Ctrl+F Find checklist item + UI Uniformity row.
- **Tooling** — `New-CostTestUti.ps1` fixture generator + mutual workflow-testing doc in CLAUDE.md.

## Related Issues

- Closes #2385

## Follow-ups filed

- #2403 unwire SafeMode, #2404 fonts→Trebuchet, #2405 tree selection, #2406 Edit popup redesign
- #2407 gender-specific clothing models, #2408 larger preview viewport, #2409 model rotation

## Tests

- Relique unit: 387/387 ✅
- Targeted Relique FlaUI: 4/4 ✅
- CI (Linux + Windows): all green ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)