### PR TITLE
[Trebuchet] Sprint: Utility & Polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Radoub.Formats 0.2.67-alpha] - 2026-06-10
 **Branch**: `trebuchet/issue-1985` | **PR**: #2452
 
-### ModuleHakResolver: resolve HAK names directly (#1162)
+### HAK resolution + first-run wizard settings (#1162, #1020)
 
-- New `ResolveHakNames(names, searchPaths)` resolves an in-memory HAK list (no module.ifo read) to file paths in priority order and reports names it could not find. Used by Trebuchet's HAK conflict checker.
+- `ModuleHakResolver.ResolveHakNames(names, searchPaths)` resolves an in-memory HAK list (no module.ifo read) to file paths in priority order and reports names it could not find. Used by Trebuchet's HAK conflict checker.
+- `RadoubSettings` gained `WizardHasRun` + `AcknowledgedWizardGaps` (with `AcknowledgeWizardGaps`) to back Trebuchet's first-run / welcome-back wizard. Additive and back-compatible — older settings files load with the wizard treated as not-yet-run.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.Formats 0.2.67-alpha] - 2026-06-10
+**Branch**: `trebuchet/issue-1985` | **PR**: #2452
+
+### ModuleHakResolver: resolve HAK names directly (#1162)
+
+- New `ResolveHakNames(names, searchPaths)` resolves an in-memory HAK list (no module.ifo read) to file paths in priority order and reports names it could not find. Used by Trebuchet's HAK conflict checker.
+
+---
+
 ## [Radoub.UI 0.2.10-alpha] - 2026-06-09
 **Branch**: `quartermaster/issue-2434` | **PR**: #2449
 

--- a/Radoub.Formats/Radoub.Formats.Tests/ModuleHakResolverTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/ModuleHakResolverTests.cs
@@ -203,6 +203,58 @@ public class ModuleHakResolverTests : IDisposable
 
     #endregion
 
+    #region ResolveHakNames (direct, no module.ifo)
+
+    [Fact]
+    public void ResolveHakNames_ResolvesNamesInOrder()
+    {
+        var hakDir = CreateHakDir("first.hak", "second.hak");
+
+        var result = ModuleHakResolver.ResolveHakNames(new[] { "first", "second" }, new[] { hakDir });
+
+        Assert.Equal(2, result.Resolved.Count);
+        Assert.EndsWith("first.hak", result.Resolved[0]);
+        Assert.EndsWith("second.hak", result.Resolved[1]);
+        Assert.Empty(result.Unresolved);
+    }
+
+    [Fact]
+    public void ResolveHakNames_ReportsUnresolvedNames()
+    {
+        var hakDir = CreateHakDir("present.hak");
+
+        var result = ModuleHakResolver.ResolveHakNames(new[] { "present", "absent" }, new[] { hakDir });
+
+        Assert.Single(result.Resolved);
+        Assert.EndsWith("present.hak", result.Resolved[0]);
+        Assert.Equal(new[] { "absent" }, result.Unresolved);
+    }
+
+    [Fact]
+    public void ResolveHakNames_StripsHakExtensionFromName()
+    {
+        var hakDir = CreateHakDir("withext.hak");
+
+        var result = ModuleHakResolver.ResolveHakNames(new[] { "withext.hak" }, new[] { hakDir });
+
+        Assert.Single(result.Resolved);
+        Assert.EndsWith("withext.hak", result.Resolved[0]);
+        Assert.Empty(result.Unresolved);
+    }
+
+    [Fact]
+    public void ResolveHakNames_EmptyNames_ReturnsEmpty()
+    {
+        var hakDir = CreateHakDir("a.hak");
+
+        var result = ModuleHakResolver.ResolveHakNames(Array.Empty<string>(), new[] { hakDir });
+
+        Assert.Empty(result.Resolved);
+        Assert.Empty(result.Unresolved);
+    }
+
+    #endregion
+
     #region Edge Cases
 
     [Fact]

--- a/Radoub.Formats/Radoub.Formats.Tests/RadoubSettingsTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/RadoubSettingsTests.cs
@@ -116,6 +116,45 @@ public class RadoubSettingsTests
     }
 
     [Fact]
+    public void WizardState_DefaultsToNotRunWithNoAcknowledgedGaps()
+    {
+        var settings = RadoubSettings.Instance;
+
+        Assert.False(settings.WizardHasRun);
+        Assert.Empty(settings.AcknowledgedWizardGaps);
+    }
+
+    [Fact]
+    public void AcknowledgeWizardGaps_PersistsAndSurvivesReload()
+    {
+        var settings = RadoubSettings.Instance;
+        settings.AcknowledgeWizardGaps(new[] { "gamePath", "theme" });
+
+        Assert.True(settings.WizardHasRun);
+        Assert.Contains("gamePath", settings.AcknowledgedWizardGaps);
+        Assert.Contains("theme", settings.AcknowledgedWizardGaps);
+
+        // Simulate a fresh process: reset singleton, reload from disk.
+        ResetAndConfigure();
+        var reloaded = RadoubSettings.Instance;
+
+        Assert.True(reloaded.WizardHasRun);
+        Assert.Contains("gamePath", reloaded.AcknowledgedWizardGaps);
+        Assert.Contains("theme", reloaded.AcknowledgedWizardGaps);
+    }
+
+    [Fact]
+    public void AcknowledgeWizardGaps_MergesWithPreviousAcknowledgements()
+    {
+        var settings = RadoubSettings.Instance;
+        settings.AcknowledgeWizardGaps(new[] { "gamePath" });
+        settings.AcknowledgeWizardGaps(new[] { "newGap" });
+
+        Assert.Contains("gamePath", settings.AcknowledgedWizardGaps);
+        Assert.Contains("newGap", settings.AcknowledgedWizardGaps);
+    }
+
+    [Fact]
     public void Settings_SurviveNewInstance()
     {
         // First instance writes settings

--- a/Radoub.Formats/Radoub.Formats/Resolver/ModuleHakResolver.cs
+++ b/Radoub.Formats/Radoub.Formats/Resolver/ModuleHakResolver.cs
@@ -72,6 +72,38 @@ public static class ModuleHakResolver
     }
 
     /// <summary>
+    /// Resolve a list of HAK names (in priority order) to file paths, without
+    /// reading module.ifo. Use this when the caller already has the HAK list in
+    /// memory (e.g. an editor's working copy with unsaved reorders). Names may
+    /// include a trailing ".hak" extension, which is stripped. Returns resolved
+    /// paths in input order plus the names that could not be found.
+    /// </summary>
+    public static HakNameResolution ResolveHakNames(IEnumerable<string> hakNames, IEnumerable<string> hakSearchPaths)
+    {
+        var searchDirs = hakSearchPaths.Where(Directory.Exists).ToList();
+        var resolved = new List<string>();
+        var unresolved = new List<string>();
+
+        foreach (var rawName in hakNames)
+        {
+            if (string.IsNullOrWhiteSpace(rawName))
+                continue;
+
+            var name = rawName.Trim();
+            if (name.EndsWith(".hak", StringComparison.OrdinalIgnoreCase))
+                name = name[..^4];
+
+            var path = searchDirs.Count > 0 ? FindHakFile(name, searchDirs) : null;
+            if (path != null)
+                resolved.Add(path);
+            else
+                unresolved.Add(name);
+        }
+
+        return new HakNameResolution(resolved, unresolved);
+    }
+
+    /// <summary>
     /// Find a HAK file by name (without extension) in the search directories.
     /// Case-insensitive search for cross-platform compatibility.
     /// </summary>
@@ -105,3 +137,9 @@ public static class ModuleHakResolver
         return null;
     }
 }
+
+/// <summary>
+/// Result of resolving HAK names to file paths: the resolved paths (in input
+/// order) and the names that could not be found in any search directory.
+/// </summary>
+public sealed record HakNameResolution(IReadOnlyList<string> Resolved, IReadOnlyList<string> Unresolved);

--- a/Radoub.Formats/Radoub.Formats/Settings/RadoubSettings.Persistence.cs
+++ b/Radoub.Formats/Radoub.Formats/Settings/RadoubSettings.Persistence.cs
@@ -85,6 +85,12 @@ public partial class RadoubSettings
                     // Backup settings
                     _backupRetentionDays = Math.Max(1, Math.Min(90, data.BackupRetentionDays));
 
+                    // First-run wizard state (#1020). Missing in older JSON → defaults
+                    // (empty list, not run) so existing users are treated as "has run
+                    // before" only once the wizard records itself.
+                    _acknowledgedWizardGaps = data.AcknowledgedWizardGaps ?? new List<string>();
+                    _wizardHasRun = data.WizardHasRun;
+
                     // Garbage filters
                     if (data.GarbageFilters != null && data.GarbageFilters.Count > 0)
                         _garbageFilters = data.GarbageFilters.Where(f => !string.IsNullOrWhiteSpace(f)).ToList();
@@ -168,6 +174,10 @@ public partial class RadoubSettings
                 // Backup settings
                 BackupRetentionDays = _backupRetentionDays,
 
+                // First-run wizard state
+                AcknowledgedWizardGaps = _acknowledgedWizardGaps,
+                WizardHasRun = _wizardHasRun,
+
                 // Garbage filters
                 GarbageFilters = _garbageFilters,
             };
@@ -217,6 +227,10 @@ public partial class RadoubSettings
 
         // Backup settings (shared across all tools)
         public int BackupRetentionDays { get; set; } = 30;
+
+        // First-run wizard state (#1020) — optional; absent in older JSON.
+        public List<string>? AcknowledgedWizardGaps { get; set; }
+        public bool WizardHasRun { get; set; }
 
         // Garbage label filters (shared across all tools)
         public List<string>? GarbageFilters { get; set; }

--- a/Radoub.Formats/Radoub.Formats/Settings/RadoubSettings.cs
+++ b/Radoub.Formats/Radoub.Formats/Settings/RadoubSettings.cs
@@ -89,6 +89,12 @@ public partial class RadoubSettings : INotifyPropertyChanged
     // Backup settings (shared across all tools)
     private int _backupRetentionDays = 30;
 
+    // First-run wizard: gap keys the user has already been shown (#1020). Lets the
+    // welcome-back wizard surface only newly-introduced no-default settings, and
+    // never re-nag about gaps the user saw and chose to leave unset.
+    private List<string> _acknowledgedWizardGaps = new();
+    private bool _wizardHasRun = false;
+
     // Garbage label filters (shared across all tools)
     private List<string> _garbageFilters = GetDefaultGarbageFilters();
 
@@ -554,6 +560,33 @@ public partial class RadoubSettings : INotifyPropertyChanged
     /// Check if game paths are configured.
     /// </summary>
     public bool HasGamePaths => !string.IsNullOrEmpty(_baseGameInstallPath) || !string.IsNullOrEmpty(_neverwinterNightsPath);
+
+    /// <summary>
+    /// True once the first-run wizard has completed at least once (#1020).
+    /// Distinguishes a genuine first run from a configured user who hit a new gap.
+    /// </summary>
+    public bool WizardHasRun => _wizardHasRun;
+
+    /// <summary>
+    /// Gap keys the wizard has already shown the user (#1020). A copy — mutate via
+    /// <see cref="AcknowledgeWizardGaps"/>.
+    /// </summary>
+    public IReadOnlyList<string> AcknowledgedWizardGaps => _acknowledgedWizardGaps.AsReadOnly();
+
+    /// <summary>
+    /// Record that the wizard ran and the given gap keys were shown. Merges with
+    /// any previously-acknowledged keys so older acknowledgements are preserved.
+    /// </summary>
+    public void AcknowledgeWizardGaps(IEnumerable<string> gapKeys)
+    {
+        var merged = new HashSet<string>(_acknowledgedWizardGaps);
+        foreach (var key in gapKeys)
+            merged.Add(key);
+
+        _acknowledgedWizardGaps = merged.ToList();
+        _wizardHasRun = true;
+        SaveSettings();
+    }
 
     /// <summary>
     /// Check if CurrentModulePath points to a valid module (not just the modules parent directory).

--- a/Radoub.IntegrationTests/Shared/FlaUITestBase.cs
+++ b/Radoub.IntegrationTests/Shared/FlaUITestBase.cs
@@ -127,10 +127,16 @@ public abstract class FlaUITestBase : IDisposable
         // IMPORTANT: Set BaseGameInstallPath to a non-empty value to prevent AutoDetectPaths() from
         // finding user's actual Steam/GOG installation (which scans 80+ HAK files and slows startup)
         // We use TestGameRoot even though it doesn't have BIF files - that's OK for UI tests
+        //
+        // WizardHasRun=true suppresses Trebuchet's first-run configuration wizard (#1020),
+        // which otherwise auto-fires over the main window for a "fresh" settings dir (which is
+        // exactly what every isolated test dir looks like) and steals focus from the tests.
         var radoubSettings = $@"{{
   ""BaseGameInstallPath"": ""{TestPaths.TestGameRoot.Replace("\\", "\\\\")}"",
   ""NeverwinterNightsPath"": ""{TestPaths.TestGameRoot.Replace("\\", "\\\\")}"",
