### PR TITLE
[Fence] Sprint: Critical Save + Cross-Tool Data Integrity (#2383)

### DIFF
--- a/Fence/CHANGELOG.md
+++ b/Fence/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.1.39-alpha] - 2026-06-07
-**Branch**: `fence/issue-2383` | **PR**: #TBD
+**Branch**: `fence/issue-2383` | **PR**: #2410
 
 ### Sprint: Critical Save + Cross-Tool Data Integrity (#2383)
 

--- a/Fence/CHANGELOG.md
+++ b/Fence/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.1.39-alpha] - 2026-06-07
+**Branch**: `fence/issue-2383` | **PR**: #TBD
+
+### Sprint: Critical Save + Cross-Tool Data Integrity (#2383)
+
+- Save-on-close race and palette cache disposal leak fixed (#2255).
+- File browser panel refreshes after creating a New file (#2307).
+- ItemDetails code-behind binding replaced with StoreItemExtrasViewModel (#2153).
+
+Undo/Redo work split out to Epic #2231.
+
+---
+
 ## [0.1.38-alpha] - 2026-06-05
 **Branch**: `radoub/issue-2350` | **PR**: #2351
 

--- a/Fence/Fence.Tests/ViewModels/StoreItemExtrasViewModelTests.cs
+++ b/Fence/Fence.Tests/ViewModels/StoreItemExtrasViewModelTests.cs
@@ -1,0 +1,98 @@
+using System.ComponentModel;
+using MerchantEditor.ViewModels;
+using Xunit;
+
+namespace MerchantEditor.Tests.ViewModels;
+
+/// <summary>
+/// Tests for StoreItemExtrasViewModel (#2153). The VM is a read-only projection of the
+/// selected StoreItemViewModel's store-listing fields (sell/buy/infinite/panel) that the
+/// StoreItemExtrasPanel binds to. It must mirror the source and stay live when the source
+/// changes (e.g. the context-menu Infinite toggle mutates the source VM).
+/// </summary>
+public class StoreItemExtrasViewModelTests
+{
+    private static StoreItemViewModel Source() => new()
+    {
+        ResRef = "longsword",
+        DisplayName = "Longsword",
+        SellPrice = 100,
+        BuyPrice = 50,
+        Infinite = false,
+        PanelId = 4
+    };
+
+    [Fact]
+    public void Constructor_ProjectsSourceFields()
+    {
+        var vm = new StoreItemExtrasViewModel(Source());
+
+        Assert.Equal(100, vm.SellPrice);
+        Assert.Equal(50, vm.BuyPrice);
+        Assert.False(vm.Infinite);
+        Assert.Equal(4, vm.PanelId);
+    }
+
+    [Fact]
+    public void SourceInfiniteChange_Propagates()
+    {
+        var source = Source();
+        var vm = new StoreItemExtrasViewModel(source);
+
+        source.Infinite = true;
+
+        Assert.True(vm.Infinite);
+    }
+
+    [Fact]
+    public void SourceInfiniteChange_RaisesPropertyChanged()
+    {
+        var source = Source();
+        var vm = new StoreItemExtrasViewModel(source);
+        var raised = new System.Collections.Generic.List<string?>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        source.Infinite = true;
+
+        Assert.Contains(nameof(StoreItemExtrasViewModel.Infinite), raised);
+    }
+
+    [Fact]
+    public void SourcePriceChange_Propagates()
+    {
+        var source = Source();
+        var vm = new StoreItemExtrasViewModel(source);
+
+        source.SellPrice = 250;
+        source.BuyPrice = 80;
+
+        Assert.Equal(250, vm.SellPrice);
+        Assert.Equal(80, vm.BuyPrice);
+    }
+
+    [Fact]
+    public void SourcePanelChange_Propagates()
+    {
+        var source = Source();
+        var vm = new StoreItemExtrasViewModel(source);
+
+        source.PanelId = 0;
+
+        Assert.Equal(0, vm.PanelId);
+    }
+
+    [Fact]
+    public void Detach_StopsRaisingPropertyChanged()
+    {
+        var source = Source();
+        var vm = new StoreItemExtrasViewModel(source);
+        var raised = new System.Collections.Generic.List<string?>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        vm.Detach();
+        source.Infinite = true;
+
+        // After detach the VM no longer forwards source change notifications.
+        Assert.Empty(raised);
+    }
+}

--- a/Fence/Fence/Controls/StoreItemExtrasPanel.axaml
+++ b/Fence/Fence/Controls/StoreItemExtrasPanel.axaml
@@ -6,7 +6,7 @@
              xmlns:converters="using:MerchantEditor.Converters"
              mc:Ignorable="d" d:DesignWidth="260" d:DesignHeight="160"
              x:Class="MerchantEditor.Controls.StoreItemExtrasPanel"
-             x:DataType="vm:StoreItemViewModel">
+             x:DataType="vm:StoreItemExtrasViewModel">
 
   <UserControl.Resources>
     <converters:StorePanelNameConverter x:Key="StorePanelNameConverter"/>

--- a/Fence/Fence/Controls/StoreItemExtrasPanel.axaml.cs
+++ b/Fence/Fence/Controls/StoreItemExtrasPanel.axaml.cs
@@ -4,10 +4,11 @@ namespace MerchantEditor.Controls;
 
 /// <summary>
 /// Fence-only companion to the shared <c>ItemDetailsPanel</c>. Displays
-/// store-listing fields (sell price, buy price, infinite flag, store panel)
-/// for the currently selected <see cref="MerchantEditor.ViewModels.StoreItemViewModel"/>.
-/// Read-only: the proper two-way <c>StoreItemExtrasViewModel</c> is tracked as
-/// follow-up tech-debt — see plan doc for the sprint that introduced this control.
+/// store-listing fields (sell price, buy price, infinite flag, store panel) for the
+/// currently selected store item, bound to a dedicated
+/// <see cref="MerchantEditor.ViewModels.StoreItemExtrasViewModel"/> (#2153).
+/// Read-only display: sell/buy are computed, infinite/panel are edited elsewhere
+/// (grid + context menu); this panel reflects them live via the VM.
 /// </summary>
 public partial class StoreItemExtrasPanel : UserControl
 {

--- a/Fence/Fence/ViewModels/StoreItemExtrasViewModel.cs
+++ b/Fence/Fence/ViewModels/StoreItemExtrasViewModel.cs
@@ -1,0 +1,70 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace MerchantEditor.ViewModels;
+
+/// <summary>
+/// Read-only projection of a <see cref="StoreItemViewModel"/>'s store-listing fields
+/// (sell price, buy price, infinite flag, store panel) for the
+/// <see cref="MerchantEditor.Controls.StoreItemExtrasPanel"/> (#2153).
+///
+/// Replaces the previous arrangement where the panel bound directly to the grid-row
+/// <see cref="StoreItemViewModel"/>. This dedicated VM owns only the store-listing
+/// concern and keeps the panel's DataContext separate from the inventory grid's VM.
+///
+/// The VM mirrors the source and stays live: it forwards the source's PropertyChanged
+/// so panel display updates when the source changes (e.g. the context-menu Infinite
+/// toggle mutates the source). Sell/Buy remain computed values owned by the source —
+/// this VM only exposes them; the markup/markdown calculation stays in MainWindow.
+/// </summary>
+public class StoreItemExtrasViewModel : INotifyPropertyChanged
+{
+    private readonly StoreItemViewModel _source;
+
+    public StoreItemExtrasViewModel(StoreItemViewModel source)
+    {
+        _source = source;
+        _source.PropertyChanged += OnSourcePropertyChanged;
+    }
+
+    public int SellPrice => _source.SellPrice;
+    public int BuyPrice => _source.BuyPrice;
+    public bool Infinite => _source.Infinite;
+    public int PanelId => _source.PanelId;
+
+    /// <summary>
+    /// Stop tracking the source. Call when the panel's DataContext changes so the old
+    /// VM does not hold the source alive or keep forwarding events.
+    /// </summary>
+    public void Detach()
+    {
+        _source.PropertyChanged -= OnSourcePropertyChanged;
+    }
+
+    private void OnSourcePropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        // Re-raise only the store-listing properties this VM projects.
+        switch (e.PropertyName)
+        {
+            case nameof(StoreItemViewModel.SellPrice):
+                OnPropertyChanged(nameof(SellPrice));
+                break;
+            case nameof(StoreItemViewModel.BuyPrice):
+                OnPropertyChanged(nameof(BuyPrice));
+                break;
+            case nameof(StoreItemViewModel.Infinite):
+                OnPropertyChanged(nameof(Infinite));
+                break;
+            case nameof(StoreItemViewModel.PanelId):
+                OnPropertyChanged(nameof(PanelId));
+                break;
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/Fence/Fence/Views/MainWindow.FileOps.cs
+++ b/Fence/Fence/Views/MainWindow.FileOps.cs
@@ -270,7 +270,7 @@ public partial class MainWindow
         // If no file path yet (new file), redirect to Save As
         if (string.IsNullOrEmpty(_currentFilePath))
         {
-            OnSaveAsClick(sender, e);
+            await SaveAsAsync();
             return;
         }
 
@@ -279,8 +279,19 @@ public partial class MainWindow
 
     private async void OnSaveAsClick(object? sender, RoutedEventArgs e)
     {
+        await SaveAsAsync();
+    }
+
+    /// <summary>
+    /// Show the Save As picker and save to the chosen path. Returns true if the file
+    /// was written, false if the user cancelled or no store is loaded. Awaitable so the
+    /// close path can wait for the save to finish before deciding to close (#2255) —
+    /// the old fire-and-forget OnSaveAsClick let the close decision race the picker.
+    /// </summary>
+    private async Task<bool> SaveAsAsync()
+    {
         if (_currentStore == null)
-            return;
+            return false;
 
         // Default to current module directory if available
         IStorageFolder? suggestedFolder = null;
@@ -305,10 +316,11 @@ public partial class MainWindow
             SuggestedStartLocation = suggestedFolder
         });
 
-        if (file != null)
-        {
-            await SaveFile(file.Path.LocalPath);
-        }
+        if (file == null)
+            return false;
+
+        await SaveFile(file.Path.LocalPath);
+        return true;
     }
 
     private async Task SaveFile(string filePath)

--- a/Fence/Fence/Views/MainWindow.FileOps.cs
+++ b/Fence/Fence/Views/MainWindow.FileOps.cs
@@ -52,6 +52,10 @@ public partial class MainWindow
         // Clear item resolution context (no file yet)
         _itemResolutionService?.SetCurrentFilePath(null);
 
+        // Deselect the previously-loaded file's row so the browser panel state matches
+        // the new unsaved in-memory document (no on-disk file selected) (#2307).
+        UpdateStoreBrowserCurrentFile(null);
+
         // Update UI
         PopulateStoreProperties();
         StoreItems.Clear();

--- a/Fence/Fence/Views/MainWindow.ItemDetails.cs
+++ b/Fence/Fence/Views/MainWindow.ItemDetails.cs
@@ -79,7 +79,7 @@ public partial class MainWindow
         detailVm.IconBitmap = item.IconBitmap ?? _itemIconService?.GetItemIcon(item.BaseItemIndex);
 
         ItemDetailsView.DataContext = detailVm;
-        StoreItemExtrasView.DataContext = item;
+        SetStoreItemExtras(new StoreItemExtrasViewModel(item));
     }
 
     private void ShowPaletteItemDetails(ItemViewModel item)
@@ -92,13 +92,23 @@ public partial class MainWindow
         }
 
         ItemDetailsView.DataContext = item;
-        StoreItemExtrasView.DataContext = null;
+        SetStoreItemExtras(null);
     }
 
     private void ClearItemDetails()
     {
         ItemDetailsView.DataContext = null;
-        StoreItemExtrasView.DataContext = null;
+        SetStoreItemExtras(null);
+    }
+
+    /// <summary>
+    /// Swap the store-extras panel's DataContext, detaching the previous
+    /// <see cref="StoreItemExtrasViewModel"/> so it stops tracking its source (#2153).
+    /// </summary>
+    private void SetStoreItemExtras(StoreItemExtrasViewModel? extras)
+    {
+        (StoreItemExtrasView.DataContext as StoreItemExtrasViewModel)?.Detach();
+        StoreItemExtrasView.DataContext = extras;
     }
 
     #endregion

--- a/Fence/Fence/Views/MainWindow.axaml.cs
+++ b/Fence/Fence/Views/MainWindow.axaml.cs
@@ -356,9 +356,9 @@ public partial class MainWindow : Window, INotifyPropertyChanged
             {
                 if (string.IsNullOrEmpty(_currentFilePath))
                 {
-                    // New unsaved file - trigger SaveAs
-                    OnSaveAsClick(null, new RoutedEventArgs());
-                    return !_documentState.IsDirty; // true if save succeeded
+                    // New unsaved file - await SaveAs so the close decision does not
+                    // race the file picker (#2255). Returns true only if a file was written.
+                    return await SaveAsAsync();
                 }
                 await SaveFile(_currentFilePath);
                 return true;
@@ -386,8 +386,10 @@ public partial class MainWindow : Window, INotifyPropertyChanged
             // Dispose TlkService to unsubscribe from settings events
             _tlkService?.Dispose();
 
-            // Dispose shared palette cache lock (#2034)
+            // Dispose shared palette cache locks (#2034). Both cache services are
+            // IDisposable; _storePaletteCache was previously leaked on close (#2255).
             (_sharedCacheService as IDisposable)?.Dispose();
+            (_storePaletteCache as IDisposable)?.Dispose();
 
             if (e.Cancel)
             {

--- a/Manifest/CHANGELOG.md
+++ b/Manifest/CHANGELOG.md
@@ -9,9 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [0.15.10-alpha] - 2026-06-07
 **Branch**: `fence/issue-2383` | **PR**: #2410
 
-### Fix: Atomic journal save + duplicate-ID validation (#2253)
+### Fix: Atomic journal save + duplicate-ID handling (#2253)
 
-- Journal save now uses an atomic write. Duplicate entry-ID validation added. Bundled in Fence sprint #2383; Undo/Redo split to Epic #2231.
+- Journal save now uses an atomic write, with a once-per-session backup to `~/Radoub/Backups/`. Duplicate entry IDs within a category bump to the next free ID instead of being accepted. Bundled in Fence sprint #2383; Undo/Redo split to Epic #2231.
 
 ---
 

--- a/Manifest/CHANGELOG.md
+++ b/Manifest/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.15.10-alpha] - 2026-06-07
+**Branch**: `fence/issue-2383` | **PR**: #TBD
+
+### Fix: Atomic journal save + duplicate-ID validation (#2253)
+
+- Journal save now uses an atomic write. Duplicate entry-ID validation added. Bundled in Fence sprint #2383; Undo/Redo split to Epic #2231.
+
+---
+
 ## [0.15.9-alpha] - 2026-05-29
 **Branch**: `manifest/issue-2254` | **PR**: #2316
 

--- a/Manifest/CHANGELOG.md
+++ b/Manifest/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.15.10-alpha] - 2026-06-07
-**Branch**: `fence/issue-2383` | **PR**: #TBD
+**Branch**: `fence/issue-2383` | **PR**: #2410
 
 ### Fix: Atomic journal save + duplicate-ID validation (#2253)
 

--- a/Manifest/Manifest.Tests/PropertyPanelTests.cs
+++ b/Manifest/Manifest.Tests/PropertyPanelTests.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using Manifest.Views;
+using Radoub.Formats.Jrl;
 using Xunit;
 
 namespace Manifest.Tests;
@@ -49,6 +51,52 @@ public class PropertyPanelTests
         var result = MainWindow.FormatStrRef(0xFFFFFFFE);
 
         Assert.Equal("4294967294 (0xFFFFFFFE)", result);
+    }
+
+    #endregion
+
+    #region IsEntryIdDuplicate (#2253)
+
+    private static JournalCategory CategoryWithIds(params uint[] ids)
+    {
+        var cat = new JournalCategory();
+        foreach (var id in ids)
+            cat.Entries.Add(new JournalEntry { ID = id });
+        return cat;
+    }
+
+    [Fact]
+    public void IsEntryIdDuplicate_UniqueId_ReturnsFalse()
+    {
+        var cat = CategoryWithIds(100, 200, 300);
+        var moving = cat.Entries[0]; // ID 100
+
+        Assert.False(MainWindow.IsEntryIdDuplicate(cat, moving, 150));
+    }
+
+    [Fact]
+    public void IsEntryIdDuplicate_CollidesWithSibling_ReturnsTrue()
+    {
+        var cat = CategoryWithIds(100, 200, 300);
+        var moving = cat.Entries[0]; // ID 100
+
+        Assert.True(MainWindow.IsEntryIdDuplicate(cat, moving, 200));
+    }
+
+    [Fact]
+    public void IsEntryIdDuplicate_SameAsOwnCurrentId_ReturnsFalse()
+    {
+        // The entry being edited must not count itself as a duplicate.
+        var cat = CategoryWithIds(100, 200, 300);
+        var moving = cat.Entries[1]; // ID 200
+
+        Assert.False(MainWindow.IsEntryIdDuplicate(cat, moving, 200));
+    }
+
+    [Fact]
+    public void IsEntryIdDuplicate_NullCategory_ReturnsFalse()
+    {
+        Assert.False(MainWindow.IsEntryIdDuplicate(null, new JournalEntry { ID = 5 }, 5));
     }
 
     #endregion

