### PR TITLE
[Radoub] Feat: Break palette source filter into Override/HAK/Module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Radoub.UI 0.2.13-alpha] - 2026-06-18
-**Branch**: `radoub/issue-1995` | **PR**: #TBD
+**Branch**: `radoub/issue-1995` | **PR**: #2503
 
 ### Feat: Per-source palette filter — Override/HAK/Module (#1995)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.13-alpha] - 2026-06-18
+**Branch**: `radoub/issue-1995` | **PR**: #TBD
+
+### Feat: Per-source palette filter — Override/HAK/Module (#1995)
+
+- The item palette source filter splits the old binary Standard/Custom toggle into four independent checkboxes (Standard, Override, HAK, Module). The real `GameResourceSource` is now plumbed through `SharedPaletteCacheItem` (cache rebuilt under a new version) so Fence, Quartermaster, and Reliquary all distinguish all four sources. Note: module/HAK content now shows by default; Override is hidden by default.
+
+---
+
 ## [Radoub.UI 0.2.12-alpha] - 2026-06-18
 **Branch**: `quartermaster/issue-1485` | **PR**: #2502
 

--- a/Fence/Fence/Views/MainWindow.ItemPalette.cs
+++ b/Fence/Fence/Views/MainWindow.ItemPalette.cs
@@ -203,7 +203,7 @@ public partial class MainWindow
                                 BaseItemType = item.BaseItem,
                                 BaseValue = item.Cost,
                                 Tag = item.Tag ?? string.Empty,
-                                IsStandard = resourceInfo.Source == GameResourceSource.Bif,
+                                Source = resourceInfo.Source,
                                 PropertiesDisplay = propertiesDisplay,
                                 SourceLocation = !string.IsNullOrEmpty(resourceInfo.SourcePath)
                                     ? Path.GetFileName(resourceInfo.SourcePath)
@@ -268,7 +268,7 @@ public partial class MainWindow
                     Value = cached.BaseValue,
                     Tag = !string.IsNullOrEmpty(cached.Tag) ? cached.Tag : cached.ResRef,
                     PropertiesDisplay = cached.PropertiesDisplay,
-                    Source = cached.IsStandard ? GameResourceSource.Bif : GameResourceSource.Override,
+                    Source = cached.Source,
                     SourceLocation = cached.SourceLocation,
                     IconBitmap = _itemIconService?.GetItemIcon(cached.BaseItemType)
                 };
@@ -292,8 +292,8 @@ public partial class MainWindow
             {
                 _paletteFilter.Items = PaletteItems;
                 _paletteFilter.GameDataService = _gameDataService;
-                // Show all sources by default (including module/custom items)
-                _paletteFilter.ShowCustom = true;
+                // Source visibility defaults come from FilterState (#1995): Standard/HAK/Module on,
+                // Override off. No per-source force here.
                 _paletteFilter.ApplyFilter();
             }
 

--- a/Quartermaster/Quartermaster/Views/MainWindow.ItemPalette.cs
+++ b/Quartermaster/Quartermaster/Views/MainWindow.ItemPalette.cs
@@ -254,7 +254,7 @@ public partial class MainWindow
                         PropertiesDisplay = propertiesDisplay,
                         BaseItemType = item.BaseItem,
                         BaseValue = item.Cost,
-                        IsStandard = gameSource == GameResourceSource.Bif,
+                        Source = gameSource,
                         SourceLocation = !string.IsNullOrEmpty(resourceInfo.SourcePath)
                             ? Path.GetFileName(resourceInfo.SourcePath)
                             : resourceInfo.Source.ToString()
@@ -339,7 +339,7 @@ public partial class MainWindow
                         Value = cached.BaseValue,
                         Tag = !string.IsNullOrEmpty(cached.Tag) ? cached.Tag : cached.ResRef,
                         PropertiesDisplay = cached.PropertiesDisplay,
-                        Source = cached.IsStandard ? GameResourceSource.Bif : GameResourceSource.Override
+                        Source = cached.Source
                     };
                     ItemFactory.PopulateEquipableSlots(vm, cached.BaseItemType);
                     vms.Add(vm);

--- a/Radoub.UI/Radoub.UI.Tests/FilterStateTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/FilterStateTests.cs
@@ -13,12 +13,17 @@ public class FilterStateTests
         Assert.True(state.ShowStandard);
     }
 
+    // #1995 — the binary ShowCustom is replaced by three per-source toggles.
+    // Defaults: Standard/HAK/Module visible, Override hidden.
+
     [Fact]
-    public void Defaults_ShowCustomTrue()
+    public void Defaults_ShowHakAndModuleTrue_OverrideFalse()
     {
         var state = new FilterState();
 
-        Assert.True(state.ShowCustom);
+        Assert.True(state.ShowHak);
+        Assert.True(state.ShowModule);
+        Assert.False(state.ShowOverride);
     }
 
     [Fact]