-  ""CurrentModulePath"": ""{TestPaths.TestModuleDirectory.Replace("\\", "\\\\")}""
+  ""CurrentModulePath"": ""{TestPaths.TestModuleDirectory.Replace("\\", "\\\\")}"",
+  ""WizardHasRun"": true,
+  ""AcknowledgedWizardGaps"": [ ""gamePath"", ""appearance"", ""logging"", ""backup"" ]
 }}";
         File.WriteAllText(Path.Combine(_isolatedSettingsDir, "RadoubSettings.json"), radoubSettings);
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.37.0-alpha] - 2026-06-10
+**Branch**: `trebuchet/issue-1985` | **PR**: #TBD
+
+### Sprint: Utility & Polish
+
+- HAK conflict checker in the Module Editor HAK Files tab — lists ResRefs that appear in multiple HAKs and the winning (first-priority) HAK (#1162).
+- First-run / welcome-back configuration wizard that fills required settings with no good default, then lands on an editable summary (#1020).
+- Desktop shortcut creation offered from the wizard (Windows/Linux), replacing the standalone-scripts approach (#1437).
+
+---
+
 ## [1.36.9-alpha] - 2026-06-06
 **Branch**: `trebuchet/sprint/data-loss-marlinspike` | **PR**: #2387
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [1.37.0-alpha] - 2026-06-10
-**Branch**: `trebuchet/issue-1985` | **PR**: #TBD
+**Branch**: `trebuchet/issue-1985` | **PR**: #2452
 
 ### Sprint: Utility & Polish
 

--- a/Trebuchet/Trebuchet.Tests/DesktopShortcutServiceTests.cs
+++ b/Trebuchet/Trebuchet.Tests/DesktopShortcutServiceTests.cs
@@ -62,18 +62,23 @@ public class DesktopShortcutServiceTests
     [Fact]
     public void GetLinuxDesktopFilePath_SanitizesNameToLowercaseDashed()
     {
-        var path = DesktopShortcutService.GetLinuxDesktopFilePath("/home/u/.local/share/applications", "Trebuchet");
+        // Neutral root (not /home/<user> or /Users/<user>) so the privacy scanner
+        // doesn't flag a hardcoded user path. Path.Combine keeps it separator-agnostic.
+        var appsDir = Path.Combine("apps");
+        var path = DesktopShortcutService.GetLinuxDesktopFilePath(appsDir, "Trebuchet");
 
-        Assert.Equal(
-            Path.Combine("/home/u/.local/share/applications", "trebuchet.desktop"),
-            path);
+        Assert.Equal(Path.Combine(appsDir, "trebuchet.desktop"), path);
     }
 
     [Fact]
     public void GetWindowsShortcutPath_EndsWithLnkOnDesktop()
     {
-        var path = DesktopShortcutService.GetWindowsShortcutPath(@"C:\Users\u\Desktop", "Trebuchet");
+        // Neutral root (not C:\Users\<user>) for the privacy scanner; Path.Combine
+        // matches the host separator, and the production code uses Path.Combine too,
+        // so this passes on both Windows and the Linux CI runner.
+        var desktop = Path.Combine("desktop");
+        var path = DesktopShortcutService.GetWindowsShortcutPath(desktop, "Trebuchet");
 
-        Assert.Equal(@"C:\Users\u\Desktop\Trebuchet.lnk", path);
+        Assert.Equal(Path.Combine(desktop, "Trebuchet.lnk"), path);
     }
 }

--- a/Trebuchet/Trebuchet.Tests/DesktopShortcutServiceTests.cs
+++ b/Trebuchet/Trebuchet.Tests/DesktopShortcutServiceTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using RadoubLauncher.Services;
+using Xunit;
+
+namespace Trebuchet.Tests;
+
+/// <summary>
+/// Tests for the platform-agnostic parts of desktop shortcut creation (#1437):
+/// the freedesktop .desktop entry content and target-path construction. Actual
+/// .lnk COM creation and filesystem writes are platform side effects verified
+/// manually.
+/// </summary>
+public class DesktopShortcutServiceTests
+{
+    [Fact]
+    public void BuildLinuxDesktopEntry_StartsWithDesktopEntryHeader()
+    {
+        var entry = DesktopShortcutService.BuildLinuxDesktopEntry(
+            name: "Trebuchet", execPath: "/opt/trebuchet/Trebuchet", iconPath: "/opt/trebuchet/icon.png",
+            comment: "Radoub launcher");
+
+        Assert.StartsWith("[Desktop Entry]", entry);
+    }
+
+    [Fact]
+    public void BuildLinuxDesktopEntry_ContainsRequiredKeys()
+    {
+        var entry = DesktopShortcutService.BuildLinuxDesktopEntry(
+            name: "Trebuchet", execPath: "/opt/trebuchet/Trebuchet", iconPath: "/opt/trebuchet/icon.png",
+            comment: "Radoub launcher");
+
+        Assert.Contains("Type=Application", entry);
+        Assert.Contains("Name=Trebuchet", entry);
+        Assert.Contains("Exec=/opt/trebuchet/Trebuchet", entry);
+        Assert.Contains("Icon=/opt/trebuchet/icon.png", entry);
+        Assert.Contains("Comment=Radoub launcher", entry);
+        Assert.Contains("Terminal=false", entry);
+        Assert.Contains("Categories=", entry);
+    }
+
+    [Fact]
+    public void BuildLinuxDesktopEntry_QuotesExecPathWithSpaces()
+    {
+        // freedesktop spec: arguments with spaces must be quoted in Exec.
+        var entry = DesktopShortcutService.BuildLinuxDesktopEntry(
+            name: "Trebuchet", execPath: "/home/My Apps/Trebuchet", iconPath: "/home/My Apps/icon.png",
+            comment: "x");
+
+        Assert.Contains("Exec=\"/home/My Apps/Trebuchet\"", entry);
+    }
+
+    [Fact]
+    public void BuildLinuxDesktopEntry_OmitsIconLineWhenIconPathEmpty()
+    {
+        var entry = DesktopShortcutService.BuildLinuxDesktopEntry(
+            name: "Trebuchet", execPath: "/opt/trebuchet/Trebuchet", iconPath: "", comment: "x");
+
+        Assert.DoesNotContain("Icon=", entry);
+    }
+
+    [Fact]
+    public void GetLinuxDesktopFilePath_SanitizesNameToLowercaseDashed()
+    {
+        var path = DesktopShortcutService.GetLinuxDesktopFilePath("/home/u/.local/share/applications", "Trebuchet");
+
+        Assert.Equal(
+            Path.Combine("/home/u/.local/share/applications", "trebuchet.desktop"),
+            path);
+    }
+
+    [Fact]
+    public void GetWindowsShortcutPath_EndsWithLnkOnDesktop()
+    {
+        var path = DesktopShortcutService.GetWindowsShortcutPath(@"C:\Users\u\Desktop", "Trebuchet");
+
+        Assert.Equal(@"C:\Users\u\Desktop\Trebuchet.lnk", path);
+    }
+}

--- a/Trebuchet/Trebuchet.Tests/FirstRunWizardViewModelTests.cs
+++ b/Trebuchet/Trebuchet.Tests/FirstRunWizardViewModelTests.cs
@@ -1,0 +1,72 @@
+using System.Linq;
+using RadoubLauncher.Services;
+using RadoubLauncher.ViewModels;
+using Xunit;
+
+namespace Trebuchet.Tests;
+
+/// <summary>
+/// Tests for the first-run wizard navigation and summary behavior (#1020).
+/// These exercise the crash fixed after the backup-slider report: changing a
+/// value must not rebuild the summary collection on every tick, and summary rows
+/// must carry their own jump command (no fragile $parent-cast XAML binding).
+///
+/// The view model is constructed headless (no Window, no ThemeManager) via the
+/// test constructor so navigation/summary logic is unit-testable without FlaUI.
+/// </summary>
+public class FirstRunWizardViewModelTests
+{
+    private static FirstRunWizardViewModel CreateHeadless() =>
+        FirstRunWizardViewModel.CreateForTest(WizardMode.Welcome);
+
+    [Fact]
+    public void ChangingBackupRetention_DoesNotRebuildSummaryRows()
+    {
+        var vm = CreateHeadless();
+        vm.StepIndex = vm.LastStepIndex; // show summary → builds rows once
+        var rowsBefore = vm.SummaryRows.ToList();
+
+        vm.BackupRetentionDays = 45;
+
+        // The collection instance contents should not have been cleared/rebuilt by
+        // the value change itself (that thrash + the summary's live bindings was the
+        // crash). The displayed value updates when the summary is (re)entered.
+        Assert.Same(rowsBefore[0], vm.SummaryRows[0]);
+    }
+
+    [Fact]
+    public void EnteringSummaryStep_RefreshesValues()
+    {
+        var vm = CreateHeadless();
+        vm.BackupRetentionDays = 60;
+
+        vm.StepIndex = vm.LastStepIndex; // enter summary
+
+        var backupRow = vm.SummaryRows.Single(r => r.Label == "Backup retention");
+        Assert.Contains("60", backupRow.Value);
+    }
+
+    [Fact]
+    public void SummaryRow_JumpCommand_NavigatesToItsStep()
+    {
+        var vm = CreateHeadless();
+        vm.StepIndex = vm.LastStepIndex;
+
+        var gameRow = vm.SummaryRows.Single(r => r.Label == "Game path");
+        gameRow.Jump.Execute(null);
+
+        Assert.Equal(gameRow.StepIndex, vm.StepIndex);
+    }
+
+    [Fact]
+    public void BackupRetentionDays_ClampsToValidRange()
+    {
+        var vm = CreateHeadless();
+
+        vm.BackupRetentionDays = 999;
+        Assert.True(vm.BackupRetentionDays <= 90);
+
+        vm.BackupRetentionDays = 0;
+        Assert.True(vm.BackupRetentionDays >= 1);
+    }
+}

--- a/Trebuchet/Trebuchet.Tests/HakConflictCheckerServiceTests.cs
+++ b/Trebuchet/Trebuchet.Tests/HakConflictCheckerServiceTests.cs
@@ -1,0 +1,137 @@
+using System.Collections.Generic;
+using System.Linq;
+using Radoub.Formats.Common;
+using Radoub.Formats.Erf;
+using RadoubLauncher.Services;
+using Xunit;
+
+namespace Trebuchet.Tests;
+
+/// <summary>
+/// Tests for HAK conflict detection (#1162). Exercises the pure detection core
+/// (FindConflicts) so no real .hak files on disk are needed — each "HAK" is a
+/// named list of ErfResourceEntry rows. Winner = first HAK in priority order
+/// (BioWare IFO spec: earlier HAKs override later ones).
+/// </summary>
+public class HakConflictCheckerServiceTests
+{
+    private static ErfResourceEntry Res(string resRef, ushort type) =>
+        new() { ResRef = resRef, ResourceType = type };
+
+    private static HakContents Hak(string name, params ErfResourceEntry[] entries) =>
+        new(name, entries.ToList());
+
+    [Fact]
+    public void FindConflicts_NoOverlap_ReturnsEmpty()
+    {
+        var haks = new[]
+        {
+            Hak("top", Res("alpha", ResourceTypes.Utc)),
+            Hak("bottom", Res("beta", ResourceTypes.Utc)),
+        };
+
+        var conflicts = HakConflictCheckerService.FindConflicts(haks);
+
+        Assert.Empty(conflicts);
+    }
+
+    [Fact]
+    public void FindConflicts_SameResRefSameTypeInTwoHaks_IsConflict()
+    {
+        var haks = new[]
+        {
+            Hak("top", Res("dupe", ResourceTypes.Utc)),
+            Hak("bottom", Res("dupe", ResourceTypes.Utc)),
+        };
+
+        var conflicts = HakConflictCheckerService.FindConflicts(haks);
+
+        var conflict = Assert.Single(conflicts);
+        Assert.Equal("dupe", conflict.ResRef);
+        Assert.Equal(ResourceTypes.Utc, conflict.ResourceType);
+        Assert.Equal(new[] { "top", "bottom" }, conflict.ContainingHaks);
+    }
+
+    [Fact]
+    public void FindConflicts_WinnerIsFirstHakInPriorityOrder()
+    {
+        // "top" appears before "bottom" in the list → top wins (first = highest priority).
+        var haks = new[]
+        {
+            Hak("top", Res("dupe", ResourceTypes.Mdl)),
+            Hak("bottom", Res("dupe", ResourceTypes.Mdl)),
+        };
+
+        var conflict = Assert.Single(HakConflictCheckerService.FindConflicts(haks));
+
+        Assert.Equal("top", conflict.WinnerHak);
+    }
+
+    [Fact]
+    public void FindConflicts_SameResRefDifferentType_IsNotConflict()
+    {
+        // foo.nss and foo.utc are different resources despite sharing the ResRef.
+        var haks = new[]
+        {
+            Hak("top", Res("foo", ResourceTypes.Nss)),
+            Hak("bottom", Res("foo", ResourceTypes.Utc)),
+        };
+
+        Assert.Empty(HakConflictCheckerService.FindConflicts(haks));
+    }
+
+    [Fact]
+    public void FindConflicts_ThreeWayConflict_ListsAllHaksInPriorityOrder()
+    {
+        var haks = new[]
+        {
+            Hak("first", Res("shared", ResourceTypes.TwoDA)),
+            Hak("second", Res("shared", ResourceTypes.TwoDA)),
+            Hak("third", Res("shared", ResourceTypes.TwoDA)),
+        };
+
+        var conflict = Assert.Single(HakConflictCheckerService.FindConflicts(haks));
+
+        Assert.Equal(new[] { "first", "second", "third" }, conflict.ContainingHaks);
+        Assert.Equal("first", conflict.WinnerHak);
+    }
+
+    [Fact]
+    public void FindConflicts_ResRefMatchIsCaseInsensitive()
+    {
+        // Aurora ResRefs are case-insensitive; "Dupe" and "dupe" are the same resource.
+        var haks = new[]
+        {
+            Hak("top", Res("Dupe", ResourceTypes.Utc)),
+            Hak("bottom", Res("dupe", ResourceTypes.Utc)),
+        };
+
+        var conflict = Assert.Single(HakConflictCheckerService.FindConflicts(haks));
+        Assert.Equal(new[] { "top", "bottom" }, conflict.ContainingHaks);
+    }
+
+    [Fact]
+    public void FindConflicts_DuplicateResRefWithinSingleHak_IsNotConflict()
+    {
+        // A resource appearing twice in ONE hak is not a cross-hak conflict.
+        var haks = new[]
+        {
+            Hak("only", Res("dupe", ResourceTypes.Utc), Res("dupe", ResourceTypes.Utc)),
+        };
+
+        Assert.Empty(HakConflictCheckerService.FindConflicts(haks));
+    }
+
+    [Fact]
+    public void FindConflicts_PopulatesExtensionForDisplay()
+    {
+        var haks = new[]
+        {
+            Hak("top", Res("dupe", ResourceTypes.Nss)),
+            Hak("bottom", Res("dupe", ResourceTypes.Nss)),
+        };
+
+        var conflict = Assert.Single(HakConflictCheckerService.FindConflicts(haks));
+        Assert.Equal(".nss", conflict.Extension);
+    }
+}

--- a/Trebuchet/Trebuchet.Tests/WizardGapServiceTests.cs
+++ b/Trebuchet/Trebuchet.Tests/WizardGapServiceTests.cs
@@ -17,8 +17,10 @@ public class WizardGapServiceTests
         new(key, satisfied, hasGoodDefault);
 
     [Fact]
-    public void Decide_FirstRun_UnsetRequiredGap_ShowsWelcome()
+    public void Decide_FirstRun_AlwaysShowsWelcome_SurfacingAllSteps()
     {
+        // First run always reviews everything once — even an auto-detected game path
+        // gets shown for confirmation. GapStepKeys is every registered key.
         var gaps = new[] { Gap("gamePath", satisfied: false) };
 
         var decision = WizardGapService.Decide(gaps, acknowledgedKeys: Array.Empty<string>(), hasRunBefore: false);
@@ -29,25 +31,39 @@ public class WizardGapServiceTests
     }
 
     [Fact]
-    public void Decide_AllSatisfied_FirstRun_DoesNotShow()
+    public void Decide_FirstRun_EvenWhenAllSatisfied_StillShowsWelcome()
     {
+        // The original bug (#1985 follow-up): auto-detect fills the game path, so a
+        // "show only when something is unset" rule never fired on a configured
+        // machine. First run is a one-time review, so it must show regardless.
         var gaps = new[] { Gap("gamePath", satisfied: true) };
 
         var decision = WizardGapService.Decide(gaps, acknowledgedKeys: Array.Empty<string>(), hasRunBefore: false);
 
-        Assert.False(decision.ShouldShow);
-        Assert.Equal(WizardMode.None, decision.Mode);
+        Assert.True(decision.ShouldShow);
+        Assert.Equal(WizardMode.Welcome, decision.Mode);
     }
 
     [Fact]
-    public void Decide_GapWithGoodDefault_NotForced_DoesNotShow()
+    public void Decide_FirstRun_WithOnlyGoodDefaultGaps_StillShowsForReview()
     {
-        // A setting with a good default is never a forced gap even when "unset".
-        var gaps = new[] { Gap("theme", satisfied: false, hasGoodDefault: true) };
+        // Logging/backup have good defaults but are part of the one-time review.
+        var gaps = new[] { Gap("logging", satisfied: true, hasGoodDefault: true) };
 
         var decision = WizardGapService.Decide(gaps, acknowledgedKeys: Array.Empty<string>(), hasRunBefore: false);
 
+        Assert.True(decision.ShouldShow);
+        Assert.Equal(WizardMode.Welcome, decision.Mode);
+    }
+
+    [Fact]
+    public void Decide_FirstRun_NoGapsRegistered_DoesNotShow()
+    {
+        var decision = WizardGapService.Decide(
+            Array.Empty<WizardGap>(), acknowledgedKeys: Array.Empty<string>(), hasRunBefore: false);
+
         Assert.False(decision.ShouldShow);
+        Assert.Equal(WizardMode.None, decision.Mode);
     }
 
     [Fact]
@@ -99,20 +115,22 @@ public class WizardGapServiceTests
     }
 
     [Fact]
-    public void Decide_FirstRun_MultipleGaps_SurfacesAllUnsatisfied()
+    public void Decide_FirstRun_MultipleGaps_SurfacesAllStepsForReview()
     {
+        // First run surfaces every registered step (all reviewable), regardless of
+        // satisfaction or whether a step has a good default.
         var gaps = new[]
         {
             Gap("gamePath", satisfied: false),
             Gap("anotherRequired", satisfied: false),
-            Gap("theme", satisfied: false, hasGoodDefault: true), // not forced
+            Gap("theme", satisfied: true, hasGoodDefault: true),
         };
 
         var decision = WizardGapService.Decide(gaps, acknowledgedKeys: Array.Empty<string>(), hasRunBefore: false);
 
         Assert.True(decision.ShouldShow);
         Assert.Equal(WizardMode.Welcome, decision.Mode);
-        Assert.Equal(new[] { "gamePath", "anotherRequired" }, decision.GapStepKeys);
+        Assert.Equal(new[] { "gamePath", "anotherRequired", "theme" }, decision.GapStepKeys);
     }
 
     [Fact]

--- a/Trebuchet/Trebuchet.Tests/WizardGapServiceTests.cs
+++ b/Trebuchet/Trebuchet.Tests/WizardGapServiceTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using RadoubLauncher.Services;
+using Xunit;
+
+namespace Trebuchet.Tests;
+
+/// <summary>
+/// Tests for the wizard gap registry (#1020): decides whether the first-run /
+/// welcome-back wizard should fire, in which mode, and which steps are the
+/// genuine unfilled gaps. Pure logic — no settings I/O or UI.
+/// </summary>
+public class WizardGapServiceTests
+{
+    private static WizardGap Gap(string key, bool satisfied, bool hasGoodDefault = false) =>
+        new(key, satisfied, hasGoodDefault);
+
+    [Fact]
+    public void Decide_FirstRun_UnsetRequiredGap_ShowsWelcome()
+    {
+        var gaps = new[] { Gap("gamePath", satisfied: false) };
+
+        var decision = WizardGapService.Decide(gaps, acknowledgedKeys: Array.Empty<string>(), hasRunBefore: false);
+
+        Assert.True(decision.ShouldShow);
+        Assert.Equal(WizardMode.Welcome, decision.Mode);
+        Assert.Equal(new[] { "gamePath" }, decision.GapStepKeys);
+    }
+
+    [Fact]
+    public void Decide_AllSatisfied_FirstRun_DoesNotShow()
+    {
+        var gaps = new[] { Gap("gamePath", satisfied: true) };
+
+        var decision = WizardGapService.Decide(gaps, acknowledgedKeys: Array.Empty<string>(), hasRunBefore: false);
+
+        Assert.False(decision.ShouldShow);
+        Assert.Equal(WizardMode.None, decision.Mode);
+    }
+
+    [Fact]
+    public void Decide_GapWithGoodDefault_NotForced_DoesNotShow()
+    {
+        // A setting with a good default is never a forced gap even when "unset".
+        var gaps = new[] { Gap("theme", satisfied: false, hasGoodDefault: true) };
+
+        var decision = WizardGapService.Decide(gaps, acknowledgedKeys: Array.Empty<string>(), hasRunBefore: false);
+
+        Assert.False(decision.ShouldShow);
+    }
+
+    [Fact]
+    public void Decide_HasRunBefore_NewUnacknowledgedGap_ShowsWelcomeBack()
+    {
+        // Configured before (gamePath set + acknowledged), but a new no-default
+        // gap appeared that was never acknowledged.
+        var gaps = new[]
+        {
+            Gap("gamePath", satisfied: true),
+            Gap("newThing", satisfied: false),
+        };
+
+        var decision = WizardGapService.Decide(
+            gaps, acknowledgedKeys: new[] { "gamePath" }, hasRunBefore: true);
+
+        Assert.True(decision.ShouldShow);
+        Assert.Equal(WizardMode.WelcomeBack, decision.Mode);
+        Assert.Equal(new[] { "newThing" }, decision.GapStepKeys);
+    }
+
+    [Fact]
+    public void Decide_HasRunBefore_AllAcknowledged_DoesNotShow()
+    {
+        var gaps = new[]
+        {
+            Gap("gamePath", satisfied: true),
+            Gap("newThing", satisfied: false),
+        };
+
+        var decision = WizardGapService.Decide(
+            gaps, acknowledgedKeys: new[] { "gamePath", "newThing" }, hasRunBefore: true);
+
+        Assert.False(decision.ShouldShow);
+        Assert.Equal(WizardMode.None, decision.Mode);
+    }
+
+    [Fact]
+    public void Decide_HasRunBefore_UnsetButAcknowledgedGap_DoesNotReshow()
+    {
+        // The user saw the gap, acknowledged it, but chose to leave it unset.
+        // We must not nag every launch.
+        var gaps = new[] { Gap("gamePath", satisfied: false) };
+
+        var decision = WizardGapService.Decide(
+            gaps, acknowledgedKeys: new[] { "gamePath" }, hasRunBefore: true);
+
+        Assert.False(decision.ShouldShow);
+    }
+
+    [Fact]
+    public void Decide_FirstRun_MultipleGaps_SurfacesAllUnsatisfied()
+    {
+        var gaps = new[]
+        {
+            Gap("gamePath", satisfied: false),
+            Gap("anotherRequired", satisfied: false),
+            Gap("theme", satisfied: false, hasGoodDefault: true), // not forced
+        };
+
+        var decision = WizardGapService.Decide(gaps, acknowledgedKeys: Array.Empty<string>(), hasRunBefore: false);
+
+        Assert.True(decision.ShouldShow);
+        Assert.Equal(WizardMode.Welcome, decision.Mode);
+        Assert.Equal(new[] { "gamePath", "anotherRequired" }, decision.GapStepKeys);
+    }
+
+    [Fact]
+    public void AllKeys_ReturnsEveryRegisteredKey_ForAcknowledgement()
+    {
+        // When the wizard completes it acknowledges ALL registered gap keys, so a
+        // setting the user deliberately left unset is not re-surfaced next launch.
+        var gaps = new[]
+        {
+            Gap("gamePath", satisfied: false),
+            Gap("theme", satisfied: false, hasGoodDefault: true),
+        };
+
+        var keys = WizardGapService.AllKeys(gaps);
+
+        Assert.Equal(new[] { "gamePath", "theme" }, keys);
+    }
+}

--- a/Trebuchet/Trebuchet/App.axaml.cs
+++ b/Trebuchet/Trebuchet/App.axaml.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using Avalonia.Markup.Xaml;
 using RadoubLauncher.Services;
+using RadoubLauncher.ViewModels;
 using Radoub.Formats.Logging;
 using RadoubLauncher.Views;
 using Radoub.UI.Services;
@@ -103,7 +104,17 @@ public partial class App : Application
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             DisableAvaloniaDataAnnotationValidation();
-            desktop.MainWindow = new MainWindow();
+            var mainWindow = new MainWindow();
+            desktop.MainWindow = mainWindow;
+
+            // First-run / welcome-back configuration wizard (#1020). Shown over the
+            // main window (non-blocking) once it is up, only when a required setting
+            // with no good default is unfilled and unacknowledged. Skipped in SafeMode.
+            var safeMode = Program.SafeMode?.SafeModeActive ?? false;
+            if (!safeMode)
+            {
+                mainWindow.Opened += OnMainWindowOpenedShowWizardIfNeeded;
+            }
 
             // Unsubscribe from singleton events and dispose services on app exit (#1282, #1292)
             desktop.Exit += (_, _) =>
@@ -114,6 +125,40 @@ public partial class App : Application
         }
 
         base.OnFrameworkInitializationCompleted();
