### PR TITLE
[Manifest] Sprint: Undo/Redo + Focused-Edit Revert Fix (#2231 S3)

### DIFF
--- a/Manifest/CHANGELOG.md
+++ b/Manifest/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Sprint 3: Undo/Redo + focused-edit revert (#2231, #2461, #2253)
 
 - Fix focused-text-box edit reverting on focus change, and the missing dirty flag on edit (#2461).
-- Wire Ctrl+Z / Ctrl+Y undo/redo: non-text edits use document/whole-field undo (Relique pattern); prose/quest-body text keeps native per-character undo (#2253 undo portion, #2231 Sprint 3).
+- Wire Ctrl+Z / Ctrl+Y undo/redo. Every editable field records one whole-field document undo step per focus session (matching Parley's dialogue-prose behavior); add/delete of categories and entries are undoable too (#2253 undo portion, #2231 Sprint 3).
 - Re-audit the atomic save + duplicate-ID handling that landed in #2410.
 
 ---

--- a/Manifest/CHANGELOG.md
+++ b/Manifest/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.15.11-alpha] - 2026-06-14
-**Branch**: `manifest/sprint/undo-redo-focus-fix` | **PR**: #TBD
+**Branch**: `manifest/sprint/undo-redo-focus-fix` | **PR**: #2469
 
 ### Sprint 3: Undo/Redo + focused-edit revert (#2231, #2461, #2253)
 

--- a/Manifest/CHANGELOG.md
+++ b/Manifest/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.15.11-alpha] - 2026-06-14
+**Branch**: `manifest/sprint/undo-redo-focus-fix` | **PR**: #TBD
+
+### Sprint 3: Undo/Redo + focused-edit revert (#2231, #2461, #2253)
+
+- Fix focused-text-box edit reverting on focus change, and the missing dirty flag on edit (#2461).
+- Wire Ctrl+Z / Ctrl+Y undo/redo: non-text edits use document/whole-field undo (Relique pattern); prose/quest-body text keeps native per-character undo (#2253 undo portion, #2231 Sprint 3).
+- Re-audit the atomic save + duplicate-ID handling that landed in #2410.
+
+---
+
 ## [0.15.10-alpha] - 2026-06-07
 **Branch**: `fence/issue-2383` | **PR**: #2410
 

--- a/Manifest/Manifest.Tests/JournalFieldEditorTests.cs
+++ b/Manifest/Manifest.Tests/JournalFieldEditorTests.cs
@@ -1,0 +1,122 @@
+using Manifest.Services;
+using Radoub.Formats.Jrl;
+using Xunit;
+
+namespace Manifest.Tests;
+
+/// <summary>
+/// Tests for <see cref="JournalFieldEditor"/> — the pure commit kernel that pushes a
+/// pending text-box value into the journal model and reports whether anything changed
+/// (so the caller can mark the document dirty). Extracted so the focus-commit fix
+/// (#2461) is unit-testable without FlaUI: the same kernel runs on LostFocus AND on
+/// the force-commit-before-save path, guaranteeing a save-while-focused persists the
+/// visible value instead of reverting.
+/// </summary>
+public class JournalFieldEditorTests
+{
+    // --- Entry text (language slot 0 / default) ---
+
+    [Fact]
+    public void ApplyEntryText_DifferentValue_UpdatesModelAndReportsChanged()
+    {
+        var entry = new JournalEntry();
+        entry.Text.SetString(0, "old quest text");
+
+        var changed = JournalFieldEditor.ApplyEntryText(entry, "new quest text");
+
+        Assert.True(changed);
+        Assert.Equal("new quest text", entry.Text.GetDefault());
+    }
+
+    [Fact]
+    public void ApplyEntryText_SameValue_NoChangeReported()
+    {
+        var entry = new JournalEntry();
+        entry.Text.SetString(0, "same");
+
+        var changed = JournalFieldEditor.ApplyEntryText(entry, "same");
+
+        Assert.False(changed);
+        Assert.Equal("same", entry.Text.GetDefault());
+    }
+
+    [Fact]
+    public void ApplyEntryText_NullTreatedAsEmpty()
+    {
+        var entry = new JournalEntry();
+        entry.Text.SetString(0, "had text");
+
+        var changed = JournalFieldEditor.ApplyEntryText(entry, null);
+
+        Assert.True(changed);
+        Assert.Equal("", entry.Text.GetDefault());
+    }
+
+    // --- Category name (language slot 0 / default) ---
+
+    [Fact]
+    public void ApplyCategoryName_DifferentValue_UpdatesModelAndReportsChanged()
+    {
+        var cat = new JournalCategory();
+        cat.Name.SetString(0, "Old Name");
+
+        var changed = JournalFieldEditor.ApplyCategoryName(cat, "New Name");
+
+        Assert.True(changed);
+        Assert.Equal("New Name", cat.Name.GetDefault());
+    }
+
+    [Fact]
+    public void ApplyCategoryName_SameValue_NoChangeReported()
+    {
+        var cat = new JournalCategory();
+        cat.Name.SetString(0, "Quest");
+
+        Assert.False(JournalFieldEditor.ApplyCategoryName(cat, "Quest"));
+    }
+
+    // --- Category tag (plain string) ---
+
+    [Fact]
+    public void ApplyCategoryTag_DifferentValue_UpdatesModelAndReportsChanged()
+    {
+        var cat = new JournalCategory { Tag = "old_tag" };
+
+        var changed = JournalFieldEditor.ApplyCategoryTag(cat, "new_tag");
+
+        Assert.True(changed);
+        Assert.Equal("new_tag", cat.Tag);
+    }
+
+    [Fact]
+    public void ApplyCategoryTag_SameValue_NoChangeReported()
+    {
+        var cat = new JournalCategory { Tag = "tag" };
+
+        Assert.False(JournalFieldEditor.ApplyCategoryTag(cat, "tag"));
+    }
+
+    // --- Category comment (plain string) ---
+
+    [Fact]
+    public void ApplyCategoryComment_DifferentValue_UpdatesModelAndReportsChanged()
+    {
+        var cat = new JournalCategory { Comment = "old" };
+
+        var changed = JournalFieldEditor.ApplyCategoryComment(cat, "new");
+
+        Assert.True(changed);
+        Assert.Equal("new", cat.Comment);
+    }
+
+    [Fact]
+    public void ApplyCategoryComment_NullTreatedAsEmpty()
+    {
+        var cat = new JournalCategory { Comment = "old" };
+
+        var changed = JournalFieldEditor.ApplyCategoryComment(cat, null);
+
+        Assert.True(changed);
+        Assert.Equal("", cat.Comment);
+    }
+}

--- a/Manifest/Manifest.Tests/JournalStructuralCommandTests.cs
+++ b/Manifest/Manifest.Tests/JournalStructuralCommandTests.cs
@@ -1,0 +1,151 @@
+using Manifest.Services;
+using Radoub.Formats.Jrl;
+using Radoub.UI.Undo;
+using Xunit;
+
+namespace Manifest.Tests;
+
+/// <summary>
+/// Tests for the structural undo commands (#2253 / #2231 Sprint 3): add/delete of journal
+/// categories and entries routed through <see cref="IUndoableCommand"/>. These are the
+/// highest data-loss-risk operations, so they get pure unit coverage independent of FlaUI.
+/// Do/Undo/Redo round-trips and index preservation mirror Reliquary's command tests.
+/// </summary>
+public class JournalStructuralCommandTests
+{
+    private static JournalCategory Cat(string tag)
+    {
+        var c = new JournalCategory { Tag = tag };
+        return c;
+    }
+
+    private static JournalEntry Entry(uint id)
+    {
+        var e = new JournalEntry { ID = id };
+        e.Text.SetString(0, $"entry {id}");
+        return e;
+    }
+
+    // --- Add category ---
+
+    [Fact]
+    public void AddCategory_DoAppends_UndoRemoves_RedoReAppends()
+    {
+        var jrl = new JrlFile();
+        var added = Cat("new_quest");
+        var cmd = new AddCategoryCommand(jrl, added);
+
+        Assert.True(cmd.Do());
+        Assert.Single(jrl.Categories);
+        Assert.Same(added, jrl.Categories[0]);
+
+        cmd.Undo();
+        Assert.Empty(jrl.Categories);
+
+        Assert.True(cmd.Do()); // redo
+        Assert.Single(jrl.Categories);
+        Assert.Same(added, jrl.Categories[0]);
+    }
+
+    // --- Delete category (index preserved) ---
+
+    [Fact]
+    public void DeleteCategory_UndoRestoresAtOriginalIndex()
+    {
+        var jrl = new JrlFile();
+        var a = Cat("a"); var b = Cat("b"); var c = Cat("c");
+        jrl.Categories.Add(a); jrl.Categories.Add(b); jrl.Categories.Add(c);
+
+        var cmd = new DeleteCategoryCommand(jrl, b); // middle item
+
+        Assert.True(cmd.Do());
+        Assert.Equal(new[] { a, c }, jrl.Categories);
+
+        cmd.Undo();
+        Assert.Equal(new[] { a, b, c }, jrl.Categories); // b back at index 1
+    }
+
+    [Fact]
+    public void DeleteCategory_NotPresent_DoReturnsFalse()
+    {
+        var jrl = new JrlFile();
+        jrl.Categories.Add(Cat("a"));
+        var orphan = Cat("orphan");
+
+        var cmd = new DeleteCategoryCommand(jrl, orphan);
+
+        Assert.False(cmd.Do()); // refuse-to-push: nothing to delete
+        Assert.Single(jrl.Categories);
+    }
+
+    // --- Add entry ---
+
+    [Fact]
+    public void AddEntry_DoAppends_UndoRemoves_RedoReAppends()
+    {
+        var cat = Cat("quest");
+        var entry = Entry(100);
+        var cmd = new AddEntryCommand(cat, entry);
+
+        Assert.True(cmd.Do());
+        Assert.Single(cat.Entries);
+
+        cmd.Undo();
+        Assert.Empty(cat.Entries);
+
+        Assert.True(cmd.Do()); // redo
+        Assert.Single(cat.Entries);
+        Assert.Same(entry, cat.Entries[0]);
+    }
+
+    // --- Delete entry (index preserved) ---
+
+    [Fact]
+    public void DeleteEntry_UndoRestoresAtOriginalIndex()
+    {
+        var cat = Cat("quest");
+        var e1 = Entry(100); var e2 = Entry(200); var e3 = Entry(300);
+        cat.Entries.Add(e1); cat.Entries.Add(e2); cat.Entries.Add(e3);
+
+        var cmd = new DeleteEntryCommand(cat, e2);
+
+        Assert.True(cmd.Do());
+        Assert.Equal(new[] { e1, e3 }, cat.Entries);
+
+        cmd.Undo();
+        Assert.Equal(new[] { e1, e2, e3 }, cat.Entries);
+    }
+
+    // --- Through the manager (refuse-to-push contract) ---
+
+    [Fact]
+    public void Manager_DeleteAbsentCategory_NotPushed()
+    {
+        var jrl = new JrlFile();
+        jrl.Categories.Add(Cat("a"));
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new DeleteCategoryCommand(jrl, Cat("absent")));
+
+        Assert.False(mgr.CanUndo); // self-rolled-back command not recorded
+    }
+
+    [Fact]
+    public void Manager_AddThenUndoRedo_RoundTrips()
+    {
+        var jrl = new JrlFile();
+        var mgr = new UndoRedoManager();
+        var cat = Cat("q");
+
+        mgr.Execute(new AddCategoryCommand(jrl, cat));
+        Assert.Single(jrl.Categories);
+        Assert.True(mgr.CanUndo);
+
+        mgr.Undo();
+        Assert.Empty(jrl.Categories);
+        Assert.True(mgr.CanRedo);
+
+        mgr.Redo();
+        Assert.Single(jrl.Categories);
+    }
+}

--- a/Manifest/Manifest/Services/JournalFieldEditor.cs
+++ b/Manifest/Manifest/Services/JournalFieldEditor.cs
@@ -1,0 +1,57 @@
+using Radoub.Formats.Jrl;
+
+namespace Manifest.Services;
+
+/// <summary>
+/// Pure commit kernel for journal text fields (#2461). Pushes a pending text-box value
+/// into the journal model and returns whether the value actually changed, so the caller
+/// can mark the document dirty.
+///
+/// Extracted from MainWindow.PropertyPanel so the same logic runs on both the LostFocus
+/// handlers AND a force-commit-before-save path. The #2461 data-loss bug was that text
+/// fields committed to the model only on LostFocus: a Save (Ctrl+S / menu) issued while a
+/// text box still had focus wrote the pre-edit model value, so the visible edit silently
+/// reverted. Routing save through a force-commit that calls these helpers guarantees the
+/// visible value is persisted.
+///
+/// Text writes target language slot 0 (default), matching the existing handler behavior.
+/// Keeping it pure (no UI types) makes it unit-testable without FlaUI.
+/// </summary>
+internal static class JournalFieldEditor
+{
+    /// <summary>Apply entry text to the model. Returns true if the value changed.</summary>
+    public static bool ApplyEntryText(JournalEntry entry, string? newText)
+    {
+        var value = newText ?? "";
+        if (entry.Text.GetDefault() == value) return false;
+        entry.Text.SetString(0, value);
+        return true;
+    }
+
+    /// <summary>Apply category name to the model. Returns true if the value changed.</summary>
+    public static bool ApplyCategoryName(JournalCategory category, string? newName)
+    {
+        var value = newName ?? "";
+        if (category.Name.GetDefault() == value) return false;
+        category.Name.SetString(0, value);
+        return true;
+    }
+
+    /// <summary>Apply category tag to the model. Returns true if the value changed.</summary>
+    public static bool ApplyCategoryTag(JournalCategory category, string? newTag)
+    {
+        var value = newTag ?? "";
+        if (category.Tag == value) return false;
+        category.Tag = value;
+        return true;
+    }
+
+    /// <summary>Apply category comment to the model. Returns true if the value changed.</summary>
+    public static bool ApplyCategoryComment(JournalCategory category, string? newComment)
+    {
+        var value = newComment ?? "";
+        if (category.Comment == value) return false;
+        category.Comment = value;
+        return true;
+    }
+}

--- a/Manifest/Manifest/Services/JournalStructuralCommands.cs
+++ b/Manifest/Manifest/Services/JournalStructuralCommands.cs
@@ -1,0 +1,118 @@
+using System.Collections.Generic;
+using Radoub.Formats.Jrl;
+using Radoub.UI.Undo;
+
+namespace Manifest.Services;
+
+/// <summary>
+/// Undoable structural operations for the journal (#2253 / #2231 Sprint 3): add and delete of
+/// categories and entries. These mutate the model lists directly and capture enough state to
+/// restore the prior arrangement (delete records the original index). The host passes a UI
+/// refresh callback separately (it rebuilds the tree after Do/Undo); these commands stay pure so
+/// they are unit-testable without FlaUI.
+///
+/// Delete commands return false from <see cref="IUndoableCommand.Do"/> when the target is not
+/// present, honoring the manager's refuse-to-push contract so a no-op delete never lands on the
+/// undo stack.
+/// </summary>
+public sealed class AddCategoryCommand : IUndoableCommand
+{
+    private readonly List<JournalCategory> _categories;
+    private readonly JournalCategory _category;
+
+    public AddCategoryCommand(JrlFile jrl, JournalCategory category)
+    {
+        _categories = jrl.Categories;
+        _category = category;
+    }
+
+    public string Description => "add category";
+
+    public bool Do()
+    {
+        _categories.Add(_category);
+        return true;
+    }
+
+    public void Undo() => _categories.Remove(_category);
+}
+
+public sealed class DeleteCategoryCommand : IUndoableCommand
+{
+    private readonly List<JournalCategory> _categories;
+    private readonly JournalCategory _category;
+    private int _index = -1;
+
+    public DeleteCategoryCommand(JrlFile jrl, JournalCategory category)
+    {
+        _categories = jrl.Categories;
+        _category = category;
+    }
+
+    public string Description => "delete category";
+
+    public bool Do()
+    {
+        _index = _categories.IndexOf(_category);
+        if (_index < 0) return false; // not present → nothing to delete, don't record
+        _categories.RemoveAt(_index);
+        return true;
+    }
+
+    public void Undo()
+    {
+        if (_index < 0) return;
+        _categories.Insert(_index, _category);
+    }
+}
+
+public sealed class AddEntryCommand : IUndoableCommand
+{
+    private readonly List<JournalEntry> _entries;
+    private readonly JournalEntry _entry;
+
+    public AddEntryCommand(JournalCategory category, JournalEntry entry)
+    {
+        _entries = category.Entries;
+        _entry = entry;
+    }
+
+    public string Description => "add entry";
+
+    public bool Do()
+    {
+        _entries.Add(_entry);
+        return true;
+    }
+
+    public void Undo() => _entries.Remove(_entry);
+}
+
+public sealed class DeleteEntryCommand : IUndoableCommand
+{
+    private readonly List<JournalEntry> _entries;
+    private readonly JournalEntry _entry;
+    private int _index = -1;
+
+    public DeleteEntryCommand(JournalCategory category, JournalEntry entry)
+    {
+        _entries = category.Entries;
+        _entry = entry;
+    }
+
+    public string Description => "delete entry";
+
+    public bool Do()
+    {
+        _index = _entries.IndexOf(_entry);
+        if (_index < 0) return false;
+        _entries.RemoveAt(_index);
+        return true;
+    }
+
+    public void Undo()
+    {
+        if (_index < 0) return;
+        _entries.Insert(_index, _entry);
+    }
+}

--- a/Manifest/Manifest/Views/MainWindow.EditOps.cs
+++ b/Manifest/Manifest/Views/MainWindow.EditOps.cs
@@ -37,14 +37,10 @@ public partial class MainWindow
             Comment = ""
         };
 
-        // #2254 — guard the model.Add → UpdateTree sequence: if UpdateTree throws,
-        // the category is rolled back so the model never ends up dirty + half-rendered.
-        if (!TryMutateWithRollback(_currentJrl.Categories, newCategory, UpdateTree))
-        {
-            UnifiedLogger.LogJournal(LogLevel.ERROR, $"Add category rolled back (tree refresh failed): {uniqueTag}");
-            UpdateStatus("Could not add category — change was rolled back.");
-            return;
-        }
+        // Route through undo (#2231). The structural command appends + the wrapper refreshes the
+        // tree; undo removes + refreshes. UpdateTree is the same refresh path the rollback guard
+        // protected, so a refresh failure still leaves the model consistent.
+        ExecuteStructural(new Manifest.Services.AddCategoryCommand(_currentJrl, newCategory));
 
         MarkDirty();
         UpdateStatusBarCounts();
@@ -129,13 +125,8 @@ public partial class MainWindow
             End = false
         };
 
-        // #2254 — same rollback guard as OnAddCategoryClick.
-        if (!TryMutateWithRollback(category.Entries, newEntry, UpdateTree))
-        {
-            UnifiedLogger.LogJournal(LogLevel.ERROR, $"Add entry rolled back (tree refresh failed): ID {nextId}");
-            UpdateStatus("Could not add entry — change was rolled back.");
-            return;
-        }
+        // Route through undo (#2231), same as Add Category.
+        ExecuteStructural(new Manifest.Services.AddEntryCommand(category, newEntry));
 
         MarkDirty();
         UpdateStatusBarCounts();
@@ -150,22 +141,23 @@ public partial class MainWindow
     {
         if (_currentJrl == null || _selectedItem == null) return;
 
+        // Route deletes through undo (#2231) so they can be reversed (data-safety: deleting a
+        // category/entry is the highest-loss action). The structural command records the original
+        // index for restore; the wrapper rebuilds tree/panel on Do/Undo/Redo.
         if (_selectedItem is CategoryTreeItem catItem)
         {
-            _currentJrl.Categories.Remove(catItem.Category);
             UnifiedLogger.LogJournal(LogLevel.INFO, $"Deleted category: {catItem.Category.Tag}");
+            _selectedItem = null;
+            ExecuteStructural(new Manifest.Services.DeleteCategoryCommand(_currentJrl, catItem.Category));
         }
         else if (_selectedItem is EntryTreeItem entItem)
         {
-            entItem.ParentCategory.Entries.Remove(entItem.Entry);
             UnifiedLogger.LogJournal(LogLevel.INFO, $"Deleted entry: {entItem.Entry.ID}");
+            _selectedItem = null;
+            ExecuteStructural(new Manifest.Services.DeleteEntryCommand(entItem.ParentCategory, entItem.Entry));
         }
 
-        _selectedItem = null;
         MarkDirty();
-        UpdateTree();
-        UpdatePropertyPanel();
-        UpdateStatusBarCounts();
     }
 
     private void SelectNewCategory(JournalCategory category)

--- a/Manifest/Manifest/Views/MainWindow.FileOps.cs
+++ b/Manifest/Manifest/Views/MainWindow.FileOps.cs
@@ -148,6 +148,7 @@ public partial class MainWindow
             _currentJrl = await Task.Run(() => JrlReader.Read(filePath));
             _documentState.CurrentFilePath = filePath;
             _documentState.ClearDirty();
+            ClearUndo(); // per-document history (#2231)
 
             // Clear selection and update UI
             _selectedItem = null;
@@ -320,6 +321,7 @@ public partial class MainWindow
             _currentJrl = newJrl;
             _currentFilePath = filePath;
             _documentState.ClearDirty();
+            ClearUndo(); // per-document history (#2231)
 
             UpdateTree();
             UpdateTitle();

--- a/Manifest/Manifest/Views/MainWindow.FileOps.cs
+++ b/Manifest/Manifest/Views/MainWindow.FileOps.cs
@@ -202,6 +202,11 @@ public partial class MainWindow
     {
         if (_currentJrl == null || string.IsNullOrEmpty(_currentFilePath)) return;
 
+        // #2461 — commit any in-progress edit from a focused text box into the model BEFORE
+        // writing. Text fields otherwise commit only on LostFocus, so saving while a box still
+        // has focus would persist the stale model value and the visible edit would revert.
+        CommitFocusedEdit();
+
         if (_documentState.IsReadOnly)
         {
             UnifiedLogger.LogApplication(LogLevel.WARN, $"Save blocked: file is read-only (locked by another tool): {UnifiedLogger.SanitizePath(_currentFilePath)}");

--- a/Manifest/Manifest/Views/MainWindow.FileOps.cs
+++ b/Manifest/Manifest/Views/MainWindow.FileOps.cs
@@ -264,11 +264,14 @@ public partial class MainWindow
         }
         finally
         {
-            // Clean up temp file if it still exists (write failed before the move)
+            // Clean up temp file if it still exists (write failed before the move).
+            // Best-effort: catch only the IO/access errors a delete can raise; never
+            // swallow everything (CLAUDE.md — no bare catch).
             if (File.Exists(tempPath))
             {
                 try { File.Delete(tempPath); }
-                catch { /* temp cleanup is best-effort */ }
+                catch (IOException ex) { UnifiedLogger.LogJournal(LogLevel.WARN, $"Temp cleanup failed: {ex.Message}"); }
+                catch (UnauthorizedAccessException ex) { UnifiedLogger.LogJournal(LogLevel.WARN, $"Temp cleanup denied: {ex.Message}"); }
             }
         }
     }

--- a/Manifest/Manifest/Views/MainWindow.PropertyPanel.cs
+++ b/Manifest/Manifest/Views/MainWindow.PropertyPanel.cs
@@ -224,24 +224,22 @@ public partial class MainWindow
     {
         if (_isUpdatingPanel || _selectedItem is not CategoryTreeItem catItem) return;
 
-        if (JournalFieldEditor.ApplyCategoryName(catItem.Category, CategoryNameBox.Text))
-        {
-            MarkDirty();
-            UpdateTreeItemHeader(catItem);
-            UnifiedLogger.LogJournal(LogLevel.DEBUG, "Category name changed");
-        }
+        var cat = catItem.Category;
+        CommitTextField(CategoryNameBox,
+            v => JournalFieldEditor.ApplyCategoryName(cat, v),
+            () => { UpdateTreeItemHeader(catItem); },
+            "edit category name");
     }
 
     private void OnCategoryTagChanged(object? sender, RoutedEventArgs e)
     {
         if (_isUpdatingPanel || _selectedItem is not CategoryTreeItem catItem) return;
 
-        if (JournalFieldEditor.ApplyCategoryTag(catItem.Category, CategoryTagBox.Text))
-        {
-            MarkDirty();
-            UpdateTreeItemHeader(catItem);
-            UnifiedLogger.LogJournal(LogLevel.DEBUG, "Category tag changed");
-        }
+        var cat = catItem.Category;
+        CommitTextField(CategoryTagBox,
+            v => JournalFieldEditor.ApplyCategoryTag(cat, v),
+            () => { UpdateTreeItemHeader(catItem); },
+            "edit category tag");
     }
 
     private void OnCategoryPriorityChanged(object? sender, SelectionChangedEventArgs e)
@@ -251,10 +249,15 @@ public partial class MainWindow
         if (CategoryPriorityBox.SelectedItem is ComboBoxItem item &&
             item.Tag is string tagStr && uint.TryParse(tagStr, out var newPriority))
         {
-            if (catItem.Category.Priority != newPriority)
+            var oldPriority = catItem.Category.Priority;
+            if (oldPriority != newPriority)
             {
-                catItem.Category.Priority = newPriority;
+                var cat = catItem.Category;
+                cat.Priority = newPriority;
                 MarkDirty();
+                // Whole-field undo (#2231): mutate the model; the panel repaint after undo/redo
+                // re-selects the combo from the model.
+                RecordFieldEdit(oldPriority, newPriority, v => cat.Priority = v, "change priority");
                 UnifiedLogger.LogJournal(LogLevel.DEBUG, $"Category priority changed to: {newPriority}");
             }
         }
@@ -265,10 +268,13 @@ public partial class MainWindow
         if (_isUpdatingPanel || _selectedItem is not CategoryTreeItem catItem) return;
 
         var newXP = (uint)(CategoryXPBox.Value ?? 0);
-        if (catItem.Category.XP != newXP)
+        var oldXP = catItem.Category.XP;
+        if (oldXP != newXP)
         {
-            catItem.Category.XP = newXP;
+            var cat = catItem.Category;
+            cat.XP = newXP;
             MarkDirty();
+            RecordFieldEdit(oldXP, newXP, v => cat.XP = v, "change XP");
             UnifiedLogger.LogJournal(LogLevel.DEBUG, $"Category XP changed to: {newXP}");
         }
     }
@@ -277,11 +283,11 @@ public partial class MainWindow
     {
         if (_isUpdatingPanel || _selectedItem is not CategoryTreeItem catItem) return;
 
-        if (JournalFieldEditor.ApplyCategoryComment(catItem.Category, CategoryCommentBox.Text))
-        {
-            MarkDirty();
-            UnifiedLogger.LogJournal(LogLevel.DEBUG, "Category comment changed");
-        }
+        var cat = catItem.Category;
+        CommitTextField(CategoryCommentBox,
+            v => JournalFieldEditor.ApplyCategoryComment(cat, v),
+            null,
+            "edit category comment");
     }
 
     /// <summary>
@@ -337,9 +343,15 @@ public partial class MainWindow
             finally { _isUpdatingPanel = false; }
         }
 
