### PR TITLE
[Quartermaster] Feat: Wings & Tail Support in 3D Appearance Render

### DIFF
--- a/.claude/scripts/New-WingTailTestUtc.ps1
+++ b/.claude/scripts/New-WingTailTestUtc.ps1
@@ -1,0 +1,45 @@
+# Build a throwaway part-based test creature with WINGS + TAIL set, for QM #1485 verification.
+# Clones a base UTC (default Bucky.utc in LNS_DLG), sets a part-based (MODELTYPE=P) Appearance_Type
+# (Human=6) plus Wings_New / Tail_New, and writes wingtail.utc into the module.
+# Uses the built Radoub.Formats.dll so the GFF round-trip matches QM.
+#
+# Requires PowerShell 7 (net assembly load). Use the full PS7 path, NOT the WindowsApps pwsh stub:
+#   & "C:\Program Files\PowerShell\7\pwsh.exe" -NoProfile -ExecutionPolicy Bypass `
+#       -File ".claude/scripts/New-WingTailTestUtc.ps1"
+
+param(
+    [uint16] $Appearance = 6,   # Human (MODELTYPE=P)
+    [int]    $Wings = 2,        # wingmodel.2da row
+    [int]    $Tail = 1,         # tailmodel.2da row
+    [string] $OutName = 'wingtail',
+    [string] $ModuleDir = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Neverwinter Nights\modules\LNS_DLG'),
+    [string] $BaseUtc = 'Bucky.utc'
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+$dll = Join-Path $repoRoot 'Radoub.Formats\Radoub.Formats\bin\Debug\net9.0\Radoub.Formats.dll'
+if (-not (Test-Path $dll)) { throw "Radoub.Formats.dll not found at $dll - build Radoub.Formats first." }
+Add-Type -Path $dll
+
+$basePath = Join-Path $ModuleDir $BaseUtc
+if (-not (Test-Path $basePath)) { throw "Base UTC not found: $basePath" }
+
+$utc = [Radoub.Formats.Utc.UtcReader]::Read($basePath)
+$utc.AppearanceType = $Appearance
+$utc.Wings = [byte]$Wings
+$utc.Tail = [byte]$Tail
+$utc.TemplateResRef = $OutName
+$utc.Tag = $OutName
+$loc = New-Object Radoub.Formats.Gff.CExoLocString
+$loc.SetString(0, "WingTail test (app=$Appearance wings=$Wings tail=$Tail)")
+$utc.FirstName = $loc
+
+$outPath = Join-Path $ModuleDir ($OutName + '.utc')
+[Radoub.Formats.Utc.UtcWriter]::Write($utc, $outPath)
+
+$check = [Radoub.Formats.Utc.UtcReader]::Read($outPath)
+if ($check.AppearanceType -ne $Appearance -or $check.Wings -ne [byte]$Wings -or $check.Tail -ne [byte]$Tail) {
+    throw "Round-trip failed: app=$($check.AppearanceType) wings=$($check.Wings) tail=$($check.Tail)"
+}
+Write-Host "Wrote $outPath  (Appearance=$Appearance Wings=$Wings Tail=$Tail)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.12-alpha] - 2026-06-18
+**Branch**: `quartermaster/issue-1485` | **PR**: #2502
+
+### Feat: MdlPartComposer wing/tail supermodel graft (#1485)
+
+- `MdlPartComposer.Compose` gained an optional supermodel-attachment path: wing/tail MDLs graft under the body's named `wings`/`tail` bone, scaled by `WING_TAIL_SCALE`, with their authored textures preserved and their animations merged by name into the body's so they flap in sync. Consumed by the Quartermaster appearance preview (see Quartermaster CHANGELOG).
+
+---
+
 ## [Radoub.UI 0.2.11-alpha] - 2026-06-18
 **Branch**: `quartermaster/issue-2497` | **PR**: #2500
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.123-alpha] - 2026-06-18
-**Branch**: `quartermaster/issue-1485` | **PR**: #TBD
+**Branch**: `quartermaster/issue-1485` | **PR**: #2502
 
 ### Feat: Wings & Tail in 3D appearance render (#1485)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.123-alpha] - 2026-06-18
+**Branch**: `quartermaster/issue-1485` | **PR**: #TBD
+
+### Feat: Wings & Tail in 3D appearance render (#1485)
+
+- Part-based creature previews now render wings (`wingmodel.2da`) and tail (`tailmodel.2da`) with `WING_TAIL_SCALE` applied, flapping in sync with the body animation.
+
+---
+
 ## [0.2.122-alpha] - 2026-06-18
 **Branch**: `quartermaster/issue-2497` | **PR**: #2500
 

--- a/Quartermaster/Quartermaster.Tests/AppearanceServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/AppearanceServiceTests.cs
@@ -600,6 +600,51 @@ public class AppearanceServiceTests
         Assert.Equal("Tail 50", _service.GetTailName(50));
     }
 
+    [Fact]
+    public void GetWingModel_Zero_ReturnsNull()
+    {
+        Assert.Null(_service.GetWingModel(0));
+    }
+
+    [Fact]
+    public void GetWingModel_ValidId_ReturnsModelResRef()
+    {
+        Assert.Equal("c_wingsan", _service.GetWingModel(1));
+        Assert.Equal("c_wingsdm", _service.GetWingModel(2));
+    }
+
+    [Fact]
+    public void GetWingModel_StarModel_ReturnsNull()
+    {
+        // Butterfly (row 3) has a LABEL but MODEL is **** — no renderable model.
+        Assert.Null(_service.GetWingModel(3));
+    }
+
+    [Fact]
+    public void GetWingModel_MissingRow_ReturnsNull()
+    {
+        Assert.Null(_service.GetWingModel(250));
+    }
+
+    [Fact]
+    public void GetTailModel_Zero_ReturnsNull()
+    {
+        Assert.Null(_service.GetTailModel(0));
+    }
+
+    [Fact]
+    public void GetTailModel_ValidId_ReturnsModelResRef()
+    {
+        Assert.Equal("c_tailliz", _service.GetTailModel(1));
+        Assert.Equal("c_tailbone", _service.GetTailModel(2));
+    }
+
+    [Fact]
+    public void GetTailModel_MissingRow_ReturnsNull()
+    {
+        Assert.Null(_service.GetTailModel(250));
+    }
+
     #endregion
 
     #region Sound Sets

--- a/Quartermaster/Quartermaster.Tests/AppearanceServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/AppearanceServiceTests.cs
@@ -645,6 +645,48 @@ public class AppearanceServiceTests
         Assert.Null(_service.GetTailModel(250));
     }
 