+    }
+
+    /// <summary>
+    /// On main-window open, decide whether the first-run / welcome-back wizard
+    /// should appear and show it non-modally over the main window (#1020). Fires
+    /// once — the handler unsubscribes itself.
+    /// </summary>
+    private void OnMainWindowOpenedShowWizardIfNeeded(object? sender, EventArgs e)
+    {
+        if (sender is not Avalonia.Controls.Window mainWindow)
+            return;
+
+        mainWindow.Opened -= OnMainWindowOpenedShowWizardIfNeeded;
+
+        var settings = Radoub.Formats.Settings.RadoubSettings.Instance;
+
+        // Gap registry. Today the only required no-default setting is the game path.
+        // Theme/font/logging/backup always have good defaults — shown for review,
+        // never forcing the wizard open.
+        var gaps = new[]
+        {
+            new WizardGap(FirstRunWizardViewModel.GapGamePath, settings.HasGamePaths, HasGoodDefault: false),
+            new WizardGap(FirstRunWizardViewModel.GapAppearance, true, HasGoodDefault: true),
+            new WizardGap(FirstRunWizardViewModel.GapLogging, true, HasGoodDefault: true),
+            new WizardGap(FirstRunWizardViewModel.GapBackup, true, HasGoodDefault: true),
+        };
+
+        var decision = WizardGapService.Decide(gaps, settings.AcknowledgedWizardGaps, settings.WizardHasRun);
+        if (!decision.ShouldShow)
+            return;
+
+        var wizard = new FirstRunWizardWindow();
+        wizard.Initialize(decision.Mode);
+        wizard.Show(mainWindow);
     }
 
     private void OnSharedSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/Trebuchet/Trebuchet/App.axaml.cs
