### PR TITLE
[Fence] Sprint: Critical Save/Undo + Cross-Tool Data Integrity (#2383)

### DIFF
--- a/Fence/CHANGELOG.md
+++ b/Fence/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.1.40-alpha] - 2026-06-18
-**Branch**: `fence/sprint/2383-undo-data-integrity` | **PR**: #TBD
+**Branch**: `fence/sprint/2383-undo-data-integrity` | **PR**: #2504
 
 ### Sprint: Critical Save/Undo + Cross-Tool Data Integrity (#2383)
 

--- a/Fence/CHANGELOG.md
+++ b/Fence/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.1.40-alpha] - 2026-06-18
+**Branch**: `fence/sprint/2383-undo-data-integrity` | **PR**: #TBD
+
+### Sprint: Critical Save/Undo + Cross-Tool Data Integrity (#2383)
+
+- Undo/Redo wired in Fence per Epic #2231 — document/whole-field undo across all editable fields; disabled menu stubs replaced (#2255).
+
+This closes out the remaining item in Sprint #2383 (save race, cache leak, file-panel refresh, and ItemDetails refactor already shipped in 0.1.39-alpha).
+
+---
+
 ## [0.1.39-alpha] - 2026-06-07
 **Branch**: `fence/issue-2383` | **PR**: #2410
 