-        entItem.Entry.ID = resolvedId;
+        var oldId = entItem.Entry.ID;
+        var ent = entItem.Entry;
+        ent.ID = resolvedId;
         MarkDirty();
         UpdateTreeItemHeader(entItem);
+        // Whole-field undo (#2231): restore the original ID on undo, reapply resolved on redo.
+        // Setter mutates the model + tree header; the panel repaint after undo/redo restores the
+        // NumericUpDown from the model.
+        RecordFieldEdit(oldId, resolvedId, v => { ent.ID = v; UpdateTreeItemHeader(entItem); }, "change entry ID");
         UnifiedLogger.LogJournal(LogLevel.DEBUG, $"Entry ID changed to: {resolvedId}");
     }
 
@@ -348,11 +360,14 @@ public partial class MainWindow
         if (_isUpdatingPanel || _selectedItem is not EntryTreeItem entItem) return;
 
         var newEnd = EntryEndBox.IsChecked ?? false;
-        if (entItem.Entry.End != newEnd)
+        var oldEnd = entItem.Entry.End;
+        if (oldEnd != newEnd)
         {
-            entItem.Entry.End = newEnd;
+            var ent = entItem.Entry;
+            ent.End = newEnd;
             MarkDirty();
             UpdateTreeItemHeader(entItem);
+            RecordFieldEdit(oldEnd, newEnd, v => { ent.End = v; UpdateTreeItemHeader(entItem); }, "toggle End");
             UnifiedLogger.LogJournal(LogLevel.DEBUG, $"Entry End changed to: {newEnd}");
         }
     }