+++ b/Trebuchet/Trebuchet/App.axaml.cs
@@ -141,9 +141,12 @@ public partial class App : Application
 
         var settings = Radoub.Formats.Settings.RadoubSettings.Instance;
 
-        // Gap registry. Today the only required no-default setting is the game path.
-        // Theme/font/logging/backup always have good defaults — shown for review,
-        // never forcing the wizard open.
+        // Gap registry. On first run every step is reviewed once (the wizard fires
+        // regardless of these flags). The IsSatisfied / HasGoodDefault flags only
+        // govern the welcome-back path: a future required no-default setting that is
+        // unsatisfied and unacknowledged re-opens the wizard. Today the game path is
+        // the only no-default setting; appearance/logging/backup have good defaults
+        // and are part of the one-time first-run review only.
         var gaps = new[]
         {
             new WizardGap(FirstRunWizardViewModel.GapGamePath, settings.HasGamePaths, HasGoodDefault: false),

--- a/Trebuchet/Trebuchet/Controls/ModuleEditorPanel.axaml
+++ b/Trebuchet/Trebuchet/Controls/ModuleEditorPanel.axaml
@@ -201,6 +201,9 @@
                         <Button Content="▼ Down"
                                 Command="{Binding MoveHakDownCommand}"
                                 IsEnabled="{Binding SelectedHak, Converter={x:Static ObjectConverters.IsNotNull}}"/>
+                        <Button Content="Check Conflicts"
+                                Click="OnCheckHakConflictsClick"
+                                IsEnabled="{Binding HasMultipleHaks}"/>
                     </StackPanel>
                 </Grid>
             </TabItem>

--- a/Trebuchet/Trebuchet/Controls/ModuleEditorPanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/ModuleEditorPanel.axaml.cs
@@ -1,7 +1,12 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Radoub.Formats.Settings;
 using Radoub.UI.Controls;
 using RadoubLauncher.ViewModels;
+using RadoubLauncher.Views;
 
 namespace RadoubLauncher.Controls;
 
@@ -62,4 +67,26 @@ public partial class ModuleEditorPanel : UserControl
         if (_viewModel != null)
             _viewModel.HasUnsavedChanges = true;
     }
+
+    /// <summary>
+    /// Open the HAK conflict checker for the current (in-editor) HAK list (#1162).
+    /// Uses the working-copy HAK list so unsaved reorders are reflected.
+    /// </summary>
+    private async void OnCheckHakConflictsClick(object? sender, RoutedEventArgs e)
+    {
+        if (_viewModel == null) return;
+
+        var hakNames = _viewModel.HakList.ToList();
+        var searchPaths = RadoubSettings.Instance.GetAllHakSearchPaths().ToList();
+
+        var window = new HakConflictWindow();
+        var owner = GetParentWindow();
+        if (owner != null)
+            window.Show(owner);
+        else
+            window.Show();
+        await window.RunCheckAsync(hakNames, searchPaths);
+    }
+
+    private Window? GetParentWindow() => TopLevel.GetTopLevel(this) as Window;
 }

--- a/Trebuchet/Trebuchet/Services/DesktopShortcutService.cs
+++ b/Trebuchet/Trebuchet/Services/DesktopShortcutService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Runtime.Versioning;
 using System.Text;
 
 namespace RadoubLauncher.Services;
@@ -73,6 +74,7 @@ public static class DesktopShortcutService
         }
     }
 
+    [SupportedOSPlatform("linux")]
     private static ShortcutResult CreateLinuxShortcut(string exePath, string? iconPath)
     {
         var appsDir = GetXdgDataApplications();
@@ -89,6 +91,7 @@ public static class DesktopShortcutService
         return ShortcutResult.Ok(path);
     }
 
+    [SupportedOSPlatform("windows")]
     private static ShortcutResult CreateWindowsShortcut(string exePath, string? iconPath)
     {
         var desktop = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);

--- a/Trebuchet/Trebuchet/Services/DesktopShortcutService.cs
+++ b/Trebuchet/Trebuchet/Services/DesktopShortcutService.cs
@@ -1,0 +1,147 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace RadoubLauncher.Services;
+
+/// <summary>
+/// Creates a desktop shortcut for Trebuchet (#1437). Windows produces a .lnk via
+/// the WScript.Shell COM object; Linux writes a freedesktop .desktop file. The
+/// content/path construction is pure and unit-tested; the actual COM call and
+/// filesystem writes are platform side effects.
+/// </summary>
+public static class DesktopShortcutService
+{
+    private const string LinuxCategories = "Utility;Development;";
+
+    /// <summary>
+    /// Build a freedesktop .desktop entry. <paramref name="iconPath"/> may be
+    /// empty to omit the Icon line. Exec/Icon paths containing spaces are quoted.
+    /// </summary>
+    public static string BuildLinuxDesktopEntry(string name, string execPath, string iconPath, string comment)
+    {
+        var sb = new StringBuilder();
+        sb.Append("[Desktop Entry]\n");
+        sb.Append("Type=Application\n");
+        sb.Append($"Name={name}\n");
+        if (!string.IsNullOrEmpty(comment))
+            sb.Append($"Comment={comment}\n");
+        sb.Append($"Exec={QuoteIfNeeded(execPath)}\n");
+        if (!string.IsNullOrEmpty(iconPath))
+            sb.Append($"Icon={QuoteIfNeeded(iconPath)}\n");
+        sb.Append("Terminal=false\n");
+        sb.Append($"Categories={LinuxCategories}\n");
+        return sb.ToString();
+    }
+
+    /// <summary>Path of the .desktop file: lowercase, dashed name in the applications dir.</summary>
+    public static string GetLinuxDesktopFilePath(string applicationsDir, string name)
+    {
+        var fileName = Sanitize(name) + ".desktop";
+        return Path.Combine(applicationsDir, fileName);
+    }
+
+    /// <summary>Path of the Windows .lnk file in the given directory (usually the Desktop).</summary>
+    public static string GetWindowsShortcutPath(string desktopDir, string name)
+    {
+        return Path.Combine(desktopDir, name + ".lnk");
+    }
+
+    /// <summary>
+    /// Create a desktop shortcut for the running Trebuchet executable. Idempotent —
+    /// re-running overwrites any existing shortcut. Returns a result describing the
+    /// outcome and the shortcut path (or the error).
+    /// </summary>
+    public static ShortcutResult CreateForCurrentApp(string? iconPath = null)
+    {
+        var exePath = Environment.ProcessPath;
+        if (string.IsNullOrEmpty(exePath))
+            return ShortcutResult.Fail("Could not determine the Trebuchet executable path.");
+
+        try
+        {
+            if (OperatingSystem.IsWindows())
+                return CreateWindowsShortcut(exePath, iconPath);
+            if (OperatingSystem.IsLinux())
+                return CreateLinuxShortcut(exePath, iconPath);
+
+            return ShortcutResult.Fail("Desktop shortcuts are only supported on Windows and Linux.");
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            return ShortcutResult.Fail($"Failed to create shortcut: {ex.Message}");
+        }
+    }
+
+    private static ShortcutResult CreateLinuxShortcut(string exePath, string? iconPath)
+    {
+        var appsDir = GetXdgDataApplications();
+        Directory.CreateDirectory(appsDir);
+
+        var path = GetLinuxDesktopFilePath(appsDir, "Trebuchet");
+        var entry = BuildLinuxDesktopEntry("Trebuchet", exePath, iconPath ?? string.Empty, "Radoub toolset launcher");
+        File.WriteAllText(path, entry);
+
+        // Mark executable where the platform supports it (best-effort; ignored on FS without modes).
+        try { File.SetUnixFileMode(path, UnixFileModeAllReadExecuteOwnerWrite()); }
+        catch (PlatformNotSupportedException) { /* not Unix — fine */ }
+
+        return ShortcutResult.Ok(path);
+    }
+
+    private static ShortcutResult CreateWindowsShortcut(string exePath, string? iconPath)
+    {
+        var desktop = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
+        var path = GetWindowsShortcutPath(desktop, "Trebuchet");
+
+        // Late-bound WScript.Shell COM — avoids a hard Windows-only reference and
+        // works without adding interop assemblies.
+        var shellType = Type.GetTypeFromProgID("WScript.Shell")
+            ?? throw new InvalidOperationException("WScript.Shell is unavailable.");
+        dynamic shell = Activator.CreateInstance(shellType)
+            ?? throw new InvalidOperationException("Could not create WScript.Shell.");
+
+        dynamic shortcut = shell.CreateShortcut(path);
+        shortcut.TargetPath = exePath;
+        shortcut.WorkingDirectory = Path.GetDirectoryName(exePath) ?? string.Empty;
+        shortcut.Description = "Radoub toolset launcher";
+        if (!string.IsNullOrEmpty(iconPath))
+            shortcut.IconLocation = iconPath;
+        shortcut.Save();
+
+        return ShortcutResult.Ok(path);
+    }
+
+    private static string GetXdgDataApplications()
+    {
+        // $XDG_DATA_HOME/applications, defaulting to ~/.local/share/applications.
+        var xdg = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+        var dataHome = string.IsNullOrEmpty(xdg)
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share")
+            : xdg;
+        return Path.Combine(dataHome, "applications");
+    }
+
+    private static UnixFileMode UnixFileModeAllReadExecuteOwnerWrite() =>
+        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+        UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+        UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
+
+    private static string QuoteIfNeeded(string value) =>
+        value.Contains(' ') ? $"\"{value}\"" : value;
+
+    private static string Sanitize(string name)
+    {
+        var sb = new StringBuilder(name.Length);
+        foreach (var c in name.ToLowerInvariant())
+            sb.Append(char.IsLetterOrDigit(c) ? c : '-');
+        return sb.ToString();
+    }
+}
+
+/// <summary>Outcome of a shortcut-creation attempt.</summary>
+public sealed record ShortcutResult(bool Success, string? Path, string? Error)
+{
+    public static ShortcutResult Ok(string path) => new(true, path, null);
+    public static ShortcutResult Fail(string error) => new(false, null, error);
+}

