### PR TITLE
[Quartermaster] feat: MTR (3007) reader + MDL materialname parse (#2496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Radoub.Formats 0.2.70-alpha] - 2026-06-18
-**Branch**: `quartermaster/issue-2496` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2496` | **PR**: #2499
 
 ### Feat: MTR (3007) reader + MDL materialname parsing (#2496)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.Formats 0.2.70-alpha] - 2026-06-18
+**Branch**: `quartermaster/issue-2496` | **PR**: #TBD
+
+### Feat: MTR (3007) reader + MDL materialname parsing (#2496)
+
+- Added the NWN:EE MTR material format (resource type 3007) reader and parsed the MDL `materialname` field in both binary and ASCII readers, so meshes can resolve their material/diffuse from model data instead of a `_d`-suffix guess. Format layer only; consumed by the #2482 model-preview white-model fix.
+
+---
+
 ## [Radoub.UI] - 2026-06-14
 **Branch**: `trebuchet/issue-2477` | **PR**: #2483
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.121-alpha] - 2026-06-18
+**Branch**: `quartermaster/issue-2496` | **PR**: #TBD
+
+### Feat: MTR reader + MDL materialname (#2496)
+
+- Format-layer foundation for the model-preview white-model fix (#2482): MTR (3007) reader and MDL `materialname` parsing land in `Radoub.Formats` — see root CHANGELOG.
+
+---
+
 ## [0.2.120-alpha] - 2026-06-18
 **Branch**: `quartermaster/issue-2487` | **PR**: #2494
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.121-alpha] - 2026-06-18
-**Branch**: `quartermaster/issue-2496` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2496` | **PR**: #2499
 
 ### Feat: MTR reader + MDL materialname (#2496)
 

--- a/Radoub.Formats/Radoub.Formats.Tests/Mdl/TrimeshMaterialNameTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Mdl/TrimeshMaterialNameTests.cs
@@ -1,0 +1,41 @@
+using Radoub.Formats.Mdl;
+using Xunit;
+
+namespace Radoub.Formats.Tests.Mdl;
+
+/// <summary>
+/// #2496: the binary MDL trimesh header stores the NWN:EE material name in the
+/// 4th texture slot (texture3). rollnw confirms this authoritatively
+/// (MdlBinaryParser.cpp: <c>mesh->materialname = to_string(data.texture3)</c>,
+/// header comment "This is material name in NWN:EE"). The reader already reads that
+/// 64-byte slot — this verifies it is captured into <see cref="MdlTrimeshNode.MaterialName"/>.
+/// </summary>
+public class TrimeshMaterialNameTests
+{
+    [Fact]
+    public void Parse_BinaryTrimesh_CapturesMaterialNameFromTexture3()
+    {
+        var mdl = TrimeshMdlFixture.BuildSingleTrimesh(
+            bitmap: "c_zod_boar",
+            materialName: "c_zod_boar_mat");
+
+        var model = new MdlBinaryReader().Parse(mdl);
+        var mesh = Assert.IsType<MdlTrimeshNode>(model.GeometryRoot);
+
+        Assert.Equal("c_zod_boar", mesh.Bitmap);
+        Assert.Equal("c_zod_boar_mat", mesh.MaterialName);
+    }
+
+    [Fact]
+    public void Parse_BinaryTrimesh_EmptyMaterialName_StaysEmpty()
+    {
+        var mdl = TrimeshMdlFixture.BuildSingleTrimesh(
+            bitmap: "sometex",
+            materialName: "");
+
+        var model = new MdlBinaryReader().Parse(mdl);
+        var mesh = Assert.IsType<MdlTrimeshNode>(model.GeometryRoot);
+
+        Assert.Equal(string.Empty, mesh.MaterialName);
+    }
+}

--- a/Radoub.Formats/Radoub.Formats.Tests/Mdl/TrimeshMdlFixture.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Mdl/TrimeshMdlFixture.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Text;
+
+namespace Radoub.Formats.Tests.Mdl;
+
+/// <summary>
+/// Builds a minimal, byte-valid binary NWN MDL whose geometry root is a single trimesh
+/// node with zero geometry (no verts/faces). Used to verify texture/material-name capture
+/// (#2496) without hand-building vertex/face raw data — the reader guards all geometry reads
+/// on count &gt; 0, so a zero-geometry mesh still exercises the texture-slot reads.
+///
+/// Layout mirrors the binary reader's expectations:
+///   File header (12 bytes): zeroField=0, modelDataSize, rawDataSize=0
+///   [0x000] model/geometry header (0xE8) — pointerBase=0, root ptr @0x48, nodeCount @0x4C
+///   [0x0E8] trimesh node = 0x70 node header + 0x200 mesh header (0x270 total)
+///
+/// Texture slots live at mesh-header-relative 0x078 (4 × 64 bytes). texture3 (slot 4) is the
+/// NWN:EE material name — confirmed by rollnw (MdlBinaryParser.hpp: "This is material name in NWN:EE").
+/// </summary>
+public static class TrimeshMdlFixture
+{
+    private const int FileHeaderSize = 12;
+    private const int ModelHeaderSize = 0xE8;
+    private const int NodeHeaderSize = 0x70;
+    private const int MeshHeaderSize = 0x200;
+    private const int TrimeshNodeSize = NodeHeaderSize + MeshHeaderSize; // 0x270
+
+    private const uint NodeFlagHasMesh = 0x00000020;
+
+    private const uint TrimeshNodeOffset = ModelHeaderSize; // 0x0E8
+
+    // Mesh-header-relative texture block: 0x078, then 4 × 64-byte slots.
+    private const int MeshTextureBlockRel = 0x078;
+    private const int TextureSlotSize = 64;
+
+    public static byte[] BuildSingleTrimesh(string bitmap, string materialName)
+    {
+        int modelDataSize = (int)TrimeshNodeOffset + TrimeshNodeSize;
+        var modelData = new byte[modelDataSize];
+
+        // ---- Model / geometry header ----
+        WriteUInt32(modelData, 0x00, 0);                  // pointerBase = 0
+        WriteFixedString(modelData, 0x08, "mattest", 64); // model name
+        WriteUInt32(modelData, 0x48, TrimeshNodeOffset);  // root node pointer
+        WriteUInt32(modelData, 0x4C, 1);                  // node count
+
+        // ---- Trimesh node header (0x70) ----
+        int n = (int)TrimeshNodeOffset;
+        WriteUInt32(modelData, n + 24, 0);                       // inheritColor
+        WriteInt32(modelData, n + 28, 0);                        // partNumber
+        WriteFixedString(modelData, n + 32, "mat_mesh", 32);     // node name
+        WriteUInt32(modelData, n + 0x40, 0);                     // geometry header ptr
+        WriteUInt32(modelData, n + 0x44, 0);                     // parent ptr
+        WriteUInt32(modelData, n + 0x48, 0);                     // child array ptr (none)
+        WriteUInt32(modelData, n + 0x4C, 0);                     // child count
+        WriteUInt32(modelData, n + 0x50, 0);                     // child allocated
+        WriteUInt32(modelData, n + 0x54, 0);                     // ctrl key ptr (none)
+        WriteUInt32(modelData, n + 0x58, 0);                     // ctrl key count
+        WriteUInt32(modelData, n + 0x5C, 0);                     // ctrl key alloc
+        WriteUInt32(modelData, n + 0x60, 0);                     // ctrl data ptr
+        WriteUInt32(modelData, n + 0x64, 0);                     // ctrl data count
+        WriteUInt32(modelData, n + 0x68, 0);                     // ctrl data alloc
+        WriteUInt32(modelData, n + 0x6C, NodeFlagHasMesh);       // node flags -> trimesh
+
+        // ---- Mesh header (0x200) relative to node + 0x70 ----
+        int m = n + NodeHeaderSize;
+        // 0x000 mesh routines (8) — zero. 0x008 faces array ptr/count/alloc — zero (no faces).
+        // 0x014 bounding box / radius / avg (40) — zero. 0x03C material colors (Diffuse..Shininess) — zero.
+        // 0x064 flags (shadow/beaming/render/transparency) — leave render=0 is fine for parsing.
+        // 0x074 unknown — zero.
+        // 0x078 texture block: 4 × 64-byte slots.
+        WriteFixedString(modelData, m + MeshTextureBlockRel + 0 * TextureSlotSize, bitmap, TextureSlotSize);       // texture0 = bitmap
+        WriteFixedString(modelData, m + MeshTextureBlockRel + 1 * TextureSlotSize, string.Empty, TextureSlotSize); // texture1
+        WriteFixedString(modelData, m + MeshTextureBlockRel + 2 * TextureSlotSize, string.Empty, TextureSlotSize); // texture2
+        WriteFixedString(modelData, m + MeshTextureBlockRel + 3 * TextureSlotSize, materialName, TextureSlotSize); // texture3 = materialname (EE)
+        // Remaining mesh-header fields (vertex/tvert/normal/color pointers, counts) stay zero;
+        // vertexCount=0 and faceCount=0 short-circuit all geometry reads.
+
+        // ---- Prepend file header (12 bytes) ----
+        var file = new byte[FileHeaderSize + modelData.Length];
+        WriteUInt32(file, 0, 0);                            // zeroField
+        WriteUInt32(file, 4, (uint)modelData.Length);       // model data size
+        WriteUInt32(file, 8, 0);                            // raw data size
+        Array.Copy(modelData, 0, file, FileHeaderSize, modelData.Length);
+        return file;
+    }
+
+    private static void WriteUInt32(byte[] buf, int offset, uint value) =>
+        BitConverter.GetBytes(value).CopyTo(buf, offset);
+
+    private static void WriteInt32(byte[] buf, int offset, int value) =>
+        BitConverter.GetBytes(value).CopyTo(buf, offset);
+
+    private static void WriteFixedString(byte[] buf, int offset, string value, int length)
+    {
+        var bytes = Encoding.ASCII.GetBytes(value ?? string.Empty);
+        int count = Math.Min(bytes.Length, length - 1); // leave room for null terminator
+        Array.Copy(bytes, 0, buf, offset, count);
+    }
+}

--- a/Radoub.Formats/Radoub.Formats.Tests/MdlAsciiReaderTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/MdlAsciiReaderTests.cs
@@ -482,4 +482,52 @@ donemodel bounds
         Assert.Equal(new Vector3(1, 1, 1), model.BoundingMax);
         Assert.True(model.Radius > 0);
     }