@@ -43,14 +48,61 @@ public class FilterStateTests
         var state = new FilterState
         {
             ShowStandard = false,
-            ShowCustom = false,
+            ShowOverride = true,
+            ShowHak = false,
+            ShowModule = false,
             SearchText = "sword",
             SelectedBaseItemIndex = 5
         };
 
         Assert.False(state.ShowStandard);
-        Assert.False(state.ShowCustom);
+        Assert.True(state.ShowOverride);
+        Assert.False(state.ShowHak);
+        Assert.False(state.ShowModule);
         Assert.Equal("sword", state.SearchText);
         Assert.Equal(5, state.SelectedBaseItemIndex);
+    }
+
+    // ---- Legacy migration (old persisted state had a single ShowCustom bool) ----
+
+    [Fact]
+    public void MigrateLegacy_LegacyCustomTrue_SeedsAllThreeCustomTogglesOn()
+    {
+        // An old file with ShowCustom=true should keep showing custom content.
+        var state = new FilterState { LegacyShowCustom = true };
+
+        state.MigrateLegacy();
+
+        Assert.True(state.ShowOverride);
+        Assert.True(state.ShowHak);
+        Assert.True(state.ShowModule);
+        Assert.Null(state.LegacyShowCustom); // consumed
+    }
+
+    [Fact]
+    public void MigrateLegacy_LegacyCustomFalse_SeedsAllThreeCustomTogglesOff()
+    {
+        var state = new FilterState { LegacyShowCustom = false };
+
+        state.MigrateLegacy();
+
+        Assert.False(state.ShowOverride);
+        Assert.False(state.ShowHak);
+        Assert.False(state.ShowModule);
+        Assert.Null(state.LegacyShowCustom);
+    }
+
+    [Fact]
+    public void MigrateLegacy_NoLegacyValue_LeavesNewDefaultsUntouched()
+    {
+        // A fresh / already-migrated file has no legacy value; new defaults stand.
+        var state = new FilterState();
+
+        state.MigrateLegacy();
+
+        Assert.True(state.ShowStandard);
+        Assert.False(state.ShowOverride);
+        Assert.True(state.ShowHak);
+        Assert.True(state.ShowModule);
     }
 }

--- a/Radoub.UI/Radoub.UI.Tests/HakPaletteScannerServiceTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/HakPaletteScannerServiceTests.cs
@@ -3,6 +3,7 @@ using Radoub.Formats.Common;
 using Radoub.Formats.Erf;
 using Radoub.Formats.Gff;
 using Radoub.Formats.Ifo;
+using Radoub.Formats.Services;
 using Radoub.Formats.Uti;
 using Radoub.UI.Services;
 
@@ -268,7 +269,8 @@ public class HakPaletteScannerServiceTests : IDisposable
         Assert.Equal("CHAINMAIL", item.Tag);
         Assert.Equal(16, item.BaseItemType);
         Assert.Equal(500u, item.BaseValue);
-        Assert.False(item.IsStandard); // HAK items are not standard/base game
+        Assert.Equal(GameResourceSource.Hak, item.Source); // #1995: real source recorded, not just a bool
+        Assert.False(item.IsStandard); // convenience getter still reflects non-BIF
     }
 
     [Fact]

--- a/Radoub.UI/Radoub.UI.Tests/ItemFilterPredicateTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/ItemFilterPredicateTests.cs
@@ -40,9 +40,12 @@ public class ItemFilterPredicateTests
         ItemTypeInfo? type = null,
         SlotFilterInfo? slot = null,
         bool showStandard = true,
-        bool showCustom = true,
+        bool showOverride = true,
+        bool showHak = true,
+        bool showModule = true,
         bool showCreatureItems = true)
-        => ItemFilterPredicate.Matches(item, search, propertySearch, type, slot, showStandard, showCustom, showCreatureItems);
+        => ItemFilterPredicate.Matches(item, search, propertySearch, type, slot,
+            showStandard, showOverride, showHak, showModule, showCreatureItems);
 
     // ---- Creature/internal item filter (#2411 follow-up) ----
 
@@ -69,23 +72,48 @@ public class ItemFilterPredicateTests
     public void NoCriteria_MatchesEverything()
         => Assert.True(Matches(Item()));
 
-    // ---- Source filter ----
+    // ---- Source filter (#1995: four independent sources) ----
 
     [Fact]
     public void Standard_Hidden_WhenShowStandardFalse()
         => Assert.False(Matches(Item(source: GameResourceSource.Bif), showStandard: false));
 
     [Fact]
-    public void Custom_Hidden_WhenShowCustomFalse()
-        => Assert.False(Matches(Item(source: GameResourceSource.Hak), showCustom: false));
-
-    [Fact]
-    public void Custom_Shown_WhenShowCustomTrue()
-        => Assert.True(Matches(Item(source: GameResourceSource.Override), showCustom: true, showStandard: false));
-
-    [Fact]
     public void Standard_Shown_WhenShowStandardTrue()