+    [Fact]
+    public void GetAllTails_WithModelFilter_ExcludesNonTails()
+    {
+        // tailmodel.2da reuses the slot for mounts (horses); only models with a 'tail' connector
+        // node are real tails. The filter predicate receives the MODEL resref. Mock: Lizard/Bone
+        // are tails; add a 'horse' row the predicate rejects.
+        _mockGameData.Set2DAValue("tailmodel", 5, "LABEL", "Horse, Walnut");
+        _mockGameData.Set2DAValue("tailmodel", 5, "MODEL", "c_horse1");
+
+        bool IsTail(string model) => model.StartsWith("c_tail"); // stand-in for the MDL connector check
+
+        var tails = _service.GetAllTails(IsTail);
+
+        Assert.Contains(tails, t => t.Name == "Lizard");
+        Assert.Contains(tails, t => t.Name == "Bone");
+        Assert.DoesNotContain(tails, t => t.Name == "Horse, Walnut");
+        Assert.Equal((byte)0, tails[0].Id); // None always first
+    }
+
+    [Fact]
+    public void GetAllTails_NullFilter_KeepsAllRows()
+    {
+        // No predicate (back-compat) → original behavior, every labeled row included.
+        _mockGameData.Set2DAValue("tailmodel", 5, "LABEL", "Horse, Walnut");
+        _mockGameData.Set2DAValue("tailmodel", 5, "MODEL", "c_horse1");
+
+        var tails = _service.GetAllTails();
+
+        Assert.Contains(tails, t => t.Name == "Horse, Walnut");
+    }
+
+    [Fact]
+    public void GetAllWings_WithModelFilter_ExcludesRejected()
+    {
+        bool KeepAngelOnly(string model) => model == "c_wingsan";
+
+        var wings = _service.GetAllWings(KeepAngelOnly);
+
+        Assert.Contains(wings, w => w.Name == "Angel");   // c_wingsan kept
+        Assert.DoesNotContain(wings, w => w.Name == "Demon"); // c_wingsdm rejected
+    }
+
     #endregion
 
     #region Sound Sets

--- a/Quartermaster/Quartermaster.Tests/ModelNameConstructionTests.cs
+++ b/Quartermaster/Quartermaster.Tests/ModelNameConstructionTests.cs
@@ -74,4 +74,33 @@ public class ModelNameConstructionTests
 
         Assert.Equal(1.0f, ModelService.GetWingTailScale(mock, 7), 3);
     }
+
+    [Fact]
+    public void HasConnectorNode_TrueWhenTopLevelNodeMatches()
+    {
+        // A real tail MDL: root → 'tail' connector. A horse MDL has no 'tail' child.
+        var tail = new Radoub.Formats.Mdl.MdlModel
+        {
+            GeometryRoot = new Radoub.Formats.Mdl.MdlNode { Name = "c_tailliz" }
+        };
+        tail.GeometryRoot.Children.Add(new Radoub.Formats.Mdl.MdlNode { Name = "tail" });
+
+        var horse = new Radoub.Formats.Mdl.MdlModel
+        {
+            GeometryRoot = new Radoub.Formats.Mdl.MdlNode { Name = "c_horse1" }
+        };
+        horse.GeometryRoot.Children.Add(new Radoub.Formats.Mdl.MdlNode { Name = "HorseBody" });
+        horse.GeometryRoot.Children.Add(new Radoub.Formats.Mdl.MdlNode { Name = "HorseTail" });
+
+        Assert.True(ModelService.HasConnectorNode(tail, "tail"));
+        Assert.False(ModelService.HasConnectorNode(horse, "tail")); // 'HorseTail' != 'tail'
+    }
+
+    [Fact]
+    public void HasConnectorNode_FalseForNullOrEmpty()
+    {
+        Assert.False(ModelService.HasConnectorNode(null, "tail"));
+        Assert.False(ModelService.HasConnectorNode(
+            new Radoub.Formats.Mdl.MdlModel { GeometryRoot = null }, "tail"));
+    }
 }

--- a/Quartermaster/Quartermaster.Tests/ModelNameConstructionTests.cs
+++ b/Quartermaster/Quartermaster.Tests/ModelNameConstructionTests.cs
@@ -46,4 +46,32 @@ public class ModelNameConstructionTests
         var result = ModelService.BuildModelPrefix(1, "h", 0);
         Assert.StartsWith("pf", result);
     }
+
+    [Fact]
+    public void GetWingTailScale_ReadsColumnValue()
+    {
+        var mock = new Radoub.TestUtilities.Mocks.MockGameDataService(includeSampleData: false);
+        mock.Set2DAValue("appearance", 5, "WING_TAIL_SCALE", "0.5");
+
+        Assert.Equal(0.5f, ModelService.GetWingTailScale(mock, 5), 3);
+    }
+
+    [Fact]
+    public void GetWingTailScale_MissingOrStar_DefaultsToOne()
+    {
+        var mock = new Radoub.TestUtilities.Mocks.MockGameDataService(includeSampleData: false);
+        mock.Set2DAValue("appearance", 6, "WING_TAIL_SCALE", "****");
+
+        Assert.Equal(1.0f, ModelService.GetWingTailScale(mock, 6), 3); // **** -> default
+        Assert.Equal(1.0f, ModelService.GetWingTailScale(mock, 99), 3); // missing -> default
+    }
+
+    [Fact]
+    public void GetWingTailScale_Unparseable_DefaultsToOne()
+    {
+        var mock = new Radoub.TestUtilities.Mocks.MockGameDataService(includeSampleData: false);
+        mock.Set2DAValue("appearance", 7, "WING_TAIL_SCALE", "abc");
+
+        Assert.Equal(1.0f, ModelService.GetWingTailScale(mock, 7), 3);
+    }
 }

--- a/Quartermaster/Quartermaster/Services/AppearanceService.cs
+++ b/Quartermaster/Quartermaster/Services/AppearanceService.cs
@@ -446,6 +446,40 @@ public class AppearanceService
     }
 
     /// <summary>
+    /// Gets the MDL ResRef for a wing type from wingmodel.2da (MODEL column).
+    /// Returns null for "None" (0), an empty/"****" model, or a missing row — callers skip
+    /// attachment when null.
+    /// </summary>
+    public string? GetWingModel(byte wingId)
+    {
+        if (wingId == 0)
+            return null;
+
+        var model = _gameDataService.Get2DAValue("wingmodel", wingId, "MODEL");
+        if (string.IsNullOrEmpty(model) || model == "****")
+            return null;
+
+        return model;
+    }
+
+    /// <summary>
+    /// Gets the MDL ResRef for a tail type from tailmodel.2da (MODEL column).
+    /// Returns null for "None" (0), an empty/"****" model, or a missing row — callers skip
+    /// attachment when null.
+    /// </summary>
+    public string? GetTailModel(byte tailId)
+    {
+        if (tailId == 0)
+            return null;
+
+        var model = _gameDataService.Get2DAValue("tailmodel", tailId, "MODEL");
+        if (string.IsNullOrEmpty(model) || model == "****")
+            return null;
+
+        return model;
+    }
+
+    /// <summary>
     /// Gets all wing types from wingmodel.2da.
     /// </summary>
     public List<(byte Id, string Name)> GetAllWings()

--- a/Quartermaster/Quartermaster/Services/AppearanceService.cs
+++ b/Quartermaster/Quartermaster/Services/AppearanceService.cs
@@ -482,41 +482,37 @@ public class AppearanceService
     /// <summary>
     /// Gets all wing types from wingmodel.2da.
     /// </summary>