--- a/Manifest/Manifest.Tests/PropertyPanelTests.cs
+++ b/Manifest/Manifest.Tests/PropertyPanelTests.cs
@@ -100,4 +100,45 @@ public class PropertyPanelTests
     }
 
     #endregion
+
+    #region NextFreeEntryId (#2253)
+
+    [Fact]
+    public void NextFreeEntryId_UniqueId_ReturnsUnchanged()
+    {
+        var cat = CategoryWithIds(100, 200, 300);
+        var moving = cat.Entries[0]; // ID 100
+
+        Assert.Equal(150u, MainWindow.NextFreeEntryId(cat, moving, 150));
+    }
+
+    [Fact]
+    public void NextFreeEntryId_Collision_BumpsByOne()
+    {
+        var cat = CategoryWithIds(100, 200, 300);
+        var moving = cat.Entries[0]; // ID 100 — editing it to collide with 200
+
+        Assert.Equal(201u, MainWindow.NextFreeEntryId(cat, moving, 200));
+    }
+
+    [Fact]
+    public void NextFreeEntryId_ConsecutiveCollisions_BumpsToFirstFree()
+    {
+        var cat = CategoryWithIds(100, 200, 201, 202);
+        var moving = cat.Entries[0]; // ID 100
+
+        // 200, 201, 202 all taken → first free is 203
+        Assert.Equal(203u, MainWindow.NextFreeEntryId(cat, moving, 200));
+    }
+
+    [Fact]
+    public void NextFreeEntryId_SameAsOwnCurrentId_ReturnsUnchanged()
+    {
+        var cat = CategoryWithIds(100, 200, 300);
+        var moving = cat.Entries[1]; // ID 200
+
+        Assert.Equal(200u, MainWindow.NextFreeEntryId(cat, moving, 200));
+    }
+
+    #endregion
 }