-        => Assert.True(Matches(Item(source: GameResourceSource.Bif), showStandard: true, showCustom: false));
+        => Assert.True(Matches(Item(source: GameResourceSource.Bif), showStandard: true));
+
+    [Fact]
+    public void Override_Hidden_WhenShowOverrideFalse()
+        => Assert.False(Matches(Item(source: GameResourceSource.Override), showOverride: false));
+
+    [Fact]
+    public void Override_Shown_WhenShowOverrideTrue()
+        => Assert.True(Matches(Item(source: GameResourceSource.Override), showOverride: true));
+
+    [Fact]
+    public void Hak_Hidden_WhenShowHakFalse()
+        => Assert.False(Matches(Item(source: GameResourceSource.Hak), showHak: false));
+
+    [Fact]
+    public void Hak_Shown_WhenShowHakTrue()
+        => Assert.True(Matches(Item(source: GameResourceSource.Hak), showHak: true));
+
+    [Fact]
+    public void Module_Hidden_WhenShowModuleFalse()
+        => Assert.False(Matches(Item(source: GameResourceSource.Module), showModule: false));
+
+    [Fact]
+    public void Module_Shown_WhenShowModuleTrue()
+        => Assert.True(Matches(Item(source: GameResourceSource.Module), showModule: true));
+
+    [Fact]
+    public void Override_Hidden_DoesNotHideHakOrModule()
+    {
+        // The granularity the old binary could not express: hide Override but keep HAK + Module.
+        Assert.False(Matches(Item(source: GameResourceSource.Override), showOverride: false));
+        Assert.True(Matches(Item(source: GameResourceSource.Hak), showOverride: false));
+        Assert.True(Matches(Item(source: GameResourceSource.Module), showOverride: false));
+    }
 
     // ---- Type filter ----
 
@@ -164,7 +192,7 @@ public class ItemFilterPredicateTests
             type: new ItemTypeInfo(5, "Longsword", "longsword"),
             slot: new SlotFilterInfo(0x08, "Right Hand"),
             showStandard: false,
-            showCustom: true));
+            showHak: true));
     }
 
     [Fact]
@@ -177,6 +205,6 @@ public class ItemFilterPredicateTests
             search: "holy",
             type: new ItemTypeInfo(99, "Wrong", "wrong"),
             slot: new SlotFilterInfo(0x08, "Right Hand"),
-            showCustom: true));
+            showHak: true));
     }
 }

--- a/Radoub.UI/Radoub.UI.Tests/SharedPaletteCacheServiceTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/SharedPaletteCacheServiceTests.cs
@@ -1,4 +1,5 @@
 using Xunit;
+using Radoub.Formats.Services;
 using Radoub.UI.Services;
 
 namespace Radoub.UI.Tests;
@@ -43,7 +44,7 @@ public class SharedPaletteCacheServiceTests : IDisposable
                 BaseItemTypeName = "Sword",
                 BaseItemType = 1,
                 BaseValue = (uint)(100 * (i + 1)),
-                IsStandard = true
+                Source = GameResourceSource.Bif
             });
         }
         return items;
@@ -80,6 +81,44 @@ public class SharedPaletteCacheServiceTests : IDisposable
         Assert.Equal(1, loaded[0].BaseItemType);
         Assert.Equal(100u, loaded[0].BaseValue);
         Assert.True(loaded[0].IsStandard);
+    }
+
+    [Fact]
+    public async Task LoadSourceCache_PreservesGameResourceSource()
+    {
+        // #1995 — the real four-way source must survive the cache round-trip (not flatten to a bool).
+        var items = new List<SharedPaletteCacheItem>
+        {
+            new() { ResRef = "bif_item", Source = GameResourceSource.Bif },
+            new() { ResRef = "ovr_item", Source = GameResourceSource.Override },
+            new() { ResRef = "hak_item", Source = GameResourceSource.Hak },
+            new() { ResRef = "mod_item", Source = GameResourceSource.Module },
+        };
+        await _service.SaveSourceCacheAsync("override", items, validationPath: "/nwn/path");
+
+        var loaded = _service.LoadSourceCache("override");
+
+        Assert.NotNull(loaded);
+        Assert.Equal(GameResourceSource.Bif, loaded[0].Source);
+        Assert.Equal(GameResourceSource.Override, loaded[1].Source);
+        Assert.Equal(GameResourceSource.Hak, loaded[2].Source);
+        Assert.Equal(GameResourceSource.Module, loaded[3].Source);
+    }
+
+    [Fact]
+    public async Task LoadSourceCache_RejectsPriorCacheVersion()
+    {
+        // #1995 — bumping CacheVersion (3 -> 4) must invalidate v3 caches on disk so the
+        // new Source field is rebuilt rather than read as a default. v3 had no Source field.
+        await _service.SaveSourceCacheAsync("bif", CreateTestItems(), validationPath: "/game");
+        var cacheFile = Path.Combine(_testCacheDir, "bif.json");
+        var json = File.ReadAllText(cacheFile);
+        // Rewrite the on-disk version to the prior version (3).
+        json = System.Text.RegularExpressions.Regex.Replace(json, "\"Version\":\\d+", "\"Version\":3");
+        File.WriteAllText(cacheFile, json);
+
+        Assert.False(_service.HasValidSourceCache("bif"));
+        Assert.Null(_service.LoadSourceCache("bif"));
     }
 
     [Fact]
