### PR TITLE
[Quartermaster] Fix: Resolve mesh diffuse from MTR texture0 (white-model, #2482 C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Radoub.UI 0.2.11-alpha] - 2026-06-18
 **Branch**: `quartermaster/issue-2497` | **PR**: #2500
 
-### Fix: Resolve mesh diffuse from MTR texture0 (#2497)
+### Feat: MTR-driven diffuse resolution + diagnostics (#2497)
 
-- `TextureService` now resolves a mesh's diffuse from its MTR `texture0` (via the mesh `materialname`) before the bare-name `_d` guess — the remaining half of the #1755 white-model fix for CEP3 creatures whose diffuse differs from the mesh bitmap. The #1755 bare/`_d` fallback is preserved when no MTR applies. Consumed by the Quartermaster model preview.
+- `TextureService` now resolves a mesh's diffuse from its MTR `texture0` (via the mesh `materialname`) ahead of the bare-name/`_d` chain, with the #1755 fallback preserved when no MTR applies. Forward-looking support: the common CEP/PRC HAKs ship no `.mtr` and the original beetle white-model was already fixed in #1200, so this no-ops on current content. Added `[MTR]` diagnostic logging so the first genuinely MTR-driven model is captured in logs. Consumed by the Quartermaster model preview.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.11-alpha] - 2026-06-18
+**Branch**: `quartermaster/issue-2497` | **PR**: #2500
+
+### Fix: Resolve mesh diffuse from MTR texture0 (#2497)
+
+- `TextureService` now resolves a mesh's diffuse from its MTR `texture0` (via the mesh `materialname`) before the bare-name `_d` guess — the remaining half of the #1755 white-model fix for CEP3 creatures whose diffuse differs from the mesh bitmap. The #1755 bare/`_d` fallback is preserved when no MTR applies. Consumed by the Quartermaster model preview.
+
+---
+
 ## [Radoub.Formats 0.2.70-alpha] - 2026-06-18
 **Branch**: `quartermaster/issue-2496` | **PR**: #2499
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.122-alpha] - 2026-06-18
+**Branch**: `quartermaster/issue-2497` | **PR**: #TBD
+
+### Fix: Resolve mesh diffuse from MTR texture0 (#2497)
+
+- Model preview now resolves a mesh's diffuse texture from its `.mtr` material (`texture0`) instead of guessing the `_d` suffix — the remaining half of the #1755 white-model fix. Bare-name/`_d` fallback preserved.
+
+---
+
 ## [0.2.121-alpha] - 2026-06-18
 **Branch**: `quartermaster/issue-2496` | **PR**: #2499
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -8,9 +8,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ## [0.2.122-alpha] - 2026-06-18
 **Branch**: `quartermaster/issue-2497` | **PR**: #2500
 
-### Fix: Resolve mesh diffuse from MTR texture0 (#2497)
+### Feat: MTR-driven diffuse resolution + diagnostics (#2497)
 