@@ -361,12 +376,51 @@ public partial class MainWindow
     {
         if (_isUpdatingPanel || _selectedItem is not EntryTreeItem entItem) return;
 
-        if (JournalFieldEditor.ApplyEntryText(entItem.Entry, EntryTextBox.Text))
+        var ent = entItem.Entry;
+        CommitTextField(EntryTextBox,
+            v => JournalFieldEditor.ApplyEntryText(ent, v),
+            () => { UpdateTreeItemHeader(entItem); },
+            "edit entry text");
+    }
+
+    /// <summary>
+    /// Commit a prose/text box into the model and record it as one whole-field undo step
+    /// (#2231 / #2461). The baseline (value when the box gained focus) is the undo target;
+    /// <paramref name="applyToModel"/> writes the box's current text into the model and returns
+    /// whether it changed; <paramref name="afterApply"/> refreshes dependent UI. Re-arms the
+    /// baseline so a later edit in the same focus session records from here. No-op when nothing
+    /// changed. The undo setter restores the whole previous value (never char-by-char).
+    /// </summary>
+    private void CommitTextField(TextBox box, System.Func<string?, bool> applyToModel,
+        System.Action? afterApply, string description)
+    {
+        var current = box.Text ?? string.Empty;
+        var baseline = ReferenceEquals(_activeFieldBox, box) ? _activeFieldBaseline : null;
+
+        if (!applyToModel(current))
         {
-            MarkDirty();
-            UpdateTreeItemHeader(entItem);
-            UnifiedLogger.LogJournal(LogLevel.DEBUG, "Entry text changed");
+            // No model change (e.g. focus lost without editing). Keep baseline aligned.
+            if (ReferenceEquals(_activeFieldBox, box)) _activeFieldBaseline = current;
+            return;
         }
+
+        MarkDirty();
+        afterApply?.Invoke();
+
+        // Record whole-field undo from the focus-session baseline to the new value. The setter
+        // only mutates the model; OnUndoClick/OnRedoClick repaint the panel from the model after,
+        // so we never drive the TextBox here (avoids fighting the repopulate).
+        if (baseline != null && baseline != current)
+        {
+            RecordFieldEdit(baseline, current, v =>
+            {
+                applyToModel(v);
+                afterApply?.Invoke();
+            }, description);
+        }
+
+        // Re-arm baseline for further edits in the same focus session.
+        if (ReferenceEquals(_activeFieldBox, box)) _activeFieldBaseline = current;
     }
 
     /// <summary>