--- a/Fence/Fence.Tests/FenceUndoCommandTests.cs
+++ b/Fence/Fence.Tests/FenceUndoCommandTests.cs
@@ -1,0 +1,412 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using MerchantEditor.Commands;
+using MerchantEditor.ViewModels;
+using Radoub.Formats.Gff;
+using Radoub.UI.Undo;
+using Radoub.UI.ViewModels;
+using Xunit;
+
+namespace MerchantEditor.Tests;
+
+/// <summary>
+/// Undo/redo coverage for Fence mutation commands (#2255 / epic #2231). Fence is a blueprint
+/// editor: the UTM model is rebuilt from the UI at save time, so the inventory and variable
+/// commands operate on the single UI <see cref="ObservableCollection{T}"/> that is the live
+/// source of truth — there is no parallel model list to keep index-aligned during editing.
+/// </summary>
+public class FenceUndoCommandTests
+{
+    private static StoreItemViewModel Item(string resRef, int panelId = 0)
+        => new() { ResRef = resRef, DisplayName = resRef, PanelId = panelId };
+
+    // --- AddStoreItems (batch add as one undo step) ---
+
+    [Fact]
+    public void AddStoreItems_AddsAllToCollection()
+    {
+        var ui = new ObservableCollection<StoreItemViewModel>();
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new AddStoreItemsCommand(ui, new[] { Item("sw_a"), Item("sw_b") }));
+
+        Assert.Equal(2, ui.Count);
+        Assert.Equal("sw_a", ui[0].ResRef);
+        Assert.Equal("sw_b", ui[1].ResRef);
+    }
+
+    [Fact]
+    public void AddStoreItems_UndoRemovesAll()
+    {
+        var ui = new ObservableCollection<StoreItemViewModel>();
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new AddStoreItemsCommand(ui, new[] { Item("sw_a"), Item("sw_b") }));
+        mgr.Undo();
+
+        Assert.Empty(ui);
+    }
+
+    [Fact]
+    public void AddStoreItems_RedoReappliesAll()
+    {
+        var ui = new ObservableCollection<StoreItemViewModel>();
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new AddStoreItemsCommand(ui, new[] { Item("sw_a"), Item("sw_b") }));
+        mgr.Undo();
+        mgr.Redo();
+
+        Assert.Equal(2, ui.Count);
+        Assert.Equal("sw_b", ui[1].ResRef);
+    }
+
+    [Fact]
+    public void AddStoreItems_Empty_DoesNotRecord()
+    {
+        var ui = new ObservableCollection<StoreItemViewModel>();
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new AddStoreItemsCommand(ui, System.Array.Empty<StoreItemViewModel>()));
+
+        Assert.False(mgr.CanUndo);
+    }
+
+    // --- RemoveStoreItems (batch remove as one undo step, restoring positions) ---
+
+    [Fact]
+    public void RemoveStoreItems_RemovesSelected()
+    {
+        var a = Item("a"); var b = Item("b"); var c = Item("c");
+        var ui = new ObservableCollection<StoreItemViewModel> { a, b, c };
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new RemoveStoreItemsCommand(ui, new[] { b }));
+
+        Assert.Equal(2, ui.Count);
+        Assert.Equal("a", ui[0].ResRef);
+        Assert.Equal("c", ui[1].ResRef);
+    }
+
+    [Fact]
+    public void RemoveStoreItems_UndoReinsertsAtOriginalIndex()
+    {
+        var a = Item("a"); var b = Item("b"); var c = Item("c");
+        var ui = new ObservableCollection<StoreItemViewModel> { a, b, c };
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new RemoveStoreItemsCommand(ui, new[] { b })); // remove middle
+        mgr.Undo();
+
+        Assert.Equal(3, ui.Count);
+        Assert.Equal("b", ui[1].ResRef); // back in the middle
+    }
+
+    [Fact]
+    public void RemoveStoreItems_MultipleNonContiguous_UndoRestoresAllPositions()
+    {
+        var a = Item("a"); var b = Item("b"); var c = Item("c"); var d = Item("d");
+        var ui = new ObservableCollection<StoreItemViewModel> { a, b, c, d };
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new RemoveStoreItemsCommand(ui, new[] { a, c })); // remove indices 0 and 2
+        Assert.Equal(2, ui.Count);
+
+        mgr.Undo();
+        Assert.Equal(4, ui.Count);
+        Assert.Equal("a", ui[0].ResRef);
+        Assert.Equal("b", ui[1].ResRef);
+        Assert.Equal("c", ui[2].ResRef);
+        Assert.Equal("d", ui[3].ResRef);
+    }
+
+    [Fact]
+    public void RemoveStoreItems_RedoRemovesAgain()
+    {
+        var a = Item("a");
+        var ui = new ObservableCollection<StoreItemViewModel> { a };
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new RemoveStoreItemsCommand(ui, new[] { a }));
+        mgr.Undo();
+        mgr.Redo();
+
+        Assert.Empty(ui);
+    }
+
+    [Fact]
+    public void RemoveStoreItems_None_DoesNotRecord()
+    {
+        var ui = new ObservableCollection<StoreItemViewModel> { Item("a") };
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new RemoveStoreItemsCommand(ui, System.Array.Empty<StoreItemViewModel>()));
+
+        Assert.False(mgr.CanUndo);
+    }
+
+    // --- AddVariable ---
+
+    [Fact]
+    public void AddVariable_AddsToCollection()
+    {
+        var ui = new ObservableCollection<VariableViewModel>();
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new AddVariableCommand(ui,
+            new VariableViewModel { Name = "X", Type = VariableType.Int, ValueText = "5" }));
+
+        Assert.Single(ui);
+        Assert.Equal("X", ui[0].Name);
+    }
+
+    [Fact]
+    public void AddVariable_UndoRemoves()
+    {
+        var ui = new ObservableCollection<VariableViewModel>();
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new AddVariableCommand(ui,
+            new VariableViewModel { Name = "X", Type = VariableType.Int, ValueText = "5" }));
+        mgr.Undo();
+
+        Assert.Empty(ui);
+    }
+
+    [Fact]
+    public void AddVariable_RedoReapplies()
+    {
+        var ui = new ObservableCollection<VariableViewModel>();
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new AddVariableCommand(ui,
+            new VariableViewModel { Name = "X", Type = VariableType.Int, ValueText = "5" }));
+        mgr.Undo();
+        mgr.Redo();
+
+        Assert.Single(ui);
+        Assert.Equal("X", ui[0].Name);
+    }
+
+    // --- RemoveVariable ---
+
+    [Fact]
+    public void RemoveVariables_RemovesSelected()
+    {
+        var vmA = new VariableViewModel { Name = "A", Type = VariableType.Int, ValueText = "1" };
+        var vmB = new VariableViewModel { Name = "B", Type = VariableType.Int, ValueText = "2" };
+        var ui = new ObservableCollection<VariableViewModel> { vmA, vmB };
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new RemoveVariablesCommand(ui, new[] { vmB }));
+
+        Assert.Single(ui);
+        Assert.Equal("A", ui[0].Name);
+    }
+
+    [Fact]
+    public void RemoveVariables_UndoReinsertsAtOriginalIndex()
+    {
+        var vmA = new VariableViewModel { Name = "A", Type = VariableType.Int, ValueText = "1" };
+        var vmB = new VariableViewModel { Name = "B", Type = VariableType.Int, ValueText = "2" };
+        var vmC = new VariableViewModel { Name = "C", Type = VariableType.Int, ValueText = "3" };
+        var ui = new ObservableCollection<VariableViewModel> { vmA, vmB, vmC };
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new RemoveVariablesCommand(ui, new[] { vmB }));
+        mgr.Undo();
+
+        Assert.Equal(3, ui.Count);
+        Assert.Equal("B", ui[1].Name);
+    }
+
+    [Fact]
+    public void RemoveVariables_RedoRemovesAgain()
+    {
+        var vmA = new VariableViewModel { Name = "A", Type = VariableType.Int, ValueText = "1" };
+        var ui = new ObservableCollection<VariableViewModel> { vmA };
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new RemoveVariablesCommand(ui, new[] { vmA }));
+        mgr.Undo();
+        mgr.Redo();
+
+        Assert.Empty(ui);
+    }
+
+    // --- SetInfinite (toggle Infinite on a set of items, restoring each item's prior value) ---
+
+    [Fact]
+    public void SetInfinite_SetsAllTargetsToValue()
+    {
+        var a = Item("a"); var b = Item("b"); b.Infinite = true;
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new SetInfiniteCommand(new[] { a, b }, true));
+
+        Assert.True(a.Infinite);
+        Assert.True(b.Infinite);
+    }
+
+    [Fact]
+    public void SetInfinite_UndoRestoresEachPriorValue()
+    {
+        var a = Item("a"); a.Infinite = false;
+        var b = Item("b"); b.Infinite = true;
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new SetInfiniteCommand(new[] { a, b }, true));
+        mgr.Undo();
+
+        Assert.False(a.Infinite); // restored to its own prior value
+        Assert.True(b.Infinite);  // unchanged, stays true
+    }
+
+    [Fact]
+    public void SetInfinite_NoActualChange_DoesNotRecord()
+    {
+        var a = Item("a"); a.Infinite = true;
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new SetInfiniteCommand(new[] { a }, true)); // already true
+
+        Assert.False(mgr.CanUndo);
+    }
+
+    [Fact]
+    public void SetInfinite_RedoReapplies()
+    {
+        var a = Item("a"); a.Infinite = false;
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new SetInfiniteCommand(new[] { a }, true));
+        mgr.Undo();
+        mgr.Redo();
+
+        Assert.True(a.Infinite);
+    }
+
+    // --- SetResRef (single store item ResRef edit) ---
+
+    [Fact]
+    public void SetResRef_AppliesNewValue()
+    {
+        var a = Item("old");
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new SetResRefCommand(a, "old", "new"));
+
+        Assert.Equal("new", a.ResRef);
+    }
+
+    [Fact]
+    public void SetResRef_UndoRestoresOld()
+    {
+        var a = Item("old");
+        a.ResRef = "new"; // simulate the grid binding already applied the edit
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new SetResRefCommand(a, "old", "new"));
+        mgr.Undo();
+
+        Assert.Equal("old", a.ResRef);
+    }
+
+    [Fact]
+    public void SetResRef_RedoReapplies()
+    {
+        var a = Item("old");
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new SetResRefCommand(a, "old", "new"));
+        mgr.Undo();
+        mgr.Redo();
+
+        Assert.Equal("new", a.ResRef);
+    }
+
+    [Fact]
+    public void SetResRef_NoChange_DoesNotRecord()
+    {
+        var a = Item("same");
+        var mgr = new UndoRedoManager();
+
+        mgr.Execute(new SetResRefCommand(a, "same", "same"));
+
+        Assert.False(mgr.CanUndo);
+    }
+
+    // --- BuyRestrictionsSnapshot (whole-state capture/restore) ---
+
+    private static ObservableCollection<SelectableBaseItemTypeViewModel> Types(params int[] indices)
+    {
+        var c = new ObservableCollection<SelectableBaseItemTypeViewModel>();
+        foreach (var i in indices)
+            c.Add(new SelectableBaseItemTypeViewModel(i, $"type{i}"));
+        return c;
+    }
+
+    [Fact]
+    public void BuyRestrictions_CaptureRecordsModeAndSelection()
+    {
+        var types = Types(1, 2, 3);
+        types[0].IsSelected = true;
+        types[2].IsSelected = true;
+
+        var snap = BuyRestrictionsSnapshot.Capture(BuyMode.WillOnlyBuy, types);
+
+        Assert.Equal(BuyMode.WillOnlyBuy, snap.Mode);
+        Assert.Equal(new[] { 1, 3 }, snap.SelectedIndices.OrderBy(x => x));
+    }
+
+    [Fact]
+    public void BuyRestrictions_ApplyRestoresSelection()
+    {
+        var types = Types(1, 2, 3);
+        var snap = new BuyRestrictionsSnapshot(BuyMode.WillNotBuy, new[] { 2 });
+
+        snap.ApplyTo(types);
+
+        Assert.False(types[0].IsSelected);
+        Assert.True(types[1].IsSelected);
+        Assert.False(types[2].IsSelected);
+    }
+
+    [Fact]
+    public void BuyRestrictions_UndoRestoresPriorState_ViaRelayCommand()
+    {
+        var types = Types(1, 2, 3);
+        types[0].IsSelected = true; // initial: OnlyBuy {1}
+        var mode = BuyMode.WillOnlyBuy;
+
+        var before = BuyRestrictionsSnapshot.Capture(mode, types);
+
+        // Simulate user switching to "Buy All" (clears selection).
+        foreach (var t in types) t.IsSelected = false;
+        mode = BuyMode.All;
+        var after = BuyRestrictionsSnapshot.Capture(mode, types);
+
+        var mgr = new UndoRedoManager();
+        mgr.Execute(new RelayUndoableCommand(
+            () => { after.ApplyTo(types); },
+            () => { before.ApplyTo(types); },
+            "change buy restrictions"));
+
+        Assert.False(types[0].IsSelected); // after state
+
+        mgr.Undo();
+        Assert.True(types[0].IsSelected);  // before state restored
+        Assert.False(types[1].IsSelected);
+
+        mgr.Redo();
+        Assert.False(types[0].IsSelected); // after re-applied
+    }
+
+    [Fact]
+    public void BuyRestrictions_Equality_IgnoresOrder()
+    {
+        var a = new BuyRestrictionsSnapshot(BuyMode.WillNotBuy, new[] { 3, 1, 2 });
+        var b = new BuyRestrictionsSnapshot(BuyMode.WillNotBuy, new[] { 1, 2, 3 });
+        Assert.Equal(a, b);
+    }
+}