@@ -157,7 +196,7 @@ public class SharedPaletteCacheServiceTests : IDisposable
         await _service.SaveSourceCacheAsync("bif", CreateTestItems(), validationPath: "/path");
         var cacheFile = Path.Combine(_testCacheDir, "bif.json");
         var json = File.ReadAllText(cacheFile);
-        json = json.Replace("\"Version\":3", "\"Version\":999");
+        json = System.Text.RegularExpressions.Regex.Replace(json, "\"Version\":\\d+", "\"Version\":999");
         File.WriteAllText(cacheFile, json);
 
         Assert.False(_service.HasValidSourceCache("bif"));

--- a/Radoub.UI/Radoub.UI/Controls/ItemFilterPanel.axaml
+++ b/Radoub.UI/Radoub.UI/Controls/ItemFilterPanel.axaml
@@ -25,26 +25,34 @@
       </Grid>
 
       <!-- Row 2: Source checkboxes, Type filter, and Slot filter -->
-      <Grid ColumnDefinitions="Auto,Auto,Auto,Auto,*,Auto">
-        <CheckBox x:Name="StandardCheck"
-                  Grid.Column="0"
-                  Content="Standard"
-                  IsChecked="{Binding ShowStandard, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay}"
-                  ToolTip.Tip="Show base game items"/>
-        <CheckBox x:Name="CustomCheck"
-                  Grid.Column="1"
-                  Content="Custom"
-                  Margin="16,0,0,0"
-                  IsChecked="{Binding ShowCustom, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay}"
-                  ToolTip.Tip="Show module/HAK items"/>
+      <Grid ColumnDefinitions="Auto,Auto,Auto,*,Auto">
+        <!-- Four independent source toggles (#1995). -->
+        <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="16">
+          <CheckBox x:Name="StandardCheck"
+                    Content="Standard"
+                    IsChecked="{Binding ShowStandard, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay}"
+                    ToolTip.Tip="Show base game items (BIF)"/>
+          <CheckBox x:Name="OverrideCheck"
+                    Content="Override"
+                    IsChecked="{Binding ShowOverride, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay}"
+                    ToolTip.Tip="Show items from the user's Override folder"/>
+          <CheckBox x:Name="HakCheck"
+                    Content="HAK"
+                    IsChecked="{Binding ShowHak, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay}"
+                    ToolTip.Tip="Show items from module-referenced HAK packs"/>
+          <CheckBox x:Name="ModuleCheck"
+                    Content="Module"
+                    IsChecked="{Binding ShowModule, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay}"
+                    ToolTip.Tip="Show loose UTI files in the module directory"/>
+        </StackPanel>
         <CheckBox x:Name="CreatureItemsCheck"
-                  Grid.Column="4"
+                  Grid.Column="3"
                   HorizontalAlignment="Left"
                   Content="Creature/internal"
                   IsChecked="{Binding ShowCreatureItems, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay}"
                   ToolTip.Tip="Show creature natural weapons + internal items (e.g. a custom monster's claws). Hidden by default."/>
 
-        <StackPanel Grid.Column="2" Orientation="Horizontal" Margin="16,0,0,0">
+        <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="16,0,0,0">
           <TextBlock Text="Type:" VerticalAlignment="Center" Margin="0,0,8,0"/>
           <ComboBox x:Name="TypeCombo"
                     MinWidth="150"
@@ -58,7 +66,7 @@
           </ComboBox>
         </StackPanel>
 
-        <StackPanel Grid.Column="3" Orientation="Horizontal" Margin="16,0,0,0">
+        <StackPanel Grid.Column="2" Orientation="Horizontal" Margin="16,0,0,0">
           <TextBlock Text="Slot:" VerticalAlignment="Center" Margin="0,0,8,0"/>
           <ComboBox x:Name="SlotCombo"
                     MinWidth="130"
@@ -74,7 +82,7 @@
         </StackPanel>
 
         <TextBlock x:Name="ResultCount"
-                   Grid.Column="5"
+                   Grid.Column="4"
                    VerticalAlignment="Center"
                    Margin="16,0,0,0"
                    Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>

--- a/Radoub.UI/Radoub.UI/Controls/ItemFilterPanel.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ItemFilterPanel.axaml.cs
@@ -47,11 +47,23 @@ public partial class ItemFilterPanel : UserControl
         AvaloniaProperty.Register<ItemFilterPanel, bool>(nameof(ShowStandard), defaultValue: true);
 
     /// <summary>
-    /// Show items from module/HAK (Custom).
-    /// Default false - custom items can be numerous (CEP adds thousands).
+    /// Show items from the user's Override folder. Default false (#1995): overrides shadow base
+    /// content and are not usually wanted in the palette.
     /// </summary>
-    public static readonly StyledProperty<bool> ShowCustomProperty =
-        AvaloniaProperty.Register<ItemFilterPanel, bool>(nameof(ShowCustom), defaultValue: false);
+    public static readonly StyledProperty<bool> ShowOverrideProperty =
+        AvaloniaProperty.Register<ItemFilterPanel, bool>(nameof(ShowOverride), defaultValue: false);
+
+    /// <summary>
+    /// Show items from module-referenced HAK packs. Default true.
+    /// </summary>
+    public static readonly StyledProperty<bool> ShowHakProperty =
+        AvaloniaProperty.Register<ItemFilterPanel, bool>(nameof(ShowHak), defaultValue: true);
+
+    /// <summary>
+    /// Show loose UTI files from the module directory. Default true.
+    /// </summary>
+    public static readonly StyledProperty<bool> ShowModuleProperty =
+        AvaloniaProperty.Register<ItemFilterPanel, bool>(nameof(ShowModule), defaultValue: true);
 
     /// <summary>
     /// Show creature natural weapons + internal/marker items (base types 69-73, 255). Default false:
@@ -184,12 +196,30 @@ public partial class ItemFilterPanel : UserControl
     }
 
     /// <summary>