@@ -381,31 +435,26 @@ public partial class MainWindow
     {
         if (_isUpdatingPanel) return;
 
+        // Route through CommitTextField so the commit also records a whole-field undo step
+        // (consistent with the LostFocus path) and re-arms the focus-session baseline.
         if (_selectedItem is CategoryTreeItem catItem)
         {
-            var changed = false;
+            var cat = catItem.Category;
             if (CategoryNameBox.IsFocused)
-                changed = JournalFieldEditor.ApplyCategoryName(catItem.Category, CategoryNameBox.Text);
+                CommitTextField(CategoryNameBox, v => JournalFieldEditor.ApplyCategoryName(cat, v),
+                    () => UpdateTreeItemHeader(catItem), "edit category name");
             else if (CategoryTagBox.IsFocused)
-                changed = JournalFieldEditor.ApplyCategoryTag(catItem.Category, CategoryTagBox.Text);
+                CommitTextField(CategoryTagBox, v => JournalFieldEditor.ApplyCategoryTag(cat, v),
+                    () => UpdateTreeItemHeader(catItem), "edit category tag");
             else if (CategoryCommentBox.IsFocused)
-                changed = JournalFieldEditor.ApplyCategoryComment(catItem.Category, CategoryCommentBox.Text);
-
-            if (changed)
-            {
-                MarkDirty();
-                UpdateTreeItemHeader(catItem);
-                UnifiedLogger.LogJournal(LogLevel.DEBUG, "Committed focused category edit before save");
-            }
+                CommitTextField(CategoryCommentBox, v => JournalFieldEditor.ApplyCategoryComment(cat, v),
+                    null, "edit category comment");
         }
-        else if (_selectedItem is EntryTreeItem entItem)
+        else if (_selectedItem is EntryTreeItem entItem && EntryTextBox.IsFocused)
         {
-            if (EntryTextBox.IsFocused && JournalFieldEditor.ApplyEntryText(entItem.Entry, EntryTextBox.Text))
-            {
-                MarkDirty();
-                UpdateTreeItemHeader(entItem);
-                UnifiedLogger.LogJournal(LogLevel.DEBUG, "Committed focused entry edit before save");
-            }
+            var ent = entItem.Entry;
+            CommitTextField(EntryTextBox, v => JournalFieldEditor.ApplyEntryText(ent, v),
+                () => UpdateTreeItemHeader(entItem), "edit entry text");
         }
     }
 