--- a/Fence/Fence/Commands/AddStoreItemsCommand.cs
+++ b/Fence/Fence/Commands/AddStoreItemsCommand.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using MerchantEditor.ViewModels;
+using Radoub.UI.Undo;
+
+namespace MerchantEditor.Commands;
+
+/// <summary>
+/// Adds one or more items to the store inventory collection as a single undo step. Fence rebuilds
+/// the UTM <c>StoreList</c> from this collection at save time (see <c>UpdateStoreFromUI</c>), so the
+/// collection is the live source of truth and the command needs no parallel model list. Reversible:
+/// Undo removes exactly the appended items. An empty add records nothing (Do returns false).
+/// </summary>
+public sealed class AddStoreItemsCommand : IUndoableCommand
+{
+    private readonly ObservableCollection<StoreItemViewModel> _items;
+    private readonly List<StoreItemViewModel> _added;
+
+    public AddStoreItemsCommand(ObservableCollection<StoreItemViewModel> items,
+        IEnumerable<StoreItemViewModel> toAdd)
+    {
+        _items = items ?? throw new ArgumentNullException(nameof(items));
+        _added = (toAdd ?? throw new ArgumentNullException(nameof(toAdd))).ToList();
+    }
+
+    public string Description => _added.Count == 1
+        ? (string.IsNullOrEmpty(_added[0].ResRef) ? "add item" : $"add item {_added[0].ResRef}")
+        : $"add {_added.Count} items";
+
+    public bool Do()
+    {
+        if (_added.Count == 0) return false; // nothing to add → don't record
+        foreach (var item in _added)
+            _items.Add(item);
+        return true;
+    }
+
+    public void Undo()
+    {
+        foreach (var item in _added)
+            _items.Remove(item);
+    }
+}

--- a/Fence/Fence/Commands/AddVariableCommand.cs
+++ b/Fence/Fence/Commands/AddVariableCommand.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.ObjectModel;
+using Radoub.UI.Undo;
+using Radoub.UI.ViewModels;
+
+namespace MerchantEditor.Commands;
+
+/// <summary>
+/// Adds a local variable to the UI <see cref="VariableViewModel"/> collection as one undo step.
+/// Fence rebuilds the UTM <c>VarTable</c> from this collection at save time (see
+/// <c>UpdateVarTable</c>), so the collection is the live source of truth — no parallel model list.
+/// The shared <see cref="Radoub.UI.Controls.VariablesPanel"/> is undo-agnostic (#2293); the host
+/// turns its AddRequested event into this command. Reversible: Undo removes the same entry.
+/// </summary>
+public sealed class AddVariableCommand : IUndoableCommand
+{
+    private readonly ObservableCollection<VariableViewModel> _ui;
+    private readonly VariableViewModel _vm;
+
+    public AddVariableCommand(ObservableCollection<VariableViewModel> ui, VariableViewModel vm)
+    {
+        _ui = ui ?? throw new ArgumentNullException(nameof(ui));
+        _vm = vm ?? throw new ArgumentNullException(nameof(vm));
+    }
+
+    public string Description => string.IsNullOrEmpty(_vm.Name) ? "add variable" : $"add variable {_vm.Name}";
+
+    public bool Do()
+    {
+        _ui.Add(_vm);
+        return true;
+    }
+
+    public void Undo() => _ui.Remove(_vm);
+}

--- a/Fence/Fence/Commands/BuyRestrictionsSnapshot.cs
+++ b/Fence/Fence/Commands/BuyRestrictionsSnapshot.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using MerchantEditor.ViewModels;
+
+namespace MerchantEditor.Commands;
+
+/// <summary>
+/// The buy mode for a store's buy restrictions.
+/// </summary>
+public enum BuyMode
+{
+    All,
+    WillOnlyBuy,
+    WillNotBuy
+}
+
+/// <summary>
+/// An immutable snapshot of the buy-restrictions state: the buy <see cref="Mode"/> plus the set of
+/// selected base-item-type indices. Buy restrictions are interrelated (choosing "Buy All" clears the
+/// selection), so undo treats the whole state as one unit rather than recording each checkbox edit.
+/// <see cref="Capture"/> reads the current state and <see cref="ApplyTo"/> restores it onto the
+/// selectable item-type collection; the host applies the <see cref="Mode"/> to the radio buttons.
+/// </summary>
+public sealed class BuyRestrictionsSnapshot : IEquatable<BuyRestrictionsSnapshot>
+{
+    public BuyMode Mode { get; }
+    public IReadOnlySet<int> SelectedIndices { get; }
+
+    public BuyRestrictionsSnapshot(BuyMode mode, IEnumerable<int> selectedIndices)
+    {
+        Mode = mode;
+        SelectedIndices = new HashSet<int>(selectedIndices ?? Enumerable.Empty<int>());
+    }
+
+    /// <summary>Capture the current mode + selected item-type indices.</summary>
+    public static BuyRestrictionsSnapshot Capture(
+        BuyMode mode, IEnumerable<SelectableBaseItemTypeViewModel> types)
+        => new(mode, (types ?? Enumerable.Empty<SelectableBaseItemTypeViewModel>())
+            .Where(t => t.IsSelected)
+            .Select(t => t.BaseItemIndex));
+
+    /// <summary>Restore the selected state onto the item-type collection (mode is applied by the host).</summary>
+    public void ApplyTo(IEnumerable<SelectableBaseItemTypeViewModel> types)
+    {
+        foreach (var t in types ?? Enumerable.Empty<SelectableBaseItemTypeViewModel>())
+            t.IsSelected = SelectedIndices.Contains(t.BaseItemIndex);
+    }
+
+    public bool Equals(BuyRestrictionsSnapshot? other)
+        => other != null && Mode == other.Mode && SelectedIndices.SetEquals(other.SelectedIndices);
+
+    public override bool Equals(object? obj) => Equals(obj as BuyRestrictionsSnapshot);
+
+    public override int GetHashCode()
+    {
+        var hash = (int)Mode;
+        foreach (var i in SelectedIndices.OrderBy(x => x))
+            hash = HashCode.Combine(hash, i);
+        return hash;
+    }
+}

--- a/Fence/Fence/Commands/RemoveStoreItemsCommand.cs
+++ b/Fence/Fence/Commands/RemoveStoreItemsCommand.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using MerchantEditor.ViewModels;
+using Radoub.UI.Undo;
+
+namespace MerchantEditor.Commands;
+
+/// <summary>
+/// Removes one or more selected items from the store inventory collection as a single undo step,
+/// capturing each item's original index so Undo reinserts them in place. Reversible across any
+/// selection (contiguous or not). Removing nothing records nothing (Do returns false).
+/// </summary>
+public sealed class RemoveStoreItemsCommand : IUndoableCommand
+{
+    private readonly ObservableCollection<StoreItemViewModel> _items;
+    private readonly List<StoreItemViewModel> _targets;
+    private List<(int Index, StoreItemViewModel Item)> _removed = new();
+
+    public RemoveStoreItemsCommand(ObservableCollection<StoreItemViewModel> items,
+        IEnumerable<StoreItemViewModel> toRemove)
+    {
+        _items = items ?? throw new ArgumentNullException(nameof(items));
+        _targets = (toRemove ?? throw new ArgumentNullException(nameof(toRemove))).ToList();
+    }
+
+    public string Description => _targets.Count == 1
+        ? (string.IsNullOrEmpty(_targets[0].ResRef) ? "remove item" : $"remove item {_targets[0].ResRef}")
+        : $"remove {_targets.Count} items";
+
+    public bool Do()
+    {
+        // Capture (index, item) for present targets, then remove descending so earlier
+        // indices stay valid as we delete.
+        _removed = _targets
+            .Select(t => (Index: _items.IndexOf(t), Item: t))
+            .Where(e => e.Index >= 0)
+            .OrderByDescending(e => e.Index)
+            .ToList();
+
+        if (_removed.Count == 0) return false; // nothing present → don't record
+
+        foreach (var (index, _) in _removed)
+            _items.RemoveAt(index);
+        return true;
+    }
+
+    public void Undo()
+    {
+        // Reinsert ascending so each item lands at its original index.
+        foreach (var (index, item) in _removed.OrderBy(e => e.Index))
+            _items.Insert(Math.Min(index, _items.Count), item);
+    }
+}