--- a/Manifest/Manifest/Views/MainWindow.FileOps.cs
+++ b/Manifest/Manifest/Views/MainWindow.FileOps.cs
@@ -10,6 +10,7 @@ using DirtyCheckResult = Radoub.UI.Services.DirtyCheckResult;
 using FileOperationsHelper = Radoub.UI.Services.FileOperationsHelper;
 using FileSessionLockService = Radoub.UI.Services.FileSessionLockService;
 using LockResult = Radoub.UI.Services.LockResult;
+using BackupService = Radoub.UI.Services.Search.BackupService;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -204,18 +205,36 @@ public partial class MainWindow
         }
 
         // Write to a temp file beside the destination (same volume = atomic move),
-        // then swap it into place with the shared cross-OS atomic helper. The helper
-        // backs up the previous file to .bak and performs a single File.Move
-        // (overwrite:true) so the original is never missing mid-save (#2253, #2256).
+        // then swap it into place with the shared cross-OS atomic helper. A single
+        // File.Move(overwrite:true) means the original is never missing mid-save
+        // (#2253, #2256). The pre-save backup goes to the shared ~/Radoub/Backups/
+        // folder (under retention) rather than a .bak in the module dir — modules hold
+        // exactly one .jrl and must not accumulate backup clutter (#2253).
         var jrl = _currentJrl;
         var path = _currentFilePath!;
         var tempPath = path + ".tmp";
         try
         {
+            // Snapshot the existing journal to the shared Backups folder before replacing.
+            if (File.Exists(path))
+            {
+                var moduleName = Path.GetFileName(Path.GetDirectoryName(path)) ?? "Manifest";
+                try
+                {
+                    await new BackupService().BackupFilesAsync(new[] { path }, moduleName);
+                }
+                catch (Exception bex)
+                {
+                    // Backup is best-effort; a failed snapshot must not block the save.
+                    UnifiedLogger.LogJournal(LogLevel.WARN, $"Pre-save backup failed: {bex.Message}");
+                }
+            }
+
             // #2254 — actually-async write so multi-MB journals don't block the UI thread.
             await Task.Run(() => JrlWriter.Write(jrl, tempPath));
 
-            Radoub.Formats.Common.AtomicFile.Replace(tempPath, path, path + ".bak");
+            // backupPath null: the in-module .bak is intentionally not created (see above).
+            Radoub.Formats.Common.AtomicFile.Replace(tempPath, path, backupPath: null);
 
             _documentState.ClearDirty();
             UpdateTitle();

--- a/Manifest/Manifest/Views/MainWindow.FileOps.cs
+++ b/Manifest/Manifest/Views/MainWindow.FileOps.cs
@@ -24,6 +24,11 @@ namespace Manifest.Views;
 /// </summary>
 public partial class MainWindow
 {
+    // Paths backed up this session — we snapshot a journal to ~/Radoub/Backups/ only on
+    // the first save after open, not on every save, to avoid backup clutter (#2253).
+    private readonly HashSet<string> _backedUpThisSession =
+        new(StringComparer.OrdinalIgnoreCase);
+
     private void UpdateRecentFilesMenu()
     {
         Radoub.UI.Services.RecentFilesMenuHelper.Populate(
@@ -207,7 +212,7 @@ public partial class MainWindow
         // Write to a temp file beside the destination (same volume = atomic move),
         // then swap it into place with the shared cross-OS atomic helper. A single
         // File.Move(overwrite:true) means the original is never missing mid-save
-        // (#2253, #2256). The pre-save backup goes to the shared ~/Radoub/Backups/
+        // (#2253, #2256). A one-per-session snapshot goes to the shared ~/Radoub/Backups/
         // folder (under retention) rather than a .bak in the module dir — modules hold
         // exactly one .jrl and must not accumulate backup clutter (#2253).
         var jrl = _currentJrl;
@@ -215,13 +220,16 @@ public partial class MainWindow
         var tempPath = path + ".tmp";
         try
         {
-            // Snapshot the existing journal to the shared Backups folder before replacing.
-            if (File.Exists(path))
+            // Snapshot the existing journal to the shared Backups folder before the first
+            // save of this file this session. Atomic write below protects every save from
+            // mid-write corruption; the backup is a once-per-session safety net.
+            if (File.Exists(path) && !_backedUpThisSession.Contains(path))
             {
                 var moduleName = Path.GetFileName(Path.GetDirectoryName(path)) ?? "Manifest";
                 try
                 {
                     await new BackupService().BackupFilesAsync(new[] { path }, moduleName);
+                    _backedUpThisSession.Add(path);
                 }
                 catch (Exception bex)
                 {

--- a/Manifest/Manifest/Views/MainWindow.FileOps.cs
+++ b/Manifest/Manifest/Views/MainWindow.FileOps.cs
@@ -203,12 +203,20 @@ public partial class MainWindow
             return;
         }
 
+        // Write to a temp file beside the destination (same volume = atomic move),
+        // then swap it into place with the shared cross-OS atomic helper. The helper
+        // backs up the previous file to .bak and performs a single File.Move
+        // (overwrite:true) so the original is never missing mid-save (#2253, #2256).
+        var jrl = _currentJrl;
+        var path = _currentFilePath!;
+        var tempPath = path + ".tmp";
         try
         {
             // #2254 — actually-async write so multi-MB journals don't block the UI thread.
-            var jrl = _currentJrl;
-            var path = _currentFilePath!;
-            await Task.Run(() => JrlWriter.Write(jrl, path));
+            await Task.Run(() => JrlWriter.Write(jrl, tempPath));
+
+            Radoub.Formats.Common.AtomicFile.Replace(tempPath, path, path + ".bak");
+
             _documentState.ClearDirty();
             UpdateTitle();
             UpdateStatus($"Saved: {Path.GetFileName(_currentFilePath)}");
@@ -220,6 +228,15 @@ public partial class MainWindow
             UnifiedLogger.LogJournal(LogLevel.ERROR, $"Failed to save journal: {ex.Message}");
             UpdateStatus($"Error saving file: {ex.Message}");
             ShowErrorDialog("Save Error", $"Failed to save journal file:\n{ex.Message}");
+        }
+        finally
+        {
+            // Clean up temp file if it still exists (write failed before the move)
+            if (File.Exists(tempPath))
+            {
+                try { File.Delete(tempPath); }
+                catch { /* temp cleanup is best-effort */ }
+            }
         }
     }
 

--- a/Manifest/Manifest/Views/MainWindow.PropertyPanel.cs
+++ b/Manifest/Manifest/Views/MainWindow.PropertyPanel.cs
@@ -3,6 +3,7 @@ using Avalonia.Interactivity;
 using Manifest.Services;
 using Radoub.Formats.Common;
 using Radoub.Formats.Gff;
+using Radoub.Formats.Jrl;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Tokens;
 using System.Collections.Generic;
@@ -266,18 +267,47 @@ public partial class MainWindow
         }
     }
 
+    /// <summary>
+    /// True if <paramref name="proposedId"/> collides with another entry in the same
+    /// category (#2253). The entry being edited never counts as a collision with itself.
+    /// NWN's journal system treats two entries sharing an ID within one category as
+    /// ambiguous, so duplicates must be rejected.
+    /// </summary>
+    internal static bool IsEntryIdDuplicate(JournalCategory? category, JournalEntry editing, uint proposedId)
+    {
+        if (category == null) return false;
+        foreach (var entry in category.Entries)
+        {
+            if (!ReferenceEquals(entry, editing) && entry.ID == proposedId)
+                return true;
+        }
+        return false;
+    }
+
     private void OnEntryIdChanged(object? sender, NumericUpDownValueChangedEventArgs e)
     {
         if (_isUpdatingPanel || _selectedItem is not EntryTreeItem entItem) return;
 
         var newId = (uint)(EntryIdBox.Value ?? 0);
-        if (entItem.Entry.ID != newId)
+        if (entItem.Entry.ID == newId) return;
+
+        // Reject duplicate IDs within the same category — revert the box to the
+        // current ID and warn, rather than persisting an ambiguous journal (#2253).
+        if (IsEntryIdDuplicate(entItem.ParentCategory, entItem.Entry, newId))
         {
-            entItem.Entry.ID = newId;
-            MarkDirty();
-            UpdateTreeItemHeader(entItem);
-            UnifiedLogger.LogJournal(LogLevel.DEBUG, $"Entry ID changed to: {newId}");
+            UnifiedLogger.LogJournal(LogLevel.WARN,
+                $"Rejected duplicate entry ID {newId} in category '{entItem.ParentCategory?.Tag}'");
+            UpdateStatus($"Entry ID {newId} already exists in this category.");
+            _isUpdatingPanel = true;
+            try { EntryIdBox.Value = entItem.Entry.ID; }
+            finally { _isUpdatingPanel = false; }
+            return;
         }
+
+        entItem.Entry.ID = newId;
+        MarkDirty();
+        UpdateTreeItemHeader(entItem);
+        UnifiedLogger.LogJournal(LogLevel.DEBUG, $"Entry ID changed to: {newId}");
     }
 
     private void OnEntryEndChanged(object? sender, RoutedEventArgs e)

--- a/Manifest/Manifest/Views/MainWindow.PropertyPanel.cs
+++ b/Manifest/Manifest/Views/MainWindow.PropertyPanel.cs
@@ -271,7 +271,7 @@ public partial class MainWindow
     /// True if <paramref name="proposedId"/> collides with another entry in the same
     /// category (#2253). The entry being edited never counts as a collision with itself.
     /// NWN's journal system treats two entries sharing an ID within one category as
-    /// ambiguous, so duplicates must be rejected.
+    /// ambiguous, so duplicates must be resolved.
     /// </summary>
     internal static bool IsEntryIdDuplicate(JournalCategory? category, JournalEntry editing, uint proposedId)
     {
@@ -284,6 +284,21 @@ public partial class MainWindow
         return false;
     }
 
+    /// <summary>
+    /// Resolve a duplicate entry ID by incrementing by 1 until a free slot is found
+    /// within the category (#2253). Entries are naturally spaced by 100 on add, so a
+    /// +1 bump drops the entry just after the colliding one (or fills a gap) — better
+    /// UX than reverting the user's edit. Returns <paramref name="proposedId"/>
+    /// unchanged when it is already unique.
+    /// </summary>
+    internal static uint NextFreeEntryId(JournalCategory? category, JournalEntry editing, uint proposedId)
+    {
+        var candidate = proposedId;
+        while (IsEntryIdDuplicate(category, editing, candidate) && candidate < uint.MaxValue)
+            candidate++;
+        return candidate;
+    }
+
     private void OnEntryIdChanged(object? sender, NumericUpDownValueChangedEventArgs e)
     {
         if (_isUpdatingPanel || _selectedItem is not EntryTreeItem entItem) return;
@@ -291,23 +306,24 @@ public partial class MainWindow
         var newId = (uint)(EntryIdBox.Value ?? 0);
         if (entItem.Entry.ID == newId) return;
 
-        // Reject duplicate IDs within the same category — revert the box to the
-        // current ID and warn, rather than persisting an ambiguous journal (#2253).
-        if (IsEntryIdDuplicate(entItem.ParentCategory, entItem.Entry, newId))
+        // Resolve duplicate IDs within the same category by bumping +1 to the next free
+        // slot rather than persisting an ambiguous journal (#2253). Natural 100-step
+        // spacing means the bumped entry lands just after the collision.
+        var resolvedId = NextFreeEntryId(entItem.ParentCategory, entItem.Entry, newId);
+        if (resolvedId != newId)
         {
-            UnifiedLogger.LogJournal(LogLevel.WARN,
-                $"Rejected duplicate entry ID {newId} in category '{entItem.ParentCategory?.Tag}'");
-            UpdateStatus($"Entry ID {newId} already exists in this category.");
+            UnifiedLogger.LogJournal(LogLevel.INFO,
+                $"Entry ID {newId} taken in category '{entItem.ParentCategory?.Tag}' — bumped to {resolvedId}");
+            UpdateStatus($"Entry ID {newId} already exists — used {resolvedId} instead.");
             _isUpdatingPanel = true;
-            try { EntryIdBox.Value = entItem.Entry.ID; }
+            try { EntryIdBox.Value = resolvedId; }
             finally { _isUpdatingPanel = false; }
-            return;
         }
 
-        entItem.Entry.ID = newId;
+        entItem.Entry.ID = resolvedId;
         MarkDirty();
         UpdateTreeItemHeader(entItem);
-        UnifiedLogger.LogJournal(LogLevel.DEBUG, $"Entry ID changed to: {newId}");
+        UnifiedLogger.LogJournal(LogLevel.DEBUG, $"Entry ID changed to: {resolvedId}");
     }
 
     private void OnEntryEndChanged(object? sender, RoutedEventArgs e)

--- a/Manifest/Manifest/Views/MainWindow.axaml.cs
+++ b/Manifest/Manifest/Views/MainWindow.axaml.cs
@@ -393,9 +393,6 @@ public partial class MainWindow : Window, INotifyPropertyChanged
                         e.Handled = true;
                     }
                     break;
-                case Key.S:
-                    // Save As - future feature
-                    break;
             }
         }
         else if (e.KeyModifiers == KeyModifiers.None)