--- a/Manifest/Manifest/Views/MainWindow.PropertyPanel.cs
+++ b/Manifest/Manifest/Views/MainWindow.PropertyPanel.cs
@@ -167,6 +167,9 @@ public partial class MainWindow
         CategoryPriorityBox.SelectionChanged -= OnCategoryPriorityChanged;
         CategoryXPBox.ValueChanged -= OnCategoryXPChanged;
         CategoryCommentBox.LostFocus -= OnCategoryCommentChanged;
+        CategoryNameBox.TextChanged -= OnTextEditedMarkDirty;
+        CategoryTagBox.TextChanged -= OnTextEditedMarkDirty;
+        CategoryCommentBox.TextChanged -= OnTextEditedMarkDirty;
 
         // Add handlers
         CategoryNameBox.LostFocus += OnCategoryNameChanged;
@@ -174,6 +177,11 @@ public partial class MainWindow
         CategoryPriorityBox.SelectionChanged += OnCategoryPriorityChanged;
         CategoryXPBox.ValueChanged += OnCategoryXPChanged;
         CategoryCommentBox.LostFocus += OnCategoryCommentChanged;
+        // #2461 — mark dirty while typing so the close guard sees unsaved edits even
+        // before focus leaves the box. Model commit still happens on LostFocus/save.
+        CategoryNameBox.TextChanged += OnTextEditedMarkDirty;
+        CategoryTagBox.TextChanged += OnTextEditedMarkDirty;
+        CategoryCommentBox.TextChanged += OnTextEditedMarkDirty;
     }
 
     private void WireEntryHandlers()
@@ -195,19 +203,32 @@ public partial class MainWindow
     {
         // Update the token preview as the user types
         UpdateTokenPreview();
+
+        // #2461 — mark dirty while typing so the close guard sees unsaved edits even
+        // before focus leaves the box. Model commit still happens on LostFocus/save.
+        if (!_isUpdatingPanel) MarkDirty();
+    }
+
+    /// <summary>
+    /// Mark the document dirty as the user types in a journal text box (#2461). The
+    /// actual model commit happens on LostFocus / save; this only ensures the dirty
+    /// flag (and the close guard) reflect unsaved edits during typing. Suppressed while
+    /// the panel is being repopulated so bind-time TextChanged events do not mark dirty.
+    /// </summary>
+    private void OnTextEditedMarkDirty(object? sender, TextChangedEventArgs e)
+    {
+        if (!_isUpdatingPanel) MarkDirty();
     }
 
     private void OnCategoryNameChanged(object? sender, RoutedEventArgs e)
     {
         if (_isUpdatingPanel || _selectedItem is not CategoryTreeItem catItem) return;
 
-        var newName = CategoryNameBox.Text ?? "";
-        if (catItem.Category.Name.GetDefault() != newName)
+        if (JournalFieldEditor.ApplyCategoryName(catItem.Category, CategoryNameBox.Text))
         {
-            catItem.Category.Name.SetString(0, newName);
             MarkDirty();
             UpdateTreeItemHeader(catItem);
-            UnifiedLogger.LogJournal(LogLevel.DEBUG, $"Category name changed to: {newName}");
+            UnifiedLogger.LogJournal(LogLevel.DEBUG, "Category name changed");
         }
     }
 
@@ -215,13 +236,11 @@ public partial class MainWindow
     {
         if (_isUpdatingPanel || _selectedItem is not CategoryTreeItem catItem) return;
 
-        var newTag = CategoryTagBox.Text ?? "";
-        if (catItem.Category.Tag != newTag)
+        if (JournalFieldEditor.ApplyCategoryTag(catItem.Category, CategoryTagBox.Text))
         {
-            catItem.Category.Tag = newTag;
             MarkDirty();
             UpdateTreeItemHeader(catItem);
-            UnifiedLogger.LogJournal(LogLevel.DEBUG, $"Category tag changed to: {newTag}");
+            UnifiedLogger.LogJournal(LogLevel.DEBUG, "Category tag changed");
         }
     }
 