-- Model preview now resolves a mesh's diffuse texture from its `.mtr` material (`texture0`) instead of guessing the `_d` suffix — the remaining half of the #1755 white-model fix. Bare-name/`_d` fallback preserved.
+- Model preview now resolves a mesh's diffuse from its `.mtr` material (`texture0`, via the mesh `materialname`) ahead of the existing bare-name/`_d` chain. Forward-looking MTR support — current CEP/PRC packs ship no `.mtr`, so this no-ops on today's content; added `[MTR]` diagnostic logging to capture the first genuinely MTR-driven model.
 
 ---
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.122-alpha] - 2026-06-18
-**Branch**: `quartermaster/issue-2497` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2497` | **PR**: #2500
 
 ### Fix: Resolve mesh diffuse from MTR texture0 (#2497)
 

--- a/Radoub.UI/Radoub.UI.Tests/MtrDiffuseResolutionTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/MtrDiffuseResolutionTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using Radoub.Formats.Mtr;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// #2497: resolve a mesh's diffuse texture from its MTR <c>texture0</c> instead of
+/// guessing the <c>_d</c> suffix — the remaining half of the #1755 white-model fix.
+/// The decision logic (which diffuse resrefs to try, in order) is pure and unit-tested
+/// here; the IO that loads the bytes lives in <see cref="TextureService"/>.
+/// </summary>
+public class MtrDiffuseResolutionTests
+{
+    [Fact]
+    public void DivergentMtr_DiffuseFromTexture0_LeadsCandidates()
+    {
+        // The white-model trigger: a CEP3-shaped MTR whose texture0 differs from the
+        // mesh bitmap. Bare-name resolution would never find the real diffuse.
+        var mtr = MtrReader.Parse("texture0 c_real_diffuse\n");
+
+        var candidates = TextureService.ResolveDiffuseCandidates("c_mesh_bitmap", mtr);
+
+        Assert.Equal("c_real_diffuse", candidates[0]);
+    }
+
+    [Fact]
+    public void DivergentMtr_StillFallsBackToBareNameAndDSuffix()
+    {
+        // MTR texture0 leads, but if it misses on disk we must still try the bare name
+        // and the #1755 _d variant — defense in depth, not a hard override.
+        var mtr = MtrReader.Parse("texture0 c_real_diffuse\n");
+
+        var candidates = TextureService.ResolveDiffuseCandidates("c_mesh_bitmap", mtr);
+
+        Assert.Contains("c_mesh_bitmap", candidates);
+        Assert.Contains("c_mesh_bitmap_d", candidates);
+    }
+
+    [Fact]
+    public void NoMtr_PreservesBareNameThenDSuffix_1755Behavior()
+    {
+        var candidates = TextureService.ResolveDiffuseCandidates("cre_017_t_b01", mtr: null);
+
+        Assert.Equal(new[] { "cre_017_t_b01", "cre_017_t_b01_d" }, candidates);
+    }
+
+    [Fact]
+    public void MtrWithNullTexture0_FallsBackToBareNameChain()
+    {
+        // An MTR that declares no usable texture0 must not blank out the bare-name chain.
+        var mtr = MtrReader.Parse("texture0 null\ntexture1 c_normalmap\n");
+
+        var candidates = TextureService.ResolveDiffuseCandidates("cre_017_t_b01", mtr);
+
+        Assert.Equal(new[] { "cre_017_t_b01", "cre_017_t_b01_d" }, candidates);
+    }
+
+    [Fact]
+    public void Texture0EqualsBitmap_NoDuplicateCandidate()
+    {
+        // The Zodiac case: texture0 == bitmap. The bare name already resolves; we must
+        // not emit it twice.
+        var mtr = MtrReader.Parse("texture0 c_zod_boar\n");
+
+        var candidates = TextureService.ResolveDiffuseCandidates("c_zod_boar", mtr);
+
+        Assert.Equal(new[] { "c_zod_boar", "c_zod_boar_d" }, candidates);
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/MtrTextureLoadTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/MtrTextureLoadTests.cs
@@ -1,0 +1,76 @@
+using System.Text;
+using Radoub.Formats.Common;
+using Radoub.TestUtilities.Mocks;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// #2497 IO-level resolution: when a mesh names an MTR material, the diffuse must be
+/// loaded from the MTR <c>texture0</c> even though the mesh bitmap itself has no texture
+/// on disk (the white-model case). Falls back to the #1755 bare/<c>_d</c> chain otherwise.
+/// </summary>
+public class MtrTextureLoadTests
+{
+    // Minimal 1x1 32-bit uncompressed true-color TGA (18-byte header + one BGRA pixel).
+    private static byte[] OnePixelTga(byte b, byte g, byte r, byte a)
+    {
+        var tga = new byte[18 + 4];
+        tga[2] = 2;       // image type: uncompressed true-color
+        tga[12] = 1;      // width = 1
+        tga[14] = 1;      // height = 1
+        tga[16] = 32;     // 32 bpp
+        tga[18] = b; tga[19] = g; tga[20] = r; tga[21] = a;
+        return tga;
+    }
+
+    private static byte[] Mtr(string text) => Encoding.ASCII.GetBytes(text);
+
+    [Fact]
+    public void DivergentMtr_LoadsDiffuseFromTexture0_WhenBitmapMissing()
+    {
+        var game = new MockGameDataService(includeSampleData: false);
+        // The mesh bitmap "c_mesh_bitmap" has NO texture on disk (white-model trigger).
+        // Its material file points at a different diffuse via texture0.
+        game.SetResource("c_mesh_bitmap", ResourceTypes.Mtr, Mtr("texture0 c_real_diffuse\n"));
+        game.SetResource("c_real_diffuse", ResourceTypes.Tga, OnePixelTga(10, 20, 30, 255));
+
+        var service = new TextureService(game);
+
+        var result = service.LoadTextureWithKind("c_mesh_bitmap", "c_mesh_bitmap");
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.Value.width);
+        Assert.Equal(1, result.Value.height);
+    }
+
+    [Fact]
+    public void NoMtr_StillResolvesBareName_1755Unbroken()
+    {
+        var game = new MockGameDataService(includeSampleData: false);
+        game.SetResource("c_zod_boar", ResourceTypes.Tga, OnePixelTga(1, 2, 3, 255));
+
+        var service = new TextureService(game);
+
+        // No materialName supplied — must behave exactly like the existing loader.
+        var result = service.LoadTextureWithKind("c_zod_boar");
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void MtrPresentButMissingTexture0_FallsBackToDSuffix()
+    {
+        var game = new MockGameDataService(includeSampleData: false);
+        game.SetResource("cre_017_t_b01", ResourceTypes.Mtr, Mtr("texture0 null\ntexture1 cre_017_t_b01_n\n"));
+        // Only the #1755 _d diffuse exists on disk.
+        game.SetResource("cre_017_t_b01_d", ResourceTypes.Tga, OnePixelTga(9, 9, 9, 255));
+
+        var service = new TextureService(game);
+
+        var result = service.LoadTextureWithKind("cre_017_t_b01", "cre_017_t_b01");
+
+        Assert.NotNull(result);
+    }
+}

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
@@ -1602,12 +1602,19 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
 
         _textureRemapping.Clear();
 
-        // Collect unique texture names from meshes
+        // Collect unique texture names from meshes, remembering the mesh's MTR material
+        // name (#2497) so the loader can resolve diffuse from the .mtr texture0 when the
+        // bare bitmap misses (the white-model case).
         var textureNames = new HashSet<string>();
+        var materialByTexture = new Dictionary<string, string>();
         foreach (var mesh in _model.GetMeshNodes())
         {
-            if (!string.IsNullOrEmpty(mesh.Bitmap))
-                textureNames.Add(mesh.Bitmap.ToLowerInvariant());
+            if (string.IsNullOrEmpty(mesh.Bitmap))
+                continue;
+            var bitmap = mesh.Bitmap.ToLowerInvariant();
+            textureNames.Add(bitmap);
+            if (!string.IsNullOrEmpty(mesh.MaterialName) && !materialByTexture.ContainsKey(bitmap))
+                materialByTexture[bitmap] = mesh.MaterialName.ToLowerInvariant();
         }
 
         // #2395: include emitter particle textures so they load into _textureCache
@@ -1652,9 +1659,10 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
 
             try
             {
+                materialByTexture.TryGetValue(texName, out var materialName);
                 var textureData = _preferBifTextures
                     ? _textureService.LoadTexturePreferBIFWithKind(texName, _colorIndices)
-                    : _textureService.LoadTextureWithKind(texName, _colorIndices);
+                    : _textureService.LoadTextureWithKind(texName, materialName, _colorIndices);
                 if (textureData == null)
                 {
                     UnifiedLogger.LogApplication(LogLevel.DEBUG, $"  Texture '{texName}' returned null");

--- a/Radoub.UI/Radoub.UI/Services/TextureService.cs
+++ b/Radoub.UI/Radoub.UI/Services/TextureService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using Pfim;
 using Radoub.Formats.Common;
 using Radoub.Formats.Logging;
+using Radoub.Formats.Mtr;
 using Radoub.Formats.Plt;
 using Radoub.Formats.Services;
 using Radoub.Formats.Tga;
@@ -566,6 +567,60 @@ public class TextureService
         return false;
     }
 
+    /// <summary>
+    /// #2497: material-aware texture load. When <paramref name="materialName"/> names an MTR
+    /// (resource type 3007) with a <c>texture0</c> diffuse, that named diffuse is tried first —
+    /// the white-model fix for CEP3 creatures whose diffuse differs from the mesh bitmap. Falls
+    /// back to the bare-name / <c>_d</c> chain (#1755) when the MTR is absent, declares no usable
+    /// texture0, or its texture0 itself misses on disk.
+    /// </summary>
+    public (int width, int height, byte[] pixels, bool isPlt)? LoadTextureWithKind(
+        string resRef,
+        string? materialName,
+        PltColorIndices? colorIndices = null)
+    {
+        colorIndices ??= new PltColorIndices();
+
+        var mtr = LoadMtr(materialName);
+        var mtrDiffuse = mtr?.DiffuseTexture;
+        // Only worth a separate attempt when the MTR points somewhere the bare-name chain
+        // would not already reach (the divergent texture0 != bitmap case).
+        if (!string.IsNullOrEmpty(mtrDiffuse)
+            && !mtrDiffuse.Equals(resRef, StringComparison.OrdinalIgnoreCase))
+        {
+            var mtrResult = LoadTextureWithKind(mtrDiffuse, colorIndices);
+            if (mtrResult.HasValue)
+                return mtrResult;
+        }
+
+        return LoadTextureWithKind(resRef, colorIndices);
+    }
+
+    /// <summary>
+    /// Resolve and parse the MTR material file (resource type 3007) named by a mesh's
+    /// <c>materialname</c>. Returns null when there is no material name or no such resource.
+    /// </summary>
+    private MtrFile? LoadMtr(string? materialName)
+    {
+        if (string.IsNullOrEmpty(materialName))
+            return null;
+
+        var data = _gameDataService.FindResource(materialName.ToLowerInvariant(), ResourceTypes.Mtr);
+        if (data == null || data.Length == 0)
+            return null;
+
+        try
+        {
+            return MtrReader.Read(data);
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                $"TextureService.LoadMtr: MTR '{materialName}' parse failed ({data.Length} bytes): {ex.Message}");
+            return null;
+        }
+    }
+
     public (int width, int height, byte[] pixels, bool isPlt)? LoadTextureWithKind(
         string resRef,
         PltColorIndices? colorIndices = null)
@@ -704,6 +759,39 @@ public class TextureService
             return null;
 
         return baseName + "_d";
+    }
+
+    /// <summary>
+    /// #2497: build the ordered list of diffuse texture resrefs to try for a mesh, given
+    /// its bare bitmap name and the parsed MTR material (or null when it has none). When
+    /// the MTR declares a <c>texture0</c>, that named diffuse leads — this is the white-model
+    /// fix for CEP3 creatures whose diffuse differs from the mesh bitmap (<c>texture0 != bitmap</c>).
+    /// The bare name and its <c>_d</c> variant always follow as fallback so the #1755 behavior is
+    /// preserved when the MTR is absent or its texture0 itself misses on disk. Candidates are
+    /// de-duplicated (case-insensitive) preserving order.
+    /// </summary>
+    internal static IReadOnlyList<string> ResolveDiffuseCandidates(string? bitmap, MtrFile? mtr)
+    {
+        var ordered = new List<string>();
+
+        void Add(string? name)
+        {
+            if (string.IsNullOrEmpty(name))
+                return;
+            foreach (var existing in ordered)
+                if (existing.Equals(name, StringComparison.OrdinalIgnoreCase))
+                    return;
+            ordered.Add(name);
+        }
+
+        // MTR texture0 leads when present (the actual white-model trigger).
+        Add(mtr?.DiffuseTexture);
+
+        // Existing #1755 chain: bare name, then the _d diffuse variant.
+        Add(bitmap);
+        Add(PbrDiffuseFallbackName(bitmap));
+
+        return ordered;
     }
 
     /// <summary>

--- a/Radoub.UI/Radoub.UI/Services/TextureService.cs
+++ b/Radoub.UI/Radoub.UI/Services/TextureService.cs
@@ -583,6 +583,28 @@ public class TextureService
 
         var mtr = LoadMtr(materialName);
         var mtrDiffuse = mtr?.DiffuseTexture;
+
+        // #2497 diagnostics: MTR-driven creatures are rare in the wild (no MTR exists in the
+        // common CEP/PRC HAKs as of this writing), so the first real one is worth a loud trail.
+        // Whenever a mesh actually carries a materialname, log the full resolution decision so a
+        // white-model report can be diagnosed from logs alone. Tag: [MTR].
+        if (!string.IsNullOrEmpty(materialName))
+        {
+            if (mtr == null)
+            {
+                UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                    $"[MTR] mesh '{resRef}' names material '{materialName}' but no .mtr (3007) resolved — using bare/_d chain.");
+            }
+            else
+            {
+                var diverges = !string.IsNullOrEmpty(mtrDiffuse)
+                    && !mtrDiffuse.Equals(resRef, StringComparison.OrdinalIgnoreCase);
+                UnifiedLogger.LogApplication(LogLevel.INFO,
+                    $"[MTR] mesh '{resRef}' material '{materialName}': texture0='{mtrDiffuse ?? "(none)"}', " +
+                    $"diverges={diverges}, companions=[{string.Join(",", DescribeMtrTextures(mtr))}].");
+            }
+        }
+
         // Only worth a separate attempt when the MTR points somewhere the bare-name chain
         // would not already reach (the divergent texture0 != bitmap case).
         if (!string.IsNullOrEmpty(mtrDiffuse)
@@ -590,10 +612,31 @@ public class TextureService
         {
             var mtrResult = LoadTextureWithKind(mtrDiffuse, colorIndices);
             if (mtrResult.HasValue)
+            {
+                UnifiedLogger.LogApplication(LogLevel.INFO,
+                    $"[MTR] mesh '{resRef}' diffuse resolved from MTR texture0 '{mtrDiffuse}' " +
+                    $"({mtrResult.Value.width}x{mtrResult.Value.height}).");
                 return mtrResult;
+            }
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"[MTR] mesh '{resRef}' material '{materialName}' texture0 '{mtrDiffuse}' did not load — " +
+                $"falling back to bare/_d chain (possible white model).");
         }
 
         return LoadTextureWithKind(resRef, colorIndices);
+    }
+
+    /// <summary>
+    /// Diagnostic helper: list the non-empty MTR sampler slots as <c>texN=name</c> for logging.
+    /// </summary>
+    private static IEnumerable<string> DescribeMtrTextures(MtrFile mtr)
+    {
+        for (int i = 0; i < mtr.Textures.Length; i++)
+        {
+            var t = mtr.Textures[i];
+            if (!string.IsNullOrEmpty(t))
+                yield return $"tex{i}={t}";
+        }
     }
 
     /// <summary>
@@ -611,12 +654,16 @@ public class TextureService
 
         try
         {
-            return MtrReader.Read(data);
+            var mtr = MtrReader.Read(data);
+            UnifiedLogger.LogApplication(LogLevel.INFO,
+                $"[MTR] loaded material '{materialName}' ({data.Length} bytes): texture0='{mtr.DiffuseTexture ?? "(none)"}', " +
+                $"renderhint='{mtr.RenderHint ?? "(none)"}'.");
+            return mtr;
         }
         catch (Exception ex)
         {
-            UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                $"TextureService.LoadMtr: MTR '{materialName}' parse failed ({data.Length} bytes): {ex.Message}");
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"[MTR] material '{materialName}' parse failed ({data.Length} bytes): {ex.Message}");
             return null;
         }
     }


### PR DESCRIPTION
## Summary

Resolve a mesh's diffuse from its MTR `texture0` (via the mesh `materialname`) ahead of the bare-name → `_d` chain, with the #1755 fallback preserved when no MTR applies. Sub-task C of tracker #2482; builds on #2496 (MtrReader + materialname parse, merged).

## Scope correction (important)

This PR was opened to "fix the remaining half of the #1755 white-model." Investigation during the branch showed that framing is wrong:

- **No `.mtr` (3007) resources exist in any CEP/PRC HAK** (verified via `GetResourcesByType` + a raw ERF key-list scan). The Zodiac loose samples are all non-divergent (`texture0 == bitmap`).
- **The actual broken CEP creatures don't use MTR.** Tracing `c_roachbeetle` (CEP3) and `pack_beetle` (CEP2): every mesh has empty `materialname` and no MTR. `c_roachbeetle`'s diffuse resolves fine as a plain DDS under the bare bitmap name.
- **The beetle white-model was already fixed by PR #1200** ("Static appearance model rendering fixes (beholder, troll, beetles)", Feb 11) — confirmed by the user flipping through all beetle models in QM.

So the MTR path is **forward-looking support**: it activates only when a mesh names an `.mtr`, which never happens on current content, so it no-ops and falls through to the existing chain. It does **not** fix the CEP white models, because those aren't MTR-driven.

## What's in this PR

- `TextureService.ResolveDiffuseCandidates` (pure) + `LoadTextureWithKind(resRef, materialName, …)` overload + `LoadMtr` — MTR `texture0` resolution, divergence-aware, fallback preserved.
- `ModelPreviewGLControl` threads each mesh's `MaterialName` to the loader.
- `[MTR]` diagnostic logging so the first genuinely MTR-driven model is captured in logs.
- Unit tests: `MtrDiffuseResolutionTests` (5), `MtrTextureLoadTests` (3) — divergent `texture0 != bitmap` case red-green verified.

## Related Issues

- Closes #2497
- Parent: #2482 · Relates to #1755 (already resolved by #1200)
- Spun off: #2501 (ErfReader.ReadMetadataOnly throws on PRC HAKs, found during the fixture hunt)

## Checklist

- [x] Diffuse resolved from MTR `texture0` when present (unit-tested)
- [x] `_d` / bare-name fallback preserved
- [x] `[MTR]` diagnostic logging added
- [x] CHANGELOG updated (reframed as forward-looking)
- [ ] In-app visual verification — N/A: no MTR-driven content exists to render; logging readies the first real case

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)