--- a/Trebuchet/Trebuchet/Services/HakConflictCheckerService.cs
+++ b/Trebuchet/Trebuchet/Services/HakConflictCheckerService.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Radoub.Formats.Common;
+using Radoub.Formats.Erf;
+
+namespace RadoubLauncher.Services;
+
+/// <summary>
+/// Detects resource conflicts across a module's HAK files (#1162).
+///
+/// A conflict is a resource (same ResRef + same ResourceType) present in two or
+/// more HAKs. The winner is the HAK earliest in the priority-ordered list:
+/// BioWare's IFO spec states resources in earlier HAKs override later ones
+/// (see Bioware-Legacy-IFO_Format.md and ModuleHakResolver, which both encode
+/// "first = highest priority").
+///
+/// Detection only — this does not compare resource content, so identical
+/// duplicates are still reported as conflicts.
+/// </summary>
+public static class HakConflictCheckerService
+{
+    /// <summary>
+    /// Read each HAK's resource list (metadata only — large HAKs are not loaded
+    /// into memory) and detect cross-HAK conflicts. HAK paths must be supplied in
+    /// priority order (first = highest priority), as returned by
+    /// <see cref="Radoub.Formats.Resolver.ModuleHakResolver"/>.
+    /// </summary>
+    public static IReadOnlyList<HakConflict> CheckHakPaths(IEnumerable<string> hakPathsInPriorityOrder)
+    {
+        var contents = new List<HakContents>();
+        foreach (var path in hakPathsInPriorityOrder)
+        {
+            var name = Path.GetFileNameWithoutExtension(path);
+            var erf = ErfReader.ReadMetadataOnly(path);
+            contents.Add(new HakContents(name, erf.Resources));
+        }
+
+        return FindConflicts(contents);
+    }
+
+    /// <summary>
+    /// Pure conflict-detection core. Each HAK is a named resource list, supplied
+    /// in priority order. Returns one <see cref="HakConflict"/> per resource that
+    /// appears in two or more HAKs.
+    /// </summary>
+    public static IReadOnlyList<HakConflict> FindConflicts(IEnumerable<HakContents> haksInPriorityOrder)
+    {
+        var haks = haksInPriorityOrder.ToList();
+
+        // Map each resource key to the ordered, de-duplicated list of HAKs that contain it.
+        // Order is the order HAKs appear in the input (priority order).
+        var byResource = new Dictionary<ResourceKey, List<string>>();
+
+        foreach (var hak in haks)
+        {
+            // De-dup within a single HAK so a resource listed twice in one HAK
+            // does not look like a cross-HAK conflict.
+            var seenInThisHak = new HashSet<ResourceKey>();
+            foreach (var entry in hak.Resources)
+            {
+                var key = new ResourceKey(entry.ResRef, entry.ResourceType);
+                if (!seenInThisHak.Add(key))
+                    continue;
+
+                if (!byResource.TryGetValue(key, out var list))
+                {
+                    list = new List<string>();
+                    byResource[key] = list;
+                }
+                list.Add(hak.Name);
+            }
+        }
+
+        var conflicts = new List<HakConflict>();
+        foreach (var (key, containingHaks) in byResource)
+        {
+            if (containingHaks.Count < 2)
+                continue;
+
+            conflicts.Add(new HakConflict(
+                ResRef: key.ResRef,
+                ResourceType: key.ResourceType,
+                Extension: ResourceTypes.GetExtension(key.ResourceType),
+                ContainingHaks: containingHaks,
+                WinnerHak: containingHaks[0]));
+        }
+
+        return conflicts;
+    }
+
+    /// <summary>Case-insensitive resource identity: ResRef + ResourceType.</summary>
+    private readonly record struct ResourceKey
+    {
+        public string ResRef { get; }
+        public ushort ResourceType { get; }
+
+        public ResourceKey(string resRef, ushort resourceType)
+        {
+            ResRef = resRef;
+            ResourceType = resourceType;
+        }
+
+        public bool Equals(ResourceKey other) =>
+            ResourceType == other.ResourceType &&
+            string.Equals(ResRef, other.ResRef, StringComparison.OrdinalIgnoreCase);
+
+        public override int GetHashCode() =>
+            HashCode.Combine(ResRef.ToLowerInvariant(), ResourceType);
+    }
+}
+
+/// <summary>A HAK's resource list, identified by name (filename without extension).</summary>
+public sealed record HakContents(string Name, IReadOnlyList<ErfResourceEntry> Resources);
+
+/// <summary>
+/// A single cross-HAK conflict: one resource present in multiple HAKs.
+/// <see cref="ContainingHaks"/> is in priority order; <see cref="WinnerHak"/> is the first.
+/// </summary>
+public sealed record HakConflict(
+    string ResRef,
+    ushort ResourceType,
+    string Extension,
+    IReadOnlyList<string> ContainingHaks,
+    string WinnerHak);

--- a/Trebuchet/Trebuchet/Services/HakConflictCheckerService.cs
+++ b/Trebuchet/Trebuchet/Services/HakConflictCheckerService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Radoub.Formats.Common;
 using Radoub.Formats.Erf;
+using Radoub.Formats.Resolver;
 
 namespace RadoubLauncher.Services;
 