@@ -258,10 +277,8 @@ public partial class MainWindow
     {
         if (_isUpdatingPanel || _selectedItem is not CategoryTreeItem catItem) return;
 
-        var newComment = CategoryCommentBox.Text ?? "";
-        if (catItem.Category.Comment != newComment)
+        if (JournalFieldEditor.ApplyCategoryComment(catItem.Category, CategoryCommentBox.Text))
         {
-            catItem.Category.Comment = newComment;
             MarkDirty();
             UnifiedLogger.LogJournal(LogLevel.DEBUG, "Category comment changed");
         }
@@ -344,14 +361,51 @@ public partial class MainWindow
     {
         if (_isUpdatingPanel || _selectedItem is not EntryTreeItem entItem) return;
 
-        var newText = EntryTextBox.Text ?? "";
-        var oldText = entItem.Entry.Text.GetDefault();
-        if (oldText != newText)
+        if (JournalFieldEditor.ApplyEntryText(entItem.Entry, EntryTextBox.Text))
         {
-            entItem.Entry.Text.SetString(0, newText);
             MarkDirty();
             UpdateTreeItemHeader(entItem);
             UnifiedLogger.LogJournal(LogLevel.DEBUG, "Entry text changed");
+        }
+    }
+
+    /// <summary>
+    /// Push the value of whichever journal text box currently has focus into the model
+    /// (#2461). Text fields otherwise commit only on LostFocus, so a Save issued while a
+    /// text box still holds focus would persist the pre-edit model value and the visible
+    /// edit would silently revert. Save and the close-guard save call this first so the
+    /// visible value is always the saved value. No-op when the focused control is not a
+    /// journal text box or nothing changed.
+    /// </summary>
+    private void CommitFocusedEdit()
+    {
+        if (_isUpdatingPanel) return;
+
+        if (_selectedItem is CategoryTreeItem catItem)
+        {
+            var changed = false;
+            if (CategoryNameBox.IsFocused)
+                changed = JournalFieldEditor.ApplyCategoryName(catItem.Category, CategoryNameBox.Text);
+            else if (CategoryTagBox.IsFocused)
+                changed = JournalFieldEditor.ApplyCategoryTag(catItem.Category, CategoryTagBox.Text);
+            else if (CategoryCommentBox.IsFocused)
+                changed = JournalFieldEditor.ApplyCategoryComment(catItem.Category, CategoryCommentBox.Text);
+
+            if (changed)
+            {
+                MarkDirty();
+                UpdateTreeItemHeader(catItem);
+                UnifiedLogger.LogJournal(LogLevel.DEBUG, "Committed focused category edit before save");
+            }
+        }
+        else if (_selectedItem is EntryTreeItem entItem)
+        {
+            if (EntryTextBox.IsFocused && JournalFieldEditor.ApplyEntryText(entItem.Entry, EntryTextBox.Text))
+            {
+                MarkDirty();
+                UpdateTreeItemHeader(entItem);
+                UnifiedLogger.LogJournal(LogLevel.DEBUG, "Committed focused entry edit before save");
+            }
         }
     }
 

--- a/Manifest/Manifest/Views/MainWindow.Undo.cs
+++ b/Manifest/Manifest/Views/MainWindow.Undo.cs
@@ -47,31 +47,19 @@ public partial class MainWindow
     {
         // Commit any in-progress text edit so it lands on the stack before we undo it.
         CommitFocusedEdit();
+        // Each command refreshes its own UI (field commands repaint the panel and keep selection;
+        // structural commands rebuild the tree). We do NOT blanket-rebuild the tree here — doing so
+        // cleared the TreeView selection and blanked the property panel on a field undo (#2253 UAT).
         _undo.Undo();
-        // The model changed underneath the UI; rebuild tree + panel to reflect it.
-        RefreshAfterUndoRedo();
+        MarkDirty();
     }
 
     private void OnRedoClick(object? sender, RoutedEventArgs e)
     {
         _undo.Redo();
-        RefreshAfterUndoRedo();
+        MarkDirty();
     }
 
-    /// <summary>Rebuild the tree and property panel after an undo/redo mutated the model.
-    /// Suppressed-flag keeps the repopulation from re-recording via field change handlers.</summary>
-    private void RefreshAfterUndoRedo()
-    {
-        _suppressUndo = true;
-        try
-        {
-            UpdateTree();
-            UpdatePropertyPanel();
-            UpdateStatusBarCounts();
-            MarkDirty();
-        }
-        finally { _suppressUndo = false; }
-    }
 
     /// <summary>
     /// Record an already-applied whole-field edit through the undo manager (#2231). The caller has
@@ -84,10 +72,20 @@ public partial class MainWindow
         if (_suppressUndo || _isUpdatingPanel) return;
         if (Equals(oldValue, newValue)) return;
 
+        // The model is already at newValue (the handler set it before recording). On the initial
+        // Execute we must NOT repaint the panel — the user is mid-edit and a repaint would reset
+        // the caret/selection. On undo/redo we DO repaint so the reverted/redone value shows, while
+        // keeping the tree selection (no tree rebuild — that blanked the panel, #2253 UAT).
+        var firstDo = true;
         _undo.Execute(new RecordedFieldEditCommand<T>(oldValue, newValue, v =>
         {
             _suppressUndo = true;
-            try { apply(v); }
+            try
+            {
+                apply(v);
+                if (!firstDo) UpdatePropertyPanel();
+                firstDo = false;
+            }
             finally { _suppressUndo = false; }
         }, description));
     }
@@ -107,17 +105,20 @@ public partial class MainWindow
         _undo.Execute(wrapped);
     }
 
-    /// <summary>Wire whole-field text undo on a prose/text box: snapshot the committed model value
-    /// on focus-in via <paramref name="getter"/>; recording happens in the existing LostFocus
-    /// change handler / CommitFocusedEdit through <see cref="RecordFieldEdit{T}"/>.</summary>
-    private void WireTextFieldUndo(TextBox? box, Func<string> getter)
+    /// <summary>Wire whole-field text undo on a prose/text box: snapshot the box's CURRENTLY
+    /// DISPLAYED text on focus-in as the undo baseline. We read the box (not a model getter)
+    /// because the displayed value can differ from the model's slot-0 default — e.g. a category
+    /// name resolved from a TLK StrRef shows resolved text while GetDefault() is empty. Capturing
+    /// the model would make undo revert to that empty/wrong value (the #2253 UAT bug; same class
+    /// of issue hit in Relique). Recording happens in the LostFocus handler / CommitFocusedEdit.</summary>
+    private void WireTextFieldUndo(TextBox? box)
     {
         if (box == null) return;
         box.GotFocus += (_, _) =>
         {
             if (_isUpdatingPanel) return;
             _activeFieldBox = box;
-            _activeFieldBaseline = getter();
+            _activeFieldBaseline = box.Text ?? string.Empty;
         };
     }
 