--- a/Fence/Fence/Commands/RemoveVariablesCommand.cs
+++ b/Fence/Fence/Commands/RemoveVariablesCommand.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Radoub.UI.Undo;
+using Radoub.UI.ViewModels;
+
+namespace MerchantEditor.Commands;
+
+/// <summary>
+/// Removes one or more selected local variables from the UI collection as a single undo step,
+/// capturing each entry's original index so Undo reinserts them in place. The shared
+/// <see cref="Radoub.UI.Controls.VariablesPanel"/> is undo-agnostic (#2293); the host turns its
+/// DeleteRequested event into this command. Removing nothing records nothing (Do returns false).
+/// </summary>
+public sealed class RemoveVariablesCommand : IUndoableCommand
+{
+    private readonly ObservableCollection<VariableViewModel> _ui;
+    private readonly List<VariableViewModel> _targets;
+    private List<(int Index, VariableViewModel Item)> _removed = new();
+
+    public RemoveVariablesCommand(ObservableCollection<VariableViewModel> ui,
+        IEnumerable<VariableViewModel> toRemove)
+    {
+        _ui = ui ?? throw new ArgumentNullException(nameof(ui));
+        _targets = (toRemove ?? throw new ArgumentNullException(nameof(toRemove))).ToList();
+    }
+
+    public string Description => _targets.Count == 1
+        ? (string.IsNullOrEmpty(_targets[0].Name) ? "remove variable" : $"remove variable {_targets[0].Name}")
+        : $"remove {_targets.Count} variables";
+
+    public bool Do()
+    {
+        _removed = _targets
+            .Select(t => (Index: _ui.IndexOf(t), Item: t))
+            .Where(e => e.Index >= 0)
+            .OrderByDescending(e => e.Index)
+            .ToList();
+
+        if (_removed.Count == 0) return false; // nothing present → don't record
+
+        foreach (var (index, _) in _removed)
+            _ui.RemoveAt(index);
+        return true;
+    }
+
+    public void Undo()
+    {
+        foreach (var (index, item) in _removed.OrderBy(e => e.Index))
+            _ui.Insert(Math.Min(index, _ui.Count), item);
+    }
+}

--- a/Fence/Fence/Commands/SetInfiniteCommand.cs
+++ b/Fence/Fence/Commands/SetInfiniteCommand.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MerchantEditor.ViewModels;
+using Radoub.UI.Undo;
+
+namespace MerchantEditor.Commands;
+
+/// <summary>
+/// Sets the <see cref="StoreItemViewModel.Infinite"/> flag on a set of store items to a single value
+/// as one undo step, capturing each item's prior value so Undo restores them individually. Records
+/// nothing if no item actually changes (Do returns false).
+/// </summary>
+public sealed class SetInfiniteCommand : IUndoableCommand
+{
+    private readonly List<(StoreItemViewModel Item, bool OldValue)> _changes;
+    private readonly bool _newValue;
+
+    public SetInfiniteCommand(IEnumerable<StoreItemViewModel> items, bool newValue)
+    {
+        if (items == null) throw new ArgumentNullException(nameof(items));
+        _newValue = newValue;
+        _changes = items
+            .Where(i => i.Infinite != newValue)
+            .Select(i => (Item: i, OldValue: i.Infinite))
+            .ToList();
+    }
+
+    public string Description => _changes.Count == 1
+        ? (_newValue ? "set infinite" : "clear infinite")
+        : (_newValue ? $"set infinite ({_changes.Count})" : $"clear infinite ({_changes.Count})");
+
+    public bool Do()
+    {
+        if (_changes.Count == 0) return false; // no real change → don't record
+        foreach (var (item, _) in _changes)
+            item.Infinite = _newValue;
+        return true;
+    }
+
+    public void Undo()
+    {
+        foreach (var (item, oldValue) in _changes)
+            item.Infinite = oldValue;
+    }
+}

--- a/Fence/Fence/Commands/SetResRefCommand.cs
+++ b/Fence/Fence/Commands/SetResRefCommand.cs
@@ -1,0 +1,36 @@
+using System;
+using MerchantEditor.ViewModels;
+using Radoub.UI.Undo;
+
+namespace MerchantEditor.Commands;
+
+/// <summary>
+/// Records an inline ResRef edit on a single store item as one undo step. The DataGrid's TwoWay
+/// binding writes the new value to the item before the host builds this command, so Do() re-applies
+/// the new value (idempotent, correct redo) and Undo restores the captured old value. Records nothing
+/// if old and new are equal (Do returns false).
+/// </summary>
+public sealed class SetResRefCommand : IUndoableCommand
+{
+    private readonly StoreItemViewModel _item;
+    private readonly string _oldValue;
+    private readonly string _newValue;
+
+    public SetResRefCommand(StoreItemViewModel item, string oldValue, string newValue)
+    {
+        _item = item ?? throw new ArgumentNullException(nameof(item));
+        _oldValue = oldValue ?? string.Empty;
+        _newValue = newValue ?? string.Empty;
+    }
+
+    public string Description => $"edit ResRef {_newValue}";
+
+    public bool Do()
+    {
+        if (_oldValue == _newValue) return false; // no change → don't record
+        _item.ResRef = _newValue;
+        return true;
+    }
+
+    public void Undo() => _item.ResRef = _oldValue;
+}

--- a/Fence/Fence/Views/MainWindow.FileOps.cs
+++ b/Fence/Fence/Views/MainWindow.FileOps.cs
@@ -65,6 +65,9 @@ public partial class MainWindow
 
         OnPropertyChanged(nameof(HasFile));
 
+        // Fresh undo history per document (#2255).
+        _undo.Clear();
+
         // End loading state, then mark dirty — new files are always unsaved
         _documentState.IsLoading = false;
         _documentState.ForceDirty();