@@ -22,10 +23,24 @@ namespace RadoubLauncher.Services;
 public static class HakConflictCheckerService
 {
     /// <summary>
+    /// Resolve a module's in-editor HAK list (names, in priority order) to file
+    /// paths and check for conflicts. Names that cannot be found in the search
+    /// paths are reported in <see cref="HakConflictReport.UnresolvedHaks"/> so the
+    /// UI can warn that the check was incomplete.
+    /// </summary>
+    public static HakConflictReport CheckHakNames(
+        IEnumerable<string> hakNamesInPriorityOrder, IEnumerable<string> hakSearchPaths)
+    {
+        var resolution = ModuleHakResolver.ResolveHakNames(hakNamesInPriorityOrder, hakSearchPaths);
+        var conflicts = CheckHakPaths(resolution.Resolved);
+        return new HakConflictReport(conflicts, resolution.Unresolved);
+    }
+
+    /// <summary>
     /// Read each HAK's resource list (metadata only — large HAKs are not loaded
     /// into memory) and detect cross-HAK conflicts. HAK paths must be supplied in
     /// priority order (first = highest priority), as returned by
-    /// <see cref="Radoub.Formats.Resolver.ModuleHakResolver"/>.
+    /// <see cref="ModuleHakResolver"/>.
     /// </summary>
     public static IReadOnlyList<HakConflict> CheckHakPaths(IEnumerable<string> hakPathsInPriorityOrder)
     {
@@ -113,6 +128,15 @@ public static class HakConflictCheckerService
 
 /// <summary>A HAK's resource list, identified by name (filename without extension).</summary>
 public sealed record HakContents(string Name, IReadOnlyList<ErfResourceEntry> Resources);
+
+/// <summary>
+/// Result of a conflict check over a module's HAK list: the detected conflicts
+/// plus any HAK names that could not be resolved to files (so the check was
+/// incomplete for those).
+/// </summary>
+public sealed record HakConflictReport(
+    IReadOnlyList<HakConflict> Conflicts,
+    IReadOnlyList<string> UnresolvedHaks);
 
 /// <summary>
 /// A single cross-HAK conflict: one resource present in multiple HAKs.

--- a/Trebuchet/Trebuchet/Services/WizardGapService.cs
+++ b/Trebuchet/Trebuchet/Services/WizardGapService.cs
@@ -5,34 +5,50 @@ namespace RadoubLauncher.Services;
 
 /// <summary>
 /// Decides whether the first-run / welcome-back configuration wizard (#1020)
-/// should appear, in which mode, and which steps are the genuine unfilled gaps.
+/// should appear, in which mode, and which steps to surface.
 ///
-/// A "forced gap" is a setting that is required, has no good default, and is not
-/// yet satisfied. The wizard exists to fill those — settings that have good
-/// defaults are shown for review but never force the wizard open.
+/// Two distinct triggers:
+/// <list type="bullet">
+/// <item><b>First run</b> (<paramref name="hasRunBefore"/> false): a one-time review.
+/// The wizard always shows if any steps are registered, surfacing every step — even a
+/// game path that auto-detect already filled is shown for confirmation. This is the
+/// fix for the original bug where auto-detect satisfied the only gap, so a
+/// "show only when unset" rule never fired on a configured machine.</item>
+/// <item><b>Welcome-back</b> (has run before): shows only when a <i>forced gap</i> —
+/// required (no good default), unsatisfied, and not yet acknowledged — has appeared
+/// since last run (e.g. a newly-introduced no-default setting). Surfaces just those.</item>
+/// </list>
 ///
-/// To avoid nagging, completing the wizard acknowledges every registered gap key
-/// (see <see cref="AllKeys"/>); an acknowledged gap is not re-surfaced even if the
-/// user deliberately left it unset.
+/// Completing the wizard acknowledges every registered gap key (see
+/// <see cref="AllKeys"/>), so a setting the user deliberately left unset is not
+/// re-surfaced.
 /// </summary>
 public static class WizardGapService
 {
     public static WizardDecision Decide(
         IEnumerable<WizardGap> gaps, IEnumerable<string> acknowledgedKeys, bool hasRunBefore)
     {
-        var acknowledged = new HashSet<string>(acknowledgedKeys);
+        var gapList = gaps.ToList();
 
-        // Forced gaps: required (no good default), unsatisfied, and not yet acknowledged.
-        var forced = gaps
+        if (!hasRunBefore)
+        {
+            // First run: one-time review of everything. Show if anything is registered.
+            if (gapList.Count == 0)
+                return new WizardDecision(false, WizardMode.None, gapList.Select(g => g.Key).ToList());
+
+            return new WizardDecision(true, WizardMode.Welcome, gapList.Select(g => g.Key).ToList());
+        }
+
+        // Has run before: only a newly-appeared forced gap re-opens the wizard.
+        var acknowledged = new HashSet<string>(acknowledgedKeys);
+        var forced = gapList
             .Where(g => !g.HasGoodDefault && !g.IsSatisfied && !acknowledged.Contains(g.Key))
             .Select(g => g.Key)
             .ToList();
 
-        if (forced.Count == 0)
-            return new WizardDecision(false, WizardMode.None, forced);
-
-        var mode = hasRunBefore ? WizardMode.WelcomeBack : WizardMode.Welcome;
-        return new WizardDecision(true, mode, forced);
+        return forced.Count == 0
+            ? new WizardDecision(false, WizardMode.None, forced)
+            : new WizardDecision(true, WizardMode.WelcomeBack, forced);
     }
 
     /// <summary>Every registered gap key — acknowledged on wizard completion.</summary>

--- a/Trebuchet/Trebuchet/Services/WizardGapService.cs
+++ b/Trebuchet/Trebuchet/Services/WizardGapService.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RadoubLauncher.Services;
+
+/// <summary>
+/// Decides whether the first-run / welcome-back configuration wizard (#1020)
+/// should appear, in which mode, and which steps are the genuine unfilled gaps.
+///
+/// A "forced gap" is a setting that is required, has no good default, and is not
+/// yet satisfied. The wizard exists to fill those — settings that have good
+/// defaults are shown for review but never force the wizard open.
+///
+/// To avoid nagging, completing the wizard acknowledges every registered gap key
+/// (see <see cref="AllKeys"/>); an acknowledged gap is not re-surfaced even if the
+/// user deliberately left it unset.
+/// </summary>
+public static class WizardGapService
+{
+    public static WizardDecision Decide(
+        IEnumerable<WizardGap> gaps, IEnumerable<string> acknowledgedKeys, bool hasRunBefore)
+    {
+        var acknowledged = new HashSet<string>(acknowledgedKeys);
+
+        // Forced gaps: required (no good default), unsatisfied, and not yet acknowledged.
+        var forced = gaps
+            .Where(g => !g.HasGoodDefault && !g.IsSatisfied && !acknowledged.Contains(g.Key))
+            .Select(g => g.Key)
+            .ToList();
+
+        if (forced.Count == 0)
+            return new WizardDecision(false, WizardMode.None, forced);
+
+        var mode = hasRunBefore ? WizardMode.WelcomeBack : WizardMode.Welcome;
+        return new WizardDecision(true, mode, forced);
+    }
+
+    /// <summary>Every registered gap key — acknowledged on wizard completion.</summary>
+    public static IReadOnlyList<string> AllKeys(IEnumerable<WizardGap> gaps) =>
+        gaps.Select(g => g.Key).ToList();
+}
+
+/// <summary>
+/// A single configurable setting the wizard can surface.
+/// </summary>
+/// <param name="Key">Stable identifier, persisted in the acknowledged-gaps record.</param>
+/// <param name="IsSatisfied">Whether the setting currently has a usable value.</param>
+/// <param name="HasGoodDefault">Whether a sensible default exists — if so, this gap never forces the wizard open.</param>
+public sealed record WizardGap(string Key, bool IsSatisfied, bool HasGoodDefault = false);
+
+public enum WizardMode
+{
+    None,
+    Welcome,
+    WelcomeBack,
+}
+
+/// <summary>The wizard launch decision.</summary>
+public sealed record WizardDecision(bool ShouldShow, WizardMode Mode, IReadOnlyList<string> GapStepKeys);

--- a/Trebuchet/Trebuchet/ViewModels/FirstRunWizardViewModel.cs
+++ b/Trebuchet/Trebuchet/ViewModels/FirstRunWizardViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -35,20 +36,35 @@ public partial class FirstRunWizardViewModel : ObservableObject
     private static readonly string[] StepTitles =
         { "Game Path", "Appearance", "Logging", "Backup", "Summary" };
 
-    private readonly Window _window;
+    private readonly Window? _window;
+    private readonly bool _headless;
 
     public FirstRunWizardViewModel(Window window, WizardMode mode)
+        : this(window, mode, headless: false) { }
+
+    private FirstRunWizardViewModel(Window? window, WizardMode mode, bool headless)
     {
         _window = window;
+        _headless = headless;
         Mode = mode;
 
         foreach (var level in new[] { "TRACE", "DEBUG", "INFO", "WARN", "ERROR" })
             AvailableLogLevels.Add(level);
-        foreach (var theme in ThemeManager.Instance.AvailableThemes)
-            AvailableThemes.Add(theme.Plugin.Name);
+
+        // ThemeManager is only available once a tool has initialized it. In headless
+        // tests it isn't, so guard the theme list population.
+        if (!headless)
+        {
+            foreach (var theme in ThemeManager.Instance.AvailableThemes)
+                AvailableThemes.Add(theme.Plugin.Name);
+        }
 
         LoadFromSettings();
     }
+
+    /// <summary>Headless factory for unit tests (no Window, no ThemeManager).</summary>
+    public static FirstRunWizardViewModel CreateForTest(WizardMode mode) =>
+        new(window: null, mode, headless: true);
 
     public WizardMode Mode { get; }
 
@@ -77,7 +93,13 @@ public partial class FirstRunWizardViewModel : ObservableObject
         OnPropertyChanged(nameof(CanGoBack));
         OnPropertyChanged(nameof(IsLastStep));
         OnPropertyChanged(nameof(IsSummary));
-        RefreshSummary();
+
+        // Rebuild the summary only when the summary step is shown. Doing it on every
+        // value change (slider drags fire continuously) thrashed the bound
+        // collection and crashed the render loop when the summary's item bindings
+        // re-materialized mid-drag.
+        if (IsSummary)
+            RefreshSummary();
     }
 
     [RelayCommand]
@@ -117,12 +139,13 @@ public partial class FirstRunWizardViewModel : ObservableObject
         var result = ResourcePathDetector.ValidateBaseGamePathWithMessage(value);
         GamePathValidation = result.Message;
         OnPropertyChanged(nameof(HasGamePathValidation));
-        RefreshSummary();
     }
 
     [RelayCommand]
     private async Task BrowseGamePath()
     {
+        if (_window == null) return; // headless (test) — no picker
+
         var folder = await _window.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
         {
             Title = "Select NWN Base Game Installation (contains data\\ folder)",
@@ -156,11 +179,9 @@ public partial class FirstRunWizardViewModel : ObservableObject
 
     public string FontSizePointsText => $"{(int)FontSizePoints}pt";
 
-    partial void OnSelectedThemeChanged(string value) => RefreshSummary();
     partial void OnFontSizePointsChanged(double value)
     {
         OnPropertyChanged(nameof(FontSizePointsText));
-        RefreshSummary();
     }
 
     // Logging
@@ -170,19 +191,26 @@ public partial class FirstRunWizardViewModel : ObservableObject
     [ObservableProperty]
     private string _selectedLogLevel = "INFO";
 
-    partial void OnSelectedLogLevelChanged(string value) => RefreshSummary();
-
     // Backup
 
+    // Slider binds to BackupRetentionSlider (a double) to avoid a fragile
+    // double→int two-way binding; the int property below is derived from it and is
+    // what gets persisted/clamped.
     [ObservableProperty]
-    private int _backupRetentionDays = 30;
+    private double _backupRetentionSlider = 30.0;
+
+    public int BackupRetentionDays
+    {
+        get => (int)Math.Round(BackupRetentionSlider);
+        set => BackupRetentionSlider = Math.Max(1, Math.Min(90, value));
+    }
 
     public string BackupRetentionText => $"{BackupRetentionDays} day{(BackupRetentionDays == 1 ? "" : "s")}";
 
-    partial void OnBackupRetentionDaysChanged(int value)
+    partial void OnBackupRetentionSliderChanged(double value)
     {
+        OnPropertyChanged(nameof(BackupRetentionDays));
         OnPropertyChanged(nameof(BackupRetentionText));
-        RefreshSummary();
     }
 
     // Shortcut offer
@@ -195,20 +223,25 @@ public partial class FirstRunWizardViewModel : ObservableObject
 
     public bool HasShortcutResult => !string.IsNullOrEmpty(ShortcutResultMessage);
 
-    // Summary (rebuilt whenever a value changes)
+    // Summary — built only when the summary step is shown (see OnStepIndexChanged).
 
     public ObservableCollection<WizardSummaryRow> SummaryRows { get; } = new();
 
     private void RefreshSummary()
     {
         SummaryRows.Clear();
-        SummaryRows.Add(new WizardSummaryRow("Game path",
+        SummaryRows.Add(MakeRow("Game path",
             string.IsNullOrEmpty(GameInstallPath) ? "(not set)" : GameInstallPath, 0));
-        SummaryRows.Add(new WizardSummaryRow("Theme", SelectedTheme, 1));
-        SummaryRows.Add(new WizardSummaryRow("Font size", FontSizePointsText, 1));
-        SummaryRows.Add(new WizardSummaryRow("Log level", SelectedLogLevel, 2));
-        SummaryRows.Add(new WizardSummaryRow("Backup retention", BackupRetentionText, 3));
+        SummaryRows.Add(MakeRow("Theme", SelectedTheme, 1));
+        SummaryRows.Add(MakeRow("Font size", FontSizePointsText, 1));
+        SummaryRows.Add(MakeRow("Log level", SelectedLogLevel, 2));
+        SummaryRows.Add(MakeRow("Backup retention", BackupRetentionText, 3));
     }
+
+    // Each row carries its own jump command so the summary's Edit button binds to
+    // the row, not to a fragile $parent[ItemsControl]-cast back to this view model.
+    private WizardSummaryRow MakeRow(string label, string value, int stepIndex) =>
+        new(label, value, stepIndex, new RelayCommand(() => GoToStep(stepIndex)));
 
     private void LoadFromSettings()
     {
@@ -218,10 +251,13 @@ public partial class FirstRunWizardViewModel : ObservableObject
         BackupRetentionDays = shared.BackupRetentionDays;
         SelectedLogLevel = shared.SharedLogLevel.ToString();
 
-        var current = ThemeManager.Instance.CurrentTheme;
-        SelectedTheme = current != null && AvailableThemes.Contains(current.Plugin.Name)
-            ? current.Plugin.Name
-            : AvailableThemes.FirstOrDefault() ?? "";
+        if (!_headless)
+        {
+            var current = ThemeManager.Instance.CurrentTheme;
+            SelectedTheme = current != null && AvailableThemes.Contains(current.Plugin.Name)
+                ? current.Plugin.Name
+                : AvailableThemes.FirstOrDefault() ?? "";
+        }
 
         RefreshSummary();
     }
@@ -287,5 +323,9 @@ public partial class FirstRunWizardViewModel : ObservableObject
         new[] { GapGamePath, GapAppearance, GapLogging, GapBackup };
 }
 
-/// <summary>One row on the summary page: label, current value, and the step to edit it.</summary>
-public sealed record WizardSummaryRow(string Label, string Value, int StepIndex);
+/// <summary>
+/// One row on the summary page: label, current value, the step it edits, and a
+/// self-contained Jump command that navigates to that step (so the Edit button
+/// binds to the row, not via a fragile $parent-cast back to the view model).
+/// </summary>
+public sealed record WizardSummaryRow(string Label, string Value, int StepIndex, ICommand Jump);

--- a/Trebuchet/Trebuchet/ViewModels/FirstRunWizardViewModel.cs
+++ b/Trebuchet/Trebuchet/ViewModels/FirstRunWizardViewModel.cs
@@ -1,0 +1,291 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Platform.Storage;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Radoub.Formats.Logging;
+using Radoub.Formats.Settings;
+using Radoub.UI.Services;
+using RadoubLauncher.Services;
+
+namespace RadoubLauncher.ViewModels;
+
+/// <summary>
+/// First-run / welcome-back configuration wizard (#1020). Surfaces the settings
+/// that have no good default (today: the game path) and presents a summary of all
+/// key settings the user can review and edit. Settings with good defaults (theme,
+/// font, logging, backup) are shown for review but never force the wizard open.
+///
+/// Steps are linear: [Game Path] → [Appearance] → [Logging] → [Backup] → [Summary].
+/// The summary's Edit links jump back to any step. On finish, all registered gap
+/// keys are acknowledged so the wizard does not re-nag.
+/// </summary>
+public partial class FirstRunWizardViewModel : ObservableObject
+{
+    // Stable gap keys (persisted in RadoubSettings.AcknowledgedWizardGaps).
+    public const string GapGamePath = "gamePath";
+    public const string GapAppearance = "appearance";
+    public const string GapLogging = "logging";
+    public const string GapBackup = "backup";
+
+    private static readonly string[] StepTitles =
+        { "Game Path", "Appearance", "Logging", "Backup", "Summary" };
+
+    private readonly Window _window;
+
+    public FirstRunWizardViewModel(Window window, WizardMode mode)
+    {
+        _window = window;
+        Mode = mode;
+
+        foreach (var level in new[] { "TRACE", "DEBUG", "INFO", "WARN", "ERROR" })
+            AvailableLogLevels.Add(level);
+        foreach (var theme in ThemeManager.Instance.AvailableThemes)
+            AvailableThemes.Add(theme.Plugin.Name);
+
+        LoadFromSettings();
+    }
+
+    public WizardMode Mode { get; }
+
+    public string WelcomeHeading => Mode == WizardMode.WelcomeBack
+        ? "Welcome back"
+        : "Welcome to the Radoub toolset";
+
+    public string WelcomeBlurb => Mode == WizardMode.WelcomeBack
+        ? "We added a setting that needs your input. Review the values below — you can change any of these later in Settings."
+        : "Let's get a few things set up. You can change any of these later in Settings.";
+
+    // Step navigation
+
+    [ObservableProperty]
+    private int _stepIndex;
+
+    public int LastStepIndex => StepTitles.Length - 1;
+    public string CurrentStepTitle => StepTitles[StepIndex];
+    public bool CanGoBack => StepIndex > 0;
+    public bool IsLastStep => StepIndex == LastStepIndex;
+    public bool IsSummary => StepIndex == LastStepIndex;
+
+    partial void OnStepIndexChanged(int value)
+    {
+        OnPropertyChanged(nameof(CurrentStepTitle));
+        OnPropertyChanged(nameof(CanGoBack));
+        OnPropertyChanged(nameof(IsLastStep));
+        OnPropertyChanged(nameof(IsSummary));
+        RefreshSummary();
+    }
+
+    [RelayCommand]
+    private void Next()
+    {
+        if (StepIndex < LastStepIndex)
+            StepIndex++;
+    }
+
+    [RelayCommand]
+    private void Back()
+    {
+        if (StepIndex > 0)
+            StepIndex--;
+    }
+
+    /// <summary>Jump to a step by index — used by the summary's Edit links.</summary>
+    [RelayCommand]
+    private void GoToStep(int index)
+    {
+        if (index >= 0 && index <= LastStepIndex)
+            StepIndex = index;
+    }
+
+    // Game Path
+
+    [ObservableProperty]
+    private string _gameInstallPath = "";
+
+    [ObservableProperty]
+    private string _gamePathValidation = "";
+
+    public bool HasGamePathValidation => !string.IsNullOrEmpty(GamePathValidation);
+
+    partial void OnGameInstallPathChanged(string value)
+    {
+        var result = ResourcePathDetector.ValidateBaseGamePathWithMessage(value);
+        GamePathValidation = result.Message;
+        OnPropertyChanged(nameof(HasGamePathValidation));
+        RefreshSummary();
+    }
+
+    [RelayCommand]
+    private async Task BrowseGamePath()
+    {
+        var folder = await _window.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = "Select NWN Base Game Installation (contains data\\ folder)",
+            AllowMultiple = false
+        });
+
+        if (folder.Count > 0)
+            GameInstallPath = folder[0].Path.LocalPath;
+    }
+
+    [RelayCommand]
+    private void AutoDetectGamePath()
+    {
+        var detected = ResourcePathDetector.AutoDetectBaseGamePath();
+        if (!string.IsNullOrEmpty(detected))
+            GameInstallPath = detected;
+        else
+            GamePathValidation = "Could not auto-detect. Please browse manually.";
+        OnPropertyChanged(nameof(HasGamePathValidation));
+    }
+
+    // Appearance
+
+    public ObservableCollection<string> AvailableThemes { get; } = new();
+
+    [ObservableProperty]
+    private string _selectedTheme = "";
+
+    [ObservableProperty]
+    private double _fontSizePoints = 14.0;
+
+    public string FontSizePointsText => $"{(int)FontSizePoints}pt";
+
+    partial void OnSelectedThemeChanged(string value) => RefreshSummary();
+    partial void OnFontSizePointsChanged(double value)
+    {
+        OnPropertyChanged(nameof(FontSizePointsText));
+        RefreshSummary();
+    }
+
+    // Logging
+
+    public ObservableCollection<string> AvailableLogLevels { get; } = new();
+
+    [ObservableProperty]
+    private string _selectedLogLevel = "INFO";
+
+    partial void OnSelectedLogLevelChanged(string value) => RefreshSummary();
+
+    // Backup
+
+    [ObservableProperty]
+    private int _backupRetentionDays = 30;
+
+    public string BackupRetentionText => $"{BackupRetentionDays} day{(BackupRetentionDays == 1 ? "" : "s")}";
+
+    partial void OnBackupRetentionDaysChanged(int value)
+    {
+        OnPropertyChanged(nameof(BackupRetentionText));
+        RefreshSummary();
+    }
+
+    // Shortcut offer
+
+    [ObservableProperty]
+    private bool _createDesktopShortcut;
+
+    [ObservableProperty]
+    private string _shortcutResultMessage = "";
+
+    public bool HasShortcutResult => !string.IsNullOrEmpty(ShortcutResultMessage);
+
+    // Summary (rebuilt whenever a value changes)
+
+    public ObservableCollection<WizardSummaryRow> SummaryRows { get; } = new();
+
+    private void RefreshSummary()
+    {
+        SummaryRows.Clear();
+        SummaryRows.Add(new WizardSummaryRow("Game path",
+            string.IsNullOrEmpty(GameInstallPath) ? "(not set)" : GameInstallPath, 0));
+        SummaryRows.Add(new WizardSummaryRow("Theme", SelectedTheme, 1));
+        SummaryRows.Add(new WizardSummaryRow("Font size", FontSizePointsText, 1));
+        SummaryRows.Add(new WizardSummaryRow("Log level", SelectedLogLevel, 2));
+        SummaryRows.Add(new WizardSummaryRow("Backup retention", BackupRetentionText, 3));
+    }
+
+    private void LoadFromSettings()
+    {
+        var shared = RadoubSettings.Instance;
+        GameInstallPath = shared.BaseGameInstallPath;
+        FontSizePoints = shared.SharedFontSize;
+        BackupRetentionDays = shared.BackupRetentionDays;
+        SelectedLogLevel = shared.SharedLogLevel.ToString();
+
+        var current = ThemeManager.Instance.CurrentTheme;
+        SelectedTheme = current != null && AvailableThemes.Contains(current.Plugin.Name)
+            ? current.Plugin.Name
+            : AvailableThemes.FirstOrDefault() ?? "";
+
+        RefreshSummary();
+    }
+
+    /// <summary>
+    /// Apply all settings, optionally create the desktop shortcut, acknowledge the
+    /// wizard gaps, and signal completion. Returns true when the window should close.
+    /// </summary>
+    [RelayCommand]
+    private void Finish()
+    {
+        var shared = RadoubSettings.Instance;
+
+        if (!string.IsNullOrEmpty(GameInstallPath))
+            shared.BaseGameInstallPath = GameInstallPath;
+        shared.SharedFontSize = FontSizePoints;
+        shared.BackupRetentionDays = BackupRetentionDays;
+        if (Enum.TryParse<LogLevel>(SelectedLogLevel, out var logLevel))
+            shared.SharedLogLevel = logLevel;
+
+        var themeInfo = ThemeManager.Instance.AvailableThemes
+            .FirstOrDefault(t => t.Plugin.Name == SelectedTheme);
+        if (themeInfo != null)
+        {
+            shared.SharedThemeId = themeInfo.Plugin.Id;
+            ThemeManager.Instance.ApplyTheme(themeInfo.Plugin.Id);
+        }
+
+        if (CreateDesktopShortcut)
+        {
+            var iconPath = ResolveIconPath();
+            var result = DesktopShortcutService.CreateForCurrentApp(iconPath);
+            ShortcutResultMessage = result.Success
+                ? $"Shortcut created: {result.Path}"
+                : $"Shortcut failed: {result.Error}";
+            OnPropertyChanged(nameof(HasShortcutResult));
+        }
+
+        // Acknowledge every registered gap so the wizard does not re-nag (#1020).
+        shared.AcknowledgeWizardGaps(new[] { GapGamePath, GapAppearance, GapLogging, GapBackup });
+
+        Completed?.Invoke(this, EventArgs.Empty);
+    }
+
+    [RelayCommand]
+    private void Cancel() => Cancelled?.Invoke(this, EventArgs.Empty);
+
+    private static string? ResolveIconPath()
+    {
+        var baseDir = AppContext.BaseDirectory;
+        var ico = System.IO.Path.Combine(baseDir, "Assets", "Trebuchet.ico");
+        return System.IO.File.Exists(ico) ? ico : null;
+    }
+
+    /// <summary>Raised when Finish completes — the window closes.</summary>
+    public event EventHandler? Completed;
+
+    /// <summary>Raised when the user cancels.</summary>
+    public event EventHandler? Cancelled;
+
+    /// <summary>The gap keys this wizard run covers (acknowledged on finish/cancel).</summary>
+    public static IReadOnlyList<string> AllGapKeys =>
+        new[] { GapGamePath, GapAppearance, GapLogging, GapBackup };
+}
+
+/// <summary>One row on the summary page: label, current value, and the step to edit it.</summary>
+public sealed record WizardSummaryRow(string Label, string Value, int StepIndex);

--- a/Trebuchet/Trebuchet/ViewModels/HakConflictViewModel.cs
+++ b/Trebuchet/Trebuchet/ViewModels/HakConflictViewModel.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using RadoubLauncher.Services;
+
+namespace RadoubLauncher.ViewModels;
+
+/// <summary>
+/// View model for the HAK conflict results window (#1162). Presents the
+/// conflicts found across a module's HAK list. Detection only — see
+/// <see cref="HakConflictCheckerService"/>.
+/// </summary>
+public partial class HakConflictViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string _statusText = string.Empty;
+
+    [ObservableProperty]
+    private string _unresolvedWarning = string.Empty;
+
+    [ObservableProperty]
+    private bool _hasUnresolved;
+
+    public ObservableCollection<HakConflictRowViewModel> Conflicts { get; } = new();
+
+    /// <summary>Populate from a completed conflict report.</summary>
+    public void Load(HakConflictReport report)
+    {
+        Conflicts.Clear();
+
+        // Stable display order: by resource name, then extension.
+        var ordered = report.Conflicts
+            .OrderBy(c => c.ResRef, System.StringComparer.OrdinalIgnoreCase)
+            .ThenBy(c => c.Extension, System.StringComparer.OrdinalIgnoreCase);
+
+        foreach (var conflict in ordered)
+            Conflicts.Add(new HakConflictRowViewModel(conflict));
+
+        StatusText = Conflicts.Count == 0
+            ? "No HAK conflicts found."
+            : $"{Conflicts.Count} conflicting resource(s) found.";
+
+        HasUnresolved = report.UnresolvedHaks.Count > 0;
+        UnresolvedWarning = HasUnresolved
+            ? $"⚠ {report.UnresolvedHaks.Count} HAK(s) not found and skipped: {string.Join(", ", report.UnresolvedHaks)}"
+            : string.Empty;
+    }
+}
+
+/// <summary>One conflict row: a resource present in multiple HAKs.</summary>
+public sealed class HakConflictRowViewModel
+{
+    public HakConflictRowViewModel(HakConflict conflict)
+    {
+        Resource = $"{conflict.ResRef}{conflict.Extension}";
+        Winner = conflict.WinnerHak;
+        Haks = string.Join(" → ", conflict.ContainingHaks);
+        HakCount = conflict.ContainingHaks.Count;
+    }
+
+    /// <summary>ResRef plus extension, e.g. "myscript.nss".</summary>
+    public string Resource { get; }
+
+    /// <summary>The winning HAK (first in priority order).</summary>
+    public string Winner { get; }
+
+    /// <summary>All HAKs containing the resource, in priority order (winner first).</summary>
+    public string Haks { get; }
+
+    /// <summary>Number of HAKs containing the resource.</summary>
+    public int HakCount { get; }
+}

--- a/Trebuchet/Trebuchet/ViewModels/ModuleEditorViewModel.cs
+++ b/Trebuchet/Trebuchet/ViewModels/ModuleEditorViewModel.cs
@@ -429,5 +429,23 @@ public partial class ModuleEditorViewModel : ObservableObject
     {
         // Initialize GameDataService for script browser (built-in scripts from game BIFs)
         _ = InitializeGameDataServiceAsync();
+
+        HookHakListChanges(HakList);
+    }
+
+    /// <summary>True when the module has 2+ HAKs — i.e. a conflict check is meaningful (#1162).</summary>
+    public bool HasMultipleHaks => HakList.Count > 1;
+
+    // Keep HasMultipleHaks in sync with both whole-list replacement (load) and
+    // incremental add/remove/reorder.
+    partial void OnHakListChanged(ObservableCollection<string> value)
+    {
+        HookHakListChanges(value);
+        OnPropertyChanged(nameof(HasMultipleHaks));
+    }
+
+    private void HookHakListChanges(ObservableCollection<string> list)
+    {
+        list.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasMultipleHaks));
     }
 }