+
+    [Fact]
+    public void Parse_TrimeshMaterialName_IsCaptured()
+    {
+        // NWN:EE PBR meshes name their .mtr via materialname; #2496 captures it so the
+        // renderer can resolve the diffuse from the MTR instead of the _d-suffix guess.
+        var mdlContent = @"
+newmodel mat
+beginmodelgeom mat
+node trimesh mat_mesh
+  parent NULL
+  bitmap c_zod_boar
+  materialname c_zod_boar
+  verts 1
+    0 0 0
+endnode
+endmodelgeom mat
+donemodel mat
+";
+        var reader = new MdlAsciiReader();
+        var model = reader.Parse(mdlContent);
+
+        var mesh = model.GetMeshNodes().Single();
+        Assert.Equal("c_zod_boar", mesh.MaterialName);
+        Assert.Equal("c_zod_boar", mesh.Bitmap);
+    }
+
+    [Fact]
+    public void Parse_TrimeshWithoutMaterialName_LeavesItEmpty()
+    {
+        var mdlContent = @"
+newmodel nomat
+beginmodelgeom nomat
+node trimesh nomat_mesh
+  parent NULL
+  bitmap sometex
+  verts 1
+    0 0 0
+endnode
+endmodelgeom nomat
+donemodel nomat
+";
+        var reader = new MdlAsciiReader();
+        var model = reader.Parse(mdlContent);
+
+        var mesh = model.GetMeshNodes().Single();
+        Assert.Equal(string.Empty, mesh.MaterialName);
+    }
 }