@@ -187,6 +190,8 @@ public partial class MainWindow
         {
             await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
             {
+                // Fresh undo history per document (#2255).
+                _undo.Clear();
                 _documentState.IsLoading = false;
                 _documentState.ClearDirty();
                 UpdateTitle();
@@ -475,6 +480,9 @@ public partial class MainWindow
         Variables.Clear();
         VariablesPanelControl.CanAdd = false; // no store loaded
         ClearStoreProperties();
+
+        // Clear undo history when closing the document (#2255).
+        _undo.Clear();
 
         _documentState.IsLoading = false;
         _documentState.ClearDirty();

--- a/Fence/Fence/Views/MainWindow.Scripts.cs
+++ b/Fence/Fence/Views/MainWindow.Scripts.cs
@@ -17,32 +17,24 @@ public partial class MainWindow
     {
         var script = await BrowseForScript();
         if (script != null)
-        {
-            OnOpenStoreBox.Text = script;
-            _documentState.MarkDirty();
-        }
+            RecordProgrammaticFieldEdit(OnOpenStoreBox, script, "set OnOpenStore");
     }
 
     private void OnClearOpenScript(object? sender, RoutedEventArgs e)
     {
-        OnOpenStoreBox.Text = "";
-        _documentState.MarkDirty();
+        RecordProgrammaticFieldEdit(OnOpenStoreBox, "", "clear OnOpenStore");
     }
 
     private async void OnBrowseClosedScript(object? sender, RoutedEventArgs e)
     {
         var script = await BrowseForScript();
         if (script != null)
-        {
-            OnStoreClosedBox.Text = script;
-            _documentState.MarkDirty();
-        }
+            RecordProgrammaticFieldEdit(OnStoreClosedBox, script, "set OnStoreClosed");
     }
 
     private void OnClearClosedScript(object? sender, RoutedEventArgs e)
     {
-        OnStoreClosedBox.Text = "";
-        _documentState.MarkDirty();
+        RecordProgrammaticFieldEdit(OnStoreClosedBox, "", "clear OnStoreClosed");
     }
 
     private async System.Threading.Tasks.Task<string?> BrowseForScript()

--- a/Fence/Fence/Views/MainWindow.StoreOperations.cs
+++ b/Fence/Fence/Views/MainWindow.StoreOperations.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using MerchantEditor.Commands;
 using MerchantEditor.ViewModels;
 using Radoub.Formats.Utm;
 using Radoub.UI.Services;
@@ -41,12 +42,9 @@ public partial class MainWindow
         if (selectedItems == null || selectedItems.Count == 0)
             return;
 
-        foreach (var item in selectedItems)
-        {
-            StoreItems.Remove(item);
-        }
+        // Route through undo so the removal is reversible as one step (#2255).
+        _undo.Execute(new RemoveStoreItemsCommand(StoreItems, selectedItems));
 
-        _documentState.MarkDirty();
         UpdateItemCount();
 
         // Refresh grid view (re-apply filter if active)
@@ -68,12 +66,8 @@ public partial class MainWindow
         if (StoreItems.Count == 0)
             return;
 
-        foreach (var item in StoreItems)
-        {
-            item.Infinite = true;
-        }
-
-        _documentState.MarkDirty();
+        // Route through undo so the bulk flag change is reversible as one step (#2255).
+        _undo.Execute(new SetInfiniteCommand(StoreItems, true));
     }
 
     private void SetInfiniteFlag(bool value)
@@ -82,12 +76,8 @@ public partial class MainWindow
         if (selectedItems == null || selectedItems.Count == 0)
             return;
 
-        foreach (var item in selectedItems)
-        {
-            item.Infinite = value;
-        }
-
-        _documentState.MarkDirty();
+        // Route through undo so the flag change is reversible as one step (#2255).
+        _undo.Execute(new SetInfiniteCommand(selectedItems, value));
     }
 
     private void OnInfiniteCellClicked(object? sender, Avalonia.Input.PointerPressedEventArgs e)
@@ -95,8 +85,8 @@ public partial class MainWindow
         // Get the data context (StoreItemViewModel) from the clicked element
         if (sender is Avalonia.Controls.Border border && border.DataContext is StoreItemViewModel item)
         {
-            item.Infinite = !item.Infinite;
-            _documentState.MarkDirty();
+            // Route the per-cell toggle through undo (#2255).
+            _undo.Execute(new SetInfiniteCommand(new[] { item }, !item.Infinite));
         }
     }
 
@@ -115,6 +105,7 @@ public partial class MainWindow
         var markUp = int.TryParse(SellMarkupBox.Text, out var mu) ? mu : 100;
         var markDown = int.TryParse(BuyMarkdownBox.Text, out var md) ? md : 50;
 
+        var newStoreItems = new List<StoreItemViewModel>();
         foreach (var item in selectedItems)
         {
             var sellPrice = (int)Math.Ceiling((int)item.Value * markUp / 100.0);
@@ -126,7 +117,7 @@ public partial class MainWindow
                 Radoub.Formats.Logging.LogLevel.DEBUG,
                 $"Adding item: {item.ResRef} | Type: {item.BaseItemName} | Panel: {panelId} ({StorePanels.GetPanelName(panelId)})");
 
-            StoreItems.Add(new StoreItemViewModel
+            newStoreItems.Add(new StoreItemViewModel
             {
                 ResRef = item.ResRef,
                 DisplayName = item.Name,
@@ -142,7 +133,8 @@ public partial class MainWindow
             });
         }
 
-        _documentState.MarkDirty();
+        // Route through undo so the whole batch add is reversible as one step (#2255).
+        _undo.Execute(new AddStoreItemsCommand(StoreItems, newStoreItems));
         UpdateItemCount();
 
         // Refresh grid view (re-apply filter if active)
@@ -156,12 +148,9 @@ public partial class MainWindow
         if (selectedItems == null || selectedItems.Count == 0)
             return;
 
-        foreach (var item in selectedItems)
-        {
-            StoreItems.Remove(item);
-        }
+        // Route through undo so the removal is reversible as one step (#2255).
+        _undo.Execute(new RemoveStoreItemsCommand(StoreItems, selectedItems));
 
-        _documentState.MarkDirty();
         UpdateItemCount();
 
         // Refresh grid view (re-apply filter if active)
@@ -214,43 +203,55 @@ public partial class MainWindow
 
     private void OnBuyModeChanged(object? sender, RoutedEventArgs e)
     {
-        // When mode changes to "Buy All", clear selections
-        if (BuyAllRadio.IsChecked == true)
+        // Suppress per-checkbox recording while the "Buy All" auto-clear runs; record the whole
+        // mode+selection change as one undo step afterward (#2255).
+        _suppressBuyRestrictionsUndo = true;
+        try
         {
-            foreach (var item in SelectableBaseItemTypes)
+            // When mode changes to "Buy All", clear selections
+            if (BuyAllRadio.IsChecked == true)
             {
-                item.IsSelected = false;
+                foreach (var item in SelectableBaseItemTypes)
+                {
+                    item.IsSelected = false;
+                }
             }
         }
+        finally { _suppressBuyRestrictionsUndo = false; }
 
-        if (!_documentState.IsLoading)
-            _documentState.MarkDirty();
+        RecordBuyRestrictionsChange();
     }
 
     private void OnSelectAllTypes(object? sender, RoutedEventArgs e)
     {
-        foreach (var item in SelectableBaseItemTypes)
+        // Suppress per-checkbox recording during the bulk set; record once as a single undo step.
+        _suppressBuyRestrictionsUndo = true;
+        try
         {
-            item.IsSelected = true;
+            foreach (var item in SelectableBaseItemTypes)
+                item.IsSelected = true;
         }
+        finally { _suppressBuyRestrictionsUndo = false; }
 
-        _documentState.MarkDirty();
+        RecordBuyRestrictionsChange();
     }
 
     private void OnClearAllTypes(object? sender, RoutedEventArgs e)
     {
-        foreach (var item in SelectableBaseItemTypes)
+        _suppressBuyRestrictionsUndo = true;
+        try
         {
-            item.IsSelected = false;
+            foreach (var item in SelectableBaseItemTypes)
+                item.IsSelected = false;
         }
+        finally { _suppressBuyRestrictionsUndo = false; }
 
-        _documentState.MarkDirty();
+        RecordBuyRestrictionsChange();
     }
 
     private void OnItemTypeCheckChanged(object? sender, RoutedEventArgs e)
     {
-        if (!_documentState.IsLoading)
-            _documentState.MarkDirty();
+        RecordBuyRestrictionsChange();
     }
 
     private void UpdateBuyRestrictions()