--- a/Trebuchet/Trebuchet/Views/FirstRunWizardWindow.axaml
+++ b/Trebuchet/Trebuchet/Views/FirstRunWizardWindow.axaml
@@ -112,7 +112,7 @@
                     </DockPanel>
                     <TextBlock Text="How long module backups are kept before cleanup."
                                TextWrapping="Wrap" Opacity="0.7"/>
-                    <Slider Minimum="1" Maximum="90" Value="{Binding BackupRetentionDays}"
+                    <Slider Minimum="1" Maximum="90" Value="{Binding BackupRetentionSlider}"
                             TickFrequency="1" IsSnapToTickEnabled="True"/>
                 </StackPanel>
             </TabItem>
@@ -129,8 +129,7 @@
                                     <TextBlock Grid.Column="0" Text="{Binding Label}" FontWeight="SemiBold" VerticalAlignment="Center"/>
                                     <TextBlock Grid.Column="1" Text="{Binding Value}" TextTrimming="CharacterEllipsis" VerticalAlignment="Center"/>
                                     <Button Grid.Column="2" Content="Edit" Padding="10,3"
-                                            Command="{Binding $parent[ItemsControl].((vm:FirstRunWizardViewModel)DataContext).GoToStepCommand}"
-                                            CommandParameter="{Binding StepIndex}"/>
+                                            Command="{Binding Jump}"/>
                                 </Grid>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>

--- a/Trebuchet/Trebuchet/Views/FirstRunWizardWindow.axaml
+++ b/Trebuchet/Trebuchet/Views/FirstRunWizardWindow.axaml
@@ -13,7 +13,7 @@
 
         <!-- Header -->
         <StackPanel DockPanel.Dock="Top" Spacing="4" Margin="0,0,0,12">
-            <TextBlock Text="{Binding WelcomeHeading}" FontSize="20" FontWeight="SemiBold"/>
+            <TextBlock Text="{Binding WelcomeHeading}" FontSize="{DynamicResource FontSizeLarge}" FontWeight="SemiBold"/>
             <TextBlock Text="{Binding WelcomeBlurb}" TextWrapping="Wrap" Opacity="0.8"/>
             <TextBlock Text="{Binding CurrentStepTitle}" FontWeight="SemiBold" Margin="0,8,0,0"/>
         </StackPanel>