--- a/Radoub.Formats/Radoub.Formats.Tests/Mtr/MtrReaderTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Mtr/MtrReaderTests.cs
@@ -1,0 +1,105 @@
+using Radoub.Formats.Mtr;
+using Xunit;
+
+namespace Radoub.Formats.Tests.Mtr;
+
+public class MtrReaderTests
+{
+    // Representative of a real NWN:EE creature .mtr (Celestial Zodiac pack, c_zod_boar.mtr).
+    private const string SampleMtr = @"customshadervs vslit_nm
+customshaderfs fslit_nm
+renderhint NormalTangents
+
+// Textures
+texture0 c_zod_boar
+texture1 null
+texture2 null
+texture3 null
+texture4 null
+texture5 c_zod_boar
+
+parameter float Specularity 0.65
+parameter float Roughness 0.35
+";
+
+    [Fact]
+    public void Parse_ReadsTexture0AsDiffuse()
+    {
+        var mtr = MtrReader.Parse(SampleMtr);
+        Assert.Equal("c_zod_boar", mtr.DiffuseTexture);
+    }
+
+    [Fact]
+    public void Parse_NullTextureSlot_IsNull()
+    {
+        var mtr = MtrReader.Parse(SampleMtr);
+        Assert.Null(mtr.Textures[1]);
+        Assert.Null(mtr.Textures[2]);
+    }
+
+    [Fact]
+    public void Parse_ReadsHigherTextureSlot()
+    {
+        var mtr = MtrReader.Parse(SampleMtr);
+        Assert.Equal("c_zod_boar", mtr.Textures[5]);
+    }
+
+    [Fact]
+    public void Parse_ReadsRenderHint()
+    {
+        var mtr = MtrReader.Parse(SampleMtr);
+        Assert.Equal("NormalTangents", mtr.RenderHint);
+    }
+
+    [Fact]
+    public void Parse_ReadsShaderNames()
+    {
+        var mtr = MtrReader.Parse(SampleMtr);
+        Assert.Equal("vslit_nm", mtr.CustomShaderVs);
+        Assert.Equal("fslit_nm", mtr.CustomShaderFs);
+    }
+
+    [Fact]
+    public void Parse_ReadsFloatParameters()
+    {
+        var mtr = MtrReader.Parse(SampleMtr);
+        Assert.True(mtr.Parameters.ContainsKey("Specularity"));
+        Assert.Equal(0.65f, mtr.Parameters["Specularity"][0], 3);
+        Assert.Equal(0.35f, mtr.Parameters["Roughness"][0], 3);
+    }
+
+    [Fact]
+    public void Parse_IgnoresCommentsAndBlankLines()
+    {
+        var mtr = MtrReader.Parse("// just a comment\n\n   \ntexture0 mytex\n");
+        Assert.Equal("mytex", mtr.DiffuseTexture);
+    }
+
+    [Fact]
+    public void Parse_NoTexture0_DiffuseIsNull()
+    {
+        var mtr = MtrReader.Parse("renderhint NormalTangents\n");
+        Assert.Null(mtr.DiffuseTexture);
+    }
+
+    [Fact]
+    public void Parse_DivergentTexture0_DiffersFromMaterialName()
+    {
+        // The white-model case: texture0 is NOT the material/bitmap base name.
+        var mtr = MtrReader.Parse("texture0 skin_diffuse_actual\n");
+        Assert.Equal("skin_diffuse_actual", mtr.DiffuseTexture);
+    }
+
+    [Fact]
+    public void Read_FromBytes_Utf8Bom_IsStripped()
+    {
+        var bom = new byte[] { 0xEF, 0xBB, 0xBF };
+        var body = System.Text.Encoding.UTF8.GetBytes("texture0 bomtex\n");
+        var buffer = new byte[bom.Length + body.Length];
+        bom.CopyTo(buffer, 0);
+        body.CopyTo(buffer, bom.Length);
+
+        var mtr = MtrReader.Read(buffer);
+        Assert.Equal("bomtex", mtr.DiffuseTexture);
+    }
+}