-    /// Show module/HAK items.
+    /// Show Override-folder items.
     /// </summary>
-    public bool ShowCustom
+    public bool ShowOverride
     {
-        get => GetValue(ShowCustomProperty);
-        set => SetValue(ShowCustomProperty, value);
+        get => GetValue(ShowOverrideProperty);
+        set => SetValue(ShowOverrideProperty, value);
+    }
+
+    /// <summary>
+    /// Show module-referenced HAK items.
+    /// </summary>
+    public bool ShowHak
+    {
+        get => GetValue(ShowHakProperty);
+        set => SetValue(ShowHakProperty, value);
+    }
+
+    /// <summary>
+    /// Show loose module-directory items.
+    /// </summary>
+    public bool ShowModule
+    {
+        get => GetValue(ShowModuleProperty);
+        set => SetValue(ShowModuleProperty, value);
     }
 
     public bool ShowCreatureItems
@@ -327,7 +357,9 @@ public partial class ItemFilterPanel : UserControl
             _debounceTimer.Start();
         }
         else if (change.Property == ShowStandardProperty ||
-                 change.Property == ShowCustomProperty ||
+                 change.Property == ShowOverrideProperty ||
+                 change.Property == ShowHakProperty ||
+                 change.Property == ShowModuleProperty ||
                  change.Property == ShowCreatureItemsProperty ||
                  change.Property == SelectedItemTypeProperty ||
                  change.Property == SelectedSlotFilterProperty)
@@ -449,7 +481,9 @@ public partial class ItemFilterPanel : UserControl
         var typeFilter = SelectedItemType;
         var slotFilter = SelectedSlotFilter;
         var showStandard = ShowStandard;
-        var showCustom = ShowCustom;
+        var showOverride = ShowOverride;
+        var showHak = ShowHak;
+        var showModule = ShowModule;
         var showCreature = ShowCreatureItems;
 
         int totalCount = Items.Count;