--- a/Trebuchet/Trebuchet/Views/FirstRunWizardWindow.axaml
+++ b/Trebuchet/Trebuchet/Views/FirstRunWizardWindow.axaml
@@ -1,0 +1,149 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:RadoubLauncher.ViewModels"
+        x:Class="RadoubLauncher.Views.FirstRunWizardWindow"
+        x:DataType="vm:FirstRunWizardViewModel"
+        Title="Trebuchet Setup"
+        Width="640" Height="520"
+        MinWidth="520" MinHeight="420"
+        WindowStartupLocation="CenterScreen"
+        ShowInTaskbar="True">
+
+    <DockPanel Margin="16">
+
+        <!-- Header -->
+        <StackPanel DockPanel.Dock="Top" Spacing="4" Margin="0,0,0,12">
+            <TextBlock Text="{Binding WelcomeHeading}" FontSize="20" FontWeight="SemiBold"/>
+            <TextBlock Text="{Binding WelcomeBlurb}" TextWrapping="Wrap" Opacity="0.8"/>
+            <TextBlock Text="{Binding CurrentStepTitle}" FontWeight="SemiBold" Margin="0,8,0,0"/>
+        </StackPanel>
+
+        <!-- Footer navigation -->
+        <Grid DockPanel.Dock="Bottom" ColumnDefinitions="Auto,*,Auto,Auto,Auto" Margin="0,12,0,0">
+            <Button Grid.Column="0"
+                    Content="Cancel"
+                    Command="{Binding CancelCommand}"
+                    Padding="14,6"/>
+            <Button Grid.Column="2"
+                    Content="◀ Back"
+                    Command="{Binding BackCommand}"
+                    IsEnabled="{Binding CanGoBack}"
+                    Padding="14,6"
+                    Margin="0,0,8,0"/>
+            <Button Grid.Column="3"
+                    Content="Next ▶"
+                    Command="{Binding NextCommand}"
+                    IsVisible="{Binding !IsLastStep}"
+                    Padding="14,6"/>
+            <Button Grid.Column="4"
+                    Content="Finish"
+                    Command="{Binding FinishCommand}"
+                    IsVisible="{Binding IsLastStep}"
+                    FontWeight="SemiBold"
+                    Padding="18,6"/>
+        </Grid>
+
+        <!-- Steps -->
+        <TabControl SelectedIndex="{Binding StepIndex}">
+            <!-- TabStrip hidden; navigation is via Back/Next/Edit -->
+            <TabControl.Styles>
+                <Style Selector="TabControl /template/ ItemsPresenter#PART_ItemsPresenter">
+                    <Setter Property="IsVisible" Value="False"/>
+                </Style>
+            </TabControl.Styles>
+
+            <!-- Step 0: Game Path -->
+            <TabItem>
+                <StackPanel Spacing="8" Margin="0,8">
+                    <TextBlock Text="Where is Neverwinter Nights installed?" TextWrapping="Wrap"/>
+                    <TextBlock Text="The base game folder containing the data\ directory. Required for the tools to read game resources."
+                               TextWrapping="Wrap" Opacity="0.7"/>
+                    <DockPanel Margin="0,4,0,0">
+                        <Button DockPanel.Dock="Right" Content="Browse..."
+                                Command="{Binding BrowseGamePathCommand}" Margin="8,0,0,0" Padding="12,6"/>
+                        <Button DockPanel.Dock="Right" Content="Auto-detect"
+                                Command="{Binding AutoDetectGamePathCommand}" Margin="8,0,0,0" Padding="12,6"/>
+                        <TextBox Text="{Binding GameInstallPath}" Watermark="NWN install folder" VerticalAlignment="Center"/>
+                    </DockPanel>
+                    <TextBlock Text="{Binding GamePathValidation}"
+                               IsVisible="{Binding HasGamePathValidation}"
+                               TextWrapping="Wrap" Opacity="0.85" Margin="0,4,0,0"/>
+                </StackPanel>
+            </TabItem>
+
+            <!-- Step 1: Appearance -->
+            <TabItem>
+                <StackPanel Spacing="12" Margin="0,8">
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="Theme"/>
+                        <ComboBox ItemsSource="{Binding AvailableThemes}"
+                                  SelectedItem="{Binding SelectedTheme}"
+                                  HorizontalAlignment="Stretch"/>
+                    </StackPanel>
+                    <StackPanel Spacing="4">
+                        <DockPanel>
+                            <TextBlock DockPanel.Dock="Left" Text="Font size"/>
+                            <TextBlock DockPanel.Dock="Right" Text="{Binding FontSizePointsText}"/>
+                        </DockPanel>
+                        <Slider Minimum="8" Maximum="32" Value="{Binding FontSizePoints}"
+                                TickFrequency="1" IsSnapToTickEnabled="True"/>
+                    </StackPanel>
+                </StackPanel>
+            </TabItem>
+
+            <!-- Step 2: Logging -->
+            <TabItem>
+                <StackPanel Spacing="8" Margin="0,8">
+                    <TextBlock Text="Logging level"/>
+                    <TextBlock Text="Default INFO is fine for most users. Raise to DEBUG/TRACE only when diagnosing an issue."
+                               TextWrapping="Wrap" Opacity="0.7"/>
+                    <ComboBox ItemsSource="{Binding AvailableLogLevels}"
+                              SelectedItem="{Binding SelectedLogLevel}"
+                              HorizontalAlignment="Stretch"/>
+                </StackPanel>
+            </TabItem>
+
+            <!-- Step 3: Backup -->
+            <TabItem>
+                <StackPanel Spacing="8" Margin="0,8">
+                    <DockPanel>
+                        <TextBlock DockPanel.Dock="Left" Text="Backup retention"/>
+                        <TextBlock DockPanel.Dock="Right" Text="{Binding BackupRetentionText}"/>
+                    </DockPanel>
+                    <TextBlock Text="How long module backups are kept before cleanup."
+                               TextWrapping="Wrap" Opacity="0.7"/>
+                    <Slider Minimum="1" Maximum="90" Value="{Binding BackupRetentionDays}"
+                            TickFrequency="1" IsSnapToTickEnabled="True"/>
+                </StackPanel>
+            </TabItem>
+
+            <!-- Step 4: Summary -->
+            <TabItem>
+                <StackPanel Spacing="10" Margin="0,8">
+                    <TextBlock Text="Review your settings. Click Edit to change anything — you can also change these later in Settings."
+                               TextWrapping="Wrap" Opacity="0.8"/>
+                    <ItemsControl ItemsSource="{Binding SummaryRows}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="vm:WizardSummaryRow">
+                                <Grid ColumnDefinitions="160,*,Auto" Margin="0,3">
+                                    <TextBlock Grid.Column="0" Text="{Binding Label}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                    <TextBlock Grid.Column="1" Text="{Binding Value}" TextTrimming="CharacterEllipsis" VerticalAlignment="Center"/>
+                                    <Button Grid.Column="2" Content="Edit" Padding="10,3"
+                                            Command="{Binding $parent[ItemsControl].((vm:FirstRunWizardViewModel)DataContext).GoToStepCommand}"
+                                            CommandParameter="{Binding StepIndex}"/>
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    <CheckBox Content="Create a desktop shortcut for Trebuchet"
+                              IsChecked="{Binding CreateDesktopShortcut}"
+                              Margin="0,8,0,0"/>
+                    <TextBlock Text="{Binding ShortcutResultMessage}"
+                               IsVisible="{Binding HasShortcutResult}"
+                               TextWrapping="Wrap" Opacity="0.85"/>
+                </StackPanel>
+            </TabItem>
+        </TabControl>
+
+    </DockPanel>
+</Window>

--- a/Trebuchet/Trebuchet/Views/FirstRunWizardWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/FirstRunWizardWindow.axaml.cs
@@ -1,0 +1,28 @@
+using System;
+using Avalonia.Controls;
+using RadoubLauncher.Services;
+using RadoubLauncher.ViewModels;
+
+namespace RadoubLauncher.Views;
+
+/// <summary>
+/// First-run / welcome-back configuration wizard window (#1020).
+/// </summary>
+public partial class FirstRunWizardWindow : Window
+{
+    private FirstRunWizardViewModel? _viewModel;
+
+    public FirstRunWizardWindow()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>Initialize for the given mode. Call before showing.</summary>
+    public void Initialize(WizardMode mode)
+    {
+        _viewModel = new FirstRunWizardViewModel(this, mode);
+        _viewModel.Completed += (_, _) => Close();
+        _viewModel.Cancelled += (_, _) => Close();
+        DataContext = _viewModel;
+    }
+}

--- a/Trebuchet/Trebuchet/Views/HakConflictWindow.axaml
+++ b/Trebuchet/Trebuchet/Views/HakConflictWindow.axaml
@@ -1,0 +1,65 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:RadoubLauncher.ViewModels"
+        x:Class="RadoubLauncher.Views.HakConflictWindow"
+        x:DataType="vm:HakConflictViewModel"
+        Title="HAK Conflicts"
+        Width="720" Height="500"
+        MinWidth="520" MinHeight="360"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False">
+
+    <DockPanel Margin="12">
+
+        <!-- Header -->
+        <StackPanel DockPanel.Dock="Top" Spacing="4" Margin="0,0,0,8">
+            <TextBlock Text="{Binding StatusText}"
+                       FontWeight="SemiBold"/>
+            <TextBlock Text="Resources that appear in more than one HAK. The winning HAK is first in priority order (earlier HAKs override later ones)."
+                       TextWrapping="Wrap"
+                       Opacity="0.75"/>
+            <TextBlock Text="{Binding UnresolvedWarning}"
+                       IsVisible="{Binding HasUnresolved}"
+                       Foreground="{DynamicResource WarningBrush}"
+                       TextWrapping="Wrap"
+                       Margin="0,4,0,0"/>
+        </StackPanel>
+
+        <!-- Bottom: Close -->
+        <StackPanel DockPanel.Dock="Bottom"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Margin="0,8,0,0">
+            <Button Content="Close"
+                    Click="OnCloseClick"
+                    IsCancel="True"
+                    Padding="16,6"/>
+        </StackPanel>
+
+        <!-- Conflict List -->
+        <DataGrid ItemsSource="{Binding Conflicts}"
+                  AutoGenerateColumns="False"
+                  CanUserSortColumns="True"
+                  CanUserReorderColumns="False"
+                  CanUserResizeColumns="True"
+                  IsReadOnly="True"
+                  GridLinesVisibility="Horizontal"
+                  SelectionMode="Extended">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Resource"
+                                    Binding="{Binding Resource}"
+                                    Width="220"/>
+                <DataGridTextColumn Header="Winner"
+                                    Binding="{Binding Winner}"
+                                    Width="160"/>
+                <DataGridTextColumn Header="In HAKs (priority order)"
+                                    Binding="{Binding Haks}"
+                                    Width="*"/>
+                <DataGridTextColumn Header="Count"
+                                    Binding="{Binding HakCount}"
+                                    Width="70"/>
+            </DataGrid.Columns>
+        </DataGrid>
+
+    </DockPanel>
+</Window>

--- a/Trebuchet/Trebuchet/Views/HakConflictWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/HakConflictWindow.axaml.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using RadoubLauncher.Services;
+using RadoubLauncher.ViewModels;
+
+namespace RadoubLauncher.Views;
+
+/// <summary>
+/// Non-modal window listing HAK conflicts for the current module (#1162).
+/// </summary>
+public partial class HakConflictWindow : Window
+{
+    private readonly HakConflictViewModel _viewModel = new();
+
+    public HakConflictWindow()
+    {
+        InitializeComponent();
+        DataContext = _viewModel;
+    }
+
+    /// <summary>
+    /// Resolve the given HAK names against the search paths and run the conflict
+    /// check off the UI thread (HAK files are read from disk), then populate the
+    /// grid. Call after the window is shown.
+    /// </summary>
+    public async Task RunCheckAsync(IReadOnlyList<string> hakNamesInPriorityOrder, IReadOnlyList<string> hakSearchPaths)
+    {
+        _viewModel.StatusText = "Checking HAK files…";
+
+        var report = await Task.Run(() =>
+            HakConflictCheckerService.CheckHakNames(hakNamesInPriorityOrder, hakSearchPaths));
+
+        await Dispatcher.UIThread.InvokeAsync(() => _viewModel.Load(report));
+    }
+
+    private void OnCloseClick(object? sender, RoutedEventArgs e) => Close();
+}


### PR DESCRIPTION
## Summary

Trebuchet **Utility & Polish** sprint (#1985) — three items:

- **HAK conflict checker (#1162)** — "Check Conflicts" button on the Module Editor HAK Files tab opens a non-modal window listing resources present in 2+ HAKs and the winning (first-priority) HAK. Detection only.
- **First-run / welcome-back wizard (#1020)** — one-time setup on a fresh install: confirm the game path, review appearance/logging/backup, editable summary. Fires once per new user (acknowledged-gaps record prevents re-nagging); welcome-back re-opens only for newly-introduced no-default settings.
- **Desktop shortcut (#1437)** — offered from the wizard summary; cross-platform C# service (`.lnk` on Windows, `.desktop` on Linux). No standalone scripts.

## Notable fixes during review

- Wizard never fired when auto-detect had already filled the game path → trigger is now "first run" not "game path empty".
- Crash when dragging the backup-retention slider (summary rebuilt on every tick + fragile `$parent`-cast binding + double→int) → rebuild only on summary entry, per-row `Jump` command, double-bound slider.
- FlaUI launches suppress the wizard (pre-seed `WizardHasRun=true`) so UI tests aren't focus-stolen.

## Tests

- Unit + shared: **2726 pass** (Formats 1346, UI 1028, Dictionary 75, Trebuchet 277)
- FlaUI (Trebuchet): **14 pass**
- New TDD coverage: HAK detection, ResolveHakNames, WizardGap, DesktopShortcut, wizard VM (navigation/summary/clamp)

## Related Issues

- Closes #1985
- Closes #1162
- Closes #1020
- Closes #1437

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)