--- a/Radoub.Formats/Radoub.Formats.Tests/ResourceTypesTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/ResourceTypesTests.cs
@@ -15,6 +15,7 @@ public class ResourceTypesTests
     [InlineData(ResourceTypes.Are, ".are")]
     [InlineData(ResourceTypes.Git, ".git")]
     [InlineData(ResourceTypes.Ifo, ".ifo")]
+    [InlineData(ResourceTypes.Mtr, ".mtr")]
     public void GetExtension_ReturnsCorrectExtension(ushort resourceType, string expectedExtension)
     {
         var result = ResourceTypes.GetExtension(resourceType);
@@ -27,6 +28,8 @@ public class ResourceTypesTests
     [InlineData(".nss", ResourceTypes.Nss)]
     [InlineData(".NCS", ResourceTypes.Ncs)]
     [InlineData(".2da", ResourceTypes.TwoDA)]
+    [InlineData(".mtr", ResourceTypes.Mtr)]
+    [InlineData("MTR", ResourceTypes.Mtr)]
     public void FromExtension_ReturnsCorrectType(string extension, ushort expectedType)
     {
         var result = ResourceTypes.FromExtension(extension);
@@ -53,5 +56,6 @@ public class ResourceTypesTests
         Assert.Equal((ushort)2017, ResourceTypes.TwoDA);
         Assert.Equal((ushort)2027, ResourceTypes.Utc);
         Assert.Equal((ushort)2025, ResourceTypes.Uti);
+        Assert.Equal((ushort)3007, ResourceTypes.Mtr);  // NWN:EE material file (restype.nim)
     }
 }