@@ -457,7 +491,8 @@ public partial class ItemFilterPanel : UserControl
 
         foreach (var item in Items)
         {
-            if (MatchesFilter(item, searchLower, propertySearchLower, typeFilter, slotFilter, showStandard, showCustom, showCreature))
+            if (MatchesFilter(item, searchLower, propertySearchLower, typeFilter, slotFilter,
+                              showStandard, showOverride, showHak, showModule, showCreature))
             {
                 FilteredItems.Add(item);
                 matchCount++;
@@ -480,10 +515,13 @@ public partial class ItemFilterPanel : UserControl
         ItemTypeInfo? typeFilter,
         SlotFilterInfo? slotFilter,
         bool showStandard,
-        bool showCustom,
+        bool showOverride,
+        bool showHak,
+        bool showModule,
         bool showCreatureItems)
         => ItemFilterPredicate.Matches(
-            item, searchLower, propertySearchLower, typeFilter, slotFilter, showStandard, showCustom, showCreatureItems);
+            item, searchLower, propertySearchLower, typeFilter, slotFilter,
+            showStandard, showOverride, showHak, showModule, showCreatureItems);
 
     private void UpdateResultCount(int matchCount, int totalCount)
     {
@@ -503,8 +541,11 @@ public partial class ItemFilterPanel : UserControl
         var state = FilterSettings.GetFilterState(ContextKey);
         if (state == null) return;
 
+        state.MigrateLegacy(); // #1995: old binary ShowCustom → per-source toggles
         ShowStandard = state.ShowStandard;
-        ShowCustom = state.ShowCustom;
+        ShowOverride = state.ShowOverride;
+        ShowHak = state.ShowHak;
+        ShowModule = state.ShowModule;
         SearchText = state.SearchText ?? string.Empty;
         PropertySearchText = state.PropertySearchText ?? string.Empty;
 
@@ -538,7 +579,9 @@ public partial class ItemFilterPanel : UserControl
         var state = new FilterState
         {
             ShowStandard = ShowStandard,
-            ShowCustom = ShowCustom,
+            ShowOverride = ShowOverride,
+            ShowHak = ShowHak,
+            ShowModule = ShowModule,
             SearchText = string.IsNullOrEmpty(SearchText) ? null : SearchText,
             SelectedBaseItemIndex = SelectedItemType?.IsAllTypes == true ? null : SelectedItemType?.BaseItemIndex,
             PropertySearchText = string.IsNullOrEmpty(PropertySearchText) ? null : PropertySearchText,

--- a/Radoub.UI/Radoub.UI/Models/FilterState.cs
+++ b/Radoub.UI/Radoub.UI/Models/FilterState.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Radoub.UI.Models;
 
 /// <summary>
@@ -6,14 +8,33 @@ namespace Radoub.UI.Models;
 public class FilterState
 {
     /// <summary>
-    /// Show base game (Standard) items.
+    /// Show base game (Standard / BIF) items.
     /// </summary>
     public bool ShowStandard { get; set; } = true;
 
     /// <summary>
-    /// Show module/HAK (Custom) items.
+    /// Show items from the user's Override folder. Default off (#1995): overrides shadow base
+    /// content and are not usually what a builder wants in the palette.
     /// </summary>
-    public bool ShowCustom { get; set; } = true;
+    public bool ShowOverride { get; set; } = false;
+
+    /// <summary>
+    /// Show items from module-referenced HAK packs. Default on.
+    /// </summary>
+    public bool ShowHak { get; set; } = true;
+
+    /// <summary>
+    /// Show loose UTI files in the module directory. Default on.
+    /// </summary>
+    public bool ShowModule { get; set; } = true;
+
+    /// <summary>
+    /// Legacy binary "show custom" flag (Override/HAK/Module lumped together). Read only from old
+    /// persisted files via the original "ShowCustom" JSON key; null in new files. Consumed by
+    /// <see cref="MigrateLegacy"/> to seed the three per-source toggles, then cleared (#1995).
+    /// </summary>
+    [JsonPropertyName("ShowCustom")]
+    public bool? LegacyShowCustom { get; set; }
 
     /// <summary>
     /// Text search string.
@@ -34,4 +55,20 @@ public class FilterState
     /// Selected slot filter flag, or null for "All Slots".
     /// </summary>
     public int? SelectedSlotFlag { get; set; }
+
+    /// <summary>
+    /// One-time migration from the old binary Standard/Custom model (#1995). If a legacy
+    /// "ShowCustom" value was loaded, apply it to all three per-source toggles so a user who had
+    /// custom content visible keeps seeing it, then clear the legacy field. No-op for new files.
+    /// </summary>
+    public void MigrateLegacy()
+    {
+        if (LegacyShowCustom is { } legacy)
+        {
+            ShowOverride = legacy;
+            ShowHak = legacy;
+            ShowModule = legacy;
+            LegacyShowCustom = null;
+        }
+    }
 }

--- a/Radoub.UI/Radoub.UI/Models/ItemFilterPredicate.cs
+++ b/Radoub.UI/Radoub.UI/Models/ItemFilterPredicate.cs
@@ -1,3 +1,4 @@
+using Radoub.Formats.Services;
 using Radoub.UI.ViewModels;
 
 namespace Radoub.UI.Models;
@@ -21,7 +22,9 @@ public static class ItemFilterPredicate
     /// <param name="typeFilter">Base-item-type filter, or null / AllTypes for no type filter.</param>
     /// <param name="slotFilter">Equipment-slot filter, or null / AllSlots for no slot filter.</param>
     /// <param name="showStandard">Include base-game (BIF) items.</param>
-    /// <param name="showCustom">Include custom (Override/HAK/Module) items.</param>
+    /// <param name="showOverride">Include items from the user's Override folder.</param>
+    /// <param name="showHak">Include items from module-referenced HAK packs.</param>
+    /// <param name="showModule">Include loose UTI files from the module directory.</param>
     /// <param name="showCreatureItems">
     /// Include creature natural weapons + internal/marker base types (see
     /// <see cref="Utils.ItemPaletteExclusions"/>). Default true (no filtering) so existing callers and
@@ -34,12 +37,21 @@ public static class ItemFilterPredicate
         ItemTypeInfo? typeFilter,
         SlotFilterInfo? slotFilter,
         bool showStandard,
-        bool showCustom,
+        bool showOverride,
+        bool showHak,
+        bool showModule,
         bool showCreatureItems = true)
     {
-        // Source filter (Standard = BIF, Custom = Override/HAK/Module)
-        if (item.IsStandard && !showStandard) return false;
-        if (item.IsCustom && !showCustom) return false;
+        // Source filter (#1995: each of the four game-resource sources toggles independently).
+        var sourceVisible = item.Source switch
+        {
+            GameResourceSource.Bif => showStandard,
+            GameResourceSource.Override => showOverride,
+            GameResourceSource.Hak => showHak,
+            GameResourceSource.Module => showModule,
+            _ => true
+        };
+        if (!sourceVisible) return false;
 
         // Creature/internal items (natural weapons, marker) are hidden unless explicitly shown.
         if (!showCreatureItems && Utils.ItemPaletteExclusions.IsExcluded(item.BaseItem)) return false;

--- a/Radoub.UI/Radoub.UI/Services/HakPaletteScannerService.cs
+++ b/Radoub.UI/Radoub.UI/Services/HakPaletteScannerService.cs
@@ -2,6 +2,7 @@ using Radoub.Formats.Common;
 using Radoub.Formats.Erf;
 using Radoub.Formats.Logging;
 using Radoub.Formats.Resolver;
+using Radoub.Formats.Services;
 using Radoub.Formats.Uti;
 
 namespace Radoub.UI.Services;
@@ -83,7 +84,7 @@ public class HakPaletteScannerService
                             BaseItemTypeName = string.Empty, // Set by consumer with 2DA lookup
                             BaseItemType = uti.BaseItem,
                             BaseValue = uti.Cost,
-                            IsStandard = false, // HAK items are custom content
+                            Source = GameResourceSource.Hak,
                             SourceLocation = Path.GetFileName(hakPath)
                         });
                         seenResRefs.Add(entry.ResRef);