-    public List<(byte Id, string Name)> GetAllWings()
-    {
-        var wings = new List<(byte Id, string Name)> { (0, "None") };
-        int consecutiveEmpty = 0;
-
-        for (int i = 1; i < 255; i++)
-        {
-            var label = _gameDataService.Get2DAValue("wingmodel", i, "LABEL");
-            if (string.IsNullOrEmpty(label) || label == "****")
-            {
-                consecutiveEmpty++;
-                // Stop after 10 consecutive empty rows (likely end of valid data)
-                if (consecutiveEmpty > 10)
-                    break;
-                continue;
-            }
-
-            consecutiveEmpty = 0;
-            wings.Add(((byte)i, label));
-        }
-
-        return wings;
-    }
+    /// <param name="modelFilter">
+    /// Optional predicate receiving each row's MODEL resref; when supplied, only rows whose model
+    /// passes are included. Used to drop rows whose MDL is not a real wing (#1485).
+    /// </param>
+    public List<(byte Id, string Name)> GetAllWings(Func<string, bool>? modelFilter = null)
+        => GetAllAttachments("wingmodel", modelFilter);
 
     /// <summary>
     /// Gets all tail types from tailmodel.2da.
     /// </summary>
-    public List<(byte Id, string Name)> GetAllTails()
+    /// <param name="modelFilter">
+    /// Optional predicate receiving each row's MODEL resref; when supplied, only rows whose model
+    /// passes are included. tailmodel.2da reuses the slot for mounted horses and other body
+    /// attachments — the filter keeps only real tails (#1485).
+    /// </param>
+    public List<(byte Id, string Name)> GetAllTails(Func<string, bool>? modelFilter = null)
+        => GetAllAttachments("tailmodel", modelFilter);
+
+    /// <summary>
+    /// Enumerate a wing/tail attachment 2DA's labeled rows (row 0 is always "None"). When a
+    /// <paramref name="modelFilter"/> is supplied, a row is included only if its MODEL resref is
+    /// non-empty and passes the predicate. No hardcoded model lists — the filter is data-driven.
+    /// </summary>
+    private List<(byte Id, string Name)> GetAllAttachments(string twoDAName, Func<string, bool>? modelFilter)
     {
-        var tails = new List<(byte Id, string Name)> { (0, "None") };
+        var result = new List<(byte Id, string Name)> { (0, "None") };
         int consecutiveEmpty = 0;
 
         for (int i = 1; i < 255; i++)
         {
-            var label = _gameDataService.Get2DAValue("tailmodel", i, "LABEL");
+            var label = _gameDataService.Get2DAValue(twoDAName, i, "LABEL");
             if (string.IsNullOrEmpty(label) || label == "****")
             {
                 consecutiveEmpty++;
@@ -527,10 +523,18 @@ public class AppearanceService
             }
 
             consecutiveEmpty = 0;
-            tails.Add(((byte)i, label));
+
+            if (modelFilter != null)
+            {
+                var model = _gameDataService.Get2DAValue(twoDAName, i, "MODEL");
+                if (string.IsNullOrEmpty(model) || model == "****" || !modelFilter(model))
+                    continue;
+            }
+
+            result.Add(((byte)i, label));
         }
 
-        return tails;
+        return result;
     }
 
     #endregion

--- a/Quartermaster/Quartermaster/Services/CreatureDisplayService.cs
+++ b/Quartermaster/Quartermaster/Services/CreatureDisplayService.cs
@@ -630,8 +630,8 @@ public partial class CreatureDisplayService
     public ushort? FindPortraitIdByResRef(string? resRef) => Appearances.FindPortraitIdByResRef(resRef);
     public string GetWingName(byte wingId) => Appearances.GetWingName(wingId);
     public string GetTailName(byte tailId) => Appearances.GetTailName(tailId);
-    public List<(byte Id, string Name)> GetAllWings() => Appearances.GetAllWings();
-    public List<(byte Id, string Name)> GetAllTails() => Appearances.GetAllTails();
+    public List<(byte Id, string Name)> GetAllWings(Func<string, bool>? modelFilter = null) => Appearances.GetAllWings(modelFilter);
+    public List<(byte Id, string Name)> GetAllTails(Func<string, bool>? modelFilter = null) => Appearances.GetAllTails(modelFilter);
     public string GetSoundSetName(ushort soundSetId) => Appearances.GetSoundSetName(soundSetId);
     public List<(ushort Id, string Name)> GetAllSoundSets() => Appearances.GetAllSoundSets();
     public List<(ushort Id, string Name)> GetAllFactions(string? moduleDirectory = null) => Appearances.GetAllFactions(moduleDirectory);

--- a/Quartermaster/Quartermaster/Services/ModelService.cs
+++ b/Quartermaster/Quartermaster/Services/ModelService.cs
@@ -20,6 +20,7 @@ namespace Quartermaster.Services;
 public class ModelService
 {
     private readonly IGameDataService _gameDataService;
+    private readonly AppearanceService _appearanceService;
     private readonly MdlReader _mdlReader = new();
     private readonly Dictionary<string, MdlModel?> _modelCache = new();
     private readonly Dictionary<string, ResourceSource> _modelSourceCache = new();
@@ -37,6 +38,7 @@ public class ModelService
     public ModelService(IGameDataService gameDataService)
     {
         _gameDataService = gameDataService;
+        _appearanceService = new AppearanceService(gameDataService);
         _composer = new MdlPartComposer(_gameDataService, (resRef, _) => LoadModel(resRef));
     }
 
@@ -253,7 +255,44 @@ public class ModelService
         AddPart("footl", GetPartNumber("LFoot", creature.BodyPart_LFoot));
         AddPart("footr", GetPartNumber("RFoot", creature.BodyPart_RFoot));
 
-        return _composer.Compose(basePrefix, parts);
+        // Wings/tail (#1485): standalone supermodels (wingmodel/tailmodel.2da MODEL column),
+        // scaled by the appearance's WING_TAIL_SCALE. Only meaningful for part-based (P) bodies —
+        // full-body creatures bake wings into their single MDL and never reach this method.
+        var supermodels = new List<(string Tag, string ResRef, float Scale)>();
+        var wingTailScale = GetWingTailScale(_gameDataService, appearanceId);
+        var wingRes = _appearanceService.GetWingModel(creature.Wings);
+        if (!string.IsNullOrEmpty(wingRes))
+        {
+            UnifiedLogger.LogApplication(LogLevel.INFO,
+                $"[WingTail] wings={creature.Wings} -> '{wingRes}' scale={wingTailScale:F2}");
+            supermodels.Add(("wings", wingRes!, wingTailScale));
+        }
+        var tailRes = _appearanceService.GetTailModel(creature.Tail);
+        if (!string.IsNullOrEmpty(tailRes))
+        {
+            UnifiedLogger.LogApplication(LogLevel.INFO,
+                $"[WingTail] tail={creature.Tail} -> '{tailRes}' scale={wingTailScale:F2}");
+            supermodels.Add(("tail", tailRes!, wingTailScale));
+        }
+
+        return _composer.Compose(basePrefix, parts, adjustSeams: true,
+            supermodels: supermodels.Count > 0 ? supermodels : null);
+    }
+
+    /// <summary>
+    /// Read appearance.2da WING_TAIL_SCALE for this appearance (the size factor for attached
+    /// wings/tail). Defaults to 1.0 when the column is missing, "****", or unparseable.
+    /// </summary>
+    internal static float GetWingTailScale(IGameDataService gameDataService, ushort appearanceId)
+    {
+        var raw = gameDataService.Get2DAValue("appearance", appearanceId, "WING_TAIL_SCALE");
+        if (!string.IsNullOrEmpty(raw) && raw != "****" &&
+            float.TryParse(raw, System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var scale) && scale > 0f)
+        {
+            return scale;
+        }
+        return 1.0f;
     }
 
     /// <summary>

