### PR TITLE
[Radoub] Test: Menu/keyboard-shortcut smoke coverage + dead-stub lint (#2362)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Build 2026-06-14] - 2026-06-14
+**Branch**: `radoub/issue-2362` | **PR**: #TBD
+
+### Test: Menu/Keyboard-Shortcut Coverage + Dead-Stub Lint (#2362)
+
+- Added a lint guarding against re-introduced disabled "Not yet implemented" menu stubs (#2231 guard).
+- Added per-tool menu/keyboard-shortcut FlaUI smoke tests, closing the last gap in the UI-wiring validation epic (#2359).
+
+---
+
 ## [Radoub.Formats] - 2026-06-14
 **Branch**: `trebuchet/issue-2419` | **PR**: #2463
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Build 2026-06-14] - 2026-06-14
-**Branch**: `radoub/issue-2362` | **PR**: #TBD
+**Branch**: `radoub/issue-2362` | **PR**: #2465
 
 ### Test: Menu/Keyboard-Shortcut Coverage + Dead-Stub Lint (#2362)
 

--- a/Radoub.IntegrationTests/Fence/MenuShortcutSmokeTests.cs
+++ b/Radoub.IntegrationTests/Fence/MenuShortcutSmokeTests.cs
@@ -1,0 +1,64 @@
+using Radoub.IntegrationTests.Shared;
+using Xunit;
+
+namespace Radoub.IntegrationTests.Fence;
+
+/// <summary>
+/// Menu / keyboard-shortcut wiring smoke tests (#2362, epic #2359).
+/// Fence's Edit-menu Undo/Redo are currently disabled stubs (caught at build time by the
+/// Tier-A dead-stub lint); when #2231 wires them, add an enabled-state assertion here.
+/// </summary>
+[Collection("FenceSequential")]
+public class MenuShortcutSmokeTests : FenceTestBase
+{
+    private void Launch()
+    {
+        StartApplication();
+        WaitForTitleContains("Fence", DefaultTimeout);
+        Thread.Sleep(500);
+        MainWindow = App?.GetMainWindow(Automation!, DefaultTimeout);
+    }
+
+    [Fact]
+    [Trait("Category", "MenuSmoke")]
+    public void TopLevelMenus_Exist()
+    {
+        Launch();
+
+        Assert.NotNull(FindMenu("File"));
+        Assert.NotNull(FindMenu("Edit"));
+        Assert.NotNull(FindMenu("View"));
+    }
+
+    [Fact]
+    [Trait("Category", "MenuSmoke")]
+    public void EditMenu_Has_FindAndReplace_Items()
+    {
+        Launch();
+
+        ClickMenu("Edit");
+        Thread.Sleep(300);
+
+        Assert.NotNull(FindMenuItemOnDesktop("Find..."));
+        Assert.NotNull(FindMenuItemOnDesktop("Replace..."));
+
+        SendEscape();
+    }
+
+    [Fact]
+    [Trait("Category", "MenuSmoke")]
+    public void StoreBrowser_TogglesVia_F4()
+    {
+        Launch();
+
+        SendKeyboardShortcut(FlaUI.Core.WindowsAPI.VirtualKeyShort.F4);
+        Thread.Sleep(500);
+
+        MainWindow = App?.GetMainWindow(Automation!, DefaultTimeout);
+        Assert.NotNull(MainWindow);
+        Assert.False(App!.HasExited, "F4 should toggle the store browser, not exit the app");
+
+        SendKeyboardShortcut(FlaUI.Core.WindowsAPI.VirtualKeyShort.F4);
+        Thread.Sleep(300);
+    }
+}

--- a/Radoub.IntegrationTests/Manifest/MenuShortcutSmokeTests.cs
+++ b/Radoub.IntegrationTests/Manifest/MenuShortcutSmokeTests.cs
@@ -1,0 +1,47 @@
+using Radoub.IntegrationTests.Shared;
+using Xunit;
+
+namespace Radoub.IntegrationTests.Manifest;
+
+/// <summary>
+/// Menu / keyboard-shortcut wiring smoke tests (#2362, epic #2359).
+/// Manifest's Edit-menu Undo/Redo are currently disabled stubs (caught at build time by the
+/// Tier-A dead-stub lint); when #2231 wires them, add an enabled-state assertion here.
+/// </summary>
+[Collection("ManifestSequential")]
+public class MenuShortcutSmokeTests : ManifestTestBase
+{
+    private void Launch()
+    {
+        StartApplication();
+        WaitForTitleContains("Manifest", DefaultTimeout);
+        Thread.Sleep(500);
+        MainWindow = App?.GetMainWindow(Automation!, DefaultTimeout);
+    }
+
+    [Fact]
+    [Trait("Category", "MenuSmoke")]
+    public void TopLevelMenus_Exist()
+    {
+        Launch();
+
+        Assert.NotNull(FindMenu("File"));
+        Assert.NotNull(FindMenu("Edit"));
+        Assert.NotNull(FindMenu("View"));
+    }
+
+    [Fact]
+    [Trait("Category", "MenuSmoke")]
+    public void EditMenu_Has_FindAndReplace_Items()
+    {
+        Launch();
+
+        ClickMenu("Edit");
+        Thread.Sleep(300);
+
+        Assert.NotNull(FindMenuItemOnDesktop("Find..."));
+        Assert.NotNull(FindMenuItemOnDesktop("Replace..."));
+
+        SendEscape();
+    }
+}

--- a/Radoub.IntegrationTests/Parley/MenuShortcutSmokeTests.cs
+++ b/Radoub.IntegrationTests/Parley/MenuShortcutSmokeTests.cs
@@ -1,0 +1,92 @@
+using Radoub.IntegrationTests.Shared;
+using Xunit;
+
+namespace Radoub.IntegrationTests.Parley;
+
+/// <summary>
+/// Menu / keyboard-shortcut wiring smoke tests (#2362, epic #2359).
+///
+/// The audit found that no test asserts the menu Header→handler and gesture→handler
+/// links stay wired — a renamed handler or dropped item would regress silently while
+/// the AXAML still compiles. These are smoke tests: they prove the wire is connected
+/// (the menu opens, the item exists, the gesture has an effect), not deep behavior
+/// (covered by FileOperationTests / TreeEditingTests / UndoRedoTests).
+/// </summary>
+[Collection("ParleySequential")]
+public class MenuShortcutSmokeTests : ParleyTestBase
+{
+    private const string TestFileName = "test1.dlg";
+
+    private void LaunchWithFile()
+    {
+        var testFile = TestPaths.GetTestFile(TestFileName);
+        StartApplication($"\"{testFile}\"");
+        WaitForTitleContains(TestFileName, FileOperationTimeout);
+        Thread.Sleep(500);
+        MainWindow = App?.GetMainWindow(Automation!, DefaultTimeout);
+    }
+
+    [Fact]
+    [Trait("Category", "MenuSmoke")]
+    public void TopLevelMenus_Exist()
+    {
+        LaunchWithFile();
+
+        Assert.NotNull(FindMenu("File"));
+        Assert.NotNull(FindMenu("Edit"));
+        Assert.NotNull(FindMenu("View"));
+    }
+
+    [Fact]
+    [Trait("Category", "MenuSmoke")]
+    public void EditMenu_Has_Undo_And_Redo_Items()
+    {
+        // Parley wires Undo/Redo (OnUndoClick/OnRedoClick). This guards against a
+        // regression to the disabled-stub state the Tier-A lint catches at build time —
+        // here we confirm the live menu actually surfaces them.
+        LaunchWithFile();
+
+        ClickMenu("Edit");
+        Thread.Sleep(300);
+
+        Assert.NotNull(FindMenuItemOnDesktop("Undo"));
+        Assert.NotNull(FindMenuItemOnDesktop("Redo"));
+
+        SendEscape();
+    }
+
+    [Fact]
+    [Trait("Category", "MenuSmoke")]
+    public void EditMenu_Has_FindAndReplace_Items()
+    {
+        LaunchWithFile();
+
+        ClickMenu("Edit");
+        Thread.Sleep(300);
+
+        Assert.NotNull(FindMenuItemOnDesktop("Find..."));
+        Assert.NotNull(FindMenuItemOnDesktop("Replace..."));
+
+        SendEscape();
+    }
+
+    [Fact]
+    [Trait("Category", "MenuSmoke")]
+    public void DialogBrowser_TogglesVia_F4()
+    {
+        LaunchWithFile();
+
+        // F4 toggles the Dialog Browser panel. Smoke: the gesture is handled (no crash)
+        // and a Dialog Browser surface is reachable. We toggle on, then off.
+        SendKeyboardShortcut(FlaUI.Core.WindowsAPI.VirtualKeyShort.F4);
+        Thread.Sleep(500);
+
+        // App must still be alive and responsive after the gesture.
+        MainWindow = App?.GetMainWindow(Automation!, DefaultTimeout);
+        Assert.NotNull(MainWindow);
+        Assert.False(App!.HasExited, "F4 should toggle the browser, not exit the app");
+
+        SendKeyboardShortcut(FlaUI.Core.WindowsAPI.VirtualKeyShort.F4);
+        Thread.Sleep(300);
+    }
+}

--- a/Radoub.IntegrationTests/Parley/UndoRedoTests.cs
+++ b/Radoub.IntegrationTests/Parley/UndoRedoTests.cs
@@ -54,37 +54,6 @@ public class UndoRedoTests : ParleyTestBase
         Assert.NotNull(redoItem);
     }
 
-    /// <summary>
-    /// Searches the desktop for a menu item by name with retries.
-    /// Avalonia renders dropdown menus as separate popup windows outside MainWindow's
-    /// automation tree, so MainWindow.FindFirstDescendant() won't find them reliably.
-    /// Falls back to MainWindow search if desktop search fails.
-    /// </summary>
-    private FlaUI.Core.AutomationElements.AutomationElement? FindMenuItemOnDesktop(string itemName)
-    {
-        const int maxRetries = 5;
-        const int retryDelayMs = 300;
-
-        for (int attempt = 0; attempt < maxRetries; attempt++)
-        {
-            // Search desktop first (where Avalonia popup menus live)
-            var desktop = Automation?.GetDesktop();
-            if (desktop != null)
-            {
-                var item = desktop.FindFirstDescendant(cf => cf.ByName(itemName));
-                if (item != null) return item;
-            }
-
-            // Fallback to MainWindow
-            var fallback = MainWindow?.FindFirstDescendant(cf => cf.ByName(itemName));
-            if (fallback != null) return fallback;
-
-            Thread.Sleep(retryDelayMs);
-        }
-
-        return null;
-    }
-
     [Fact]
     [Trait("Category", "UndoRedo")]
     public void Undo_AfterModification_RestoresDialogState()

--- a/Radoub.IntegrationTests/Quartermaster/MenuShortcutSmokeTests.cs
+++ b/Radoub.IntegrationTests/Quartermaster/MenuShortcutSmokeTests.cs
@@ -1,0 +1,65 @@
+using Radoub.IntegrationTests.Shared;
+using Xunit;
+
+namespace Radoub.IntegrationTests.Quartermaster;
+
+/// <summary>
+/// Menu / keyboard-shortcut wiring smoke tests (#2362, epic #2359).
+/// Proves the top-level menus open and key items stay wired; deep behavior is covered
+/// by NavigationTests / ValueChangeTests.
+/// </summary>
+[Collection("QuartermasterSequential")]
+public class MenuShortcutSmokeTests : QuartermasterTestBase
+{
+    private void Launch()
+    {
+        StartApplication();
+        WaitForTitleContains("Quartermaster", DefaultTimeout);
+        Thread.Sleep(500);
+        MainWindow = App?.GetMainWindow(Automation!, DefaultTimeout);
+    }
+
+    [Fact]
+    [Trait("Category", "MenuSmoke")]
+    public void TopLevelMenus_Exist()
+    {
+        Launch();
+
+        Assert.NotNull(FindMenu("File"));
+        Assert.NotNull(FindMenu("Edit"));
+        Assert.NotNull(FindMenu("Character"));
+        Assert.NotNull(FindMenu("View"));
+    }
+
+    [Fact]
+    [Trait("Category", "MenuSmoke")]
+    public void EditMenu_Has_FindAndReplace_Items()
+    {
+        Launch();
+
+        ClickMenu("Edit");
+        Thread.Sleep(300);
+
+        Assert.NotNull(FindMenuItemOnDesktop("Find..."));
+        Assert.NotNull(FindMenuItemOnDesktop("Replace..."));
+
+        SendEscape();
+    }
+
+    [Fact]
+    [Trait("Category", "MenuSmoke")]
+    public void CreatureBrowser_TogglesVia_F4()
+    {
+        Launch();
+
+        SendKeyboardShortcut(FlaUI.Core.WindowsAPI.VirtualKeyShort.F4);
+        Thread.Sleep(500);
+
+        MainWindow = App?.GetMainWindow(Automation!, DefaultTimeout);
+        Assert.NotNull(MainWindow);
+        Assert.False(App!.HasExited, "F4 should toggle the creature browser, not exit the app");
+
+        SendKeyboardShortcut(FlaUI.Core.WindowsAPI.VirtualKeyShort.F4);
+        Thread.Sleep(300);
+    }
+}

--- a/Radoub.IntegrationTests/Reliquary/MenuShortcutSmokeTests.cs
+++ b/Radoub.IntegrationTests/Reliquary/MenuShortcutSmokeTests.cs
@@ -1,0 +1,47 @@
+using Radoub.IntegrationTests.Shared;
+using Xunit;
+
+namespace Radoub.IntegrationTests.Reliquary;
+
+/// <summary>
+/// Menu / keyboard-shortcut wiring smoke tests (#2362, epic #2359).
+/// Reliquary is the reference impl for wired Undo/Redo, so its Edit menu surfaces them
+/// (unlike Manifest/Fence, whose stubs the Tier-A lint catches at build time).
+/// </summary>
+[Collection("ReliquarySequential")]
+public class MenuShortcutSmokeTests : ReliquaryTestBase
+{
+    private void Launch()
+    {
+        StartApplication();
+        WaitForTitleContains("Reliquary", DefaultTimeout);
+        Thread.Sleep(500);
+        MainWindow = App?.GetMainWindow(Automation!, DefaultTimeout);
+    }
+
+    [Fact]
+    [Trait("Category", "MenuSmoke")]
+    public void TopLevelMenus_Exist()
+    {
+        Launch();
+
+        Assert.NotNull(FindMenu("File"));
+        Assert.NotNull(FindMenu("Edit"));
+        Assert.NotNull(FindMenu("Help"));
+    }
+
+    [Fact]
+    [Trait("Category", "MenuSmoke")]
+    public void EditMenu_Has_Undo_And_Redo_Items()
+    {
+        Launch();
+
+        ClickMenu("Edit");
+        Thread.Sleep(300);
+
+        Assert.NotNull(FindMenuItemOnDesktop("Undo"));
+        Assert.NotNull(FindMenuItemOnDesktop("Redo"));
+
+        SendEscape();
+    }
+}

--- a/Radoub.IntegrationTests/Relique/MenuShortcutSmokeTests.cs
+++ b/Radoub.IntegrationTests/Relique/MenuShortcutSmokeTests.cs
@@ -1,0 +1,63 @@
+using Radoub.IntegrationTests.Shared;
+using Xunit;
+
+namespace Radoub.IntegrationTests.Relique;
+
+/// <summary>
+/// Menu / keyboard-shortcut wiring smoke tests (#2362, epic #2359).
+/// </summary>
+[Collection("ReliqueSequential")]
+public class MenuShortcutSmokeTests : ReliqueTestBase
+{
+    private void Launch()
+    {
+        StartApplication();
+        WaitForTitleContains("Relique", DefaultTimeout);
+        Thread.Sleep(500);
+        MainWindow = App?.GetMainWindow(Automation!, DefaultTimeout);
+    }
+
+    [Fact]
+    [Trait("Category", "MenuSmoke")]
+    public void TopLevelMenus_Exist()
+    {
+        Launch();
+
+        Assert.NotNull(FindMenu("File"));
+        Assert.NotNull(FindMenu("Edit"));
+        Assert.NotNull(FindMenu("View"));
+        Assert.NotNull(FindMenu("Help"));
+    }
+
+    [Fact]
+    [Trait("Category", "MenuSmoke")]
+    public void EditMenu_Has_FindAndReplace_Items()
+    {
+        Launch();
+
+        ClickMenu("Edit");
+        Thread.Sleep(300);
+
+        Assert.NotNull(FindMenuItemOnDesktop("Find..."));
+        Assert.NotNull(FindMenuItemOnDesktop("Replace..."));
+
+        SendEscape();
+    }
+
+    [Fact]
+    [Trait("Category", "MenuSmoke")]
+    public void ItemBrowser_TogglesVia_F4()
+    {
+        Launch();
+
+        SendKeyboardShortcut(FlaUI.Core.WindowsAPI.VirtualKeyShort.F4);
+        Thread.Sleep(500);
+
+        MainWindow = App?.GetMainWindow(Automation!, DefaultTimeout);
+        Assert.NotNull(MainWindow);
+        Assert.False(App!.HasExited, "F4 should toggle the item browser, not exit the app");
+
+        SendKeyboardShortcut(FlaUI.Core.WindowsAPI.VirtualKeyShort.F4);
+        Thread.Sleep(300);
+    }
+}

--- a/Radoub.IntegrationTests/Shared/FlaUITestBase.cs
+++ b/Radoub.IntegrationTests/Shared/FlaUITestBase.cs
@@ -461,6 +461,40 @@ public abstract class FlaUITestBase : IDisposable
     #region Element Finding Helpers
 
     /// <summary>
+    /// Searches the desktop for a menu item by name with retries.
+    /// Avalonia renders dropdown menus as separate popup windows outside MainWindow's
+    /// automation tree, so MainWindow.FindFirstDescendant() won't find them reliably.
+    /// Falls back to a MainWindow search if the desktop search fails.
+    /// Open the parent menu (e.g. via <see cref="ClickMenu"/>) before calling this.
+    /// </summary>
+    /// <param name="itemName">The menu item Name (the Header text) to find.</param>
+    /// <param name="maxRetries">Maximum retry attempts (default 5).</param>
+    /// <returns>The menu item element if found, null otherwise.</returns>
+    protected AutomationElement? FindMenuItemOnDesktop(string itemName, int maxRetries = 5)
+    {
+        const int retryDelayMs = 300;
+
+        for (int attempt = 0; attempt < maxRetries; attempt++)
+        {
+            // Search desktop first (where Avalonia popup menus live).
+            var desktop = Automation?.GetDesktop();
+            if (desktop != null)
+            {
+                var item = desktop.FindFirstDescendant(cf => cf.ByName(itemName));
+                if (item != null) return item;
+            }
+
+            // Fallback to MainWindow.
+            var fallback = MainWindow?.FindFirstDescendant(cf => cf.ByName(itemName));
+            if (fallback != null) return fallback;
+
+            Thread.Sleep(retryDelayMs);
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Finds an element by automation ID with retries.
     /// </summary>
     /// <param name="automationId">The automation ID to search for</param>

--- a/Radoub.IntegrationTests/Trebuchet/ShortcutSmokeTests.cs
+++ b/Radoub.IntegrationTests/Trebuchet/ShortcutSmokeTests.cs
@@ -1,0 +1,71 @@
+using FlaUI.Core.WindowsAPI;
+using Radoub.IntegrationTests.Shared;
+using Xunit;
+
+namespace Radoub.IntegrationTests.Trebuchet;
+
+/// <summary>
+/// Keyboard-shortcut wiring smoke tests (#2362, epic #2359).
+///
+/// Trebuchet has no menu bar — it's a launcher hub with tab navigation driven by
+/// Ctrl+1-4 and Ctrl+Shift+F (Marlinspike), handled in MainWindow's OnKeyDown. Tab
+/// *clicking* is covered by WorkspaceTests; these tests cover the keyboard path, which
+/// was previously unverified and would regress silently if the OnKeyDown switch broke.
+/// </summary>
+[Collection("TrebuchetSequential")]
+public class ShortcutSmokeTests : TrebuchetTestBase
+{
+    private void Launch()
+    {
+        StartApplication();
+        WaitForTitleContains("Trebuchet", DefaultTimeout);
+        Thread.Sleep(1000); // Wait for module + tabs to load
+        MainWindow = App?.GetMainWindow(Automation!, DefaultTimeout);
+    }
+
+    private static bool IsSelected(FlaUI.Core.AutomationElements.AutomationElement? tab)
+    {
+        var sel = tab?.Patterns.SelectionItem.PatternOrDefault;
+        return sel?.IsSelected == true;
+    }
+
+    [Fact]
+    [Trait("Category", "ShortcutSmoke")]
+    public void CtrlNumber_SwitchesWorkspaceTab()
+    {
+        Launch();
+
+        // Ctrl+2 → Factions tab.
+        EnsureFocused();
+        SendKeyboardShortcut(VirtualKeyShort.CONTROL, VirtualKeyShort.KEY_2);
+        Thread.Sleep(500);
+
+        var factionsTab = FindTabByName("Factions");
+        Assert.NotNull(factionsTab);
+        Assert.True(IsSelected(factionsTab), "Ctrl+2 should select the Factions tab");
+
+        // Ctrl+1 → back to Module tab.
+        EnsureFocused();
+        SendKeyboardShortcut(VirtualKeyShort.CONTROL, VirtualKeyShort.KEY_1);
+        Thread.Sleep(500);
+
+        var moduleTab = FindTabByName("Module");
+        Assert.NotNull(moduleTab);
+        Assert.True(IsSelected(moduleTab), "Ctrl+1 should select the Module tab");
+    }
+
+    [Fact]
+    [Trait("Category", "ShortcutSmoke")]
+    public void CtrlShiftF_SwitchesToMarlinspike()
+    {
+        Launch();
+
+        EnsureFocused();
+        SendKeyboardShortcut(VirtualKeyShort.CONTROL, VirtualKeyShort.SHIFT, VirtualKeyShort.KEY_F);
+        Thread.Sleep(500);
+
+        var marlinspikeTab = FindTabByName("Marlinspike");
+        Assert.NotNull(marlinspikeTab);
+        Assert.True(IsSelected(marlinspikeTab), "Ctrl+Shift+F should select the Marlinspike tab");
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/MainWindowMenuStubLintTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/MainWindowMenuStubLintTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Radoub.UI.Utils;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Repo-level dead-stub lint (#2362, #2231 guard). Walks every tool's
+/// <c>MainWindow.axaml</c> and runs it through <see cref="MenuStubAnalyzer"/>.
+///
+/// This is a characterization test: it pins the <em>current</em> set of disabled
+/// menu stubs (Manifest + Fence Undo/Redo, per the #2359 audit). It fails if a new
+/// stub is introduced anywhere, OR if a known stub is removed without updating the
+/// list below — the latter is the signal that #2231 wired undo for that tool and the
+/// expectation should shrink. Either way, a silent regression cannot ship.
+/// </summary>
+public class MainWindowMenuStubLintTests
+{
+    /// <summary>
+    /// Known, accepted dead stubs as of #2362. Keyed by tool name (the directory under
+    /// the repo root). Each value is the set of menu Headers that are currently disabled
+    /// stubs. When #2231 wires undo for a tool, remove its entry here.
+    /// </summary>
+    private static readonly Dictionary<string, string[]> KnownStubs = new()
+    {
+        ["Manifest"] = new[] { "_Undo", "_Redo" },
+        ["Fence"] = new[] { "_Undo", "_Redo" },
+    };
+
+    [Fact]
+    public void NoTool_Introduces_Unexpected_MenuStubs()
+    {
+        var repoRoot = FindRepoRoot();
+        var mainWindows = Directory
+            .GetFiles(repoRoot, "MainWindow.axaml", SearchOption.AllDirectories)
+            .Where(p => p.Replace('\\', '/').Contains("/Views/"))
+            .Where(p => !p.Replace('\\', '/').Contains("/bin/") &&
+                        !p.Replace('\\', '/').Contains("/obj/"))
+            .OrderBy(p => p)
+            .ToList();
+
+        Assert.NotEmpty(mainWindows); // sanity: we actually found the views
+
+        var unexpected = new List<string>();
+
+        foreach (var path in mainWindows)
+        {
+            string tool = ToolNameFromPath(path, repoRoot);
+            var content = File.ReadAllText(path);
+            var found = MenuStubAnalyzer.FindDisabledMenuStubs(content)
+                .Select(v => v.Header)
+                .OrderBy(h => h)
+                .ToArray();
+
+            var expected = (KnownStubs.TryGetValue(tool, out var e) ? e : Array.Empty<string>())
+                .OrderBy(h => h)
+                .ToArray();
+
+            if (!found.SequenceEqual(expected))
+            {
+                unexpected.Add(
+                    $"{tool} ({path}): expected stubs [{string.Join(", ", expected)}], " +
+                    $"found [{string.Join(", ", found)}]");
+            }
+        }
+
+        Assert.True(
+            unexpected.Count == 0,
+            "Menu dead-stub lint mismatch (#2362 / #2231 guard):\n" +
+            string.Join("\n", unexpected) +
+            "\n\nIf you WIRED undo (good — #2231), remove that tool from KnownStubs. " +
+            "If you ADDED a disabled menu stub, wire it via a binding instead.");
+    }
+
+    private static string ToolNameFromPath(string axamlPath, string repoRoot)
+    {
+        // <repoRoot>/<Tool>/<Tool>/Views/MainWindow.axaml  →  <Tool>
+        var rel = Path.GetRelativePath(repoRoot, axamlPath).Replace('\\', '/');
+        return rel.Split('/').First();
+    }
+
+    private static string FindRepoRoot()
+    {
+        // Walk up from the test assembly until we find the repo marker (Radoub.sln).
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Radoub.sln")))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            "Could not locate repo root (Radoub.sln) above " + AppContext.BaseDirectory);
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/MenuStubAnalyzerTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/MenuStubAnalyzerTests.cs
@@ -1,0 +1,132 @@
+using Radoub.UI.Utils;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Dead-stub lint for top-level menus (#2362, #2231 guard).
+///
+/// A "dead stub" is a top-level <c>&lt;Menu&gt;</c> item with a hardcoded
+/// <c>IsEnabled="False"</c> — the disabled "Not yet implemented" anti-pattern.
+/// A genuinely wired menu item controls its enabled state via a binding or
+/// code-behind, never a literal False. The audit (#2359 Part 4) found disabled
+/// Undo/Redo stubs in Manifest and Fence; this lint guards against re-introducing
+/// them and complements the #2231 Undo/Redo wiring work.
+///
+/// The analyzer is a pure string-in / violations-out function so the rule itself
+/// is unit-testable without the filesystem; a companion test walks the real
+/// MainWindow.axaml files.
+/// </summary>
+public class MenuStubAnalyzerTests
+{
+    [Fact]
+    public void Flags_TopLevelMenuItem_With_Literal_IsEnabledFalse()
+    {
+        const string axaml = """
+            <Window xmlns="https://github.com/avaloniaui">
+              <Menu>
+                <MenuItem Header="_Edit">
+                  <MenuItem Header="_Undo" InputGesture="Ctrl+Z" IsEnabled="False"/>
+                </MenuItem>
+              </Menu>
+            </Window>
+            """;
+
+        var violations = MenuStubAnalyzer.FindDisabledMenuStubs(axaml);
+
+        Assert.Single(violations);
+        Assert.Contains("Undo", violations[0].Header);
+    }
+
+    [Fact]
+    public void Flags_Stub_With_NotYetImplemented_Tooltip()
+    {
+        const string axaml = """
+            <Window xmlns="https://github.com/avaloniaui">
+              <Menu>
+                <MenuItem Header="_Edit">
+                  <MenuItem Header="_Redo" IsEnabled="False" ToolTip.Tip="Not yet implemented"/>
+                </MenuItem>
+              </Menu>
+            </Window>
+            """;
+
+        var violations = MenuStubAnalyzer.FindDisabledMenuStubs(axaml);
+
+        Assert.Single(violations);
+        Assert.Contains("Redo", violations[0].Header);
+    }
+
+    [Fact]
+    public void Ignores_Binding_Controlled_IsEnabled()
+    {
+        // The wired pattern: enabled state driven by a binding, not a literal.
+        const string axaml = """
+            <Window xmlns="https://github.com/avaloniaui">
+              <Menu>
+                <MenuItem Header="_File">
+                  <MenuItem Header="_Save" InputGesture="Ctrl+S" IsEnabled="{Binding HasFile}"/>
+                </MenuItem>
+              </Menu>
+            </Window>
+            """;
+
+        var violations = MenuStubAnalyzer.FindDisabledMenuStubs(axaml);
+
+        Assert.Empty(violations);
+    }
+
+    [Fact]
+    public void Ignores_IsEnabledFalse_On_NonMenu_Controls()
+    {
+        // Buttons disabled-until-valid (OK buttons, wizard nav) are legitimate and
+        // overwhelmingly common — the lint must not touch anything outside <Menu>.
+        const string axaml = """
+            <Window xmlns="https://github.com/avaloniaui">
+              <StackPanel>
+                <Button Content="OK" IsEnabled="False"/>
+              </StackPanel>
+            </Window>
+            """;
+
+        var violations = MenuStubAnalyzer.FindDisabledMenuStubs(axaml);
+
+        Assert.Empty(violations);
+    }
+
+    [Fact]
+    public void Ignores_IsEnabledFalse_In_ContextMenu()
+    {
+        // ContextMenu items (e.g. Parley FlowchartPanel "Go to Parent Node") legitimately
+        // pair IsEnabled="False" with an IsVisible binding — not a top-level menu stub.
+        const string axaml = """
+            <Window xmlns="https://github.com/avaloniaui">
+              <Border>
+                <Border.ContextMenu>
+                  <ContextMenu>
+                    <MenuItem Header="Go to Parent Node" IsEnabled="False" IsVisible="{Binding !IsLink}"/>
+                  </ContextMenu>
+                </Border.ContextMenu>
+              </Border>
+            </Window>
+            """;
+
+        var violations = MenuStubAnalyzer.FindDisabledMenuStubs(axaml);
+
+        Assert.Empty(violations);
+    }
+
+    [Fact]
+    public void Empty_When_No_Menu_Present()
+    {
+        const string axaml = """
+            <Window xmlns="https://github.com/avaloniaui">
+              <TextBlock Text="No menu here"/>
+            </Window>
+            """;
+
+        var violations = MenuStubAnalyzer.FindDisabledMenuStubs(axaml);
+
+        Assert.Empty(violations);
+    }
+}

--- a/Radoub.UI/Radoub.UI/Utils/MenuStubAnalyzer.cs
+++ b/Radoub.UI/Radoub.UI/Utils/MenuStubAnalyzer.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Radoub.UI.Utils;
+
+/// <summary>
+/// Pure XAML lint that flags "dead-stub" menu items (#2362, #2231 guard).
+///
+/// A dead stub is a <c>&lt;MenuItem&gt;</c> inside a top-level <c>&lt;Menu&gt;</c> whose
+/// enabled state is hardcoded <c>IsEnabled="False"</c> — the disabled
+/// "Not yet implemented" anti-pattern the #2359 audit found on Manifest/Fence Undo/Redo.
+/// A genuinely wired menu item drives its enabled state via a binding (or code-behind),
+/// never a literal False.
+///
+/// Deliberately scoped to top-level <c>&lt;Menu&gt;</c> only. Literal
+/// <c>IsEnabled="False"</c> is legitimate and common elsewhere — OK buttons disabled
+/// until a selection, wizard Back buttons, and <c>&lt;ContextMenu&gt;</c> items paired
+/// with an <c>IsVisible</c> binding — so those are not flagged.
+/// </summary>
+public static class MenuStubAnalyzer
+{
+    /// <summary>A flagged dead-stub menu item.</summary>
+    public readonly record struct MenuStubViolation(string Header, string Reason);
+
+    private const string AvaloniaNs = "https://github.com/avaloniaui";
+
+    /// <summary>
+    /// Returns the dead-stub violations in a single AXAML document. Empty when clean.
+    /// Malformed XML yields an empty list rather than throwing — a non-parseable view
+    /// would fail the build elsewhere, and the lint should not be the thing that crashes.
+    /// </summary>
+    public static IReadOnlyList<MenuStubViolation> FindDisabledMenuStubs(string axamlContent)
+    {
+        var violations = new List<MenuStubViolation>();
+        if (string.IsNullOrWhiteSpace(axamlContent))
+        {
+            return violations;
+        }
+
+        XDocument doc;
+        try
+        {
+            doc = XDocument.Parse(axamlContent);
+        }
+        catch (System.Xml.XmlException)
+        {
+            return violations;
+        }
+
+        if (doc.Root is null)
+        {
+            return violations;
+        }
+
+        XName menuName = XName.Get("Menu", AvaloniaNs);
+        XName menuItemName = XName.Get("MenuItem", AvaloniaNs);
+
+        // Only top-level <Menu> elements. ContextMenus (and anything nested inside one)
+        // are excluded by construction since we never descend from a ContextMenu root.
+        foreach (var menu in doc.Descendants(menuName))
+        {
+            foreach (var item in menu.Descendants(menuItemName))
+            {
+                if (IsLiteralDisabled(item))
+                {
+                    string header = (string?)item.Attribute("Header") ?? "(unnamed)";
+                    violations.Add(new MenuStubViolation(
+                        header,
+                        $"Top-level menu item '{header}' is hardcoded IsEnabled=\"False\" " +
+                        "(dead stub). Wire its enabled state via a binding or remove it."));
+                }
+            }
+        }
+
+        return violations;
+    }
+
+    private static bool IsLiteralDisabled(XElement menuItem)
+    {
+        string? value = (string?)menuItem.Attribute("IsEnabled");
+        if (value is null)
+        {
+            return false;
+        }
+
+        // A binding like "{Binding HasFile}" is wired, not a stub.
+        string trimmed = value.Trim();
+        if (trimmed.StartsWith('{'))
+        {
+            return false;
+        }
+
+        return string.Equals(trimmed, "False", System.StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the last open child of the UI-wiring validation epic (#2359). Two test tiers:

- **Tier A — dead-stub lint (unit, no FlaUI)**: `MenuStubAnalyzer` flags top-level `<Menu>` items with hardcoded `IsEnabled="False"` (the disabled "Not yet implemented" anti-pattern). A repo-walk characterization test pins the current Manifest + Fence Undo/Redo stubs so a *new* stub fails the build and a *fixed* one (when #2231 wires undo) prompts a one-line list update.
- **Tier B — per-tool menu/shortcut FlaUI smoke**: top-level menus open, Edit items stay wired, F4 browser toggles; Trebuchet covers Ctrl+1/2 tab nav + Ctrl+Shift+F (no menu bar). `FindMenuItemOnDesktop` hoisted into `FlaUITestBase` for reuse.

Plan: `NonPublic/Plans/2026-06-14-2362-plan.md`.

## Test Results

- **Tier A lint** (shared unit): 7/7 ✅ (part of Radoub.UI.Tests 1050/1050)
- **Shared unit suites**: 2504/2504 ✅ (Radoub.Formats 1379, Radoub.UI 1050, Radoub.Dictionary 75)
- **Tier B FlaUI smoke**: 19/19 ✅ across all 7 tools
- **Regression** (refactored Parley UndoRedo after the hoist): 7/7 ✅
- Privacy (paths): PASS · Tech debt (file size): PASS

## Related Issues

- Closes #2362
- Completes epic #2359
- Coordinates with #2231 (Undo/Redo): Manifest/Fence smoke + lint assert the current stub state; #2231 sprints flip them to enabled-state assertions when undo is wired.

## Notes

- Only production change is `Radoub.UI/Utils/MenuStubAnalyzer.cs` (a pure utility — no UI files changed, so UI auto-trigger did not fire).
- Pre-existing WARN: 16 hardcoded theme Foregrounds in `TokenSelectorWindow.axaml` — untouched by this PR, out of scope.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)