### PR DESCRIPTION
## Summary

Cross-tool sprint (Fence + Manifest) closing data-integrity bugs. Undo/Redo scope removed from the bundled critical issues and split to Epic #2231.

## Scope

| # | Tool | Work | Disposition |
|---|------|------|-------------|
| #2255 | Fence | Save-on-close race + palette cache disposal leak (undo/redo → #2231) | Partial — addresses |
| #2253 | Manifest | Atomic save + once-per-session backup + duplicate-ID bump (undo/redo → #2231) | Partial — addresses |
| #2307 | Fence | File browser panel refreshes after New file | Done — closes |
| #2153 | Fence | ItemDetails code-behind → StoreItemExtrasViewModel (plumbing only) | Done — closes |

## Related Issues

- Closes #2307
- Closes #2153
- Addresses #2255 (remaining Undo/Redo tracked in #2231)
- Addresses #2253 (remaining Undo/Redo tracked in #2231)
- Relates to #2231 (Undo/Redo epic)

## Notes

- #2255 and #2253 are intentionally **not** auto-closed: only their non-undo scope landed here. Undo/Redo for both tools is owned by Epic #2231.
- Manifest backup goes to the shared `~/Radoub/Backups/` (under retention), once per session — not a `.bak` in the module folder (modules hold a single `.jrl`).
- Duplicate journal entry IDs bump to the next free ID rather than reverting the edit.

## Tests

- Fence: 140 unit ✅ + FlaUI ✅
- Manifest: 115 unit ✅ + 10 FlaUI ✅
- Privacy ✅ · Theme ✅ · Tech-debt: pre-existing 941-line MainWindow.axaml.cs (warning only)

## Manual Verification

- ✅ Manifest dup-ID bump, atomic save, backup placement
- ✅ Fence save-on-close (save / cancel-picker both correct)
- ✅ Fence browser deselect after New
- ✅ Fence extras panel live update

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)