--- a/Radoub.Formats/Radoub.Formats/Common/ResourceTypes.cs
+++ b/Radoub.Formats/Radoub.Formats/Common/ResourceTypes.cs
@@ -113,6 +113,7 @@ public static class ResourceTypes
     public const ushort Trx = 2093;
 
     // NWN:EE specific (3000+)
+    public const ushort Mtr = 3007;  // Material file (PBR shader/texture bindings)
     public const ushort Mdb = 4000;
     public const ushort Mda = 4001;
     public const ushort Spt = 4002;
@@ -188,6 +189,7 @@ public static class ResourceTypes
             Bif => ".bif",
             Key => ".key",
             Jpg => ".jpg",
+            Mtr => ".mtr",
             _ => $".{resourceType}"
         };
     }
@@ -253,6 +255,7 @@ public static class ResourceTypes
             "bif" => Bif,
             "key" => Key,
             "jpg" => Jpg,
+            "mtr" => Mtr,
             _ => Invalid
         };
     }

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlAsciiReader.TrimeshParsing.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlAsciiReader.TrimeshParsing.cs
@@ -16,6 +16,12 @@ public partial class MdlAsciiReader
                     mesh.Bitmap = tokens[1];
                 break;
 
+            case "materialname":
+                // NWN:EE PBR material reference; names the .mtr that supplies the diffuse (#2496).
+                if (tokens.Length >= 2)
+                    mesh.MaterialName = tokens[1];
+                break;
+
             case "texture0":
             case "texture1":
                 if (tokens.Length >= 2 && string.IsNullOrEmpty(mesh.Bitmap))

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader.MeshParsing.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader.MeshParsing.cs
@@ -55,7 +55,9 @@ public partial class MdlBinaryReader
             $"[MDL] Mesh texture0 at 0x{textureOffset:X4} (relative 0x{textureOffset - meshHeaderStart:X4}): '{mesh.Bitmap}'");
         mesh.Bitmap2 = ReadFixedString(reader, 64);  // Texture1
         ReadFixedString(reader, 64);                  // Texture2