--- a/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheItem.cs
+++ b/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheItem.cs
@@ -1,3 +1,6 @@
+using System.Text.Json.Serialization;
+using Radoub.Formats.Services;
+
 namespace Radoub.UI.Services;
 
 /// <summary>
@@ -13,9 +16,22 @@ public class SharedPaletteCacheItem
     public string BaseItemTypeName { get; set; } = string.Empty;
     public int BaseItemType { get; set; }
     public uint BaseValue { get; set; }
-    public bool IsStandard { get; set; }
+
+    /// <summary>
+    /// Which game resource bucket this item came from (Bif/Override/Hak/Module). Persisted so the
+    /// palette filter can distinguish all four sources (#1995). Replaces the former bool IsStandard.
+    /// </summary>
+    public GameResourceSource Source { get; set; } = GameResourceSource.Bif;
+
     public string PropertiesDisplay { get; set; } = string.Empty;
     public string SourceLocation { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Convenience: true when this item is base-game (BIF). Not serialized — derived from Source.
+    /// Retained so existing call sites and tests that only need the standard-vs-custom split keep working.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsStandard => Source == GameResourceSource.Bif;
 }
 
 /// <summary>

--- a/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheService.cs
+++ b/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheService.cs
@@ -12,7 +12,7 @@ namespace Radoub.UI.Services;
 /// </summary>
 public class SharedPaletteCacheService : ISharedPaletteCacheService, IDisposable
 {
-    private const int CacheVersion = 3; // v3: Added SourceLocation
+    private const int CacheVersion = 4; // v4: Source enum replaces bool IsStandard (#1995); v3: Added SourceLocation
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -132,6 +132,15 @@ public class SharedPaletteCacheService : ISharedPaletteCacheService, IDisposable
             var cache = JsonSerializer.Deserialize<SourcePaletteCacheWrapper>(json, JsonOptions);
             if (cache?.Items != null)
             {
+                // Refuse a stale-schema cache: returning v3 items would silently default the new
+                // Source field to Bif and mislabel every custom item (#1995).
+                if (cache.Version != CacheVersion)
+                {
+                    UnifiedLogger.LogApplication(LogLevel.INFO,
+                        $"Shared palette {source} cache version mismatch on load - rebuild required");
+                    return null;
+                }
+
                 UnifiedLogger.LogApplication(LogLevel.DEBUG,
                     $"Loaded {cache.Items.Count} items from shared palette {source} cache");
                 return cache.Items;

--- a/Reliquary/Reliquary/Views/MainWindow.Inventory.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.Inventory.cs
@@ -203,10 +203,8 @@ public partial class MainWindow
                     Value = c.BaseValue,
                     Tag = string.IsNullOrEmpty(c.Tag) ? c.ResRef : c.Tag,
                     PropertiesDisplay = c.PropertiesDisplay,
-                    // IsStandard is a bool, so a custom item is HAK or Override; SourceLocation carries
-                    // the real origin (hak filename vs "Override"). Use it to label HAK items as Hak
-                    // instead of lumping them under Override (#2411 follow-up).
-                    Source = SourceFromCache(c),
+                    // The cache now carries the real four-way source (#1995); no filename sniffing.
+                    Source = c.Source,
                     SourceLocation = c.SourceLocation, // surface the hak filename (Fence parity)
                     // Item detail images (#2411): reuse Reliquary's ItemIconService (already used for
                     // placeable portraits) for inventory palette/details icons, matching Fence.
@@ -294,7 +292,7 @@ public partial class MainWindow
                     PropertiesDisplay = _itemFactory.GetPropertiesDisplay(uti.Properties),
                     BaseItemType = uti.BaseItem,
                     BaseValue = uti.Cost,
-                    IsStandard = gameSource == GameResourceSource.Bif,
+                    Source = gameSource,
                     SourceLocation = string.IsNullOrEmpty(res.SourcePath)
                         ? res.Source.ToString() : Path.GetFileName(res.SourcePath)
                 });