--- a/Fence/Fence/Views/MainWindow.Undo.cs
+++ b/Fence/Fence/Views/MainWindow.Undo.cs
@@ -1,0 +1,331 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using MerchantEditor.Commands;
+using MerchantEditor.ViewModels;
+using Radoub.UI.Undo;
+
+namespace MerchantEditor.Views;
+
+/// <summary>
+/// Undo/redo wiring for Fence (#2255 / epic #2231). Mirrors Relique's blueprint-editor pattern: a
+/// per-document <see cref="UndoRedoManager"/>, menu enablement refreshed on StateChanged, and
+/// Ctrl+Z/Y dispatched from <see cref="OnWindowKeyDown"/> with no TextBox-focus guard (document-level
+/// undo). Unlike Relique, Fence's store-property controls are NOT bound to a ViewModel — the control's
+/// own value is the live source of truth (the UTM model is rebuilt from the UI at save time, see
+/// <c>UpdateStoreFromUI</c>). So the field/flag undo setters drive the control directly. Inventory and
+/// variable add/remove route through <see cref="IUndoableCommand"/> instances on their collections.
+/// </summary>
+public partial class MainWindow
+{
+    private readonly UndoRedoManager _undo = new();
+    private bool _undoWired;
+
+    /// <summary>Connect the undo manager to menu refresh + dirty marking and wire each field once.</summary>
+    private void WireUndo()
+    {
+        if (_undoWired) return;
+        _undoWired = true;
+
+        _undo.StateChanged += (_, _) => RefreshUndoMenu();
+        // Command-based edits flow through the manager; mark dirty on undo state changes too so the
+        // title bar reflects undo/redo.
+        _undo.StateChanged += (_, _) => MarkDirtyFromUndo();
+        RefreshUndoMenu();
+
+        // Whole-field undo for the plain text fields (#2231). Getter/setter read & write the control
+        // directly because the control is the source of truth (no bound VM in Fence).
+        WireFieldUndo(StoreNameBox, "edit name");
+        WireFieldUndo(StoreTagBox, "edit tag");
+        WireFieldUndo(SellMarkupBox, "edit sell markup");
+        WireFieldUndo(BuyMarkdownBox, "edit buy markdown");
+        WireFieldUndo(IdentifyPriceBox, "edit identify price");
+        WireFieldUndo(OnOpenStoreBox, "edit OnOpenStore");
+        WireFieldUndo(OnStoreClosedBox, "edit OnStoreClosed");
+        WireFieldUndo(MaxBuyPriceBox, "edit max buy price");
+        WireFieldUndo(StoreGoldBox, "edit store gold");
+        WireFieldUndo(BlackMarketMarkdownBox, "edit black-market markdown");
+        WireFieldUndo(CommentBox, "edit comment");
+
+        // Flag checkboxes (#2231).
+        WireFlagUndo(BlackMarketCheck, "toggle Buy Stolen Goods");
+        WireFlagUndo(MaxBuyPriceCheck, "toggle Max Buy Price");
+        WireFlagUndo(LimitedGoldCheck, "toggle Limited Gold");
+    }
+
+    /// <summary>Mark dirty from an undo/redo state change. MarkDirty is guarded against load/read-only
+    /// and a null file path, so this is a no-op for the unsaved-no-file case.</summary>
+    private void MarkDirtyFromUndo() => _documentState.MarkDirty();
+
+    /// <summary>
+    /// Record and apply a programmatic change to a wired text field (e.g. script browse/clear) as one
+    /// undo step. Used where code sets a TextBox's value directly rather than the user typing — those
+    /// paths bypass the focus-based field recording, so they push their own command. If the field has a
+    /// pending focused edit, commit it first so the programmatic change records from the live value.
+    /// </summary>
+    private void RecordProgrammaticFieldEdit(TextBox? box, string newValue, string label)
+    {
+        if (box == null) return;
+        CommitFocusedFieldEdit();
+
+        var oldValue = box.Text ?? string.Empty;
+        if (oldValue == newValue)
+        {
+            box.Text = newValue; // keep UI consistent even when unchanged
+            return;
+        }
+
+        _undo.Execute(new RecordedFieldEditCommand<string>(oldValue, newValue,
+            v => box.Text = v, label));
+
+        // Keep the focus baseline aligned if this box is the active edit, so a later focus-loss
+        // doesn't record the programmatic change a second time.
+        if (_activeFieldEdit == box) _activeFieldBaseline = newValue;
+    }
+
+    private void OnUndoClick(object? sender, RoutedEventArgs e) => _undo.Undo();
+
+    private void OnRedoClick(object? sender, RoutedEventArgs e) => _undo.Redo();
+
+    // --- Whole-field text undo (#2231) ---
+    //
+    // A text field becomes one undo step on focus-loss/Enter: snapshot the value on GotFocus, and on
+    // LostFocus record a RecordedFieldEditCommand reverting the whole value if it changed. We read the
+    // TextBox's live Text as both baseline and new value, so binding/UpdateSource timing is irrelevant.
+
+    /// <summary>The field whose edit is currently in progress (focused), or null.</summary>
+    private TextBox? _activeFieldEdit;
+    private string _activeFieldBaseline = string.Empty;
+    private TextBox? _activeFieldBox;
+    private string _activeFieldLabel = string.Empty;
+
+    /// <summary>
+    /// Wire a plain TextBox for whole-field undo. The control is the source of truth, so undo/redo
+    /// drives its <c>Text</c> directly; the existing TextChanged → MarkDirty handler keeps the dirty
+    /// flag in step. Undo runs only on focus-loss/Enter, so driving Text while unfocused never
+    /// re-records.
+    /// </summary>
+    private void WireFieldUndo(TextBox? box, string label)
+    {
+        if (box == null) return;
+
+        box.GotFocus += (_, _) =>
+        {
+            _activeFieldEdit = box;
+            _activeFieldBaseline = box.Text ?? string.Empty;
+            _activeFieldBox = box;
+            _activeFieldLabel = label;
+        };
+        box.LostFocus += (_, _) => CommitFieldEdit(box);
+        box.KeyDown += (_, e) =>
+        {
+            if (e.Key == Key.Enter) CommitFieldEdit(box);
+        };
+    }
+
+    /// <summary>Record the focused field's edit (if any) as a single undo step. Used by the Ctrl+Z
+    /// path so an in-progress text edit lands on the stack before the undo runs.</summary>
+    private void CommitFocusedFieldEdit()
+    {
+        if (_activeFieldEdit != null) CommitFieldEdit(_activeFieldEdit);
+    }
+
+    private void CommitFieldEdit(TextBox box)
+    {
+        if (_activeFieldEdit != box || _activeFieldBox == null) return;
+
+        var newValue = box.Text ?? string.Empty;
+        var baseline = _activeFieldBaseline;
+        var target = _activeFieldBox;
+        var label = _activeFieldLabel;
+
+        // Clear active state first so re-entrancy (setter → focus changes) can't double-record.
+        _activeFieldEdit = null;
+        _activeFieldBox = null;
+
+        if (newValue == baseline) return; // no change → nothing to record
+
+        // Setter drives the control directly (the control is the model). Do() re-applies newValue
+        // (idempotent, correct redo); Undo restores the whole baseline value.
+        _undo.Execute(new RecordedFieldEditCommand<string>(baseline, newValue,
+            v => target.Text = v, label));
+
+        // Re-arm the baseline so a further edit in the same focus session records from here.
+        if (box.IsFocused)
+        {
+            _activeFieldEdit = box;
+            _activeFieldBaseline = newValue;
+            _activeFieldBox = box;
+            _activeFieldLabel = label;
+        }
+    }
+
+    // --- Inline ResRef grid-cell edit undo (#2255) ---
+
+    private StoreItemViewModel? _editingResRefItem;
+    private string _editingResRefBaseline = string.Empty;
+
+    /// <summary>Capture the editable cell's baseline value before the user edits it, so CellEditEnding
+    /// can record the whole-value change. Only the ResRef column is editable.</summary>
+    private void OnStoreCellPreparingForEdit(object? sender, DataGridPreparingCellForEditEventArgs e)
+    {
+        if (e.Row?.DataContext is StoreItemViewModel item)
+        {
+            _editingResRefItem = item;
+            _editingResRefBaseline = item.ResRef ?? string.Empty;
+        }
+    }
+
+    /// <summary>Record the inline ResRef edit as one undo step once the cell commits. The grid's TwoWay
+    /// binding has already written the new value to the item, so SetResRefCommand.Do() re-applies it
+    /// (idempotent) and Undo restores the baseline.</summary>
+    private void OnStoreCellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)
+    {
+        if (e.EditAction != DataGridEditAction.Commit) { _editingResRefItem = null; return; }
+        if (_editingResRefItem == null) return;
+
+        var item = _editingResRefItem;
+        var baseline = _editingResRefBaseline;
+        _editingResRefItem = null;
+
+        // The edited TextBox value is the source; read it so we record even before the binding flushes.
+        var newValue = (e.EditingElement as TextBox)?.Text ?? item.ResRef ?? string.Empty;
+        if (newValue == baseline) return;
+
+        _undo.Execute(new SetResRefCommand(item, baseline, newValue));
+    }
+
+    /// <summary>True while undo/redo drives a flag setter, so the resulting IsCheckedChanged is not
+    /// re-recorded as a new command (#2231).</summary>
+    private bool _suppressFlagUndo;
+
+    /// <summary>
+    /// Wire a flag CheckBox for undo. Track the checkbox's own last-known state as the undo baseline
+    /// and drive <c>IsChecked</c> directly on undo/redo. The existing IsCheckedChanged → MarkDirty
+    /// handler keeps the dirty flag in step.
+    /// </summary>
+    private void WireFlagUndo(CheckBox? box, string label)
+    {
+        if (box == null) return;
+
+        bool baseline = box.IsChecked == true;
+
+        box.IsCheckedChanged += (_, _) =>
+        {
+            bool current = box.IsChecked == true;
+
+            if (_documentState.IsLoading || _suppressFlagUndo)
+            {
+                baseline = current; // keep baseline aligned with programmatic/load-time changes
+                return;
+            }
+            if (current == baseline) return; // no real change
+
+            var oldValue = baseline;
+            baseline = current;
+
+            _undo.Execute(new RecordedFieldEditCommand<bool>(oldValue, current, v =>
+            {
+                _suppressFlagUndo = true;
+                try
+                {
+                    box.IsChecked = v;
+                    baseline = v;
+                }
+                finally { _suppressFlagUndo = false; }
+            }, label));
+        };
+    }
+
+    // --- Buy restrictions undo (#2255) ---
+    //
+    // Buy restrictions are interrelated (mode + selected item-type set), so undo treats the whole
+    // state as one unit (BuyRestrictionsSnapshot). The host tracks the last-committed snapshot; each
+    // buy-restriction handler calls RecordBuyRestrictionsChange after mutating, which records a
+    // Relay command restoring the prior snapshot and reapplying the new one.
+
+    /// <summary>The buy-restrictions state as of the last recorded change (undo baseline).</summary>
+    private BuyRestrictionsSnapshot? _lastBuyRestrictions;
+
+    /// <summary>True while undo/redo reapplies a buy-restrictions snapshot, so the resulting
+    /// radio/checkbox events don't record a new command.</summary>
+    private bool _suppressBuyRestrictionsUndo;
+
+    /// <summary>Read the current buy mode from the radio buttons.</summary>
+    private BuyMode CurrentBuyMode()
+    {
+        if (WillOnlyBuyRadio.IsChecked == true) return BuyMode.WillOnlyBuy;
+        if (WillNotBuyRadio.IsChecked == true) return BuyMode.WillNotBuy;
+        return BuyMode.All;
+    }
+
+    /// <summary>Capture the current buy-restrictions state as the baseline (called after load so the
+    /// first user change records against the loaded state, not an empty one).</summary>
+    private void ResetBuyRestrictionsBaseline()
+        => _lastBuyRestrictions = BuyRestrictionsSnapshot.Capture(CurrentBuyMode(), SelectableBaseItemTypes);
+
+    /// <summary>Drive the radio buttons to match a snapshot's mode (used on undo/redo apply).</summary>
+    private void ApplyBuyMode(BuyMode mode)
+    {
+        BuyAllRadio.IsChecked = mode == BuyMode.All;
+        WillOnlyBuyRadio.IsChecked = mode == BuyMode.WillOnlyBuy;
+        WillNotBuyRadio.IsChecked = mode == BuyMode.WillNotBuy;
+    }
+
+    /// <summary>
+    /// Record a buy-restrictions change as one undo step. The mutation has already been applied to the
+    /// controls/VMs; this captures the new state, records a Relay command (undo restores the prior
+    /// snapshot, do reapplies the new one), and advances the baseline. Suppressed while loading or
+    /// while undo/redo is itself reapplying a snapshot.
+    /// </summary>
+    private void RecordBuyRestrictionsChange()
+    {
+        if (_documentState.IsLoading || _suppressBuyRestrictionsUndo) return;
+
+        var before = _lastBuyRestrictions;
+        var after = BuyRestrictionsSnapshot.Capture(CurrentBuyMode(), SelectableBaseItemTypes);
+        if (before != null && before.Equals(after)) return; // no real change
+
+        _lastBuyRestrictions = after;
+
+        _undo.Execute(new RelayUndoableCommand(
+            () => { ApplyBuyRestrictionsSnapshot(after); },
+            () => { if (before != null) ApplyBuyRestrictionsSnapshot(before); },
+            "change buy restrictions"));
+    }
+
+    private void ApplyBuyRestrictionsSnapshot(BuyRestrictionsSnapshot snapshot)
+    {
+        _suppressBuyRestrictionsUndo = true;
+        try
+        {
+            ApplyBuyMode(snapshot.Mode);
+            snapshot.ApplyTo(SelectableBaseItemTypes);
+            _lastBuyRestrictions = snapshot;
+        }
+        finally { _suppressBuyRestrictionsUndo = false; }
+    }
+
+    /// <summary>
+    /// Sync the Edit-menu Undo/Redo items to the manager state — enablement plus the
+    /// "_Undo {description}" hint. InputGesture on a MenuItem only renders hint text in Avalonia;
+    /// the actual accelerator is dispatched from <see cref="OnWindowKeyDown"/>.
+    /// </summary>
+    private void RefreshUndoMenu()
+    {
+        var undoItem = this.FindControl<MenuItem>("UndoMenuItem");
+        if (undoItem != null)
+        {
+            undoItem.IsEnabled = _undo.CanUndo;
+            undoItem.Header = _undo.CanUndo ? $"_Undo {_undo.UndoDescription}" : "_Undo";
+        }
+
+        var redoItem = this.FindControl<MenuItem>("RedoMenuItem");
+        if (redoItem != null)
+        {
+            redoItem.IsEnabled = _undo.CanRedo;
+            redoItem.Header = _undo.CanRedo ? $"_Redo {_undo.RedoDescription}" : "_Redo";
+        }
+    }
+}