-        ReadFixedString(reader, 64);                  // Texture3
+        // Texture3 is the NWN:EE material name (names the .mtr) — #2496.
+        // Confirmed by rollnw (MdlBinaryParser.hpp: "This is material name in NWN:EE").
+        mesh.MaterialName = ReadFixedString(reader, 64);
 
         // 0x178: Tilefade (4 bytes)
         mesh.Tilefade = reader.ReadInt32();

--- a/Radoub.Formats/Radoub.Formats/Mtr/MtrFile.cs
+++ b/Radoub.Formats/Radoub.Formats/Mtr/MtrFile.cs
@@ -1,0 +1,31 @@
+namespace Radoub.Formats.Mtr;
+
+/// <summary>
+/// A parsed NWN:EE MTR material file (resource type 3007). MTR binds PBR shaders
+/// and texture samplers to a mesh material; the diffuse map is <c>texture0</c>.
+/// Reference: NWN:EE material/shader system.
+/// </summary>
+public sealed class MtrFile
+{
+    /// <summary>Custom vertex shader name (<c>customshadervs</c>), if declared.</summary>
+    public string? CustomShaderVs { get; set; }
+
+    /// <summary>Custom fragment shader name (<c>customshaderfs</c>), if declared.</summary>
+    public string? CustomShaderFs { get; set; }
+
+    /// <summary>Render hint (e.g. <c>NormalTangents</c>), if declared.</summary>
+    public string? RenderHint { get; set; }
+
+    /// <summary>
+    /// Texture sampler slots by index (<c>texture0</c>..<c>textureN</c>). A slot left
+    /// as <c>null</c> in the file (literal "null") is stored as <c>null</c> here.
+    /// </summary>
+    public string?[] Textures { get; } = new string?[16];
+
+    /// <summary>Shader parameters by name (<c>parameter &lt;type&gt; &lt;name&gt; &lt;v..&gt;</c>).</summary>
+    public Dictionary<string, float[]> Parameters { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>The diffuse map for texture resolution: <c>texture0</c>.</summary>
+    public string? DiffuseTexture => Textures[0];
+}

--- a/Radoub.Formats/Radoub.Formats/Mtr/MtrReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Mtr/MtrReader.cs
@@ -1,0 +1,118 @@
+using System.Globalization;
+using System.Text;
+
+namespace Radoub.Formats.Mtr;
+
+/// <summary>
+/// Reads NWN:EE MTR material files (resource type 3007) from the ASCII text format.
+/// The text format is whitespace-delimited with <c>//</c> line comments; blank lines
+/// are ignored. A binary <c>MTR V1.x</c> container exists in NWN:EE but is not yet
+/// supported here.
+/// </summary>
+public static class MtrReader
+{
+    static MtrReader()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+    }
+
+    /// <summary>Read an MTR file from a file path.</summary>
+    public static MtrFile Read(string filePath) => Read(File.ReadAllBytes(filePath));
+
+    /// <summary>Read an MTR file from a stream.</summary>
+    public static MtrFile Read(Stream stream)
+    {
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        return Read(ms.ToArray());
+    }
+
+    /// <summary>
+    /// Read an MTR file from a byte buffer. NWN1 text is Windows-1252; a UTF-8 BOM
+    /// (EF BB BF) opts into UTF-8 (matches <c>TwoDAReader</c>).
+    /// </summary>
+    public static MtrFile Read(byte[] buffer)
+    {
+        string text;
+        if (buffer.Length >= 3 && buffer[0] == 0xEF && buffer[1] == 0xBB && buffer[2] == 0xBF)
+            text = Encoding.UTF8.GetString(buffer, 3, buffer.Length - 3);
+        else
+            text = Encoding.GetEncoding(1252).GetString(buffer);
+        return Parse(text);
+    }
+
+    /// <summary>Parse MTR text content into an <see cref="MtrFile"/>.</summary>
+    public static MtrFile Parse(string text)
+    {
+        var mtr = new MtrFile();
+
+        foreach (var rawLine in text.Split('\n'))
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0 || line.StartsWith("//", StringComparison.Ordinal))
+                continue;
+
+            var tokens = line.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+            if (tokens.Length == 0)
+                continue;
+
+            var key = tokens[0].ToLowerInvariant();
+            switch (key)
+            {
+                case "customshadervs":
+                    mtr.CustomShaderVs = ValueOrNull(tokens, 1);
+                    break;
+                case "customshaderfs":
+                    mtr.CustomShaderFs = ValueOrNull(tokens, 1);
+                    break;
+                case "renderhint":
+                    mtr.RenderHint = ValueOrNull(tokens, 1);
+                    break;
+                case "parameter":
+                    ParseParameter(tokens, mtr);
+                    break;
+                default:
+                    if (key.StartsWith("texture", StringComparison.Ordinal))
+                        ParseTexture(key, tokens, mtr);
+                    break;
+            }
+        }
+
+        return mtr;
+    }
+
+    private static void ParseTexture(string key, string[] tokens, MtrFile mtr)
+    {
+        // key is "texture<N>"
+        if (!int.TryParse(key.AsSpan("texture".Length), out var slot)
+            || slot < 0 || slot >= mtr.Textures.Length)
+            return;
+
+        var value = ValueOrNull(tokens, 1);
+        // A literal "null" sampler is an empty slot.
+        if (value is not null && value.Equals("null", StringComparison.OrdinalIgnoreCase))
+            value = null;
+        mtr.Textures[slot] = value;
+    }
+
+    private static void ParseParameter(string[] tokens, MtrFile mtr)
+    {
+        // parameter <type> <name> <v0> [v1 ...]
+        if (tokens.Length < 4)
+            return;
+
+        var name = tokens[2];
+        var values = new List<float>(tokens.Length - 3);
+        for (var i = 3; i < tokens.Length; i++)
+        {
+            if (float.TryParse(tokens[i], NumberStyles.Float, CultureInfo.InvariantCulture, out var f))
+                values.Add(f);
+        }
+
+        if (values.Count > 0)
+            mtr.Parameters[name] = values.ToArray();
+    }
+
+    private static string? ValueOrNull(string[] tokens, int index) =>
+        index < tokens.Length ? tokens[index] : null;
+}


