### PR TITLE
[Reliquary] Sprint: 3D Preview Upgrades & Shared Status Bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.9-alpha] - 2026-06-09
+**Branch**: `reliquary/sprint/preview-and-statusbar` | **PR**: #2438
+
+### Shared model-preview camera panel (#2430)
+
+- New `ModelPreviewPanel` wraps `ModelPreviewGLControl` with a transparent input surface and a rotate/zoom/pan/reset camera bar (left-drag rotate, middle/Shift+left pan, wheel zoom, arrows/WASD, Home reset) plus an optional state selector. Camera input logic extracted from Quartermaster's AppearancePanel; adopted by Reliquary (QM/Relique migration to follow).
+
+---
+
 ## [Radoub.UI 0.2.8-alpha] - 2026-06-08
 **Branch**: `quartermaster/issue-2395` | **PR**: #2432
 

--- a/Radoub.UI/Radoub.UI.Tests/Controls/PreviewDragModeDeciderTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Controls/PreviewDragModeDeciderTests.cs
@@ -1,0 +1,54 @@
+using Radoub.UI.Controls;
+using Xunit;
+
+namespace Radoub.UI.Tests.Controls;
+
+/// <summary>
+/// Pure decision logic for the shared model-preview drag mode (#2430). Extracted from
+/// Quartermaster's AppearancePanel so the rotate-vs-pan rule is unit-testable without FlaUI.
+/// Rule (mirrors QM): middle button OR (left + Shift) → Pan; left alone → Rotate; else None.
+/// </summary>
+public class PreviewDragModeDeciderTests
+{
+    [Fact]
+    public void LeftButtonAlone_Rotates()
+    {
+        Assert.Equal(PreviewDragMode.Rotate,
+            PreviewDragModeDecider.Decide(isLeft: true, isMiddle: false, shift: false));
+    }
+
+    [Fact]
+    public void MiddleButton_Pans()
+    {
+        Assert.Equal(PreviewDragMode.Pan,
+            PreviewDragModeDecider.Decide(isLeft: false, isMiddle: true, shift: false));
+    }
+
+    [Fact]
+    public void LeftWithShift_Pans()
+    {
+        Assert.Equal(PreviewDragMode.Pan,
+            PreviewDragModeDecider.Decide(isLeft: true, isMiddle: false, shift: true));
+    }
+
+    [Fact]
+    public void MiddleTakesPrecedenceOverLeft()
+    {
+        Assert.Equal(PreviewDragMode.Pan,
+            PreviewDragModeDecider.Decide(isLeft: true, isMiddle: true, shift: false));
+    }
+
+    [Fact]
+    public void NoButton_IsNone()
+    {
+        Assert.Equal(PreviewDragMode.None,
+            PreviewDragModeDecider.Decide(isLeft: false, isMiddle: false, shift: false));
+    }
+
+    [Fact]
+    public void ShiftWithoutButton_IsNone()
+    {
+        Assert.Equal(PreviewDragMode.None,
+            PreviewDragModeDecider.Decide(isLeft: false, isMiddle: false, shift: true));
+    }
+}

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewPanel.axaml
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewPanel.axaml
@@ -1,0 +1,52 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:Radoub.UI.Controls"
+             mc:Ignorable="d" d:DesignWidth="260" d:DesignHeight="300"
+             x:Class="Radoub.UI.Controls.ModelPreviewPanel">
+
+  <!-- Shared model-preview surface (#2430): the GL control + a transparent input overlay
+       (OpenGlControlBase has no Background, so pointer/wheel must hit a sibling) + a camera
+       button bar. Hosts load models via the Preview property; camera math lives in the GL
+       control / ModelViewController. -->
+  <Grid RowDefinitions="*,Auto">
+
+    <Border Grid.Row="0"
+            Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
+            BorderThickness="1"
+            CornerRadius="4">
+      <Grid>
+        <controls:ModelPreviewGLControl x:Name="ModelPreviewGL"
+                                        HorizontalAlignment="Stretch"
+                                        VerticalAlignment="Stretch"/>
+        <!-- Transparent surface so pointer/wheel/key events always hit-test. -->
+        <Border x:Name="InputSurface"
+                Background="Transparent"
+                Focusable="True"/>
+      </Grid>
+    </Border>
+
+    <!-- Camera controls. Mirrors Quartermaster's AppearancePanel preview bar. -->
+    <Border Grid.Row="1" Padding="0,6,0,0">
+      <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Center">
+        <Button x:Name="RotateLeftButton" Content="↺" Width="30" Height="30"
+                Click="OnRotateLeftClicked" ToolTip.Tip="Rotate Left"
+                AutomationProperties.AutomationId="ModelPreview_RotateLeft"/>
+        <Button x:Name="ResetViewButton" Content="⟲" Width="30" Height="30"
+                Click="OnResetViewClicked" ToolTip.Tip="Reset View (Home)"
+                AutomationProperties.AutomationId="ModelPreview_ResetView"/>
+        <Button x:Name="RotateRightButton" Content="↻" Width="30" Height="30"
+                Click="OnRotateRightClicked" ToolTip.Tip="Rotate Right"
+                AutomationProperties.AutomationId="ModelPreview_RotateRight"/>
+        <Button x:Name="ZoomInButton" Content="+" Width="30" Height="30" Margin="14,0,0,0"
+                Click="OnZoomInClicked" ToolTip.Tip="Zoom In"
+                AutomationProperties.AutomationId="ModelPreview_ZoomIn"/>
+        <Button x:Name="ZoomOutButton" Content="–" Width="30" Height="30"
+                Click="OnZoomOutClicked" ToolTip.Tip="Zoom Out"
+                AutomationProperties.AutomationId="ModelPreview_ZoomOut"/>
+      </StackPanel>
+    </Border>
+  </Grid>
+</UserControl>

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewPanel.axaml
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewPanel.axaml
@@ -10,7 +10,7 @@
        (OpenGlControlBase has no Background, so pointer/wheel must hit a sibling) + a camera
        button bar. Hosts load models via the Preview property; camera math lives in the GL
        control / ModelViewController. -->
-  <Grid RowDefinitions="*,Auto">
+  <Grid RowDefinitions="*,Auto,Auto">
 
     <Border Grid.Row="0"
             Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
@@ -28,8 +28,19 @@
       </Grid>
     </Border>
 
+    <!-- Optional state selector (#2431). Hidden until a host populates it via ShowStateSelector;
+         used by Reliquary to switch the placeable preview between open/closed/destroyed/etc. -->
+    <Border Grid.Row="1" Padding="0,6,0,0" x:Name="StateSelectorRow" IsVisible="False">
+      <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Center">
+        <TextBlock Text="State" VerticalAlignment="Center"/>
+        <ComboBox x:Name="StateCombo" MinWidth="130"
+                  SelectionChanged="OnStateSelectionChanged"
+                  AutomationProperties.AutomationId="ModelPreview_StateCombo"/>
+      </StackPanel>
+    </Border>
+
     <!-- Camera controls. Mirrors Quartermaster's AppearancePanel preview bar. -->
-    <Border Grid.Row="1" Padding="0,6,0,0">
+    <Border Grid.Row="2" Padding="0,6,0,0">
       <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Center">
         <Button x:Name="RotateLeftButton" Content="↺" Width="30" Height="30"
                 Click="OnRotateLeftClicked" ToolTip.Tip="Rotate Left"

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewPanel.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewPanel.axaml.cs
@@ -33,6 +33,13 @@ public partial class ModelPreviewPanel : UserControl
     private Point _lastPointer;
     private bool _suppressStateEvent;
 
+    // Radoub.UI controls do not get generated x:Name backing fields, so the named children are
+    // resolved via FindControl after the XAML loads and cached here (matches the repo pattern).
+    private readonly ModelPreviewGLControl _gl;
+    private readonly Border _inputSurface;
+    private readonly Border _stateSelectorRow;
+    private readonly ComboBox _stateCombo;
+
     /// <summary>
     /// Raised when the user picks a state from the optional state selector (#2431), carrying the
     /// selected state's byte value. Only fires for user selections, never while the host populates.
@@ -43,17 +50,22 @@ public partial class ModelPreviewPanel : UserControl
     {
         InitializeComponent();
 
-        InputSurface.PointerPressed += OnPointerPressed;
-        InputSurface.PointerMoved += OnPointerMoved;
-        InputSurface.PointerReleased += OnPointerReleased;
-        InputSurface.PointerWheelChanged += OnPointerWheel;
-        InputSurface.KeyDown += OnKeyDown;
+        _gl = this.FindControl<ModelPreviewGLControl>("ModelPreviewGL")!;
+        _inputSurface = this.FindControl<Border>("InputSurface")!;
+        _stateSelectorRow = this.FindControl<Border>("StateSelectorRow")!;
+        _stateCombo = this.FindControl<ComboBox>("StateCombo")!;
+
+        _inputSurface.PointerPressed += OnPointerPressed;
+        _inputSurface.PointerMoved += OnPointerMoved;
+        _inputSurface.PointerReleased += OnPointerReleased;
+        _inputSurface.PointerWheelChanged += OnPointerWheel;
+        _inputSurface.KeyDown += OnKeyDown;
     }
 
     private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 
     /// <summary>The hosted GL control. Hosts load models and set the texture service through this.</summary>
-    public ModelPreviewGLControl Preview => ModelPreviewGL;
+    public ModelPreviewGLControl Preview => _gl;
 
     // ----- Optional state selector (#2431) -----
 
@@ -79,10 +91,10 @@ public partial class ModelPreviewPanel : UserControl
         _suppressStateEvent = true;
         try
         {
-            StateCombo.ItemsSource = states;
+            _stateCombo.ItemsSource = states;
             var match = states.FirstOrDefault(s => s.Value == selected);
-            StateCombo.SelectedItem = states.Contains(match) ? match : states[0];
-            StateSelectorRow.IsVisible = true;
+            _stateCombo.SelectedItem = states.Contains(match) ? match : states[0];
+            _stateSelectorRow.IsVisible = true;
         }
         finally
         {
@@ -96,8 +108,8 @@ public partial class ModelPreviewPanel : UserControl
         _suppressStateEvent = true;
         try
         {
-            StateSelectorRow.IsVisible = false;
-            StateCombo.ItemsSource = null;
+            _stateSelectorRow.IsVisible = false;
+            _stateCombo.ItemsSource = null;
         }
         finally
         {
@@ -108,7 +120,7 @@ public partial class ModelPreviewPanel : UserControl
     private void OnStateSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
         if (_suppressStateEvent) return;
-        if (StateCombo.SelectedItem is PreviewState state)
+        if (_stateCombo.SelectedItem is PreviewState state)
             StateSelected?.Invoke(this, state.Value);
     }
 
@@ -116,7 +128,7 @@ public partial class ModelPreviewPanel : UserControl
 
     private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
     {
-        var props = e.GetCurrentPoint(InputSurface).Properties;
+        var props = e.GetCurrentPoint(_inputSurface).Properties;
         bool shift = (e.KeyModifiers & KeyModifiers.Shift) != 0;
 
         _dragMode = PreviewDragModeDecider.Decide(
@@ -126,9 +138,9 @@ public partial class ModelPreviewPanel : UserControl
 
         if (_dragMode == PreviewDragMode.None) return;
 
-        _lastPointer = e.GetPosition(InputSurface);
-        InputSurface.Focus();
-        e.Pointer.Capture(InputSurface);
+        _lastPointer = e.GetPosition(_inputSurface);
+        _inputSurface.Focus();
+        e.Pointer.Capture(_inputSurface);
         e.Handled = true;
     }
 
@@ -136,15 +148,15 @@ public partial class ModelPreviewPanel : UserControl
     {
         if (_dragMode == PreviewDragMode.None) return;
 
-        var pos = e.GetPosition(InputSurface);
+        var pos = e.GetPosition(_inputSurface);
         double dx = pos.X - _lastPointer.X;
         double dy = pos.Y - _lastPointer.Y;
         _lastPointer = pos;
 
         if (_dragMode == PreviewDragMode.Rotate)
-            ModelPreviewGL.RotateByPixels(dx, dy);
+            _gl.RotateByPixels(dx, dy);
         else if (_dragMode == PreviewDragMode.Pan)
-            ModelPreviewGL.PanByPixels(dx, dy);
+            _gl.PanByPixels(dx, dy);
     }
 
     private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
@@ -157,8 +169,8 @@ public partial class ModelPreviewPanel : UserControl
 
     private void OnPointerWheel(object? sender, PointerWheelEventArgs e)
     {
-        var pos = e.GetPosition(ModelPreviewGL); // unproject uses GL viewport coords
-        ModelPreviewGL.ZoomAtCursorPixels(pos, e.Delta.Y);
+        var pos = e.GetPosition(_gl); // unproject uses GL viewport coords
+        _gl.ZoomAtCursorPixels(pos, e.Delta.Y);
         e.Handled = true;
     }
 
@@ -168,22 +180,22 @@ public partial class ModelPreviewPanel : UserControl
         {
             case Key.Left:
             case Key.A:
-                ModelPreviewGL.Rotate(-RotateStep, 0);
+                _gl.Rotate(-RotateStep, 0);
                 break;
             case Key.Right:
             case Key.D:
-                ModelPreviewGL.Rotate(RotateStep, 0);
+                _gl.Rotate(RotateStep, 0);
                 break;
             case Key.Up:
             case Key.W:
-                ModelPreviewGL.Rotate(0, -RotateStep);
+                _gl.Rotate(0, -RotateStep);
                 break;
             case Key.Down:
             case Key.S:
-                ModelPreviewGL.Rotate(0, RotateStep);
+                _gl.Rotate(0, RotateStep);
                 break;
             case Key.Home:
-                ModelPreviewGL.ResetView();
+                _gl.ResetView();
                 break;
             default:
                 return;
@@ -193,9 +205,9 @@ public partial class ModelPreviewPanel : UserControl
 
     // ----- Camera button handlers -----
 
-    private void OnRotateLeftClicked(object? sender, RoutedEventArgs e) => ModelPreviewGL.Rotate(-ButtonRotate);
-    private void OnRotateRightClicked(object? sender, RoutedEventArgs e) => ModelPreviewGL.Rotate(ButtonRotate);
-    private void OnResetViewClicked(object? sender, RoutedEventArgs e) => ModelPreviewGL.ResetView();
-    private void OnZoomInClicked(object? sender, RoutedEventArgs e) => ModelPreviewGL.Zoom *= ZoomFactor;
-    private void OnZoomOutClicked(object? sender, RoutedEventArgs e) => ModelPreviewGL.Zoom /= ZoomFactor;
+    private void OnRotateLeftClicked(object? sender, RoutedEventArgs e) => _gl.Rotate(-ButtonRotate);
+    private void OnRotateRightClicked(object? sender, RoutedEventArgs e) => _gl.Rotate(ButtonRotate);
+    private void OnResetViewClicked(object? sender, RoutedEventArgs e) => _gl.ResetView();
+    private void OnZoomInClicked(object? sender, RoutedEventArgs e) => _gl.Zoom *= ZoomFactor;
+    private void OnZoomOutClicked(object? sender, RoutedEventArgs e) => _gl.Zoom /= ZoomFactor;
 }

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewPanel.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewPanel.axaml.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -28,6 +31,13 @@ public partial class ModelPreviewPanel : UserControl
 
     private PreviewDragMode _dragMode = PreviewDragMode.None;
     private Point _lastPointer;
+    private bool _suppressStateEvent;
+
+    /// <summary>
+    /// Raised when the user picks a state from the optional state selector (#2431), carrying the
+    /// selected state's byte value. Only fires for user selections, never while the host populates.
+    /// </summary>
+    public event EventHandler<byte>? StateSelected;
 
     public ModelPreviewPanel()
     {
@@ -44,6 +54,63 @@ public partial class ModelPreviewPanel : UserControl
 
     /// <summary>The hosted GL control. Hosts load models and set the texture service through this.</summary>
     public ModelPreviewGLControl Preview => ModelPreviewGL;
+
+    // ----- Optional state selector (#2431) -----
+
+    /// <summary>One selectable preview state: a byte value (matching the model/engine state) + a label.</summary>
+    public readonly record struct PreviewState(byte Value, string Label)
+    {
+        public override string ToString() => Label;
+    }
+
+    /// <summary>
+    /// Show the state selector populated with the given states, preselecting <paramref name="selected"/>.
+    /// Passing one or zero states hides the row (nothing to choose). Selecting a state raises
+    /// <see cref="StateSelected"/>; the host owns posing the model. Populating never raises the event.
+    /// </summary>
+    public void ShowStateSelector(IReadOnlyList<PreviewState> states, byte selected)
+    {
+        if (states == null || states.Count <= 1)
+        {
+            HideStateSelector();
+            return;
+        }
+
+        _suppressStateEvent = true;
+        try
+        {
+            StateCombo.ItemsSource = states;
+            var match = states.FirstOrDefault(s => s.Value == selected);
+            StateCombo.SelectedItem = states.Contains(match) ? match : states[0];
+            StateSelectorRow.IsVisible = true;
+        }
+        finally
+        {
+            _suppressStateEvent = false;
+        }
+    }
+
+    /// <summary>Hide and clear the state selector (e.g. when no model is loaded).</summary>
+    public void HideStateSelector()
+    {
+        _suppressStateEvent = true;
+        try
+        {
+            StateSelectorRow.IsVisible = false;
+            StateCombo.ItemsSource = null;
+        }
+        finally
+        {
+            _suppressStateEvent = false;
+        }
+    }
+
+    private void OnStateSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (_suppressStateEvent) return;
+        if (StateCombo.SelectedItem is PreviewState state)
+            StateSelected?.Invoke(this, state.Value);
+    }
 
     // ----- Pointer / wheel / key forwarding (extracted from QM AppearancePanel #2124/#2430) -----
 

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewPanel.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewPanel.axaml.cs
@@ -1,0 +1,134 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+
+namespace Radoub.UI.Controls;
+
+/// <summary>
+/// Shared 3D model preview with rotate/zoom/pan/reset camera controls (#2430). Wraps
+/// <see cref="ModelPreviewGLControl"/> with a transparent input surface (so pointer/wheel/key
+/// events hit-test over the GL control) and a camera button bar. The camera math itself lives in
+/// the GL control / ModelViewController; this control only forwards user input to it.
+///
+/// Hosts load a model and configure textures through <see cref="Preview"/>. Extracted from
+/// Quartermaster's AppearancePanel so Reliquary (and later QM/Relique) share one implementation.
+///
+/// Interaction (mirrors QM): left-drag rotates, middle-drag or Shift+left-drag pans, wheel zooms
+/// at the cursor, arrow keys / WASD rotate, Home resets. Models default to facing the camera
+/// (ModelViewController initializes RotationY = π); fit-to-view happens automatically on load when
+/// the GL control computes the model bounds.
+/// </summary>
+public partial class ModelPreviewPanel : UserControl
+{
+    private const float RotateStep = 0.1f;     // keyboard rotate step (radians), matches QM
+    private const float ButtonRotate = 0.3f;   // rotate-button step (radians), matches QM
+    private const float ZoomFactor = 1.2f;     // zoom-button multiplier, matches QM
+
+    private PreviewDragMode _dragMode = PreviewDragMode.None;
+    private Point _lastPointer;
+
+    public ModelPreviewPanel()
+    {
+        InitializeComponent();
+
+        InputSurface.PointerPressed += OnPointerPressed;
+        InputSurface.PointerMoved += OnPointerMoved;
+        InputSurface.PointerReleased += OnPointerReleased;
+        InputSurface.PointerWheelChanged += OnPointerWheel;
+        InputSurface.KeyDown += OnKeyDown;
+    }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    /// <summary>The hosted GL control. Hosts load models and set the texture service through this.</summary>
+    public ModelPreviewGLControl Preview => ModelPreviewGL;
+
+    // ----- Pointer / wheel / key forwarding (extracted from QM AppearancePanel #2124/#2430) -----
+
+    private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        var props = e.GetCurrentPoint(InputSurface).Properties;
+        bool shift = (e.KeyModifiers & KeyModifiers.Shift) != 0;
+
+        _dragMode = PreviewDragModeDecider.Decide(
+            isLeft: props.IsLeftButtonPressed,
+            isMiddle: props.IsMiddleButtonPressed,
+            shift: shift);
+
+        if (_dragMode == PreviewDragMode.None) return;
+
+        _lastPointer = e.GetPosition(InputSurface);
+        InputSurface.Focus();
+        e.Pointer.Capture(InputSurface);
+        e.Handled = true;
+    }
+
+    private void OnPointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (_dragMode == PreviewDragMode.None) return;
+
+        var pos = e.GetPosition(InputSurface);
+        double dx = pos.X - _lastPointer.X;
+        double dy = pos.Y - _lastPointer.Y;
+        _lastPointer = pos;
+
+        if (_dragMode == PreviewDragMode.Rotate)
+            ModelPreviewGL.RotateByPixels(dx, dy);
+        else if (_dragMode == PreviewDragMode.Pan)
+            ModelPreviewGL.PanByPixels(dx, dy);
+    }
+
+    private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (_dragMode == PreviewDragMode.None) return;
+        _dragMode = PreviewDragMode.None;
+        e.Pointer.Capture(null);
+        e.Handled = true;
+    }
+
+    private void OnPointerWheel(object? sender, PointerWheelEventArgs e)
+    {
+        var pos = e.GetPosition(ModelPreviewGL); // unproject uses GL viewport coords
+        ModelPreviewGL.ZoomAtCursorPixels(pos, e.Delta.Y);
+        e.Handled = true;
+    }
+
+    private void OnKeyDown(object? sender, KeyEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case Key.Left:
+            case Key.A:
+                ModelPreviewGL.Rotate(-RotateStep, 0);
+                break;
+            case Key.Right:
+            case Key.D:
+                ModelPreviewGL.Rotate(RotateStep, 0);
+                break;
+            case Key.Up:
+            case Key.W:
+                ModelPreviewGL.Rotate(0, -RotateStep);
+                break;
+            case Key.Down:
+            case Key.S:
+                ModelPreviewGL.Rotate(0, RotateStep);
+                break;
+            case Key.Home:
+                ModelPreviewGL.ResetView();
+                break;
+            default:
+                return;
+        }
+        e.Handled = true;
+    }
+
+    // ----- Camera button handlers -----
+
+    private void OnRotateLeftClicked(object? sender, RoutedEventArgs e) => ModelPreviewGL.Rotate(-ButtonRotate);
+    private void OnRotateRightClicked(object? sender, RoutedEventArgs e) => ModelPreviewGL.Rotate(ButtonRotate);
+    private void OnResetViewClicked(object? sender, RoutedEventArgs e) => ModelPreviewGL.ResetView();
+    private void OnZoomInClicked(object? sender, RoutedEventArgs e) => ModelPreviewGL.Zoom *= ZoomFactor;
+    private void OnZoomOutClicked(object? sender, RoutedEventArgs e) => ModelPreviewGL.Zoom /= ZoomFactor;
+}