--- a/Fence/Fence/Views/MainWindow.Variables.cs
+++ b/Fence/Fence/Views/MainWindow.Variables.cs
@@ -1,3 +1,4 @@
+using MerchantEditor.Commands;
 using MerchantEditor.ViewModels;
 using Radoub.Formats.Logging;
 using Radoub.UI.Controls;
@@ -107,11 +108,10 @@ public partial class MainWindow
             Name = VariableViewModel.NextDefaultName(Variables.Select(v => v.Name)),
             Type = Radoub.Formats.Gff.VariableType.Int
         };
-        Variables.Add(newVar); // panel auto-validates via CollectionChanged
+        // Route through undo so the add is reversible as one step (#2255).
+        _undo.Execute(new AddVariableCommand(Variables, newVar)); // panel auto-validates via CollectionChanged
         VariablesPanelControl.SelectedVariable = newVar;
         VariablesPanelControl.FocusSelectedName(); // land in the name field
-
-        _documentState.MarkDirty();
 
         UnifiedLogger.LogApplication(LogLevel.INFO, "Added new variable (awaiting name)");
     }
@@ -120,10 +120,8 @@ public partial class MainWindow
     {
         if (e.Variables.Count == 0) return;
 
-        foreach (var item in e.Variables)
-            Variables.Remove(item);
-
-        _documentState.MarkDirty();
+        // Route through undo so the removal is reversible as one step (#2255).
+        _undo.Execute(new RemoveVariablesCommand(Variables, e.Variables));
 
         UnifiedLogger.LogApplication(LogLevel.INFO, $"Removed {e.Variables.Count} variable(s)");
     }