--- a/Manifest/Manifest/Views/MainWindow.Undo.cs
+++ b/Manifest/Manifest/Views/MainWindow.Undo.cs
@@ -1,0 +1,174 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Radoub.Formats.Logging;
+using Radoub.UI.Undo;
+
+namespace Manifest.Views;
+
+/// <summary>
+/// Undo/redo wiring for Manifest (#2253 / epic #2231 Sprint 3). Manifest is a writing tool, but
+/// per the cross-tool decision (and matching what Parley already does for dialogue prose) every
+/// editable field records ONE whole-field document undo step per focus session — there is no
+/// per-character native undo here. The shared <see cref="RecordedFieldEditCommand{T}"/> reverts
+/// the whole previous committed value; structural add/delete go through the dedicated commands in
+/// <see cref="Manifest.Services.AddCategoryCommand"/> et al.
+///
+/// Pattern mirrors Relique's MainWindow.Undo: a per-document <see cref="UndoRedoManager"/>, menu
+/// refreshed on StateChanged, Ctrl+Z/Y dispatched from the window key handler. Re-entrancy is
+/// guarded by <see cref="_suppressUndo"/> (undo-driven setters must not re-record) and bind-time
+/// events are guarded by the existing <c>_isUpdatingPanel</c> flag.
+/// </summary>
+public partial class MainWindow
+{
+    private readonly UndoRedoManager _undo = new();
+
+    /// <summary>True while undo/redo drives a setter, so the resulting change event is not
+    /// re-recorded as a new command.</summary>
+    private bool _suppressUndo;
+
+    // Whole-field text undo baseline: captured on GotFocus, recorded on LostFocus/save-commit.
+    private TextBox? _activeFieldBox;
+    private string _activeFieldBaseline = string.Empty;
+
+    /// <summary>Drop undo/redo history. Called per document (file open / new) so each document
+    /// starts fresh (#2231 — undo is per-document, never crosses files).</summary>
+    private void ClearUndo() => _undo.Clear();
+
+    /// <summary>Connect the undo manager to menu refresh once (called from the constructor).</summary>
+    private void WireUndo()
+    {
+        _undo.StateChanged += (_, _) => RefreshUndoMenu();
+        RefreshUndoMenu();
+    }
+
+    private void OnUndoClick(object? sender, RoutedEventArgs e)
+    {
+        // Commit any in-progress text edit so it lands on the stack before we undo it.
+        CommitFocusedEdit();
+        _undo.Undo();
+        // The model changed underneath the UI; rebuild tree + panel to reflect it.
+        RefreshAfterUndoRedo();
+    }
+
+    private void OnRedoClick(object? sender, RoutedEventArgs e)
+    {
+        _undo.Redo();
+        RefreshAfterUndoRedo();
+    }
+
+    /// <summary>Rebuild the tree and property panel after an undo/redo mutated the model.
+    /// Suppressed-flag keeps the repopulation from re-recording via field change handlers.</summary>
+    private void RefreshAfterUndoRedo()
+    {
+        _suppressUndo = true;
+        try
+        {
+            UpdateTree();
+            UpdatePropertyPanel();
+            UpdateStatusBarCounts();
+            MarkDirty();
+        }
+        finally { _suppressUndo = false; }
+    }
+
+    /// <summary>
+    /// Record an already-applied whole-field edit through the undo manager (#2231). The caller has
+    /// (or is about to) set <paramref name="newValue"/> on the model; the command's setter applies
+    /// new on redo and old on undo, guarded so it does not re-record. No-op when suppressed,
+    /// bind-time, or unchanged.
+    /// </summary>
+    private void RecordFieldEdit<T>(T oldValue, T newValue, Action<T> apply, string description)
+    {
+        if (_suppressUndo || _isUpdatingPanel) return;
+        if (Equals(oldValue, newValue)) return;
+
+        _undo.Execute(new RecordedFieldEditCommand<T>(oldValue, newValue, v =>
+        {
+            _suppressUndo = true;
+            try { apply(v); }
+            finally { _suppressUndo = false; }
+        }, description));
+    }
+
+    /// <summary>
+    /// Execute a structural command (add/delete) through the manager. The wrapper refreshes the
+    /// tree/panel on Do/Undo/Redo so the UI stays in sync without the command knowing about the UI.
+    /// </summary>
+    private void ExecuteStructural(IUndoableCommand command)
+    {
+        var wrapped = new RefreshingCommand(command, () =>
+        {
+            _suppressUndo = true;
+            try { UpdateTree(); UpdatePropertyPanel(); UpdateStatusBarCounts(); }
+            finally { _suppressUndo = false; }
+        });
+        _undo.Execute(wrapped);
+    }
+
+    /// <summary>Wire whole-field text undo on a prose/text box: snapshot the committed model value
+    /// on focus-in via <paramref name="getter"/>; recording happens in the existing LostFocus
+    /// change handler / CommitFocusedEdit through <see cref="RecordFieldEdit{T}"/>.</summary>
+    private void WireTextFieldUndo(TextBox? box, Func<string> getter)
+    {
+        if (box == null) return;
+        box.GotFocus += (_, _) =>
+        {
+            if (_isUpdatingPanel) return;
+            _activeFieldBox = box;
+            _activeFieldBaseline = getter();
+        };
+    }
+
+    /// <summary>
+    /// Sync the Edit-menu Undo/Redo items to the manager state (enablement + hint text). The
+    /// accelerator itself is dispatched from OnWindowKeyDown; InputGesture only renders the hint.
+    /// </summary>
+    private void RefreshUndoMenu()
+    {
+        if (UndoMenuItem != null)
+        {
+            UndoMenuItem.IsEnabled = _undo.CanUndo;
+            UndoMenuItem.Header = _undo.CanUndo ? $"_Undo {_undo.UndoDescription}" : "_Undo";
+        }
+        if (RedoMenuItem != null)
+        {
+            RedoMenuItem.IsEnabled = _undo.CanRedo;
+            RedoMenuItem.Header = _undo.CanRedo ? $"_Redo {_undo.RedoDescription}" : "_Redo";
+        }
+    }
+
+    /// <summary>Adapter that runs a structural command and a UI refresh together as one undo step,
+    /// so undo/redo keep the tree/panel in sync without the command knowing about the UI.
+    ///
+    /// Preserves the #2254 mutate→refresh→rollback discipline: if the refresh throws on Do(), the
+    /// inner command is undone (model rolled back) and Do() returns false so the manager does NOT
+    /// record it — the editor is never left dirty behind a half-rendered tree.</summary>
+    private sealed class RefreshingCommand : IUndoableCommand
+    {
+        private readonly IUndoableCommand _inner;
+        private readonly Action _refresh;
+        public RefreshingCommand(IUndoableCommand inner, Action refresh) { _inner = inner; _refresh = refresh; }
+        public string Description => _inner.Description;
+
+        public bool Do()
+        {
+            if (!_inner.Do()) return false;
+            try
+            {
+                _refresh();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _inner.Undo(); // roll back the model mutation
+                UnifiedLogger.LogJournal(LogLevel.ERROR,
+                    $"Refresh failed after structural '{_inner.Description}' — rolled back: {ex.GetType().Name}: {ex.Message}");
+                return false; // refuse-to-push: don't record a change that was reverted
+            }
+        }
+
+        public void Undo() { _inner.Undo(); _refresh(); }
+    }
+}

--- a/Manifest/Manifest/Views/MainWindow.axaml
+++ b/Manifest/Manifest/Views/MainWindow.axaml
@@ -49,8 +49,8 @@
                 <MenuItem Header="E_xit" Click="OnExitClick" InputGesture="Alt+F4"/>
             </MenuItem>
             <MenuItem Header="_Edit">