@@ -311,20 +309,6 @@ public partial class MainWindow
             : RadoubSettings.Instance.NeverwinterNightsPath;
         _itemCache.SaveSourceCacheAsync(cacheSource, items, validationPath).GetAwaiter().GetResult();
         UnifiedLogger.LogApplication(LogLevel.INFO, $"Reliquary: built {cacheSource} item cache ({items.Count} items).");
-    }
-
-    /// <summary>
-    /// Map a cached palette item to a source enum. BIF items are standard; custom items are HAK when
-    /// SourceLocation names a .hak file, otherwise Override. (SharedPaletteCacheItem.IsStandard is a
-    /// bool, so SourceLocation is the only signal that distinguishes HAK from Override — #2411 follow-up.)
-    /// </summary>
-    private static GameResourceSource SourceFromCache(SharedPaletteCacheItem c)
-    {
-        if (c.IsStandard) return GameResourceSource.Bif;
-        return !string.IsNullOrEmpty(c.SourceLocation)
-               && c.SourceLocation.EndsWith(".hak", StringComparison.OrdinalIgnoreCase)
-            ? GameResourceSource.Hak
-            : GameResourceSource.Override;
     }
 
     /// <summary>Load loose .uti files from the open placeable's directory as palette items.</summary>

--- a/Reliquary/Reliquary/Views/Panels/InventoryPanel.axaml.cs
+++ b/Reliquary/Reliquary/Views/Panels/InventoryPanel.axaml.cs
@@ -81,9 +81,8 @@ public partial class InventoryPanel : UserControl, INotifyPropertyChanged
             _paletteFilter.Items = _paletteItems;
             // Filter writes its results into the same collection the list shows (QM pattern).
             _paletteFilter.FilteredItems = _filteredPaletteItems;
-            // Show module/Override/HAK items by default (ShowCustom defaults false) — otherwise the
-            // palette would list only base-game BIF items and hide the module's loose UTIs.
-            _paletteFilter.ShowCustom = true;
+            // Source visibility defaults come from FilterState (#1995): Standard/HAK/Module on,
+            // Override off. No per-source force here.
         }
         if (_paletteList != null)
         {

--- a/Trebuchet/Trebuchet/Services/PaletteCacheWarmupService.cs
+++ b/Trebuchet/Trebuchet/Services/PaletteCacheWarmupService.cs
@@ -91,7 +91,7 @@ public class PaletteCacheWarmupService
                             BaseItemType = uti.BaseItem,
                             BaseItemTypeName = baseItemName,
                             BaseValue = uti.Cost,
-                            IsStandard = true,
+                            Source = Radoub.Formats.Services.GameResourceSource.Bif,
                             PropertiesDisplay = propertiesDisplay,
                             SourceLocation = "bif"
                         });


### PR DESCRIPTION
## Summary

Splits the item palette's binary Standard/Custom source filter into four independent checkboxes (Standard, Override, HAK, Module). The real `GameResourceSource` is plumbed through `SharedPaletteCacheItem` (cache version bump 3→4) so Fence, Quartermaster, and Reliquary distinguish all four sources instead of flattening Override/HAK/Module into one bucket. Removed the obsolete reconstruction heuristics (Fence/QM ternary, Reliquary `.hak` filename sniff) and both `ShowCustom = true` forces.

Defaults: Standard / HAK / Module on, Override off. `FilterState` migrates old `ShowCustom` state on first load. `LoadSourceCache` now also rejects stale-version caches (was a pre-existing gap).

## Related Issues

- Closes #1995

## Pre-Merge Checklist

| Check | Status |
|-------|--------|
| Privacy scan | ✅ No hardcoded paths |
| Tech debt | ✅ No files >800 lines |
| Unit tests (local, Windows) | ✅ 3913 + Fence 137 / Reliquary 134 / Trebuchet 304 — 0 failed |
| UI tests (FlaUI) | ⏸️ Pending user confirmation (shared ItemFilterPanel.axaml changed) |
| CHANGELOG | ✅ Root `Radoub.UI 0.2.13-alpha`, PR #2503 |
| [Unreleased] | ✅ None |
| init-item | ✅ Branch convention + linked issue |

### Manual spot-checks (need eyeballing in each tool)

- [ ] Four source checkboxes render: Standard / Override / HAK / Module
- [ ] First run (clear saved state): Standard/HAK/Module checked, Override unchecked
- [ ] Unchecking HAK hides only HAK items
- [ ] HAK items appear under HAK (not Override) — the bug this fixes
- [ ] Loose module UTIs appear under Module (Reliquary)
- [ ] Old saved "Custom on" state still shows custom content after upgrade
- [ ] Override hidden by default in Fence/Reliquary (previously force-shown)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)