--- a/Fence/Fence/Views/MainWindow.axaml
+++ b/Fence/Fence/Views/MainWindow.axaml
@@ -57,8 +57,8 @@
                 <MenuItem Header="E_xit" Click="OnExitClick" InputGesture="Alt+F4"/>
             </MenuItem>
             <MenuItem Header="_Edit">
-                <MenuItem Header="_Undo" InputGesture="Ctrl+Z" IsEnabled="False" ToolTip.Tip="Not yet implemented"/>
-                <MenuItem Header="_Redo" InputGesture="Ctrl+Y" IsEnabled="False" ToolTip.Tip="Not yet implemented"/>
+                <MenuItem x:Name="UndoMenuItem" Header="_Undo" InputGesture="Ctrl+Z" IsEnabled="False" Click="OnUndoClick"/>
+                <MenuItem x:Name="RedoMenuItem" Header="_Redo" InputGesture="Ctrl+Y" IsEnabled="False" Click="OnRedoClick"/>
                 <Separator/>
                 <MenuItem Header="_Delete Selected" Click="OnDeleteClick" InputGesture="Delete" IsEnabled="{Binding HasSelection, ElementName=MainWindowInstance}"/>
                 <Separator/>
@@ -364,6 +364,8 @@
                                   SelectionMode="Extended"
                                   GridLinesVisibility="Horizontal"
                                   SelectionChanged="OnStoreInventorySelectionChanged"
+                                  PreparingCellForEdit="OnStoreCellPreparingForEdit"
+                                  CellEditEnding="OnStoreCellEditEnding"
                                   AutomationProperties.AutomationId="StoreInventoryGrid">
                             <DataGrid.ContextMenu>
                                 <ContextMenu>

--- a/Fence/Fence/Views/MainWindow.axaml.cs
+++ b/Fence/Fence/Views/MainWindow.axaml.cs
@@ -135,6 +135,10 @@ public partial class MainWindow : Window, INotifyPropertyChanged
         // Wire up store property change tracking for dirty flag (#1536)
         WireUpStorePropertyTracking();
 
+        // Wire up undo/redo (#2255 / epic #2231) — must follow property tracking so the field
+        // handlers (GotFocus/LostFocus) sit alongside the existing TextChanged dirty handlers.
+        WireUndo();
+
         // Track property changes on store items for dirty state and validation
         StoreItems.CollectionChanged += OnStoreItemsCollectionChanged;
 
@@ -575,6 +579,9 @@ public partial class MainWindow : Window, INotifyPropertyChanged
             // No restrictions
             BuyAllRadio.IsChecked = true;
         }
+
+        // Reset the undo baseline so the first user change records against this loaded state (#2255).
+        ResetBuyRestrictionsBaseline();
     }
 
     #endregion
@@ -949,6 +956,20 @@ public partial class MainWindow : Window, INotifyPropertyChanged
         {
             switch (e.Key)
             {
+                case Key.Z:
+                    // Document/whole-field undo (#2231): Fence is a blueprint editor, so Ctrl+Z
+                    // always undoes at the document level — even with a text field focused. Text
+                    // edits are recorded as whole-field commands on focus-loss (see WireFieldUndo),
+                    // so we deliberately do NOT defer to the TextBox's native per-character undo.
+                    // Commit any pending text edit first so it lands on the stack before we undo it.
+                    CommitFocusedFieldEdit();
+                    OnUndoClick(null, e);
+                    e.Handled = true;
+                    return;
+                case Key.Y:
+                    OnRedoClick(null, e);
+                    e.Handled = true;
+                    return;
                 case Key.N:
                     OnNewClick(null, e);
                     e.Handled = true;

--- a/Radoub.IntegrationTests/Fence/MenuShortcutSmokeTests.cs
+++ b/Radoub.IntegrationTests/Fence/MenuShortcutSmokeTests.cs
@@ -5,8 +5,9 @@ namespace Radoub.IntegrationTests.Fence;
 
 /// <summary>
 /// Menu / keyboard-shortcut wiring smoke tests (#2362, epic #2359).
-/// Fence's Edit-menu Undo/Redo are currently disabled stubs (caught at build time by the
-/// Tier-A dead-stub lint); when #2231 wires them, add an enabled-state assertion here.
+/// Fence's Edit-menu Undo/Redo are wired to the shared UndoRedoManager (#2255 / epic #2231);
+/// they start disabled with no edit history. <see cref="EditMenu_HasUndoRedo_DisabledAtLaunch"/>
+/// asserts the wired-but-empty state.
 /// </summary>
 [Collection("FenceSequential")]
 public class MenuShortcutSmokeTests : FenceTestBase
@@ -41,6 +42,27 @@ public class MenuShortcutSmokeTests : FenceTestBase
 
         Assert.NotNull(FindMenuItemOnDesktop("Find..."));
         Assert.NotNull(FindMenuItemOnDesktop("Replace..."));
+
+        SendEscape();
+    }
+
+    [Fact]
+    [Trait("Category", "MenuSmoke")]
+    public void EditMenu_HasUndoRedo_DisabledAtLaunch()
+    {
+        Launch();
+
+        ClickMenu("Edit");
+        Thread.Sleep(300);
+
+        // Undo/Redo are now wired (#2255), not dead stubs — they exist but start disabled because
+        // a freshly launched app has no edit history.
+        var undo = FindMenuItemOnDesktop("Undo");
+        var redo = FindMenuItemOnDesktop("Redo");
+        Assert.NotNull(undo);
+        Assert.NotNull(redo);
+        Assert.False(undo!.Properties.IsEnabled.Value, "Undo should be disabled with no edit history");
+        Assert.False(redo!.Properties.IsEnabled.Value, "Redo should be disabled with no edit history");
 
         SendEscape();
     }


### PR DESCRIPTION
## Summary

Closes out the final open item in Sprint #2383: **Undo/Redo wiring in Fence** per Epic #2231. The sprint's other items already shipped in PR #2410 / Fence 0.1.39-alpha (save-on-close race, palette cache disposal leak, file-browser refresh, ItemDetails refactor, Manifest undo + atomic save).

## What changed

Document-level Undo/Redo across **all** editable fields, replacing the disabled "Not yet implemented" menu stubs:

- Store properties (name, tag, prices, scripts, comment) — whole-field undo on focus-loss/Enter
- Flags (Buy Stolen, Max Buy Price, Limited Gold)
- Script browse/clear
- Inventory add/remove (batch = one step, restores positions)
- Infinite toggle (cell, set/clear, set-all)
- Inline ResRef grid edits
- Local variables add/remove
- Buy restrictions (mode + checkboxes) via whole-state snapshot

Ctrl+Z/Y are document-level (no TextBox-focus guard), commit pending field edits first, and undo history clears on open/new/close. Built on the shared `Radoub.UI.Undo` types (`UndoRedoManager`, `RecordedFieldEditCommand<T>`, `RelayUndoableCommand`) plus Fence command classes under `Fence/Commands/`.

## Tests

- 27 new command unit tests (`FenceUndoCommandTests`)
- Fence unit: 164 passed, 0 failed
- Fence FlaUI: 6 passed, 0 failed (new `EditMenu_HasUndoRedo_DisabledAtLaunch` smoke test)
- Radoub.UI undo: 38 passed
- Privacy scan: pass · Tech debt: MainWindow.axaml.cs 960 lines (warning range, pre-existing)

## Related Issues

- Closes #2255 (remaining Undo/Redo part)
- Closes #2383 (sprint)
- Relates to #2231 (Undo epic)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)