-                <MenuItem Header="_Undo" InputGesture="Ctrl+Z" IsEnabled="False"/>
-                <MenuItem Header="_Redo" InputGesture="Ctrl+Y" IsEnabled="False"/>
+                <MenuItem x:Name="UndoMenuItem" Header="_Undo" InputGesture="Ctrl+Z" Click="OnUndoClick"/>
+                <MenuItem x:Name="RedoMenuItem" Header="_Redo" InputGesture="Ctrl+Y" Click="OnRedoClick"/>
                 <Separator/>
                 <MenuItem Header="Add _Category" Click="OnAddCategoryClick" IsEnabled="{Binding HasFile}"/>
                 <MenuItem Header="Add _Entry" Click="OnAddEntryClick" IsEnabled="{Binding CanAddEntry}"/>

--- a/Manifest/Manifest/Views/MainWindow.axaml
+++ b/Manifest/Manifest/Views/MainWindow.axaml
@@ -11,7 +11,6 @@
         Icon="avares://Manifest/Assets/manifest.ico"
         Width="1000" Height="700"
         MinWidth="600" MinHeight="400"
-        KeyDown="OnWindowKeyDown"
         ExtendClientAreaToDecorationsHint="True"
         ExtendClientAreaChromeHints="PreferSystemChrome"
         ExtendClientAreaTitleBarHeightHint="30">

--- a/Manifest/Manifest/Views/MainWindow.axaml.cs
+++ b/Manifest/Manifest/Views/MainWindow.axaml.cs
@@ -69,6 +69,14 @@ public partial class MainWindow : Window, INotifyPropertyChanged
         // Wire up shared document state for title bar updates
         _documentState.DirtyStateChanged += () => Title = _documentState.GetTitle();
 
+        // Undo/redo (#2231 Sprint 3): connect manager → menu, and snapshot prose fields on
+        // focus-in so a whole-field edit can be recorded on focus-out / save-commit.
+        WireUndo();
+        WireTextFieldUndo(CategoryNameBox, () => (_selectedItem as CategoryTreeItem)?.Category.Name.GetDefault() ?? string.Empty);
+        WireTextFieldUndo(CategoryTagBox, () => (_selectedItem as CategoryTreeItem)?.Category.Tag ?? string.Empty);
+        WireTextFieldUndo(CategoryCommentBox, () => (_selectedItem as CategoryTreeItem)?.Category.Comment ?? string.Empty);
+        WireTextFieldUndo(EntryTextBox, () => (_selectedItem as EntryTreeItem)?.Entry.Text.GetDefault() ?? string.Empty);
+
         // Restore window position
         RestoreWindowPosition();
 
@@ -350,6 +358,17 @@ public partial class MainWindow : Window, INotifyPropertyChanged
                         _ = SaveFile();
                         e.Handled = true;
                     }
+                    break;
+                case Key.Z:
+                    // Document/whole-field undo (#2231). Manifest records one undo step per field
+                    // focus session (like Parley), so Ctrl+Z is document-level even with a text
+                    // box focused; OnUndoClick commits the in-progress edit first.
+                    OnUndoClick(sender, e);
+                    e.Handled = true;
+                    break;
+                case Key.Y:
+                    OnRedoClick(sender, e);
+                    e.Handled = true;
                     break;
                 case Key.E:
                     if (CanAddEntry)

--- a/Manifest/Manifest/Views/MainWindow.axaml.cs
+++ b/Manifest/Manifest/Views/MainWindow.axaml.cs
@@ -72,13 +72,20 @@ public partial class MainWindow : Window, INotifyPropertyChanged
         // Undo/redo (#2231 Sprint 3): connect manager → menu, and snapshot prose fields on
         // focus-in so a whole-field edit can be recorded on focus-out / save-commit.
         WireUndo();
-        WireTextFieldUndo(CategoryNameBox, () => (_selectedItem as CategoryTreeItem)?.Category.Name.GetDefault() ?? string.Empty);
-        WireTextFieldUndo(CategoryTagBox, () => (_selectedItem as CategoryTreeItem)?.Category.Tag ?? string.Empty);
-        WireTextFieldUndo(CategoryCommentBox, () => (_selectedItem as CategoryTreeItem)?.Category.Comment ?? string.Empty);
-        WireTextFieldUndo(EntryTextBox, () => (_selectedItem as EntryTreeItem)?.Entry.Text.GetDefault() ?? string.Empty);
+        WireTextFieldUndo(CategoryNameBox);
+        WireTextFieldUndo(CategoryTagBox);
+        WireTextFieldUndo(CategoryCommentBox);
+        WireTextFieldUndo(EntryTextBox);
 
         // Restore window position
         RestoreWindowPosition();
+
+        // Keyboard shortcuts via TUNNEL so Undo/Redo (and other accelerators) reach the window
+        // even when a focused control would otherwise consume the key. ComboBox/NumericUpDown
+        // handle Ctrl+Z on the bubbling route, so a plain KeyDown="..." on the Window never saw
+        // it — Priority/XP/ID undo silently did nothing (#2253 UAT). handledEventsToo:true also
+        // lets us see keys a control already marked handled.
+        AddHandler(KeyDownEvent, OnWindowKeyDown, RoutingStrategies.Tunnel, handledEventsToo: true);
 
         // Handle window closing
         Closing += OnWindowClosing;

--- a/Radoub.UI/Radoub.UI.Tests/MainWindowMenuStubLintTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/MainWindowMenuStubLintTests.cs
@@ -26,7 +26,7 @@ public class MainWindowMenuStubLintTests
     /// </summary>
     private static readonly Dictionary<string, string[]> KnownStubs = new()
     {
-        ["Manifest"] = new[] { "_Undo", "_Redo" },
+        // Manifest Undo/Redo wired in #2231 Sprint 3 (#2253) — stubs removed.
         ["Fence"] = new[] { "_Undo", "_Redo" },
     };
 


### PR DESCRIPTION
## Summary

Sprint 3 of the Undo/Redo epic (#2231) for Manifest, bundled with the critical focused-edit data-loss bug (#2461) and the remaining undo portion of #2253.

1. **#2461 (CRITICAL):** Editing a field and saving while the text box still had focus silently reverted the edit, and typing didn't set the dirty flag. Save now commits the focused edit first (`CommitFocusedEdit`), and typing marks the document dirty.
2. **#2253 undo:** Re-enabled the Undo/Redo menu stubs and wired Ctrl+Z / Ctrl+Y. Every editable field records one whole-field document undo step per focus session (matching Parley's dialogue-prose behavior); add/delete of categories and entries are undoable too. Per-document history; menu hint text reflects the last action.
3. **#2253 re-audit:** Confirmed the #2410 atomic-write + dup-ID work is sound; tightened a bare catch in the save temp-cleanup.

## UAT fixes (found in manual testing, all verified)

- Name/Tag undo emptied the field — baseline now read from the box's displayed text, not the model's empty slot-0 default.
- Priority/XP/ID/End undo did nothing — ComboBox/NumericUpDown consumed Ctrl+Z; key handler now attached via tunnel (`handledEventsToo`).
- Field Ctrl+Z jumped/blanked the panel — field undo now repaints the panel only (selection preserved); only add/delete rebuild the tree.

## Tests

- 2646 unit tests pass (Manifest 128 incl. 16 new undo-command/field-editor tests; Radoub.UI 1064 incl. updated dead-stub lint).
- Manifest FlaUI smoke: 12 passed, 0 failed.
- Privacy scan clean; no new tech-debt.

## Related Issues

- Relates to #2231 (epic — Sprint 3 / Manifest)
- Closes #2461
- Addresses the undo portion of #2253 (atomic-write/dup-ID already landed in #2410 — do not blanket-close)
- Filed #2470: the same tunnel-key bug exists in Relique (confirmed in source)

## Follow-up note

Reliquary / Quartermaster / Fence undo sprints should apply the tunnel-key fix and the box-text-baseline fix (see #2470).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)