### PR TITLE
[Reliquary] Sprint: Browser Polish & Release Wiring (#2425, #2424)

### DIFF
--- a/.github/workflows/radoub-release.yml
+++ b/.github/workflows/radoub-release.yml
@@ -60,6 +60,7 @@ jobs:
         echo "quartermaster=$(dotnet nbgv get-version -p Quartermaster -v SemVer2)" >> $GITHUB_OUTPUT
         echo "fence=$(dotnet nbgv get-version -p Fence -v SemVer2)" >> $GITHUB_OUTPUT
         echo "relique=$(dotnet nbgv get-version -p Relique -v SemVer2)" >> $GITHUB_OUTPUT
+        echo "reliquary=$(dotnet nbgv get-version -p Reliquary -v SemVer2)" >> $GITHUB_OUTPUT
         echo "trebuchet=$(dotnet nbgv get-version -p Trebuchet -v SemVer2)" >> $GITHUB_OUTPUT
 
     - name: Restore Parley dependencies
@@ -76,6 +77,9 @@ jobs:
 
     - name: Restore Relique dependencies
       run: dotnet restore Relique/Relique/Relique.csproj -r ${{ matrix.runtime }}
+
+    - name: Restore Reliquary dependencies
+      run: dotnet restore Reliquary/Reliquary/Reliquary.csproj -r ${{ matrix.runtime }}
 
     - name: Restore Trebuchet dependencies
       run: dotnet restore Trebuchet/Trebuchet/Trebuchet.csproj -r ${{ matrix.runtime }}
@@ -102,6 +106,10 @@ jobs:
     # Relique - item blueprint editor
     - name: Publish Relique to shared folder
       run: dotnet publish Relique/Relique/Relique.csproj -c Release -r ${{ matrix.runtime }} --self-contained true -p:PublishReadyToRun=true -o ./publish/Radoub
+
+    # Reliquary - placeable blueprint editor
+    - name: Publish Reliquary to shared folder
+      run: dotnet publish Reliquary/Reliquary/Reliquary.csproj -c Release -r ${{ matrix.runtime }} --self-contained true -p:PublishReadyToRun=true -o ./publish/Radoub
 
     # Trebuchet - launcher/hub (includes bundled tools/ directory with script compiler)
     - name: Publish Trebuchet to shared folder
@@ -268,6 +276,35 @@ jobs:
         EOF
         chmod +x "./bundle/Relique.app/Contents/MacOS/Relique"
 
+        # Reliquary.app - copy from shared folder
+        mkdir -p "./bundle/Reliquary.app/Contents/MacOS"
+        mkdir -p "./bundle/Reliquary.app/Contents/Resources"
+        cp ./publish/Radoub/Reliquary "./bundle/Reliquary.app/Contents/MacOS/Reliquary"
+        cp ./publish/Radoub/*.dylib "./bundle/Reliquary.app/Contents/MacOS/" 2>/dev/null || true
+        cat > "./bundle/Reliquary.app/Contents/Info.plist" << EOF
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>CFBundleExecutable</key>
+            <string>Reliquary</string>
+            <key>CFBundleIdentifier</key>
+            <string>com.lnsdevelopment.reliquary</string>
+            <key>CFBundleName</key>
+            <string>Reliquary</string>
+            <key>CFBundleVersion</key>
+            <string>${{ steps.tool-versions.outputs.reliquary }}</string>
+            <key>CFBundleShortVersionString</key>
+            <string>${{ steps.tool-versions.outputs.reliquary }}</string>
+            <key>CFBundlePackageType</key>
+            <string>APPL</string>
+            <key>NSHighResolutionCapable</key>
+            <true/>
+        </dict>
+        </plist>
+        EOF
+        chmod +x "./bundle/Reliquary.app/Contents/MacOS/Reliquary"
+
         # Trebuchet.app - copy from shared folder (includes tools/ for script compiler)
         mkdir -p "./bundle/Trebuchet.app/Contents/MacOS"
         mkdir -p "./bundle/Trebuchet.app/Contents/Resources"
@@ -308,6 +345,7 @@ jobs:
         chmod +x ./publish/Radoub/Quartermaster
         chmod +x ./publish/Radoub/Fence
         chmod +x ./publish/Radoub/Relique
+        chmod +x ./publish/Radoub/Reliquary
         chmod +x ./publish/Radoub/Trebuchet
         chmod +x ./publish/Radoub/tools/nwn_script_comp_linux 2>/dev/null || true
 
@@ -416,6 +454,7 @@ jobs:
             extract_changelog_section "Quartermaster/CHANGELOG.md" "Quartermaster"
             extract_changelog_section "Fence/CHANGELOG.md" "Fence"
             extract_changelog_section "Relique/CHANGELOG.md" "Relique"
+            extract_changelog_section "Reliquary/CHANGELOG.md" "Reliquary"
             extract_changelog_section "Trebuchet/CHANGELOG.md" "Trebuchet"
           } > highlights.md
         fi
@@ -446,7 +485,7 @@ jobs:
         body: |
           # Radoub ${{ steps.version.outputs.version }}
 
-          Bundled release containing Parley, Manifest, Quartermaster, Fence, Relique, and Trebuchet with shared runtime.
+          Bundled release containing Parley, Manifest, Quartermaster, Fence, Relique, Reliquary, and Trebuchet with shared runtime.
 
           ${{ steps.highlights.outputs.highlights }}
 
@@ -457,12 +496,12 @@ jobs:
           These bundles include everything needed - just download and run!
 
           - **Windows**: `Radoub-win-x64.zip` (~110MB)
-            - Extract and run `Radoub/Parley.exe`, `Radoub/Manifest.exe`, `Radoub/Quartermaster.exe`, `Radoub/Fence.exe`, `Radoub/Relique.exe`, or `Radoub/Trebuchet.exe`
+            - Extract and run `Radoub/Parley.exe`, `Radoub/Manifest.exe`, `Radoub/Quartermaster.exe`, `Radoub/Fence.exe`, `Radoub/Relique.exe`, `Radoub/Reliquary.exe`, or `Radoub/Trebuchet.exe`
           - **macOS**: `Radoub-osx-arm64.zip` (~130MB)
-            - Extract and open `Parley.app`, `Manifest.app`, `Quartermaster.app`, `Fence.app`, `Relique.app`, or `Trebuchet.app`
+            - Extract and open `Parley.app`, `Manifest.app`, `Quartermaster.app`, `Fence.app`, `Relique.app`, `Reliquary.app`, or `Trebuchet.app`
             - Apple Silicon (M1/M2/M3) Macs
           - **Linux**: `Radoub-linux-x64.tar.gz` (~115MB)
-            - Extract and run `./Radoub/Parley`, `./Radoub/Manifest`, `./Radoub/Quartermaster`, `./Radoub/Fence`, `./Radoub/Relique`, or `./Radoub/Trebuchet`
+            - Extract and run `./Radoub/Parley`, `./Radoub/Manifest`, `./Radoub/Quartermaster`, `./Radoub/Fence`, `./Radoub/Relique`, `./Radoub/Reliquary`, or `./Radoub/Trebuchet`
 
           ## What's Included
 
@@ -473,6 +512,7 @@ jobs:
           | **Quartermaster** | Creature/inventory editor for `.utc`/`.bic` files |
           | **Fence** | Merchant/store editor for `.utm` files |
           | **Relique** | Item blueprint editor for `.uti` files |
+          | **Reliquary** | Placeable blueprint editor for `.utp` files |
           | **Trebuchet** | Launcher, module editor, and build system |
 
           ## Shared Infrastructure
@@ -492,13 +532,14 @@ jobs:
           - [Quartermaster CHANGELOG](https://github.com/${{ github.repository }}/blob/main/Quartermaster/CHANGELOG.md)
           - [Fence CHANGELOG](https://github.com/${{ github.repository }}/blob/main/Fence/CHANGELOG.md)
           - [Relique CHANGELOG](https://github.com/${{ github.repository }}/blob/main/Relique/CHANGELOG.md)
+          - [Reliquary CHANGELOG](https://github.com/${{ github.repository }}/blob/main/Reliquary/CHANGELOG.md)
           - [Trebuchet CHANGELOG](https://github.com/${{ github.repository }}/blob/main/Trebuchet/CHANGELOG.md)
 
           ## Installation Notes
 
           **macOS**: You may need to allow the apps in System Preferences → Security & Privacy after first launch.
 
-          **Linux**: Make binaries executable: `chmod +x Radoub/Parley Radoub/Manifest Radoub/Quartermaster Radoub/Fence Radoub/Relique Radoub/Trebuchet`
+          **Linux**: Make binaries executable: `chmod +x Radoub/Parley Radoub/Manifest Radoub/Quartermaster Radoub/Fence Radoub/Relique Radoub/Reliquary Radoub/Trebuchet`
 
           ---
           🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/Radoub.IntegrationTests/Reliquary/ReliquaryFieldEditTests.cs
+++ b/Radoub.IntegrationTests/Reliquary/ReliquaryFieldEditTests.cs
@@ -7,7 +7,7 @@ namespace Radoub.IntegrationTests.Reliquary;
 /// <summary>
 /// Deeper Reliquary interaction tests (#2304) — beyond the launch/close + single-toggle
 /// smoke set. Covers IdentityCombat field presence, a Tag edit that persists across a
-/// save→reload (re-launch) cycle, and the Behavior panel's Conversation field rendering.
+/// save→reload (re-launch) cycle, and the Conversation field rendering (moved to Identity, #2425).
 /// </summary>
 [Collection("ReliquarySequential")]
 public class ReliquaryFieldEditTests : ReliquaryTestBase
@@ -53,7 +53,7 @@ public class ReliquaryFieldEditTests : ReliquaryTestBase
 
     [Fact]
     [Trait("Category", "Behavior")]
-    public void Reliquary_BehaviorPanel_ConversationFieldRenders()
+    public void Reliquary_IdentityPanel_ConversationFieldRenders()
     {
         var tempFile = CopyFixtureToTemp("chest1.utp", "test_placeable.utp");
         try

--- a/Reliquary/CHANGELOG.md
+++ b/Reliquary/CHANGELOG.md
@@ -9,7 +9,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/); versioning via 
 ## [0.9.0-alpha] - 2026-06-07
 **Branch**: `reliquary/sprint/browser-polish-ci` | **PR**: #2427
 
-### Sprint: Browser Polish & Release Wiring
+### Sprint: Editor Layout, Open-File Rename & Release Wiring
 
 - Editor layout reorganized: Faction, Conversation, Initial State, and Treasure Model moved into the Identity & Combat panel; Scripts & Variables moved to the bottom (#2425).
 - Rename an open saved placeable via right-click in the F4 browser (lock-aware save-rename-reload); editor ResRef stays read-only (#2424).

--- a/Reliquary/CHANGELOG.md
+++ b/Reliquary/CHANGELOG.md
@@ -11,7 +11,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/); versioning via 
 
 ### Sprint: Browser Polish & Release Wiring
 
-- F4 placeable browser filter checkboxes and search box reordered/restyled to match sibling tools (#2425).
+- Editor layout reorganized: Faction, Conversation, Initial State, and Treasure Model moved into the Identity & Combat panel; Scripts & Variables moved to the bottom (#2425).
 - Rename an open saved placeable via right-click in the F4 browser (lock-aware save-rename-reload); editor ResRef stays read-only (#2424).
 - Reliquary wired into the release pipeline so the alpha ships alongside the other tools.
 

--- a/Reliquary/CHANGELOG.md
+++ b/Reliquary/CHANGELOG.md
@@ -6,6 +6,17 @@ Format based on [Keep a Changelog](https://keepachangelog.com/); versioning via 
 
 ---
 
+## [0.9.0-alpha] - 2026-06-07
+**Branch**: `reliquary/sprint/browser-polish-ci` | **PR**: #TBD
+
+### Sprint: Browser Polish & Release Wiring
+
+- F4 placeable browser filter checkboxes and search box reordered/restyled to match sibling tools (#2425).
+- Rename an open saved placeable via right-click in the F4 browser (lock-aware save-rename-reload); editor ResRef stays read-only (#2424).
+- Reliquary wired into the release pipeline so the alpha ships alongside the other tools.
+
+---
+
 ## [0.8.0-alpha] - 2026-06-07
 **Branch**: `reliquary/sprint/inventory-and-defaults` | **PR**: #2420
 

--- a/Reliquary/CHANGELOG.md
+++ b/Reliquary/CHANGELOG.md
@@ -7,7 +7,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/); versioning via 
 ---
 
 ## [0.9.0-alpha] - 2026-06-07
-**Branch**: `reliquary/sprint/browser-polish-ci` | **PR**: #TBD
+**Branch**: `reliquary/sprint/browser-polish-ci` | **PR**: #2427
 
 ### Sprint: Browser Polish & Release Wiring
 

--- a/Reliquary/Reliquary.Tests/Services/OpenFileRenameCoordinatorTests.cs
+++ b/Reliquary/Reliquary.Tests/Services/OpenFileRenameCoordinatorTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using PlaceableEditor.Services;
+
+namespace PlaceableEditor.Tests.Services;
+
+/// <summary>
+/// Unit coverage for the open-file rename orchestration (#2424). The coordinator sequences
+/// save → release-lock → move → reopen for the currently-open placeable without any UI, so the
+/// ordering and guard logic can be verified without FlaUI.
+/// </summary>
+public class OpenFileRenameCoordinatorTests
+{
+    private static OpenFileRenameCoordinator.Callbacks RecordingCallbacks(List<string> log, bool moveOk = true) => new()
+    {
+        SaveAsync = () => { log.Add("save"); return Task.FromResult(true); },
+        ReleaseLock = () => log.Add("release"),
+        Move = (_, _) => { log.Add("move"); return moveOk; },
+        ReopenAsync = _ => { log.Add("reopen"); return Task.CompletedTask; },
+    };
+
+    [Fact]
+    public async Task RenameAsync_DirtyOpenFile_SavesReleasesMovesReopensInOrder()
+    {
+        var log = new List<string>();
+        var result = await OpenFileRenameCoordinator.RenameAsync(
+            oldPath: "old.utp", newPath: "new.utp",
+            currentFilePath: "old.utp", isDirty: true,
+            RecordingCallbacks(log));
+
+        Assert.Equal(OpenFileRenameCoordinator.Result.Renamed, result);
+        Assert.Equal(new[] { "save", "release", "move", "reopen" }, log);
+    }
+
+    [Fact]
+    public async Task RenameAsync_CleanOpenFile_SkipsSave()
+    {
+        var log = new List<string>();
+        var result = await OpenFileRenameCoordinator.RenameAsync(
+            "old.utp", "new.utp", currentFilePath: "old.utp", isDirty: false,
+            RecordingCallbacks(log));
+
+        Assert.Equal(OpenFileRenameCoordinator.Result.Renamed, result);
+        Assert.Equal(new[] { "release", "move", "reopen" }, log);
+    }
+
+    [Fact]
+    public async Task RenameAsync_SelectionChangedUnderneath_DoesNothing()
+    {
+        var log = new List<string>();
+        var result = await OpenFileRenameCoordinator.RenameAsync(
+            "old.utp", "new.utp", currentFilePath: "different.utp", isDirty: true,
+            RecordingCallbacks(log));
+
+        Assert.Equal(OpenFileRenameCoordinator.Result.NotCurrentFile, result);
+        Assert.Empty(log);
+    }
+
+    [Fact]
+    public async Task RenameAsync_MoveFails_DoesNotReopen()
+    {
+        var log = new List<string>();
+        var result = await OpenFileRenameCoordinator.RenameAsync(
+            "old.utp", "new.utp", currentFilePath: "old.utp", isDirty: false,
+            RecordingCallbacks(log, moveOk: false));
+
+        Assert.Equal(OpenFileRenameCoordinator.Result.MoveFailed, result);
+        Assert.Equal(new[] { "release", "move" }, log);
+    }
+}

--- a/Reliquary/Reliquary/Services/OpenFileRenameCoordinator.cs
+++ b/Reliquary/Reliquary/Services/OpenFileRenameCoordinator.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading.Tasks;
+
+namespace PlaceableEditor.Services;
+
+/// <summary>
+/// Pure orchestration for renaming the currently-open placeable (#2424). The F4 browser validates
+/// the new name and raises FileRenameRequested; the host owns the rename because it holds the
+/// in-memory model (and any session lock) the panel can't see. This coordinator sequences the steps
+/// — save the pending edits, release the lock, move the file on disk, reopen from the new path — via
+/// injected callbacks so the ordering and guards are unit-testable without a window. Mirrors
+/// Relique's RenameOpenFileAsync; siblings share this single-resource pattern.
+/// </summary>
+public static class OpenFileRenameCoordinator
+{
+    public enum Result
+    {
+        Renamed,
+        NotCurrentFile,
+        MoveFailed,
+    }
+
+    /// <summary>Host-supplied steps. Move returns false on a failed disk move so reopen is skipped.</summary>
+    public sealed class Callbacks
+    {
+        public required Func<Task<bool>> SaveAsync { get; init; }
+        public required Action ReleaseLock { get; init; }
+        public required Func<string, string, bool> Move { get; init; }
+        public required Func<string, Task> ReopenAsync { get; init; }
+    }
+
+    /// <summary>
+    /// Save (if dirty) → release lock → move → reopen. No-ops with <see cref="Result.NotCurrentFile"/>
+    /// if the open file changed underneath us (selection moved between prompt and handler).
+    /// </summary>
+    public static async Task<Result> RenameAsync(
+        string oldPath, string newPath, string? currentFilePath, bool isDirty, Callbacks callbacks)
+    {
+        if (string.IsNullOrEmpty(currentFilePath)
+            || !string.Equals(currentFilePath, oldPath, StringComparison.OrdinalIgnoreCase))
+        {
+            return Result.NotCurrentFile;
+        }
+
+        if (isDirty)
+            await callbacks.SaveAsync();
+
+        // Release the lock before moving; reopen reacquires on the new path.
+        callbacks.ReleaseLock();
+
+        if (!callbacks.Move(oldPath, newPath))
+            return Result.MoveFailed;
+
+        await callbacks.ReopenAsync(newPath);
+        return Result.Renamed;
+    }
+}

--- a/Reliquary/Reliquary/Views/MainWindow.Editor.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.Editor.cs
@@ -46,6 +46,7 @@ public partial class MainWindow
         _undo.StateChanged += (_, _) => MarkDirty();
         RefreshUndoMenu();
 
+        // Scripts + Variables live in the Behavior panel (Faction/Conversation moved to Identity, #2425).
         var behavior = this.FindControl<BehaviorPanel>("BehaviorPanel");
         if (behavior != null)
         {
@@ -55,9 +56,6 @@ public partial class MainWindow
             behavior.ScriptEditRequested += OnScriptEditRequested;
             behavior.SaveScriptSetRequested += OnSaveScriptSetRequested;
             behavior.LoadScriptSetRequested += OnLoadScriptSetRequested;
-            behavior.EditConversationRequested += OnEditConversationRequested;
-            behavior.ConversationBrowseRequested += OnConversationBrowseRequested;
-            behavior.FactionChanged += OnFactionSelected;
         }
     }
 

--- a/Reliquary/Reliquary/Views/MainWindow.Editor.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.Editor.cs
@@ -140,6 +140,61 @@ public partial class MainWindow
     /// Load a UTP from raw bytes (HAK/BIF archive entry) as a read-only preview — no file path, so
     /// Save is a no-op until the user does Save As (future). Mirrors Relique's archive preview.
     /// </summary>
+    /// <summary>
+    /// Rename the currently-open placeable to a new ResRef in the same directory (#2424). The F4
+    /// browser already prompted + validated the destination; we save pending edits, release any
+    /// session lock, move the file, then reload from the new path so the editor + browser resync.
+    /// Sequencing + guards live in the unit-tested <see cref="OpenFileRenameCoordinator"/>.
+    /// </summary>
+    private async Task RenameOpenFileAsync(string oldPath, string newPath)
+    {
+        var result = await OpenFileRenameCoordinator.RenameAsync(
+            oldPath, newPath, _currentFilePath, _isDirty,
+            new OpenFileRenameCoordinator.Callbacks
+            {
+                SaveAsync = async () => await SavePlaceableAsync(),
+                ReleaseLock = () =>
+                {
+                    Radoub.UI.Services.FileSessionLockService.ReleaseLock(oldPath);
+                    _documentState.IsReadOnly = false;
+                },
+                Move = (from, to) =>
+                {
+                    try
+                    {
+                        File.Move(from, to);
+                        UnifiedLogger.LogApplication(LogLevel.INFO,
+                            $"Renamed open placeable: {UnifiedLogger.SanitizePath(from)} -> {UnifiedLogger.SanitizePath(to)}");
+                        return true;
+                    }
+                    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                    {
+                        UnifiedLogger.LogApplication(LogLevel.ERROR, $"Failed to rename open placeable: {ex.Message}");
+                        UpdateStatus($"Rename failed: {ex.Message}");
+                        return false;
+                    }
+                },
+                ReopenAsync = async to =>
+                {
+                    // Reopen from the new path: rebinds the editor and locks ResRef to the new identity.
+                    LoadPlaceable(to);
+                    var browser = this.FindControl<PlaceableBrowserPanel>("PlaceableBrowserPanel");
+                    if (browser != null)
+                    {
+                        browser.CurrentFilePath = to;
+                        browser.RemoveEntryByFilePath(oldPath);
+                        await browser.RefreshAsync();
+                        browser.SelectEntryByFilePath(to);
+                    }
+                    UpdateStatus($"Renamed to: {Path.GetFileName(to)}");
+                },
+            });
+
+        if (result == OpenFileRenameCoordinator.Result.NotCurrentFile)
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"Reliquary: rename ignored — open file changed (was {UnifiedLogger.SanitizePath(oldPath)})");
+    }
+
     private void LoadPlaceableFromBytes(byte[] bytes, string name)
     {
         try

--- a/Reliquary/Reliquary/Views/MainWindow.Lifecycle.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.Lifecycle.cs
@@ -23,6 +23,14 @@ public partial class MainWindow
         browser.FileSelected += OnBrowserFileSelected;
         browser.FileDeleted += OnBrowserFileDeleted;
 
+        // Rename feedback for non-open files (the base panel did the move + refresh itself).
+        browser.FileRenamed += (_, args) =>
+            UpdateStatus($"Renamed to: {Path.GetFileName(args.NewPath)}");
+        // Renaming the OPEN placeable: the base prompted + validated; we own the
+        // save → release-lock → move → reopen because we hold the model + lock (#2424).
+        browser.FileRenameRequested += async (_, args) =>
+            await RenameOpenFileAsync(args.OldPath, args.NewPath);
+
         // The base panel only flips its ◀/▶ button + raises CollapsedChanged; the host owns the
         // actual collapse by zeroing the browser's width and hiding the splitter (QM/Relique pattern).
         browser.CollapsedChanged += (_, collapsed) => SetBrowserCollapsed(collapsed);

--- a/Reliquary/Reliquary/Views/MainWindow.Services.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.Services.cs
@@ -65,14 +65,19 @@ public partial class MainWindow
         var browser = this.FindControl<PlaceableBrowserPanel>("PlaceableBrowserPanel");
         if (browser != null) browser.GameDataService = _gameData;
 
-        // Hand the texture service to the 3D preview control.
+        // Wire the Identity & Combat panel events. Faction/Conversation moved here from Behavior
+        // (#2425), so subscribe them regardless of whether the texture service (3D preview) is ready.
         var identity = this.FindControl<IdentityCombatPanel>("IdentityCombatPanel");
-        if (identity != null && _textureService != null)
+        if (identity != null)
         {
-            identity.Preview.SetTextureService(_textureService);
+            if (_textureService != null)
+                identity.Preview.SetTextureService(_textureService);
             identity.AppearanceChanged += OnAppearanceChanged;
             identity.PortraitBrowseRequested += OnPortraitBrowseRequested;
             identity.PaletteCategoryChanged += OnPaletteCategorySelected;
+            identity.FactionChanged += OnFactionSelected;
+            identity.EditConversationRequested += OnEditConversationRequested;
+            identity.ConversationBrowseRequested += OnConversationBrowseRequested;
         }
 
         // Open the startup file from the command line (--file), now that services + the model
@@ -147,15 +152,15 @@ public partial class MainWindow
         UpdateModelPreview(appearanceId);
     }
 
-    /// <summary>Populate the Behavior panel's Faction combo from the module's repute.fac (#2354).</summary>
+    /// <summary>Populate the Identity panel's Faction combo from the module's repute.fac (#2354, moved #2425).</summary>
     private void PopulateFactionCombo()
     {
         if (_placeable is null) return;
-        var behavior = this.FindControl<PlaceableEditor.Views.Panels.BehaviorPanel>("BehaviorPanel");
-        if (behavior is null) return;
+        var identity = this.FindControl<IdentityCombatPanel>("IdentityCombatPanel");
+        if (identity is null) return;
 
         var factions = PlaceableEditor.Services.FactionService.Load(GetModuleWorkingDirectory());
-        behavior.PopulateFactions(factions, _placeable.Faction);
+        identity.PopulateFactions(factions, _placeable.Faction);
     }
 
     /// <summary>Route a faction pick through undo (host owns the repute.fac list + undo wrapping).</summary>

--- a/Reliquary/Reliquary/Views/MainWindow.axaml
+++ b/Reliquary/Reliquary/Views/MainWindow.axaml
@@ -49,9 +49,9 @@
                           VerticalScrollBarVisibility="Visible">
                 <StackPanel Margin="8" Spacing="8">
                     <panels:IdentityCombatPanel x:Name="IdentityCombatPanel"/>
-                    <panels:BehaviorPanel x:Name="BehaviorPanel"/>
                     <panels:TextPanel x:Name="TextPanel"/>
                     <panels:InventoryPanel x:Name="InventoryPanel"/>
+                    <panels:BehaviorPanel x:Name="BehaviorPanel"/>
                 </StackPanel>
             </ScrollViewer>
         </Grid>

--- a/Reliquary/Reliquary/Views/Panels/BehaviorPanel.axaml
+++ b/Reliquary/Reliquary/Views/Panels/BehaviorPanel.axaml
@@ -36,7 +36,7 @@
             BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
             BorderThickness="1" CornerRadius="4">
         <StackPanel Spacing="10">
-            <TextBlock Text="Behavior" FontWeight="Bold"
+            <TextBlock Text="Scripts &amp; Variables" FontWeight="Bold"
                        FontSize="{DynamicResource FontSizeMedium}"/>
 
             <!-- Scripts: two columns -->
@@ -53,54 +53,6 @@
                         AutomationProperties.AutomationId="Reliquary_Button_SaveScriptSet"/>
                 <Button Content="Load Script Set" Click="OnLoadScriptSetClick"
                         AutomationProperties.AutomationId="Reliquary_Button_LoadScriptSet"/>
-            </StackPanel>
-
-            <Separator Margin="0,4"/>
-
-            <!-- Advanced -->
-            <TextBlock Text="Advanced" FontWeight="SemiBold"/>
-            <Grid RowDefinitions="Auto,Auto,Auto">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" MinWidth="120"/>
-                    <ColumnDefinition Width="*" MinWidth="160"/>
-                    <ColumnDefinition Width="16"/>
-                    <ColumnDefinition Width="Auto" MinWidth="120"/>
-                    <ColumnDefinition Width="Auto" MinWidth="120"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock Grid.Row="0" Grid.Column="0" Text="Faction" VerticalAlignment="Center"/>
-                <ComboBox Grid.Row="0" Grid.Column="1" x:Name="FactionCombo"
-                          HorizontalAlignment="Stretch"
-                          SelectionChanged="OnFactionChanged"
-                          AutomationProperties.AutomationId="Reliquary_Combo_Faction"/>
-
-                <TextBlock Grid.Row="0" Grid.Column="3" Text="Initial State" VerticalAlignment="Center"/>
-                <ComboBox Grid.Row="0" Grid.Column="4" MinWidth="120"
-                          ItemsSource="{Binding AnimationStates}"
-                          SelectedValue="{Binding InitialState, Mode=TwoWay}"
-                          SelectedValueBinding="{Binding Value}"
-                          DisplayMemberBinding="{Binding Display}"
-                          AutomationProperties.AutomationId="Reliquary_Combo_InitialState"/>
-
-                <TextBlock Grid.Row="1" Grid.Column="0" Text="Conversation" VerticalAlignment="Center"/>
-                <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Conversation, Mode=TwoWay}"
-                         MaxLength="16"
-                         AutomationProperties.AutomationId="Reliquary_Field_Conversation"/>
-
-                <TextBlock Grid.Row="1" Grid.Column="3" Text="Treasure Model" VerticalAlignment="Center"/>
-                <NumericUpDown Grid.Row="1" Grid.Column="4" Minimum="0" Maximum="255" Increment="1"
-                               FormatString="0" MinWidth="120"
-                               Value="{Binding TreasureModel, Mode=TwoWay}"
-                               AutomationProperties.AutomationId="Reliquary_Numeric_TreasureModel"/>
-            </Grid>
-            <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,2,0,0">
-                <Button Content="Browse…" Click="OnBrowseConversationClick"
-                        ToolTip.Tip="Browse module/HAK dialogs and set the Conversation ResRef."
-                        AutomationProperties.AutomationId="Reliquary_Button_BrowseConversation"/>
-                <Button Content="Edit → Parley" Click="OnEditConversationClick"
-                        ToolTip.Tip="Open this conversation's .dlg in Parley."
-                        AutomationProperties.AutomationId="Reliquary_Button_EditConversation"/>
-                <CheckBox Content="No Interrupt" IsChecked="{Binding NoInterrupt, Mode=TwoWay}"
-                          AutomationProperties.AutomationId="Reliquary_Check_NoInterrupt"/>
             </StackPanel>
 
             <Separator Margin="0,4"/>

--- a/Reliquary/Reliquary/Views/Panels/BehaviorPanel.axaml.cs
+++ b/Reliquary/Reliquary/Views/Panels/BehaviorPanel.axaml.cs
@@ -9,10 +9,11 @@ using PlaceableEditor.ViewModels;
 namespace PlaceableEditor.Views.Panels;
 
 /// <summary>
-/// Behavior panel (design §5.2): 13 event scripts in two columns, advanced behavior fields, and
-/// the shared <see cref="VariablesPanel"/>. Stays thin — script browse, script-set save/load, and
-/// conversation-edit dispatch are raised as events for the host (MainWindow) to service with shared
-/// dialogs + the undo manager. Faction list is populated by the host (no hardcoded factions).
+/// Scripts &amp; Variables panel (design §5.2): 13 event scripts in two columns plus the shared
+/// <see cref="VariablesPanel"/>. Faction / Conversation / Initial State / Treasure Model moved to the
+/// Identity &amp; Combat panel (#2425); this panel now lives at the bottom of the editor. Stays thin —
+/// script browse and script-set save/load are raised as events for the host (MainWindow) to service
+/// with shared dialogs + the undo manager.
 /// </summary>
 public partial class BehaviorPanel : UserControl
 {
@@ -30,18 +31,6 @@ public partial class BehaviorPanel : UserControl
 
     /// <summary>Raised when Load Script Set is clicked.</summary>
     public event EventHandler? LoadScriptSetRequested;
-
-    /// <summary>Raised when the conversation Edit→Parley button is clicked (Sprint 7 dispatch).</summary>
-    public event EventHandler? EditConversationRequested;
-
-    /// <summary>Raised when the conversation Browse… button is clicked (#2373; host opens the shared DialogBrowser).</summary>
-    public event EventHandler? ConversationBrowseRequested;
-
-    /// <summary>Raised when the user picks a faction (carries the faction id) for the host to wrap in undo.</summary>
-    public event EventHandler<uint>? FactionChanged;
-
-    /// <summary>Suppresses <see cref="FactionChanged"/> while the host populates/preselects the combo.</summary>
-    private bool _suppressFactionEvent;
 
     public BehaviorPanel()
     {
@@ -87,47 +76,4 @@ public partial class BehaviorPanel : UserControl
 
     private void OnLoadScriptSetClick(object? sender, RoutedEventArgs e)
         => LoadScriptSetRequested?.Invoke(this, EventArgs.Empty);
-
-    private void OnEditConversationClick(object? sender, RoutedEventArgs e)
-        => EditConversationRequested?.Invoke(this, EventArgs.Empty);
-
-    private void OnBrowseConversationClick(object? sender, RoutedEventArgs e)
-        => ConversationBrowseRequested?.Invoke(this, EventArgs.Empty);
-
-    /// <summary>
-    /// Fill the Faction combo from the host-provided list (loaded from the module's repute.fac). The
-    /// combo intentionally starts with no selection (per #2354 follow-up): the user opens the dropdown
-    /// to assign a faction, rather than the combo asserting a faction the placeable may not have meant.
-    /// The stored faction value is untouched until the user picks. The host owns the list + undo
-    /// wrapping; the combo only raises <see cref="FactionChanged"/> on user edits, never on populate.
-    /// </summary>
-    public void PopulateFactions(System.Collections.Generic.IReadOnlyList<(ushort Id, string Name)> factions, uint selectedId)
-    {
-        var combo = this.FindControl<ComboBox>("FactionCombo");
-        if (combo is null) return;
-
-        _suppressFactionEvent = true;
-        try
-        {
-            combo.ItemsSource = factions.Select(f => new FactionItem(f.Id, f.Name)).ToList();
-            combo.SelectedItem = null; // start blank; user pulls down to choose (#2354 follow-up)
-        }
-        finally
-        {
-            _suppressFactionEvent = false;
-        }
-    }
-
-    private void OnFactionChanged(object? sender, SelectionChangedEventArgs e)
-    {
-        if (_suppressFactionEvent) return;
-        if (sender is ComboBox { SelectedItem: FactionItem item })
-            FactionChanged?.Invoke(this, item.Id);
-    }
-
-    /// <summary>Display item for the Faction combo: shows the name, carries the faction id.</summary>
-    private sealed record FactionItem(ushort Id, string Name)
-    {
-        public override string ToString() => Name;
-    }
 }

--- a/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml
+++ b/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml
@@ -140,6 +140,56 @@
                         <CheckBox Content="Static" IsChecked="{Binding Static, Mode=TwoWay}"
                                   AutomationProperties.AutomationId="Reliquary_Check_Static"/>
                     </StackPanel>
+
+                    <Separator Margin="0,6"/>
+
+                    <!-- Faction / Conversation / Initial State / Treasure Model. Moved here from the
+                         Behavior panel (#2425): these identify the placeable's runtime behavior and are
+                         short, fixed-size fields, so they belong with Identity rather than below the
+                         scripts. Same two-column grid the Behavior panel used. -->
+                    <Grid RowDefinitions="Auto,Auto" Margin="0,2,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" MinWidth="100"/>
+                            <ColumnDefinition Width="*" MinWidth="160"/>
+                            <ColumnDefinition Width="16"/>
+                            <ColumnDefinition Width="Auto" MinWidth="100"/>
+                            <ColumnDefinition Width="Auto" MinWidth="120"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Faction" VerticalAlignment="Center"/>
+                        <ComboBox Grid.Row="0" Grid.Column="1" x:Name="FactionCombo"
+                                  HorizontalAlignment="Stretch"
+                                  SelectionChanged="OnFactionChanged"
+                                  AutomationProperties.AutomationId="Reliquary_Combo_Faction"/>
+
+                        <TextBlock Grid.Row="0" Grid.Column="3" Text="Initial State" VerticalAlignment="Center"/>
+                        <ComboBox Grid.Row="0" Grid.Column="4" MinWidth="120"
+                                  ItemsSource="{Binding AnimationStates}"
+                                  SelectedValue="{Binding InitialState, Mode=TwoWay}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  DisplayMemberBinding="{Binding Display}"
+                                  AutomationProperties.AutomationId="Reliquary_Combo_InitialState"/>
+
+                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Conversation" VerticalAlignment="Center"/>
+                        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Conversation, Mode=TwoWay}"
+                                 MaxLength="16"
+                                 AutomationProperties.AutomationId="Reliquary_Field_Conversation"/>
+
+                        <TextBlock Grid.Row="1" Grid.Column="3" Text="Treasure Model" VerticalAlignment="Center"/>
+                        <NumericUpDown Grid.Row="1" Grid.Column="4" Minimum="0" Maximum="255" Increment="1"
+                                       FormatString="0" MinWidth="120"
+                                       Value="{Binding TreasureModel, Mode=TwoWay}"
+                                       AutomationProperties.AutomationId="Reliquary_Numeric_TreasureModel"/>
+                    </Grid>
+                    <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,2,0,0">
+                        <Button Content="Browse…" Click="OnBrowseConversationClick"
+                                ToolTip.Tip="Browse module/HAK dialogs and set the Conversation ResRef."
+                                AutomationProperties.AutomationId="Reliquary_Button_BrowseConversation"/>
+                        <Button Content="Edit → Parley" Click="OnEditConversationClick"
+                                ToolTip.Tip="Open this conversation's .dlg in Parley."
+                                AutomationProperties.AutomationId="Reliquary_Button_EditConversation"/>
+                        <CheckBox Content="No Interrupt" IsChecked="{Binding NoInterrupt, Mode=TwoWay}"
+                                  AutomationProperties.AutomationId="Reliquary_Check_NoInterrupt"/>
+                    </StackPanel>
                 </StackPanel>
 
                 <GridSplitter Grid.Column="3" Width="4"

--- a/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml
+++ b/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml
@@ -150,14 +150,14 @@
                     <Grid RowDefinitions="Auto,Auto" Margin="0,2,0,0">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" MinWidth="100"/>
-                            <ColumnDefinition Width="*" MinWidth="160"/>
+                            <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="16"/>
                             <ColumnDefinition Width="Auto" MinWidth="100"/>
                             <ColumnDefinition Width="Auto" MinWidth="120"/>
                         </Grid.ColumnDefinitions>
                         <TextBlock Grid.Row="0" Grid.Column="0" Text="Faction" VerticalAlignment="Center"/>
                         <ComboBox Grid.Row="0" Grid.Column="1" x:Name="FactionCombo"
-                                  HorizontalAlignment="Stretch"
+                                  Width="220" HorizontalAlignment="Left"
                                   SelectionChanged="OnFactionChanged"
                                   AutomationProperties.AutomationId="Reliquary_Combo_Faction"/>
 
@@ -171,7 +171,7 @@
 
                         <TextBlock Grid.Row="1" Grid.Column="0" Text="Conversation" VerticalAlignment="Center"/>
                         <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Conversation, Mode=TwoWay}"
-                                 MaxLength="16"
+                                 MaxLength="16" Width="220" HorizontalAlignment="Left"
                                  AutomationProperties.AutomationId="Reliquary_Field_Conversation"/>
 
                         <TextBlock Grid.Row="1" Grid.Column="3" Text="Treasure Model" VerticalAlignment="Center"/>

--- a/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml.cs
+++ b/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml.cs
@@ -32,6 +32,18 @@ public partial class IdentityCombatPanel : UserControl
 
     private bool _suppressCategoryEvent;
 
+    /// <summary>Raised when the user picks a faction (carries the faction id) for the host to wrap in undo.</summary>
+    public event EventHandler<uint>? FactionChanged;
+
+    /// <summary>Suppresses <see cref="FactionChanged"/> while the host populates/preselects the combo.</summary>
+    private bool _suppressFactionEvent;
+
+    /// <summary>Raised when the conversation Edit→Parley button is clicked (Sprint 7 dispatch).</summary>
+    public event EventHandler? EditConversationRequested;
+
+    /// <summary>Raised when the conversation Browse… button is clicked (#2373; host opens the shared DialogBrowser).</summary>
+    public event EventHandler? ConversationBrowseRequested;
+
     public IdentityCombatPanel()
     {
         InitializeComponent();
@@ -167,5 +179,51 @@ public partial class IdentityCombatPanel : UserControl
         if (_suppressAppearanceEvent) return;
         if (sender is ComboBox { SelectedItem: PlaceableAppearance appearance })
             AppearanceChanged?.Invoke(this, appearance.Id);
+    }
+
+    // --- Faction / Conversation (moved here from BehaviorPanel, #2425) ---
+
+    /// <summary>
+    /// Fill the Faction combo from the host-provided list (loaded from the module's repute.fac). The
+    /// combo intentionally starts with no selection (per #2354 follow-up): the user opens the dropdown
+    /// to assign a faction, rather than the combo asserting a faction the placeable may not have meant.
+    /// The host owns the list + undo wrapping; the combo only raises <see cref="FactionChanged"/> on
+    /// user edits, never on populate.
+    /// </summary>
+    public void PopulateFactions(IReadOnlyList<(ushort Id, string Name)> factions, uint selectedId)
+    {
+        var combo = this.FindControl<ComboBox>("FactionCombo");
+        if (combo is null) return;
+
+        _suppressFactionEvent = true;
+        try
+        {
+            combo.ItemsSource = System.Linq.Enumerable.ToList(
+                System.Linq.Enumerable.Select(factions, f => new FactionItem(f.Id, f.Name)));
+            combo.SelectedItem = null; // start blank; user pulls down to choose (#2354 follow-up)
+        }
+        finally
+        {
+            _suppressFactionEvent = false;
+        }
+    }
+
+    private void OnFactionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (_suppressFactionEvent) return;
+        if (sender is ComboBox { SelectedItem: FactionItem item })
+            FactionChanged?.Invoke(this, item.Id);
+    }
+
+    private void OnEditConversationClick(object? sender, RoutedEventArgs e)
+        => EditConversationRequested?.Invoke(this, EventArgs.Empty);
+
+    private void OnBrowseConversationClick(object? sender, RoutedEventArgs e)
+        => ConversationBrowseRequested?.Invoke(this, EventArgs.Empty);
+
+    /// <summary>Display item for the Faction combo: shows the name, carries the faction id.</summary>
+    private sealed record FactionItem(ushort Id, string Name)
+    {
+        public override string ToString() => Name;
     }
 }


### PR DESCRIPTION
## Summary

Reliquary follow-ups to sprint #2420 plus release-pipeline wiring — the goal is to get the alpha out for others.

- **CI** — Wired Reliquary into `radoub-release.yml` (restore/publish/version/macOS-app/Linux-chmod + release-notes), so the alpha bundle ships Reliquary alongside the other six tools.
- **#2424** — Rename an open saved placeable via right-click in the F4 browser (lock-aware save → release → move → reopen, sequenced by the unit-tested `OpenFileRenameCoordinator`). Editor ResRef stays read-only; the browser Rename is the single rename path.
- **#2425** — Editor layout reorg: Faction, Conversation (+No Interrupt, Browse, Edit→Parley), Initial State, and Treasure Model moved into Identity & Combat (Faction/Conversation capped to fixed width); Behavior panel renamed "Scripts & Variables" and dropped to the bottom (Identity → Text → Inventory → Scripts & Variables).

## Related Issues

- Closes #2424
- Closes #2425

## Tests

- Reliquary unit: 119/119 pass (incl. 4 new `OpenFileRenameCoordinator` tests)
- Shared unit (Formats/UI/Dictionary): 2507/0
- Reliquary FlaUI: 7/7 pass (incl. moved Conversation field render)
- Privacy: no hardcoded paths in changed files
- CI: Linux build + test green; Windows + bundle jobs in progress

## Checklist

- [x] Implementation complete
- [x] Tests added/updated
- [x] CHANGELOG updated with date + PR number
- [x] Reliquary in release workflow

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)