--- a/Radoub.UI/Radoub.UI/Controls/PreviewDragModeDecider.cs
+++ b/Radoub.UI/Radoub.UI/Controls/PreviewDragModeDecider.cs
@@ -1,0 +1,27 @@
+namespace Radoub.UI.Controls;
+
+/// <summary>Active drag interaction in the shared model preview (#2430).</summary>
+public enum PreviewDragMode
+{
+    None,
+    Rotate,
+    Pan
+}
+
+/// <summary>
+/// Pure rotate-vs-pan decision for the model preview's pointer drag (#2430). Extracted from
+/// Quartermaster's AppearancePanel so the rule is testable without a live pointer/FlaUI.
+/// </summary>
+public static class PreviewDragModeDecider
+{
+    /// <summary>
+    /// Middle button or (left + Shift) → Pan; left alone → Rotate; anything else → None.
+    /// Middle wins over left so a middle-drag always pans even if left is also reported down.
+    /// </summary>
+    public static PreviewDragMode Decide(bool isLeft, bool isMiddle, bool shift)
+    {
+        if (isMiddle || (isLeft && shift)) return PreviewDragMode.Pan;
+        if (isLeft) return PreviewDragMode.Rotate;
+        return PreviewDragMode.None;
+    }
+}

--- a/Reliquary/CHANGELOG.md
+++ b/Reliquary/CHANGELOG.md
@@ -13,7 +13,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/); versioning via 
 
 - Adopt the shared `StatusBarControl` with a live module indicator (#2428).
 - 3D placeable preview gains rotate/zoom/pan/reset + fit-on-load camera controls and a backward-render fix, with the camera logic extracted into a shared Radoub.UI component (#2430).
-- Preview shows a state selector (open/closed/destroyed/activated) limited to states the loaded model provides (#2431).
+- Preview shows a state selector (open/closed/activated/deactivated) limited to states the loaded model provides; Destroyed is omitted since stock models render it identically to default (#2431).
 
 ---
 

--- a/Reliquary/CHANGELOG.md
+++ b/Reliquary/CHANGELOG.md
@@ -6,6 +6,17 @@ Format based on [Keep a Changelog](https://keepachangelog.com/); versioning via 
 
 ---
 
+## [0.10.0-alpha] - 2026-06-09
+**Branch**: `reliquary/sprint/preview-and-statusbar` | **PR**: #TBD
+
+### Sprint: 3D Preview Upgrades & Shared Status Bar
+
+- Adopt the shared `StatusBarControl` with a live module indicator (#2428).
+- 3D placeable preview gains rotate/zoom/pan/reset + fit-on-load camera controls and a backward-render fix, with the camera logic extracted into a shared Radoub.UI component (#2430).
+- Preview shows a state selector (open/closed/destroyed/activated) limited to states the loaded model provides (#2431).
+
+---
+
 ## [0.9.0-alpha] - 2026-06-07
 **Branch**: `reliquary/sprint/browser-polish-ci` | **PR**: #2427
 

--- a/Reliquary/CHANGELOG.md
+++ b/Reliquary/CHANGELOG.md
@@ -7,7 +7,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/); versioning via 
 ---
 
 ## [0.10.0-alpha] - 2026-06-09
-**Branch**: `reliquary/sprint/preview-and-statusbar` | **PR**: #TBD
+**Branch**: `reliquary/sprint/preview-and-statusbar` | **PR**: #2438
 
 ### Sprint: 3D Preview Upgrades & Shared Status Bar
 

--- a/Reliquary/CLAUDE.md
+++ b/Reliquary/CLAUDE.md
@@ -90,6 +90,22 @@ UTP files are GFF-based placeable blueprints. Parser/writer is in `Radoub.Format
 - `Conversation` — attached DLG resref
 - `ItemList` — inventory contents (PlaceableItem, when HasInventory)
 
+### Preview Animation States (#2431)
+
+The 3D preview state selector poses the model at the end frame of the state's MDL animation
+(`open`/`close`/`on`/`off`; BioWare Door/Placeable spec Table 4.1.2). A state is only offered when
+the model actually contains that animation.
+
+**Destroyed (state 3) is intentionally excluded from the selector.** Stock BioWare placeable MDLs
+carry these state animations as ~33 ms single-keyframe stubs with no geometry/scale transforms
+(verified on the standard chest, `PLC_A08`: `dead` is one frame, same 8 meshes / 208 verts as
+default). The model has no distinct destroyed/debris geometry — real runtime destruction (debris
+swap, removal) is **engine/script-driven**, not baked into the blueprint MDL, and the Aurora toolset
+shows the base model too. A Destroyed preview would look identical to Default, so it is filtered out
+in `PlaceableStateResolver.SelectorExcludedStates`. The other state stubs are kept (some models do
+provide visible open/close geometry). The `dead` mapping itself remains in the resolver — only the
+selector hides it.
+
 ---
 
 ## Development

--- a/Reliquary/Reliquary.Tests/Services/PlaceableStateResolverTests.cs
+++ b/Reliquary/Reliquary.Tests/Services/PlaceableStateResolverTests.cs
@@ -1,0 +1,106 @@
+using System.Linq;
+using PlaceableEditor.Services;
+using PlaceableEditor.ViewModels;
+using Radoub.Formats.Mdl;
+using Xunit;
+
+namespace PlaceableEditor.Tests.Services;
+
+/// <summary>
+/// State→animation resolution for the placeable preview (#2431). The available states for a model
+/// are Default (always) plus any of Open/Closed/Destroyed/Activated/Deactivated whose required MDL
+/// animation (open/close/dead/on/off — BioWare Door/Placeable spec Table 4.1.2) is present.
+/// </summary>
+public class PlaceableStateResolverTests
+{
+    private static MdlModel ModelWith(params string[] animationNames)
+    {
+        var model = new MdlModel();
+        foreach (var name in animationNames)
+            model.Animations.Add(new MdlAnimation { Name = name, Length = 1.0f });
+        return model;
+    }
+
+    [Fact]
+    public void ModelWithNoAnimations_OnlyDefault()
+    {
+        var states = PlaceableStateResolver.AvailableStates(ModelWith());
+        Assert.Equal(new byte[] { 0 }, states.Select(s => s.Value).ToArray());
+    }
+
+    [Fact]
+    public void NullModel_OnlyDefault()
+    {
+        var states = PlaceableStateResolver.AvailableStates(null);
+        Assert.Single(states);
+        Assert.Equal(0, states[0].Value);
+    }
+
+    [Fact]
+    public void OpenCloseAnimations_AddOpenAndClosedStates()
+    {
+        var states = PlaceableStateResolver.AvailableStates(ModelWith("open", "close"));
+        Assert.Equal(new byte[] { 0, 1, 2 }, states.Select(s => s.Value).ToArray());
+    }
+
+    [Fact]
+    public void AllStateAnimations_AllSixStates()
+    {
+        var states = PlaceableStateResolver.AvailableStates(ModelWith("open", "close", "dead", "on", "off"));
+        Assert.Equal(new byte[] { 0, 1, 2, 3, 4, 5 }, states.Select(s => s.Value).ToArray());
+    }
+
+    [Fact]
+    public void AnimationMatchIsCaseInsensitive()
+    {
+        var states = PlaceableStateResolver.AvailableStates(ModelWith("DEAD"));
+        Assert.Contains(states, s => s.Value == 3); // Destroyed
+    }
+
+    [Fact]
+    public void UnrelatedAnimations_Ignored()
+    {
+        var states = PlaceableStateResolver.AvailableStates(ModelWith("walk", "idle", "pause1"));
+        Assert.Equal(new byte[] { 0 }, states.Select(s => s.Value).ToArray());
+    }
+
+    [Theory]
+    [InlineData(1, "open")]
+    [InlineData(2, "close")]
+    [InlineData(3, "dead")]
+    [InlineData(4, "on")]
+    [InlineData(5, "off")]
+    public void AnimationNameForState_MatchesSpec(byte state, string expected)
+    {
+        Assert.Equal(expected, PlaceableStateResolver.AnimationNameForState(state));
+    }
+
+    [Fact]
+    public void AnimationNameForDefault_IsNull()
+    {
+        Assert.Null(PlaceableStateResolver.AnimationNameForState(0));
+    }
+
+    [Fact]
+    public void FindAnimation_ReturnsMatchingMdlAnimation()
+    {
+        var model = ModelWith("open", "close");
+        var anim = PlaceableStateResolver.FindAnimation(model, 1); // Open → "open"
+        Assert.NotNull(anim);
+        Assert.Equal("open", anim!.Name);
+    }
+
+    [Fact]
+    public void FindAnimation_DefaultState_ReturnsNull()
+    {
+        var model = ModelWith("open");
+        Assert.Null(PlaceableStateResolver.FindAnimation(model, 0));
+    }
+
+    [Fact]
+    public void FindAnimation_MissingAnimation_ReturnsNull()
+    {
+        var model = ModelWith("open");
+        Assert.Null(PlaceableStateResolver.FindAnimation(model, 3)); // no "dead"
+    }
+}

--- a/Reliquary/Reliquary.Tests/Services/PlaceableStateResolverTests.cs
+++ b/Reliquary/Reliquary.Tests/Services/PlaceableStateResolverTests.cs
@@ -44,17 +44,28 @@ public class PlaceableStateResolverTests
     }
 
     [Fact]
-    public void AllStateAnimations_AllSixStates()
+    public void AllStateAnimations_AllExceptDestroyed()
     {
+        // Destroyed (3) is excluded from the selector even when the model has a `dead` animation,
+        // because stock placeable `dead` stubs show no visible change (runtime/engine-driven).
         var states = PlaceableStateResolver.AvailableStates(ModelWith("open", "close", "dead", "on", "off"));
-        Assert.Equal(new byte[] { 0, 1, 2, 3, 4, 5 }, states.Select(s => s.Value).ToArray());
+        Assert.Equal(new byte[] { 0, 1, 2, 4, 5 }, states.Select(s => s.Value).ToArray());
+    }
+
+    [Fact]
+    public void DestroyedState_NeverOffered_EvenWithDeadAnimation()
+    {
+        var states = PlaceableStateResolver.AvailableStates(ModelWith("dead"));
+        Assert.DoesNotContain(states, s => s.Value == 3);
+        Assert.Equal(new byte[] { 0 }, states.Select(s => s.Value).ToArray());
     }
 
     [Fact]
     public void AnimationMatchIsCaseInsensitive()
     {
-        var states = PlaceableStateResolver.AvailableStates(ModelWith("DEAD"));
-        Assert.Contains(states, s => s.Value == 3); // Destroyed
+        // close (2) is offered; case-insensitive name match.
+        var states = PlaceableStateResolver.AvailableStates(ModelWith("CLOSE"));
+        Assert.Contains(states, s => s.Value == 2); // Closed
     }
 
     [Fact]

--- a/Reliquary/Reliquary/Services/PlaceableStateResolver.cs
+++ b/Reliquary/Reliquary/Services/PlaceableStateResolver.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PlaceableEditor.ViewModels;
+using Radoub.Formats.Mdl;
+
+namespace PlaceableEditor.Services;
+
+/// <summary>
+/// Resolves which placeable animation states a loaded model actually provides, and the MDL
+/// animation backing each (#2431). Source: BioWare Door/Placeable GFF spec Table 4.1.2 — a state
+/// is only available if the model contains an animation of the required name:
+///
+///   Open (1) → "open", Closed (2) → "close", Destroyed (3) → "dead",
+///   Activated (4) → "on", Deactivated (5) → "off".
+///
+/// Default (0) is always available and renders the base mesh with no animation. The byte values
+/// match <see cref="PlaceableAnimationState"/> / the stored UTP AnimationState.
+/// </summary>
+public static class PlaceableStateResolver
+{
+    // State byte → required MDL animation name (Default has none).
+    private static readonly IReadOnlyDictionary<byte, string> StateAnimationNames = new Dictionary<byte, string>
+    {
+        [1] = "open",
+        [2] = "close",
+        [3] = "dead",
+        [4] = "on",
+        [5] = "off",
+    };
+
+    /// <summary>
+    /// The MDL animation name required for a state, or null for Default (0) and any unknown value.
+    /// </summary>
+    public static string? AnimationNameForState(byte state)
+        => StateAnimationNames.TryGetValue(state, out var name) ? name : null;
+
+    /// <summary>
+    /// The states selectable for this model: Default (always) plus every non-default state whose
+    /// required animation is present in the model. Returned in value order (0..5).
+    /// </summary>
+    public static IReadOnlyList<PlaceableAnimationState> AvailableStates(MdlModel? model)
+    {
+        var result = new List<PlaceableAnimationState>();
+        foreach (var state in PlaceableAnimationState.All)
+        {
+            if (state.Value == 0) // Default: base mesh, always available
+            {
+                result.Add(state);
+                continue;
+            }
+            if (model != null && FindAnimation(model, state.Value) != null)
+                result.Add(state);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// The <see cref="MdlAnimation"/> backing a state in this model, or null if the state is Default
+    /// or the model has no matching animation. Name match is case-insensitive (MDL animation names
+    /// are not case-consistent across content).
+    /// </summary>
+    public static MdlAnimation? FindAnimation(MdlModel? model, byte state)
+    {
+        if (model == null) return null;
+        var name = AnimationNameForState(state);
+        if (name == null) return null;
+        return model.Animations.FirstOrDefault(
+            a => string.Equals(a.Name, name, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/Reliquary/Reliquary/Services/PlaceableStateResolver.cs
+++ b/Reliquary/Reliquary/Services/PlaceableStateResolver.cs
@@ -35,9 +35,15 @@ public static class PlaceableStateResolver
     public static string? AnimationNameForState(byte state)
         => StateAnimationNames.TryGetValue(state, out var name) ? name : null;
 
+    // States never offered in the preview selector even when the model declares the animation.
+    // Destroyed (3): stock MDLs ship a trivial single-frame `dead` stub with no debris geometry, so
+    // the preview is indistinguishable from Default. Real destruction is engine/script-driven at
+    // runtime, not baked into the blueprint MDL — showing it only misleads (user request).
+    private static readonly HashSet<byte> SelectorExcludedStates = new() { 3 };
+
     /// <summary>
-    /// The states selectable for this model: Default (always) plus every non-default state whose
-    /// required animation is present in the model. Returned in value order (0..5).
+    /// The states selectable for this model: Default (always) plus every non-default, non-excluded
+    /// state whose required animation is present in the model. Returned in value order.
     /// </summary>
     public static IReadOnlyList<PlaceableAnimationState> AvailableStates(MdlModel? model)
     {
@@ -49,6 +55,7 @@ public static class PlaceableStateResolver
                 result.Add(state);
                 continue;
             }
+            if (SelectorExcludedStates.Contains(state.Value)) continue;
             if (model != null && FindAnimation(model, state.Value) != null)
                 result.Add(state);
         }

--- a/Reliquary/Reliquary/Views/MainWindow.Document.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.Document.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Radoub.Formats.Settings;
 
 namespace PlaceableEditor.Views;
 
@@ -48,6 +49,7 @@ public partial class MainWindow
     private async void OnWindowClosing(object? sender, WindowClosingEventArgs e)
     {
         SaveWindowPosition(); // persist window size/position every close (#window-size)
+        RadoubSettings.Instance.PropertyChanged -= OnRadoubSettingsChanged; // stop reacting once closing (#2428)
 
         if (!_isDirty) return;
 

--- a/Reliquary/Reliquary/Views/MainWindow.Services.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.Services.cs
@@ -6,6 +6,7 @@ using Radoub.Formats.Common;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Services;
 using Radoub.Formats.Settings;
+using Radoub.UI.Controls;
 using Radoub.UI.Services;
 using PlaceableEditor.Services;
 using PlaceableEditor.Views.Panels;
@@ -72,6 +73,7 @@ public partial class MainWindow
         {
             if (_textureService != null)
                 identity.Preview.SetTextureService(_textureService);
+            identity.PreviewPanel.StateSelected += OnPreviewStateSelected; // #2431
             identity.AppearanceChanged += OnAppearanceChanged;
             identity.PortraitBrowseRequested += OnPortraitBrowseRequested;
             identity.PaletteCategoryChanged += OnPaletteCategorySelected;
@@ -134,11 +136,46 @@ public partial class MainWindow
         RefreshPortraitPreview();
     }
 
+    /// <summary>The model currently shown in the preview, kept so the state selector can re-pose it (#2431).</summary>
+    private Radoub.Formats.Mdl.MdlModel? _previewModel;
+
     private void UpdateModelPreview(uint appearanceId)
     {
         var identity = this.FindControl<IdentityCombatPanel>("IdentityCombatPanel");
         if (identity is null) return;
-        identity.Preview.Model = _modelLoader?.Load(appearanceId);
+
+        _previewModel = _modelLoader?.Load(appearanceId);
+        identity.Preview.Model = _previewModel;
+
+        // Offer only the states this model actually provides; default to the placeable's Initial
+        // State, falling back to Default when that state has no animation (#2431).
+        var available = PlaceableStateResolver.AvailableStates(_previewModel);
+        var initial = _placeable?.InitialState ?? 0;
+        if (available.All(s => s.Value != initial)) initial = 0;
+
+        var items = available
+            .Select(s => new ModelPreviewPanel.PreviewState(s.Value, s.Display))
+            .ToList();
+        identity.PreviewPanel.ShowStateSelector(items, initial);
+
+        PosePreviewState(initial);
+    }
+
+    /// <summary>
+    /// Pose the preview at a placeable animation state (#2431). Default (0) clears the animation and
+    /// shows the base mesh; other states select their animation and hold it at the final frame (the
+    /// state's resting pose). Resolution is model-driven via <see cref="PlaceableStateResolver"/>.
+    /// </summary>
+    private void PosePreviewState(byte state)
+    {
+        var identity = this.FindControl<IdentityCombatPanel>("IdentityCombatPanel");
+        if (identity is null) return;
+        var gl = identity.Preview;
+
+        var anim = PlaceableStateResolver.FindAnimation(_previewModel, state);
+        gl.SetActiveAnimation(anim);
+        if (anim != null)
+            gl.AnimationTime = anim.Length; // hold the end pose = the state's resting look
     }
 
     private void OnAppearanceChanged(object? sender, uint appearanceId)
@@ -151,6 +188,12 @@ public partial class MainWindow
             () => _placeable.Appearance, v => _placeable.Appearance = v, appearanceId, "change appearance"));
         UpdateModelPreview(appearanceId);
     }
+
+    /// <summary>
+    /// User picked a preview state (#2431) — pose the model. This is preview-only and does not touch
+    /// the placeable's stored InitialState (that is edited via the Initial State combo + undo).
+    /// </summary>
+    private void OnPreviewStateSelected(object? sender, byte state) => PosePreviewState(state);
 
     /// <summary>Populate the Identity panel's Faction combo from the module's repute.fac (#2354, moved #2425).</summary>
     private void PopulateFactionCombo()

--- a/Reliquary/Reliquary/Views/MainWindow.axaml
+++ b/Reliquary/Reliquary/Views/MainWindow.axaml
@@ -3,6 +3,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:panels="clr-namespace:PlaceableEditor.Views.Panels"
+        xmlns:controls="clr-namespace:Radoub.UI.Controls;assembly=Radoub.UI"
         mc:Ignorable="d" d:DesignWidth="1000" d:DesignHeight="700"
         x:Class="PlaceableEditor.Views.MainWindow"
         Title="Reliquary"
@@ -31,13 +32,8 @@
             </MenuItem>
         </Menu>
 
-        <Border DockPanel.Dock="Bottom"
-                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
-                BorderThickness="0,1,0,0"
-                Padding="8,4">
-            <TextBlock x:Name="StatusBar" Text="Ready"
-                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
-        </Border>
+        <controls:StatusBarControl x:Name="StatusBar" DockPanel.Dock="Bottom"
+                                   PrimaryText="Ready"/>
 
         <Grid x:Name="OuterContentGrid" ColumnDefinitions="260,4,*">
             <panels:PlaceableBrowserPanel x:Name="PlaceableBrowserPanel"

--- a/Reliquary/Reliquary/Views/MainWindow.axaml.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.axaml.cs
@@ -69,9 +69,19 @@ public partial class MainWindow : Window
         AvaloniaXamlLoader.Load(this);
     }
 
+    /// <summary>
+    /// The shared status bar, resolved by name. This window has a hand-written InitializeComponent
+    /// (it only calls AvaloniaXamlLoader.Load), so the name-generator's x:Name field is declared but
+    /// never assigned — accessing it directly NREs. FindControl resolves it from the loaded tree
+    /// (#2428 launch fix). Named StatusBarCtrl to avoid colliding with the generated StatusBar field.
+    /// </summary>
+    private Radoub.UI.Controls.StatusBarControl? StatusBarCtrl =>
+        this.FindControl<Radoub.UI.Controls.StatusBarControl>("StatusBar");
+
     private void UpdateStatus(string message)
     {
-        StatusBar.PrimaryText = message;
+        var bar = StatusBarCtrl;
+        if (bar != null) bar.PrimaryText = message;
     }
 
     /// <summary>
@@ -80,17 +90,20 @@ public partial class MainWindow : Window
     /// </summary>
     private void UpdateModuleIndicator()
     {
+        var bar = StatusBarCtrl;
+        if (bar == null) return;
+
         var modulePath = RadoubSettings.Instance.CurrentModulePath;
         if (!string.IsNullOrEmpty(modulePath))
         {
             var name = Path.GetFileNameWithoutExtension(modulePath);
-            StatusBar.ModuleIndicator = $"Module: {name}";
-            StatusBar.ModuleIndicatorForeground = BrushManager.GetInfoBrush(this);
+            bar.ModuleIndicator = $"Module: {name}";
+            bar.ModuleIndicatorForeground = BrushManager.GetInfoBrush(this);
         }
         else
         {
-            StatusBar.ModuleIndicator = "No module";
-            StatusBar.ModuleIndicatorForeground = BrushManager.GetWarningBrush(this);
+            bar.ModuleIndicator = "No module";
+            bar.ModuleIndicatorForeground = BrushManager.GetWarningBrush(this);
         }
     }
 

--- a/Reliquary/Reliquary/Views/MainWindow.axaml.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.axaml.cs
@@ -1,10 +1,13 @@
 using System;
+using System.ComponentModel;
+using System.IO;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.Platform.Storage;
 using Radoub.Formats.Logging;
+using Radoub.Formats.Settings;
 using Radoub.UI.Services;
 using PlaceableEditor.Views.Panels;
 
@@ -51,6 +54,10 @@ public partial class MainWindow : Window
         WireInventory();
         PopulateRecentFiles(); // show persisted MRU at launch (#2368)
 
+        // Shared status bar: show the active module and react when Trebuchet switches it (#2428).
+        UpdateModuleIndicator();
+        RadoubSettings.Instance.PropertyChanged += OnRadoubSettingsChanged;
+
         // Tunnel so F4 reaches us before a focused child (ComboBox etc.) can consume it.
         AddHandler(KeyDownEvent, OnWindowKeyDownTunnel, Avalonia.Interactivity.RoutingStrategies.Tunnel);
 
@@ -64,9 +71,45 @@ public partial class MainWindow : Window
 
     private void UpdateStatus(string message)
     {
-        var status = this.FindControl<TextBlock>("StatusBar");
-        if (status != null)
-            status.Text = message;
+        StatusBar.PrimaryText = message;
+    }
+
+    /// <summary>
+    /// Refresh the module indicator from <see cref="RadoubSettings.CurrentModulePath"/> (#2428).
+    /// Mirrors Relique's status bar: module name in the info color, or "No module" in warning.
+    /// </summary>
+    private void UpdateModuleIndicator()
+    {
+        var modulePath = RadoubSettings.Instance.CurrentModulePath;
+        if (!string.IsNullOrEmpty(modulePath))
+        {
+            var name = Path.GetFileNameWithoutExtension(modulePath);
+            StatusBar.ModuleIndicator = $"Module: {name}";
+            StatusBar.ModuleIndicatorForeground = BrushManager.GetInfoBrush(this);
+        }
+        else
+        {
+            StatusBar.ModuleIndicator = "No module";
+            StatusBar.ModuleIndicatorForeground = BrushManager.GetWarningBrush(this);
+        }
+    }
+
+    /// <summary>
+    /// React to Trebuchet switching the active module: refresh the indicator and re-point the
+    /// browser at the new module directory (#2428, mirrors Relique).
+    /// </summary>
+    private void OnRadoubSettingsChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(RadoubSettings.CurrentModulePath)) return;
+
+        UpdateModuleIndicator();
+        var moduleDir = GetModuleWorkingDirectory();
+        if (!string.IsNullOrEmpty(moduleDir))
+        {
+            var browser = this.FindControl<PlaceableBrowserPanel>("PlaceableBrowserPanel");
+            if (browser != null) browser.ModulePath = moduleDir;
+            UnifiedLogger.LogUI(LogLevel.INFO, "Reliquary: module path updated from Trebuchet");
+        }
     }
 
     private void OnExitClick(object? sender, RoutedEventArgs e) => Close();

--- a/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml
+++ b/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml
@@ -195,20 +195,14 @@
                 <GridSplitter Grid.Column="3" Width="4"
                               Background="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
 
-                <!-- 3D preview. Square (260x260) so the model fits at a 1:1 aspect; the panel root is
-                     a StackPanel, so an explicit Height (not just MinHeight) is required to give the GL
-                     control real bounds to render/camera-fit into (#2375). The control stretches to
-                     fill the Border, matching Quartermaster's AppearancePanel preview. -->
-                <Border Grid.Column="4" VerticalAlignment="Top"
-                        Height="260"
-                        Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
-                        BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
-                        BorderThickness="1">
-                    <ctrl:ModelPreviewGLControl x:Name="ModelPreview"
-                                                HorizontalAlignment="Stretch"
-                                                VerticalAlignment="Stretch"
-                                                AutomationProperties.AutomationId="Reliquary_ModelPreview"/>
-                </Border>
+                <!-- 3D preview with shared camera controls (#2430). The shared ModelPreviewPanel owns
+                     the GL control + transparent input surface + rotate/zoom/reset bar. An explicit
+                     Height (not just MinHeight) gives the GL control real bounds to camera-fit into
+                     (#2375); the +34 over the old 260 leaves room for the camera button row. -->
+                <ctrl:ModelPreviewPanel Grid.Column="4" x:Name="ModelPreview"
+                                        VerticalAlignment="Top"
+                                        Height="294"
+                                        AutomationProperties.AutomationId="Reliquary_ModelPreview"/>
             </Grid>
         </StackPanel>
     </Border>

--- a/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml.cs
+++ b/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml.cs
@@ -111,8 +111,12 @@ public partial class IdentityCombatPanel : UserControl
         AvaloniaXamlLoader.Load(this);
     }
 
-    /// <summary>The hosted 3D preview control (host loads the placeable MDL into it).</summary>
-    public ModelPreviewGLControl Preview => this.FindControl<ModelPreviewGLControl>("ModelPreview")!;
+    /// <summary>
+    /// The hosted 3D preview's GL control (host loads the placeable MDL into it). The panel now wraps
+    /// the GL control in the shared <see cref="ModelPreviewPanel"/> (camera controls, #2430), so this
+    /// reaches through to the inner control to keep the host's load/texture wiring unchanged.
+    /// </summary>
+    public ModelPreviewGLControl Preview => this.FindControl<ModelPreviewPanel>("ModelPreview")!.Preview;
 
     /// <summary>Fill the appearance combo from the shared placeable appearance service.</summary>
     public void PopulateAppearances(IPlaceableAppearanceService appearances, uint selectedId)

--- a/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml.cs
+++ b/Reliquary/Reliquary/Views/Panels/IdentityCombatPanel.axaml.cs
@@ -111,12 +111,15 @@ public partial class IdentityCombatPanel : UserControl
         AvaloniaXamlLoader.Load(this);
     }
 
+    /// <summary>The shared preview panel (camera controls #2430 + optional state selector #2431).</summary>
+    public ModelPreviewPanel PreviewPanel => this.FindControl<ModelPreviewPanel>("ModelPreview")!;
+
     /// <summary>
     /// The hosted 3D preview's GL control (host loads the placeable MDL into it). The panel now wraps
     /// the GL control in the shared <see cref="ModelPreviewPanel"/> (camera controls, #2430), so this
     /// reaches through to the inner control to keep the host's load/texture wiring unchanged.
     /// </summary>
-    public ModelPreviewGLControl Preview => this.FindControl<ModelPreviewPanel>("ModelPreview")!.Preview;
+    public ModelPreviewGLControl Preview => PreviewPanel.Preview;
 
     /// <summary>Fill the appearance combo from the shared placeable appearance service.</summary>
     public void PopulateAppearances(IPlaceableAppearanceService appearances, uint selectedId)


### PR DESCRIPTION
## Summary

Sprint bundling three Reliquary parity/preview items found while testing placeable previews after sprint #2420:

- **#2428** — Adopt shared `Radoub.UI.Controls.StatusBarControl` with a live module indicator (matches Relique).
- **#2430** — 3D preview camera controls (rotate/zoom/pan/reset + fit-on-load); extract a shared `Radoub.UI.ModelPreviewPanel` (input surface + camera bar) from Quartermaster's AppearancePanel and adopt it in Reliquary.
- **#2431** — Preview state selector (open/closed/activated/deactivated), limited to states the loaded model provides; defaults to the placeable's Initial State. Destroyed is omitted (stock models render `dead` identically to default — runtime/engine-driven; documented in CLAUDE.md).

Also fixed a startup NRE (named controls resolved via FindControl, not unassigned name-gen fields).

## Related Issues

- Closes #2428
- Closes #2430
- Closes #2431

Follow-ups filed: #2439 (emitter over-render in preview). QM/Relique migration to the shared ModelPreviewPanel is a noted follow-up (#2430 allowed Reliquary-first).

## Tests

- Unit: 2574 passed, 0 failed (Reliquary 135, Radoub.UI 1025, Formats 1339, Dictionary 75).
- FlaUI (Reliquary): 7 passed, 0 failed.
- Privacy scan ✅ · Tech debt ✅ (no files >800 lines) · Theme warnings are all pre-existing, none in changed files.

## Manual verification

Status bar module indicator, camera rotate/zoom/pan, state selector (open/closed/activated), Destroyed-omitted — all verified in the running app.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)