### PR DESCRIPTION
## Summary

Format-layer foundation for #2482 (model-preview white-model fix). Adds the NWN:EE MTR material format (resource type 3007) reader to `Radoub.Formats` and parses the MDL `materialname` field in both binary and ASCII readers.

Binary `materialname` lives in the trimesh header's 4th texture slot (`texture3`) — confirmed authoritatively by **rollnw** (`MdlBinaryParser.hpp`: "This is material name in NWN:EE"). The reader already read that slot and discarded it; now it captures it.

Spike: `NonPublic/Quartermaster/Research/spike-2482-mdl-mtr.md` (MTR is plain ASCII; prototype parsed all 19 real samples).

## Related Issues

- Closes #2496
- Parent: #2482

## Checklist

- [x] `Mtr = 3007` + extension mappings (ResourceTypes) — 21 tests
- [x] `MtrFile` + `MtrReader` (ASCII) — all directives parsed — 10 tests
- [x] `materialname` parsed in binary (texture3, rollnw-verified) + ASCII MDL readers
- [x] Tests added (TDD; in-memory binary trimesh fixture + ASCII fixtures)
- [x] CHANGELOG updated (root Radoub.Formats 0.2.70-alpha + QM one-liner)
- [x] No UI behavior change (format layer only)

## Pre-Merge Verification

- Local `Radoub.Formats.Tests`: **Passed! Failed: 0, Passed: 1402, Skipped: 1**
- Privacy scan (production + tests): clean, no hardcoded paths
- Tech debt: largest changed file 537 lines (under 800 threshold)
- CHANGELOG: versioned, PR# filled, no `[Unreleased]`
- CI: builds + privacy green; unit tests (ubuntu + windows) pending at time of writing — verify `gh pr checks 2499` green before merge