--- a/Quartermaster/Quartermaster/Services/ModelService.cs
+++ b/Quartermaster/Quartermaster/Services/ModelService.cs
@@ -22,8 +22,10 @@ public class ModelService
     private readonly IGameDataService _gameDataService;
     private readonly AppearanceService _appearanceService;
     private readonly MdlReader _mdlReader = new();
-    private readonly Dictionary<string, MdlModel?> _modelCache = new();
-    private readonly Dictionary<string, ResourceSource> _modelSourceCache = new();
+    // ConcurrentDictionary so the background attachment-list filter (#1485) can call LoadModel
+    // while the UI thread renders without corrupting a plain Dictionary.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, MdlModel?> _modelCache = new();
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, ResourceSource> _modelSourceCache = new();
     private readonly MdlPartComposer _composer;
 
     /// <summary>
@@ -293,6 +295,53 @@ public class ModelService
             return scale;
         }
         return 1.0f;
+    }
+
+    /// <summary>
+    /// True if <paramref name="model"/> has a top-level geometry node named
+    /// <paramref name="connectorNode"/> (case-insensitive). Wing/tail MDLs carry a 'wings'/'tail'
+    /// connector node that the engine attaches to the body's matching bone; mounts (horses) reused
+    /// in tailmodel.2da do not. Used to filter real wings/tails from the attachment lists (#1485).
+    /// </summary>
+    internal static bool HasConnectorNode(MdlModel? model, string connectorNode)
+    {
+        if (model?.GeometryRoot == null)
+            return false;
+
+        foreach (var child in model.GeometryRoot.Children)
+        {
+            if (string.Equals(child.Name, connectorNode, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Predicate for AppearanceService.GetAllWings/GetAllTails (#1485): true if the MODEL resref
+    /// loads and is a real attachment (has the named connector node). Loads through the model cache,
+    /// so repeated calls during list population are cheap. Tolerates load failures (returns false).
+    /// </summary>
+    public bool IsRealAttachment(string modelResRef, string connectorNode)
+    {
+        if (string.IsNullOrEmpty(modelResRef))
+            return false;
+        // Preserve the render texture-source policy: this list-filter probe must not let its
+        // LoadModel calls clobber LastLoadedModelSource for the next real creature render (#1485).
+        var savedSource = LastLoadedModelSource;
+        try
+        {
+            return HasConnectorNode(LoadModel(modelResRef), connectorNode);
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                $"IsRealAttachment: '{modelResRef}' check failed: {ex.GetType().Name}: {ex.Message}");
+            return false;
+        }
+        finally
+        {
+            LastLoadedModelSource = savedSource;
+        }
     }
 
     /// <summary>

--- a/Quartermaster/Quartermaster/Views/MainWindow.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/MainWindow.axaml.cs
@@ -201,11 +201,13 @@ public partial class MainWindow : Window, INotifyPropertyChanged
         SpellsPanelContent.SetIconService(IconService);
         SpellsPanelContent.SpellsChanged += (s, e) => MarkDirty();
 
-        // Initialize appearance panel with display service, palette colors, model service, and texture service
-        AppearancePanelContent.SetDisplayService(DisplayService);
+        // Initialize appearance panel. ModelService MUST be set before SetDisplayService, because
+        // SetDisplayService kicks off the background wing/tail list population, which uses the model
+        // service to filter the lists to real attachments (#1485). Order matters here.
         AppearancePanelContent.SetPaletteColorService(new PaletteColorService(GameData));
         AppearancePanelContent.SetModelService(new ModelService(GameData));
         AppearancePanelContent.SetTextureService(new TextureService(GameData));
+        AppearancePanelContent.SetDisplayService(DisplayService);
         AppearancePanelContent.AppearanceChanged += (s, e) => MarkDirty();
 
         // Initialize advanced panel with display service

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
@@ -208,11 +208,18 @@ public partial class AppearancePanel : UserControl
     {
         try
         {
+            // Filter wing/tail lists to real attachments (#1485): tailmodel.2da reuses the slot for
+            // mounts (horses), wingmodel for non-wings; keep only models with the matching connector
+            // node. Runs on the background thread; loads are model-cached so the cost is bounded.
+            var modelSvc = _modelService;
+            System.Func<string, bool>? tailFilter = modelSvc != null ? m => modelSvc.IsRealAttachment(m, "tail") : null;
+            System.Func<string, bool>? wingFilter = modelSvc != null ? m => modelSvc.IsRealAttachment(m, "wings") : null;
+
             var (appearances, phenotypes, tails, wings) = await System.Threading.Tasks.Task.Run(() =>
                 (displayService.GetAllAppearances(),
                  displayService.GetAllPhenotypes(),
-                 displayService.GetAllTails(),
-                 displayService.GetAllWings()));
+                 displayService.GetAllTails(tailFilter),
+                 displayService.GetAllWings(wingFilter)));
 
             await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
             {

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
@@ -208,18 +208,23 @@ public partial class AppearancePanel : UserControl
     {
         try
         {
-            // Filter wing/tail lists to real attachments (#1485): tailmodel.2da reuses the slot for
-            // mounts (horses), wingmodel for non-wings; keep only models with the matching connector
-            // node. Runs on the background thread; loads are model-cached so the cost is bounded.
-            var modelSvc = _modelService;
-            System.Func<string, bool>? tailFilter = modelSvc != null ? m => modelSvc.IsRealAttachment(m, "tail") : null;
-            System.Func<string, bool>? wingFilter = modelSvc != null ? m => modelSvc.IsRealAttachment(m, "wings") : null;
-
             var (appearances, phenotypes, tails, wings) = await System.Threading.Tasks.Task.Run(() =>
-                (displayService.GetAllAppearances(),
-                 displayService.GetAllPhenotypes(),
-                 displayService.GetAllTails(tailFilter),
-                 displayService.GetAllWings(wingFilter)));
+            {
+                // Filter wing/tail lists to real attachments (#1485): tailmodel.2da reuses the slot
+                // for mounts (horses), wingmodel for non-wings; keep only models with the matching
+                // connector node. Resolve _modelService HERE (task body) rather than capturing it
+                // before the task, so the filter survives any service-init ordering slack; loads are
+                // model-cached so the cost is bounded. If the model service is unset, fall back to
+                // the unfiltered list rather than an empty one.
+                var modelSvc = _modelService;
+                System.Func<string, bool>? tailFilter = modelSvc != null ? m => modelSvc.IsRealAttachment(m, "tail") : null;
+                System.Func<string, bool>? wingFilter = modelSvc != null ? m => modelSvc.IsRealAttachment(m, "wings") : null;
+
+                return (displayService.GetAllAppearances(),
+                        displayService.GetAllPhenotypes(),
+                        displayService.GetAllTails(tailFilter),
+                        displayService.GetAllWings(wingFilter));
+            });
 
             await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
             {

--- a/Radoub.TestUtilities/Radoub.TestUtilities/Mocks/MockGameDataService.cs
+++ b/Radoub.TestUtilities/Radoub.TestUtilities/Mocks/MockGameDataService.cs
@@ -357,21 +357,21 @@ public class MockGameDataService : IGameDataService
         AddRow(portraits, "3", "el_m_01_", "0");
         _2daFiles["portraits"] = portraits;
 
-        // wingmodel.2da - wing types
+        // wingmodel.2da - wing types (MODEL = ResRef of the wing MDL)
         var wingmodel = new TwoDAFile();
-        wingmodel.Columns.AddRange(new[] { "LABEL" });
-        AddRow(wingmodel, "0", "****");
-        AddRow(wingmodel, "1", "Angel");
-        AddRow(wingmodel, "2", "Demon");
-        AddRow(wingmodel, "3", "Butterfly");
+        wingmodel.Columns.AddRange(new[] { "LABEL", "MODEL" });
+        AddRow(wingmodel, "0", "****", "****");
+        AddRow(wingmodel, "1", "Angel", "c_wingsan");
+        AddRow(wingmodel, "2", "Demon", "c_wingsdm");
+        AddRow(wingmodel, "3", "Butterfly", "****");  // label set, no model
         _2daFiles["wingmodel"] = wingmodel;
 
-        // tailmodel.2da - tail types
+        // tailmodel.2da - tail types (MODEL = ResRef of the tail MDL)
         var tailmodel = new TwoDAFile();
-        tailmodel.Columns.AddRange(new[] { "LABEL" });
-        AddRow(tailmodel, "0", "****");
-        AddRow(tailmodel, "1", "Lizard");
-        AddRow(tailmodel, "2", "Bone");
+        tailmodel.Columns.AddRange(new[] { "LABEL", "MODEL" });
+        AddRow(tailmodel, "0", "****", "****");
+        AddRow(tailmodel, "1", "Lizard", "c_tailliz");
+        AddRow(tailmodel, "2", "Bone", "c_tailbone");
         _2daFiles["tailmodel"] = tailmodel;
 
         // soundset.2da - sound sets

--- a/Radoub.UI/Radoub.UI.Tests/MdlPartComposerWingTailTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/MdlPartComposerWingTailTests.cs
@@ -73,6 +73,7 @@ public class MdlPartComposerWingTailTests
         var wings = Bone("wings01", Vector3.Zero);
         var bone1 = Bone("Bone1", new Vector3(0.1f, 0, 0.2f));
         var lwing = Mesh("LWing", Vector3.Zero, 50);
+        lwing.Bitmap = "c_dmsucubus"; // the wing's own authored texture — must be preserved
         bone1.Children.Add(lwing); lwing.Parent = bone1;
         wings.Children.Add(bone1); bone1.Parent = wings;
         root.Children.Add(wings); wings.Parent = root;
@@ -166,6 +167,23 @@ public class MdlPartComposerWingTailTests
         Assert.True(Matrix4x4.Decompose(world, out _, out _, out var t));
         Assert.True(t.Z > 1.0f, $"wing mesh world Z={t.Z:F3} — expected back height (>1.0), got feet height");
         Assert.Equal(1.65f, t.Z, 2); // 1.2 + 0 + 0.25 + 0.2
+    }
+
+    [Fact]
+    public void GraftSupermodel_PreservesAuthoredMeshBitmap()
+    {
+        // #1485 regression: wing/tail meshes carry their OWN texture name (e.g. c_dmsucubus).
+        // Unlike body parts (whose Bitmap is overridden with the part resref), the supermodel
+        // graft must NOT overwrite it — doing so points the renderer at the model resref (no
+        // such texture) and the wings render untextured/grey.
+        var composer = MakeComposer(BuildSkeleton(), BuildWing());
+
+        var composite = composer.Compose("pmh0", System.Array.Empty<(string, string)>(),
+            adjustSeams: false, supermodels: new[] { ("wings", "c_wingsdm", 1.0f) });
+
+        var lwing = MdlPartComposer.FindBoneByName(composite!.GeometryRoot!, "LWing") as MdlTrimeshNode;
+        Assert.NotNull(lwing);
+        Assert.Equal("c_dmsucubus", lwing!.Bitmap); // authored texture preserved, not "c_wingsdm"
     }
 
     [Fact]

--- a/Radoub.UI/Radoub.UI.Tests/MdlPartComposerWingTailTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/MdlPartComposerWingTailTests.cs
@@ -1,0 +1,187 @@
+using System.Linq;
+using System.Numerics;
+using Radoub.Formats.Mdl;
+using Radoub.TestUtilities.Mocks;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Tests the wing/tail supermodel-graft path in MdlPartComposer (#1485). Wings/tail are standalone
+/// MDLs (wingmodel/tailmodel.2da MODEL column) with their own bone hierarchy + meshes AND their own
+/// animation set named to match the body (cwalkf, cidle, ...). The composer grafts the subtree at
+/// the composite root, scales it by WING_TAIL_SCALE, and merges each wing animation's keyframed
+/// nodes INTO the same-named composite animation so one playhead drives body + wings in sync.
+/// </summary>
+public class MdlPartComposerWingTailTests
+{
+    private static MdlTrimeshNode Mesh(string name, Vector3 pos, int verts)
+    {
+        var n = new MdlTrimeshNode
+        {
+            Name = name,
+            Position = pos,
+            Orientation = Quaternion.Identity,
+            Scale = 1.0f,
+            Vertices = new Vector3[verts],
+            Faces = new MdlFace[1],
+        };
+        return n;
+    }
+
+    private static MdlNode Bone(string name, Vector3 pos)
+        => new() { Name = name, Position = pos, Orientation = Quaternion.Identity, Scale = 1.0f };
+
+    /// <summary>An animation node with position keyframes (so it counts as "keyed").</summary>
+    private static MdlNode AnimNode(string name)
+        => new()
+        {
+            Name = name,
+            PositionTimes = new[] { 0f, 0.5f },
+            PositionValues = new[] { Vector3.Zero, new Vector3(0, 0, 0.1f) },
+        };
+
+    /// <summary>Skeleton: rootdummy → torso_g, with a 'cwalkf' animation keying torso_g.</summary>
+    private static MdlModel BuildSkeleton()
+    {
+        var root = Bone("rootdummy", new Vector3(0, 0, 1.2f));
+        var torso = Bone("torso_g", Vector3.Zero);
+        root.Children.Add(torso); torso.Parent = root;
+
+        var animRoot = AnimNode("rootdummy");
+        animRoot.Children.Add(AnimNode("torso_g"));
+        var skeleton = new MdlModel { Name = "pmh0", GeometryRoot = root };
+        skeleton.Animations.Add(new MdlAnimation { Name = "cwalkf", Length = 0.5f, GeometryRoot = animRoot });
+        return skeleton;
+    }
+
+    /// <summary>
+    /// Wing MDL: rootdummy → wings → Bone1 (mesh 'LWing' under Bone1). Carries a 'cwalkf' animation
+    /// keying Bone1, plus a 'wflap' animation the body lacks.
+    /// </summary>
+    private static MdlModel BuildWing()
+    {
+        var root = Bone("c_wingsdm", new Vector3(0, 0, 0));
+        var wings = Bone("wings", Vector3.Zero);
+        var bone1 = Bone("Bone1", new Vector3(0.1f, 0, 0.2f));
+        var lwing = Mesh("LWing", Vector3.Zero, 50);
+        bone1.Children.Add(lwing); lwing.Parent = bone1;
+        wings.Children.Add(bone1); bone1.Parent = wings;
+        root.Children.Add(wings); wings.Parent = root;
+
+        var wing = new MdlModel { Name = "c_wingsdm", GeometryRoot = root };
+
+        var walkRoot = AnimNode("c_wingsdm");
+        walkRoot.Children.Add(AnimNode("Bone1"));
+        wing.Animations.Add(new MdlAnimation { Name = "cwalkf", Length = 0.5f, GeometryRoot = walkRoot });
+
+        var flapRoot = AnimNode("c_wingsdm");
+        flapRoot.Children.Add(AnimNode("Bone1"));
+        wing.Animations.Add(new MdlAnimation { Name = "wflap", Length = 1.0f, GeometryRoot = flapRoot });
+
+        return wing;
+    }
+
+    /// <summary>A minimal single-mesh body part so composition yields a non-null model.</summary>
+    private static MdlModel BuildChest()
+    {
+        var root = Bone("pmh0_chest001", Vector3.Zero);
+        var chest = Mesh("chestmesh", Vector3.Zero, 40);
+        root.Children.Add(chest); chest.Parent = root;
+        return new MdlModel { Name = "pmh0_chest001", GeometryRoot = root };
+    }
+
+    private static MdlPartComposer MakeComposer(MdlModel skeleton, MdlModel wing)
+    {
+        var mock = new MockGameDataService(includeSampleData: false);
+        return new MdlPartComposer(mock, (resRef, _) => resRef switch
+        {
+            "pmh0" => skeleton,
+            "c_wingsdm" => wing,
+            "pmh0_chest001" => BuildChest(),
+            _ => null,
+        });
+    }
+
+    private static MdlNode? FindAnimNode(MdlNode root, string name)
+    {
+        if (root.Name == name) return root;
+        foreach (var c in root.Children)
+        {
+            var f = FindAnimNode(c, name);
+            if (f != null) return f;
+        }
+        return null;
+    }
+
+    [Fact]
+    public void GraftSupermodel_AddsWingMeshesToComposite()
+    {
+        var composer = MakeComposer(BuildSkeleton(), BuildWing());
+
+        var composite = composer.Compose("pmh0", System.Array.Empty<(string, string)>(),
+            adjustSeams: false, supermodels: new[] { ("wings", "c_wingsdm", 1.0f) });
+
+        Assert.NotNull(composite);
+        var lwing = MdlPartComposer.FindBoneByName(composite!.GeometryRoot!, "LWing");
+        Assert.NotNull(lwing);
+    }
+
+    [Fact]
+    public void GraftSupermodel_AppliesScaleToGraftedRoot()
+    {
+        var composer = MakeComposer(BuildSkeleton(), BuildWing());
+
+        var composite = composer.Compose("pmh0", System.Array.Empty<(string, string)>(),
+            adjustSeams: false, supermodels: new[] { ("wings", "c_wingsdm", 2.5f) });
+
+        // The grafted wing subtree root ('wings') carries the WING_TAIL_SCALE factor.
+        var wings = MdlPartComposer.FindBoneByName(composite!.GeometryRoot!, "wings");
+        Assert.NotNull(wings);
+        Assert.Equal(2.5f, wings!.Scale, 3);
+    }
+
+    [Fact]
+    public void GraftSupermodel_MissingResRef_IsNoOp()
+    {
+        var composer = MakeComposer(BuildSkeleton(), BuildWing());
+
+        var composite = composer.Compose("pmh0", new[] { ("chest", "pmh0_chest001") },
+            adjustSeams: false, supermodels: new[] { ("wings", "does_not_exist", 1.0f) });
+
+        // Composite still builds (from the chest part); no wing mesh, no throw.
+        Assert.NotNull(composite);
+        Assert.Null(MdlPartComposer.FindBoneByName(composite!.GeometryRoot!, "LWing"));
+    }
+
+    [Fact]
+    public void GraftSupermodel_MergesWingAnimIntoSameNamedBodyAnim()
+    {
+        var composer = MakeComposer(BuildSkeleton(), BuildWing());
+
+        var composite = composer.Compose("pmh0", System.Array.Empty<(string, string)>(),
+            adjustSeams: false, supermodels: new[] { ("wings", "c_wingsdm", 1.0f) });
+
+        // Exactly one 'cwalkf' animation (not a duplicate entry).
+        var walks = composite!.Animations.Where(a => a.Name == "cwalkf").ToList();
+        Assert.Single(walks);
+
+        // The wing's Bone1 keyframes are grafted into the body's cwalkf animation tree.
+        var bone1Anim = FindAnimNode(walks[0].GeometryRoot!, "Bone1");
+        Assert.NotNull(bone1Anim);
+        Assert.True(bone1Anim!.PositionTimes.Length > 1); // carries keyframes
+    }
+
+    [Fact]
+    public void GraftSupermodel_WingOnlyAnimAppendedAsNewEntry()
+    {
+        var composer = MakeComposer(BuildSkeleton(), BuildWing());
+
+        var composite = composer.Compose("pmh0", System.Array.Empty<(string, string)>(),
+            adjustSeams: false, supermodels: new[] { ("wings", "c_wingsdm", 1.0f) });
+
+        // 'wflap' exists only on the wing — appended so it is selectable.
+        Assert.Contains(composite!.Animations, a => a.Name == "wflap");
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/MdlPartComposerWingTailTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/MdlPartComposerWingTailTests.cs
@@ -42,11 +42,17 @@ public class MdlPartComposerWingTailTests
             PositionValues = new[] { Vector3.Zero, new Vector3(0, 0, 0.1f) },
         };
 
-    /// <summary>Skeleton: rootdummy → torso_g, with a 'cwalkf' animation keying torso_g.</summary>
+    /// <summary>
+    /// Skeleton: rootdummy(z=1.2) → torso_g → wings (the back attach bone, z=0.25), plus a
+    /// 'cwalkf' animation keying torso_g. Mirrors real pmh0, which carries a 'wings' bone on the
+    /// upper back and a 'tail' bone on the pelvis that the wing/tail MDLs attach to (#1485).
+    /// </summary>
     private static MdlModel BuildSkeleton()
     {
         var root = Bone("rootdummy", new Vector3(0, 0, 1.2f));
         var torso = Bone("torso_g", Vector3.Zero);
+        var wingsBone = Bone("wings", new Vector3(0, -0.12f, 0.25f)); // upper back
+        torso.Children.Add(wingsBone); wingsBone.Parent = torso;
         root.Children.Add(torso); torso.Parent = root;
 
         var animRoot = AnimNode("rootdummy");
@@ -57,13 +63,14 @@ public class MdlPartComposerWingTailTests
     }
 
     /// <summary>
-    /// Wing MDL: rootdummy → wings → Bone1 (mesh 'LWing' under Bone1). Carries a 'cwalkf' animation
+    /// Wing MDL: c_wingsdm → wings01 → Bone1 (mesh 'LWing' under Bone1), all near local origin —
+    /// authored to be parented under the body's 'wings' attach bone. Carries a 'cwalkf' animation
     /// keying Bone1, plus a 'wflap' animation the body lacks.
     /// </summary>
     private static MdlModel BuildWing()
     {
         var root = Bone("c_wingsdm", new Vector3(0, 0, 0));
-        var wings = Bone("wings", Vector3.Zero);
+        var wings = Bone("wings01", Vector3.Zero);
         var bone1 = Bone("Bone1", new Vector3(0.1f, 0, 0.2f));
         var lwing = Mesh("LWing", Vector3.Zero, 50);
         bone1.Children.Add(lwing); lwing.Parent = bone1;
@@ -136,10 +143,42 @@ public class MdlPartComposerWingTailTests
         var composite = composer.Compose("pmh0", System.Array.Empty<(string, string)>(),
             adjustSeams: false, supermodels: new[] { ("wings", "c_wingsdm", 2.5f) });
 
-        // The grafted wing subtree root ('wings') carries the WING_TAIL_SCALE factor.
-        var wings = MdlPartComposer.FindBoneByName(composite!.GeometryRoot!, "wings");
+        // The grafted wing subtree root ('wings01') carries the WING_TAIL_SCALE factor.
+        var wings = MdlPartComposer.FindBoneByName(composite!.GeometryRoot!, "wings01");
         Assert.NotNull(wings);
         Assert.Equal(2.5f, wings!.Scale, 3);
+    }
+
+    [Fact]
+    public void GraftSupermodel_AttachesUnderNamedBone_NotRoot()
+    {
+        // #1485 regression: wings must hang off the body's 'wings' attach bone (upper back),
+        // not the composite root (feet). The wing's LWing mesh world Z must reflect the bone's
+        // back-height chain (root 1.2 + torso 0 + wings 0.25 + Bone1 0.2 = 1.65), not ~0.
+        var composer = MakeComposer(BuildSkeleton(), BuildWing());
+
+        var composite = composer.Compose("pmh0", System.Array.Empty<(string, string)>(),
+            adjustSeams: false, supermodels: new[] { ("wings", "c_wingsdm", 1.0f) });
+
+        var lwing = MdlPartComposer.FindBoneByName(composite!.GeometryRoot!, "LWing");
+        Assert.NotNull(lwing);
+        var world = MdlPartComposer.GetMeshWorldTransform(lwing!);
+        Assert.True(Matrix4x4.Decompose(world, out _, out _, out var t));
+        Assert.True(t.Z > 1.0f, $"wing mesh world Z={t.Z:F3} — expected back height (>1.0), got feet height");
+        Assert.Equal(1.65f, t.Z, 2); // 1.2 + 0 + 0.25 + 0.2
+    }
+
+    [Fact]
+    public void GraftSupermodel_NoAttachBone_FallsBackToRoot()
+    {
+        // A skeleton without a 'tail' bone still gets the tail grafted (at root) rather than dropped.
+        var composer = MakeComposer(BuildSkeleton(), BuildWing());
+
+        var composite = composer.Compose("pmh0", System.Array.Empty<(string, string)>(),
+            adjustSeams: false, supermodels: new[] { ("tail", "c_wingsdm", 1.0f) }); // no 'tail' bone in skeleton
+
+        // Still attached (fallback to root), not dropped.
+        Assert.NotNull(MdlPartComposer.FindBoneByName(composite!.GeometryRoot!, "LWing"));
     }
 
     [Fact]

--- a/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
+++ b/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
@@ -376,6 +376,18 @@ public sealed class MdlPartComposer
             EnsureCompositeRoot(compositeModel);
             var root = compositeModel.GeometryRoot!;
 
+            // Wings/tail are authored at local origin and attach to a NAMED bone on the body
+            // skeleton ('wings' on the upper back, 'tail' on the pelvis) that carries the correct
+            // world transform — exactly like body parts attach to torso_g/head_g (#1485). Parent
+            // the grafted subtree under that bone so it sits at back/rear height; fall back to the
+            // composite root only if the skeleton lacks the bone (grafting at root would otherwise
+            // place the wings at the model origin — i.e. the creature's feet).
+            var attachBone = FindBoneByName(root, tag);
+            var attachParent = attachBone ?? root;
+            if (attachBone == null)
+                UnifiedLogger.LogApplication(LogLevel.WARN,
+                    $"MdlPartComposer.GraftSupermodel: no '{tag}' attach bone on skeleton — grafting at root (may mis-place)");
+
             // Graft the supermodel root's CHILDREN (skip its own root dummy, whose translation
             // duplicates the skeleton root's), cloning each subtree with hierarchy intact — same
             // mechanism as the robe graft (#1989). Apply WING_TAIL_SCALE to each grafted child's
@@ -383,11 +395,11 @@ public sealed class MdlPartComposer
             int grafted = 0;
             foreach (var child in partModel.GeometryRoot.Children)
             {
-                var clone = CloneNode(child, root);
+                var clone = CloneNode(child, attachParent);
                 if (scale > 0f && scale != 1.0f)
                     clone.Scale *= scale;
                 ApplyPartBitmap(clone, resRef, tag, meshPartTypes);
-                root.Children.Add(clone);
+                attachParent.Children.Add(clone);
                 grafted++;
             }
 

--- a/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
+++ b/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
@@ -349,6 +349,19 @@ public sealed class MdlPartComposer
     }
 
     /// <summary>
+    /// Record the part type on every mesh in a grafted subtree WITHOUT touching its Bitmap (#1485).
+    /// Wing/tail meshes carry correct authored texture names — unlike body parts, they must not be
+    /// overridden with the part resref.
+    /// </summary>
+    private static void TagSubtreeMeshes(MdlNode node, string partType, Dictionary<string, string> meshPartTypes)
+    {
+        if (node is MdlTrimeshNode mesh && mesh.Vertices.Length > 0)
+            meshPartTypes[mesh.Name] = partType;
+        foreach (var child in node.Children)
+            TagSubtreeMeshes(child, partType, meshPartTypes);
+    }
+
+    /// <summary>
     /// Graft a wing/tail supermodel (#1485) under the composite root, preserving its internal bone
     /// hierarchy + meshes, scaled by <paramref name="scale"/> (the appearance's WING_TAIL_SCALE).
     /// The supermodel's own animations (named to match the body — cwalkf, cidle, ...) are merged
@@ -398,7 +411,11 @@ public sealed class MdlPartComposer
                 var clone = CloneNode(child, attachParent);
                 if (scale > 0f && scale != 1.0f)
                     clone.Scale *= scale;
-                ApplyPartBitmap(clone, resRef, tag, meshPartTypes);
+                // Record the part type for seam handling but PRESERVE each mesh's authored Bitmap
+                // (#1485). Unlike body parts (whose Bitmap is stale and gets the part-resref override),
+                // wing/tail meshes carry their own correct texture (e.g. c_dmsucubus); overwriting it
+                // with the model resref points the renderer at a non-existent texture → grey wings.
+                TagSubtreeMeshes(clone, tag, meshPartTypes);
                 attachParent.Children.Add(clone);
                 grafted++;
             }

--- a/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
+++ b/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
@@ -90,9 +90,10 @@ public sealed class MdlPartComposer
     public MdlModel? Compose(
         string skeletonResRef,
         IReadOnlyList<(string PartType, string ResRef)> parts,
-        bool adjustSeams = true)
+        bool adjustSeams = true,
+        IReadOnlyList<(string Tag, string ResRef, float Scale)>? supermodels = null)
     {
-        if (parts.Count == 0)
+        if (parts.Count == 0 && (supermodels == null || supermodels.Count == 0))
             return null;
 
         var skeletonModel = _modelLoader(skeletonResRef, /* withSupermodelAnims */ true);
@@ -125,6 +126,16 @@ public sealed class MdlPartComposer
         foreach (var (partType, resRef) in parts)
         {
             TryAddBodyPart(compositeModel, partType, resRef, meshPartTypes);
+        }
+
+        // Wings/tail (#1485): standalone supermodels with their own bone hierarchy + meshes AND
+        // their own animation set named to match the body (cwalkf, ...). Grafted at the composite
+        // root (like a robe), scaled by WING_TAIL_SCALE, with their animations merged BY NAME into
+        // the matching body animation so one active animation drives body + wings together.
+        if (supermodels != null)
+        {
+            foreach (var (tag, resRef, scale) in supermodels)
+                GraftSupermodel(compositeModel, resRef, tag, scale, meshPartTypes);
         }
 
         if (adjustSeams)
@@ -335,6 +346,113 @@ public sealed class MdlPartComposer
         }
         foreach (var child in node.Children)
             ApplyPartBitmap(child, partResRef, partType, meshPartTypes);
+    }
+
+    /// <summary>
+    /// Graft a wing/tail supermodel (#1485) under the composite root, preserving its internal bone
+    /// hierarchy + meshes, scaled by <paramref name="scale"/> (the appearance's WING_TAIL_SCALE).
+    /// The supermodel's own animations (named to match the body — cwalkf, cidle, ...) are merged
+    /// BY NAME into the composite so one active animation drives the body and the wing/tail bones
+    /// together. The model is loaded WITH supermodel animations so inheritors (e.g. c_tail_brs →
+    /// c_tail_sil, which ships 0 own animations) still flap.
+    /// </summary>
+    public void GraftSupermodel(
+        MdlModel compositeModel,
+        string resRef,
+        string tag,
+        float scale,
+        Dictionary<string, string> meshPartTypes)
+    {
+        try
+        {
+            var partModel = _modelLoader(resRef, /* withSupermodelAnims */ true);
+            if (partModel?.GeometryRoot == null)
+            {
+                UnifiedLogger.LogApplication(LogLevel.WARN,
+                    $"MdlPartComposer.GraftSupermodel: '{tag}' model '{resRef}' not loadable — skipped");
+                return;
+            }
+
+            EnsureCompositeRoot(compositeModel);
+            var root = compositeModel.GeometryRoot!;
+
+            // Graft the supermodel root's CHILDREN (skip its own root dummy, whose translation
+            // duplicates the skeleton root's), cloning each subtree with hierarchy intact — same
+            // mechanism as the robe graft (#1989). Apply WING_TAIL_SCALE to each grafted child's
+            // root so the whole wing/tail subtree scales as a unit.
+            int grafted = 0;
+            foreach (var child in partModel.GeometryRoot.Children)
+            {
+                var clone = CloneNode(child, root);
+                if (scale > 0f && scale != 1.0f)
+                    clone.Scale *= scale;
+                ApplyPartBitmap(clone, resRef, tag, meshPartTypes);
+                root.Children.Add(clone);
+                grafted++;
+            }
+
+            MergeSupermodelAnimationsByName(compositeModel, partModel);
+
+            UnifiedLogger.LogApplication(LogLevel.INFO,
+                $"MdlPartComposer.GraftSupermodel: '{tag}' ({resRef}) scale={scale:F2} — {grafted} subtree(s), {partModel.Animations.Count} anim(s)");
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"MdlPartComposer.GraftSupermodel: failed to graft '{tag}' from '{resRef}': {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Merge a wing/tail model's animations into the composite (#1485). The renderer plays ONE
+    /// active animation and builds a node-name → pose dictionary from its GeometryRoot, so the
+    /// wing's keyframed bones must live in the SAME animation tree as the body's. For each source
+    /// animation: if the composite already has an animation of that name, graft the source's
+    /// GeometryRoot children into the existing animation's tree (so cwalkf drives body + wing bones
+    /// from one playhead). Names the body lacks are appended as new selectable entries.
+    ///
+    /// This is deliberately different from the dedup-by-name supermodel merge used for skeletons,
+    /// which would DROP the wing's cwalkf because the body already owns that name.
+    /// </summary>
+    private static void MergeSupermodelAnimationsByName(MdlModel compositeModel, MdlModel partModel)
+    {
+        if (partModel.Animations.Count == 0)
+            return;
+
+        var byName = new Dictionary<string, MdlAnimation>(StringComparer.OrdinalIgnoreCase);
+        foreach (var anim in compositeModel.Animations)
+            byName[anim.Name] = anim;
+
+        foreach (var src in partModel.Animations)
+        {
+            if (src.GeometryRoot == null)
+                continue;
+
+            if (byName.TryGetValue(src.Name, out var existing) && existing.GeometryRoot != null)
+            {
+                // Graft the wing's keyed node subtrees into the body animation's tree so a single
+                // pose lookup covers both. Clone so the cached part model is never mutated (#1735).
+                foreach (var child in src.GeometryRoot.Children)
+                {
+                    var clone = CloneNode(child, existing.GeometryRoot);
+                    existing.GeometryRoot.Children.Add(clone);
+                }
+            }
+            else
+            {
+                // Wing-only animation (body lacks the name) — append so it stays selectable.
+                var copy = new MdlAnimation
+                {
+                    Name = src.Name,
+                    Length = src.Length,
+                    TransitionTime = src.TransitionTime,
+                    AnimRoot = src.AnimRoot,
+                    GeometryRoot = CloneNode(src.GeometryRoot, null),
+                };
+                compositeModel.Animations.Add(copy);
+                byName[copy.Name] = copy;
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Render wings (`wingmodel.2da` / `Wings_New`) and tail (`tailmodel.2da` / `Tail_New`) on the part-based 3D creature preview, with `WING_TAIL_SCALE` applied and flapping in sync with the body animation.

## What it does

- Resolves the wing/tail MDL from the 2DA `MODEL` column and grafts it under the body skeleton's named `wings` / `tail` attach bone (upper back / pelvis).
- Applies the appearance's `WING_TAIL_SCALE`; preserves each wing/tail mesh's authored texture.
- Merges the wing/tail MDL's animations by name into the body's so one playhead drives both — wings flap with idle/walk.
- Filters the wing/tail dropdowns to real attachments (a tail MDL has a top-level `tail` connector node; mounts/horses reused in `tailmodel.2da` don't) — data-driven, no hardcoded lists.

## UAT findings fixed in-branch

- Wings rendered at the feet → attach to the named body bone, not the composite root.
- Wings rendered grey → preserve the mesh's authored texture instead of overwriting with the model resref.
- Tail list showed horses/liches → connector-node filter; and the filter initially never ran due to service-init order (fixed).

## Tests

- 3903 unit tests pass (Radoub.Formats 1402, Radoub.UI 1152, Radoub.Dictionary 75, Quartermaster 1274), incl. new wing/tail tests in `MdlPartComposerWingTailTests`, `AppearanceServiceTests`, `ModelNameConstructionTests`.
- Quartermaster FlaUI smoke test passes (app launches + navigates after the service-init reorder).
- Manual: fixture `wingtail.utc`, verified in-app (position, texture, list filter) — see commits.

## Related Issues

- Closes #1485

## Checklist

- [x] Implementation complete
- [x] Tests added/updated
- [x] CHANGELOG updated (Quartermaster + root Radoub.UI)
- [x] Manual spot-check (render + flap + list)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)