### PR TITLE
[Quartermaster] Fix: Dire tiger texture holes (16-char ResRef truncation) (#2029)

### DIFF
--- a/.claude/scripts/Dump-MdlMeshes.ps1
+++ b/.claude/scripts/Dump-MdlMeshes.ps1
@@ -1,0 +1,80 @@
+# Evidence dump for #2029: list every mesh in a creature MDL with the exact fields the
+# MeshSkipHeuristic uses (skin vs trimesh, vertex count, Bitmap, Render), and replay the
+# heuristic to show which meshes get SKIPPED and WHY. Read-only diagnostic.
+#
+# PS7 ONLY. Configures module HAKs (LNS_DLG) so CEP models resolve the same way QM does.
+#   & "C:\Program Files\PowerShell\7\pwsh.exe" -NoProfile -ExecutionPolicy Bypass `
+#       -File ".claude/scripts/Dump-MdlMeshes.ps1" -Model c_cat_dire
+
+param(
+    [Parameter(Mandatory = $true)] [string] $Model,
+    [string] $ModuleDir = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Neverwinter Nights\modules\LNS_DLG'),
+    [int] $TinyThreshold = 30
+)
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+$dll = Join-Path $repoRoot 'Radoub.Formats\Radoub.Formats\bin\Debug\net9.0\Radoub.Formats.dll'
+Add-Type -Path $dll
+
+$gameData = [Radoub.Formats.Services.GameDataService]::new()
+if (-not $gameData.IsConfigured) { throw "GameDataService not configured." }
+# Mirror QM: load the module's HAK list so CEP MDLs resolve.
+$gameData.ConfigureModuleHaks($ModuleDir)
+
+$MDL = [Radoub.Formats.Common.ResourceTypes]::Mdl
+$bytes = $gameData.FindResource($Model.ToLowerInvariant(), $MDL)
+if ($null -eq $bytes) { throw "MDL '$Model' not found in base/HAK resources." }
+"Resolved $Model.mdl: $($bytes.Length) bytes"
+
+$reader = [Radoub.Formats.Mdl.MdlReader]::new()
+$mdl = $reader.Parse($bytes)
+$meshes = @($mdl.GetMeshNodes())
+"Model.Name = '$($mdl.Name)'   mesh nodes = $($meshes.Count)`n"
+
+# Recompute hasSkins + skinBitmaps exactly like ModelPreviewGLControl.
+$skinType = 'Radoub.Formats.Mdl.MdlSkinNode'
+$hasSkins = $false
+$skinBitmaps = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+foreach ($m in $meshes) {
+    $isSkin = $m.GetType().FullName -eq $skinType
+    if ($isSkin -and $m.Render -and $m.Vertices.Length -gt 0) {
+        $hasSkins = $true
+        if (-not [string]::IsNullOrEmpty($m.Bitmap) -and $m.Bitmap.ToLowerInvariant() -ne 'null') {
+            [void]$skinBitmaps.Add($m.Bitmap)
+        }
+    }
+}
+"hasSkins = $hasSkins"
+"skinBitmaps = { $([string]::Join(', ', $skinBitmaps)) }`n"
+
+"{0,-3} {1,-22} {2,-9} {3,6} {4,-6} {5,-18} {6}" -f '#','Name','Type','Verts','Render','Bitmap','DECISION'
+"{0,-3} {1,-22} {2,-9} {3,6} {4,-6} {5,-18} {6}" -f '---','----','----','-----','------','------','--------'
+$skipped = 0; $shown = 0; $i = 0
+foreach ($m in $meshes) {
+    $i++
+    $isSkin = $m.GetType().FullName -eq $skinType
+    $type = if ($isSkin) { 'skin' } else { 'trimesh' }
+    $vc = $m.Vertices.Length
+    $bmp = $m.Bitmap
+
+    $decision = ''
+    if (-not $m.Render) { $decision = 'HIDE (Render=false)'; $skipped++ }
+    elseif ($vc -eq 0 -or $m.Faces.Length -eq 0) { $decision = 'HIDE (empty)'; $skipped++ }
+    else {
+        # Replay MeshSkipHeuristic.ShouldSkipTrimesh
+        $skip = $false
+        if ($hasSkins -and (-not $isSkin) -and ($vc -lt $TinyThreshold)) {
+            $hasUnique = (-not [string]::IsNullOrEmpty($bmp)) -and ($bmp.ToLowerInvariant() -ne 'null') -and (-not $skinBitmaps.Contains($bmp))
+            $skip = -not $hasUnique
+        }
+        if ($skip) {
+            $why = if ([string]::IsNullOrEmpty($bmp)) { 'empty bitmap' }
+                   elseif ($bmp.ToLowerInvariant() -eq 'null') { 'null bitmap' }
+                   else { "shares skin bmp '$bmp'" }
+            $decision = "SKIP tiny trimesh ($why)"; $skipped++
+        } else { $decision = 'render'; $shown++ }
+    }
+    "{0,-3} {1,-22} {2,-9} {3,6} {4,-6} {5,-18} {6}" -f $i, $m.Name, $type, $vc, $m.Render, $bmp, $decision
+}
+""
+"SUMMARY: $($meshes.Count) meshes  |  rendered=$shown  skipped=$skipped"

--- a/.claude/scripts/Find-AppearanceRows.ps1
+++ b/.claude/scripts/Find-AppearanceRows.ps1
@@ -1,0 +1,29 @@
+# Search appearance.2da by keyword across LABEL + RACE (model prefix) columns to find the
+# #2029 problem-model rows. Read-only; prints candidate rows for manual selection.
+param(
+    [string[]] $Keywords = @('cat','tiger','lion','bear','wolf','blink','bat','snake','cobra','serpent','umber','hulk'),
+    [switch] $TrimeshOnly  # exclude part-based (MODELTYPE=P) which already work
+)
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+$dll = Join-Path $repoRoot 'Radoub.Formats\Radoub.Formats\bin\Debug\net9.0\Radoub.Formats.dll'
+Add-Type -Path $dll
+$gameData = [Radoub.Formats.Services.GameDataService]::new()
+$twoDA = $gameData.Get2DA('appearance')
+"RowCount = $($twoDA.RowCount)`n"
+foreach ($kw in $Keywords) {
+    $k = $kw.ToLowerInvariant()
+    $rows = @()
+    for ($i = 0; $i -lt $twoDA.RowCount; $i++) {
+        $label = ($twoDA.GetValue($i, 'LABEL') ?? '')
+        $race  = ($twoDA.GetValue($i, 'RACE')  ?? '')   # model resref prefix, e.g. c_cat_dire
+        $mtype = ($twoDA.GetValue($i, 'MODELTYPE') ?? '')
+        if ($TrimeshOnly -and $mtype.ToUpperInvariant() -eq 'P') { continue }
+        if ($label.ToLowerInvariant().Contains($k) -or $race.ToLowerInvariant().Contains($k)) {
+            $rows += "    [{0,5}] LABEL={1,-22} RACE(model)={2,-18} TYPE={3}" -f $i, $label, $race, $mtype
+        }
+    }
+    "=== '$kw' ($($rows.Count)) ==="
+    if ($rows.Count -eq 0) { "    (none)" } else { $rows | Select-Object -First 30 }
+    ""
+}

--- a/.claude/scripts/Inspect-AppearanceRow.ps1
+++ b/.claude/scripts/Inspect-AppearanceRow.ps1
@@ -1,0 +1,36 @@
+# Diagnostic: dump a range of appearance.2da rows + total row count + which columns exist,
+# to figure out why row 3439 (expected zcp_lionmale) is empty. Read-only.
+param(
+    [int] $Start = 3430,
+    [int] $End = 3450
+)
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+$dll = Join-Path $repoRoot 'Radoub.Formats\Radoub.Formats\bin\Debug\net9.0\Radoub.Formats.dll'
+Add-Type -Path $dll
+$gameData = [Radoub.Formats.Services.GameDataService]::new()
+$twoDA = $gameData.Get2DA('appearance')
+"RowCount = $($twoDA.RowCount)"
+"Columns  = $($twoDA.Columns -join ', ')"
+""
+"Rows $Start..$End  (idx | LABEL | RACE | STRING_REF | MODELTYPE):"
+for ($i = $Start; $i -le $End -and $i -lt $twoDA.RowCount; $i++) {
+    $label = $twoDA.GetValue($i, 'LABEL')
+    $race  = $twoDA.GetValue($i, 'RACE')
+    $str   = $twoDA.GetValue($i, 'STRING_REF')
+    $mt    = $twoDA.GetValue($i, 'MODELTYPE')
+    "  [{0,5}] '{1}' | RACE='{2}' | STRING_REF='{3}' | TYPE='{4}'" -f $i, $label, $race, $str, $mt
+}
+# How many rows have a non-empty RACE vs empty?
+$nonEmpty = 0; $empty = 0
+for ($i = 0; $i -lt $twoDA.RowCount; $i++) {
+    if ([string]::IsNullOrWhiteSpace($twoDA.GetValue($i,'RACE'))) { $empty++ } else { $nonEmpty++ }
+}
+""
+"RACE populated: $nonEmpty   empty/blank: $empty"
+# Highest populated row, to see if the 2DA is truncated before 3439.
+$maxPop = -1
+for ($i = 0; $i -lt $twoDA.RowCount; $i++) {
+    if (-not [string]::IsNullOrWhiteSpace($twoDA.GetValue($i,'RACE'))) { $maxPop = $i }
+}
+"Highest row with non-empty RACE = $maxPop"

--- a/.claude/scripts/New-Issue2029TestUtc.ps1
+++ b/.claude/scripts/New-Issue2029TestUtc.ps1
@@ -1,0 +1,74 @@
+# Generate the #2029 skin/trimesh problem-model test creatures for QM model-preview review.
+# Resolves each named CEP/base model by LABEL in the loaded appearance.2da (same source QM
+# uses, incl. CEP HAKs via RadoubSettings), clones Bucky.utc with that Appearance_Type, and
+# writes aN.utc into LNS_DLG. Overwrites existing a1..aN (continues the unpadded a-file scheme).
+#
+# PS7 ONLY (loads net9.0 Radoub.Formats.dll):
+#   & "C:\Program Files\PowerShell\7\pwsh.exe" -NoProfile -ExecutionPolicy Bypass `
+#       -File ".claude/scripts/New-Issue2029TestUtc.ps1"
+
+param(
+    [string] $ModuleDir = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Neverwinter Nights\modules\LNS_DLG'),
+    [string] $BaseUtc = 'Bucky.utc'
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+$dll = Join-Path $repoRoot 'Radoub.Formats\Radoub.Formats\bin\Debug\net9.0\Radoub.Formats.dll'
+if (-not (Test-Path $dll)) { throw "Radoub.Formats.dll not found at $dll - build Radoub.Formats first." }
+Add-Type -Path $dll
+
+$basePath = Join-Path $ModuleDir $BaseUtc
+if (-not (Test-Path $basePath)) { throw "Base UTC not found: $basePath" }
+
+# Load appearance.2da exactly as QM does.
+$gameData = [Radoub.Formats.Services.GameDataService]::new()
+if (-not $gameData.IsConfigured) { throw "GameDataService not configured - set game paths in a Radoub tool first." }
+$twoDA = $gameData.Get2DA('appearance')
+if ($null -eq $twoDA) { throw "Could not load appearance.2da." }
+
+# The #2029 problem set. Rows resolved from appearance.2da (RACE/model column) via
+# Find-AppearanceRows.ps1. The two CEP rows (zcp_lionmale) come straight from the issue.
+$wanted = @(
+    @{ File = 'a1'; Row = 95;   Model = 'c_cat_dire';   Desc = 'Dire tiger - BROKEN per issue (19/24 meshes skipped)' },
+    @{ File = 'a2'; Row = 97;   Model = 'c_cat_lion';   Desc = 'Lion - works (mane renders correctly)' },
+    @{ File = 'a3'; Row = 21;   Model = 'c_boar';       Desc = 'Boar - control (simple static model, should render fine)' },
+    @{ File = 'a4'; Row = 15;   Model = 'c_beardire';   Desc = 'Dire bear - improved' },
+    @{ File = 'a5'; Row = 175;  Model = 'c_direwolf';   Desc = 'Dire wolf - improved' },
+    @{ File = 'a6'; Row = 174;  Model = 'c_blinkdog';   Desc = 'Blinkdog - improved' },
+    @{ File = 'a7'; Row = 10;   Model = 'c_a_bat';      Desc = 'Bat - improved (wing textures, was gray)' },
+    @{ File = 'a8'; Row = 183;  Model = 'c_cobra01';    Desc = 'Cobra - skins only (fangs/tongue correctly skipped)' },
+    @{ File = 'a9'; Row = 168;  Model = 'c_umberhulk';  Desc = 'Umber hulk - needs investigation per issue' }
+)
+
+$results = @()
+foreach ($w in $wanted) {
+    $row = [uint16]$w.Row
+    # Verify the row still maps to the expected model in this install (guards 2DA drift / CEP).
+    $actualModel = $twoDA.GetValue([int]$w.Row, 'RACE')
+    $modelNote = if ($actualModel -and ($actualModel.ToLowerInvariant() -eq $w.Model.ToLowerInvariant())) {
+        $w.Model
+    } else {
+        "$($w.Model) (2DA row $($w.Row) actually = '$actualModel')"
+    }
+
+    $utc = [Radoub.Formats.Utc.UtcReader]::Read($basePath)
+    $utc.AppearanceType = $row
+    $utc.TemplateResRef = $w.File
+    $utc.Tag = $w.File
+    $loc = New-Object Radoub.Formats.Gff.CExoLocString
+    $loc.SetString(0, "$($w.File): $($w.Desc) [row $($w.Row), $($w.Model)]")
+    $utc.FirstName = $loc
+
+    $outPath = Join-Path $ModuleDir ($w.File + '.utc')
+    [Radoub.Formats.Utc.UtcWriter]::Write($utc, $outPath)
+    $check = [Radoub.Formats.Utc.UtcReader]::Read($outPath)
+    if ($check.AppearanceType -ne $row) { throw "Round-trip failed for $($w.File) - expected $row, got $($check.AppearanceType)" }
+
+    Write-Host ("OK   {0,-4} row={1,-5} {2}  <- {3}" -f $w.File, $w.Row, $w.Desc, $modelNote) -ForegroundColor Green
+    $results += [pscustomobject]@{ File = $w.File; Row = $w.Row; Model = $modelNote; Desc = $w.Desc }
+}
+
+Write-Host ""
+Write-Host "=== Summary (#2029 model-preview test creatures) ==="
+$results | Format-Table -AutoSize File, Row, Model, Desc

--- a/.claude/scripts/Read-AppearanceUtc.ps1
+++ b/.claude/scripts/Read-AppearanceUtc.ps1
@@ -1,0 +1,12 @@
+# Quick dump of Appearance_Type + Tag for existing aN.utc test files (#2029 verification).
+param(
+    [string] $ModuleDir = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Neverwinter Nights\modules\LNS_DLG')
+)
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+$dll = Join-Path $repoRoot 'Radoub.Formats\Radoub.Formats\bin\Debug\net9.0\Radoub.Formats.dll'
+Add-Type -Path $dll
+Get-ChildItem -Path $ModuleDir -Filter 'a*.utc' | Sort-Object Name | ForEach-Object {
+    $utc = [Radoub.Formats.Utc.UtcReader]::Read($_.FullName)
+    "{0,-12} Appearance_Type={1,-5} Tag={2}" -f $_.Name, $utc.AppearanceType, $utc.Tag
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.Formats 0.2.71-alpha] - 2026-06-18
+**Branch**: `quartermaster/issue-2029` | **PR**: #2506
+
+### Fix: Truncate ResRefs to 16 chars at resource lookup (#2029)
+
+- `GameResourceResolver` now caps lookup ResRefs at Aurora's 16-char limit, matching the engine. Resources referenced by a >16-char name (e.g. CEP dire tiger's `N_Tiger_LaoHu02_D` texture, stored truncated as `N_Tiger_LaoHu02_`) now resolve instead of falling back to a wrong texture. Fixes the dire-tiger "holes" in the Quartermaster model preview.
+
+---
+
 ## [Radoub.UI 0.2.13-alpha] - 2026-06-18
 **Branch**: `radoub/issue-1995` | **PR**: #2503
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.14-alpha] - 2026-06-19
+**Branch**: `quartermaster/issue-2029` | **PR**: #2506
+
+### Fix: Model preview "base-game textures" false warning (#2029)
+
+- The "Preview may be inaccurate — using base-game textures" warning no longer fires falsely. The preview now collects textures only from rendered meshes (skipping `Render=false` bone/internal meshes whose stub bitmaps a visible surface never uses) and computes the warning in a single deterministic pass over the rendered set — fixing both the false positive (e.g. the CEP boar) and the intermittent flicker across reloads (the old check skipped already-cached textures).
+
+---
+
 ## [Radoub.UI 0.2.13-alpha] - 2026-06-18
 **Branch**: `radoub/issue-1995` | **PR**: #2503
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.124-alpha] - 2026-06-18
-**Branch**: `quartermaster/issue-2029` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2029` | **PR**: #2506
 
 ### Fix: Skin mesh rendering strategy refinement (#2029)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -11,6 +11,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ### Fix: Dire tiger model-preview holes (#2029)
 
 - The dire tiger (and other CEP creatures with >16-char texture references) now render textured correctly in the appearance preview. Root cause and fix are a shared-library ResRef-truncation change — see the root CHANGELOG (`Radoub.Formats 0.2.71-alpha`).
+- Appearance preview no longer shows the misleading "N of M meshes hidden (Render=false)" status — those are the model author's intentional bone/internal meshes, normal for nearly every creature.
 
 ---
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -8,9 +8,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ## [0.2.124-alpha] - 2026-06-18
 **Branch**: `quartermaster/issue-2029` | **PR**: #2506
 
-### Fix: Skin mesh rendering strategy refinement (#2029)
+### Fix: Dire tiger model-preview holes (#2029)
 
-- Refine the model-preview mesh-visibility and texture-resolution strategy so CEP creatures render correctly (dire tiger holes, umber hulk exploded geometry, grey-instead-of-textured models, over-aggressive trimesh hiding).
+- The dire tiger (and other CEP creatures with >16-char texture references) now render textured correctly in the appearance preview. Root cause and fix are a shared-library ResRef-truncation change — see the root CHANGELOG (`Radoub.Formats 0.2.71-alpha`).
 
 ---
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.124-alpha] - 2026-06-18
+**Branch**: `quartermaster/issue-2029` | **PR**: #TBD
+
+### Fix: Skin mesh rendering strategy refinement (#2029)
+
+- Refine the model-preview mesh-visibility and texture-resolution strategy so CEP creatures render correctly (dire tiger holes, umber hulk exploded geometry, grey-instead-of-textured models, over-aggressive trimesh hiding).
+
+---
+
 ## [0.2.123-alpha] - 2026-06-18
 **Branch**: `quartermaster/issue-1485` | **PR**: #2502
 

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
@@ -677,11 +677,14 @@ public partial class AppearancePanel
             return;
         }
 
+        // Only surface conditions caused by OUR preview heuristics. Meshes flagged
+        // Render=false in the MDL are bone-visualization/internal geometry the model
+        // author intentionally hid — that is the normal Aurora convention for nearly
+        // every creature, so reporting it as a status line reads as a false alarm
+        // (e.g. boar/dire tiger "19 of 24 hidden" when nothing is wrong). (#2029)
         var parts = new List<string>();
         if (info.SkippedTrimeshCount > 0)
             parts.Add($"{info.SkippedTrimeshCount} tiny trimeshes filtered");
-        if (info.HiddenMeshCount > 0)
-            parts.Add($"{info.HiddenMeshCount} of {info.TotalMeshes} meshes hidden (Render=false)");
 
         if (parts.Count > 0)
         {

--- a/Radoub.Formats/Radoub.Formats.Tests/GameResourceResolverTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/GameResourceResolverTests.cs
@@ -389,6 +389,47 @@ public class GameResourceResolverTests : IDisposable
 
     #endregion
 
+    #region ResRef Truncation Tests (#2029)
+
+    [Fact]
+    public void FindResource_ResRefLongerThan16Chars_ResolvesToTruncatedResource()
+    {
+        // Aurora caps ResRefs at 16 chars. A model can reference a 17-char texture
+        // (e.g. CEP dire tiger's "N_Tiger_LaoHu02_D"), but the stored resource is the
+        // 16-char-truncated "N_Tiger_LaoHu02_". Aurora truncates the lookup too, so it
+        // matches. The resolver must do the same. (#2029)
+        var testContent = new byte[] { 0xAA, 0xBB, 0xCC };
+        // Stored file uses the 16-char truncated name (what Aurora actually writes).
+        File.WriteAllBytes(Path.Combine(_overrideDir, "n_tiger_laohu02_.tga"), testContent);
+
+        var config = new GameResourceConfig { OverridePath = _overrideDir };
+        using var resolver = new GameResourceResolver(config);
+
+        // Look up with the full 17-char reference the MDL carries.
+        var result = resolver.FindResource("n_tiger_laohu02_d", ResourceTypes.Tga);
+
+        Assert.NotNull(result);
+        Assert.Equal(testContent, result);
+    }
+
+    [Fact]
+    public void FindResource_ResRefExactly16Chars_StillResolves()
+    {
+        // Guard: the truncation must not break normal <=16-char lookups.
+        var testContent = new byte[] { 0x11, 0x22 };
+        File.WriteAllBytes(Path.Combine(_overrideDir, "sixteen_char_nam.tga"), testContent);
+
+        var config = new GameResourceConfig { OverridePath = _overrideDir };
+        using var resolver = new GameResourceResolver(config);
+
+        var result = resolver.FindResource("sixteen_char_nam", ResourceTypes.Tga);
+
+        Assert.NotNull(result);
+        Assert.Equal(testContent, result);
+    }
+
+    #endregion
+
     #region Deduplication Tests
 
     [Fact]

--- a/Radoub.Formats/Radoub.Formats/Resolver/GameResourceResolver.cs
+++ b/Radoub.Formats/Radoub.Formats/Resolver/GameResourceResolver.cs
@@ -73,6 +73,8 @@ public class GameResourceResolver : IDisposable
     /// </summary>
     public byte[]? FindBaseResource(string resRef, ushort resourceType)
     {
+        resRef = NormalizeResRef(resRef);
+
         // 1. Check override folder
         var overrideResult = FindInOverride(resRef, resourceType);
         if (overrideResult != null)
@@ -89,6 +91,8 @@ public class GameResourceResolver : IDisposable
     /// </summary>
     public ResourceResult? FindResourceWithSource(string resRef, ushort resourceType)
     {
+        resRef = NormalizeResRef(resRef);
+
         // 1. Check module directory (highest priority for module-local resources)
         var moduleResult = FindInModule(resRef, resourceType);
         if (moduleResult != null)
@@ -188,6 +192,22 @@ public class GameResourceResolver : IDisposable
     }
 
     #region Module Resolution
+
+    /// <summary>
+    /// Aurora caps ResRefs at 16 characters and truncates both stored names and
+    /// references to that length. A model can therefore reference a >16-char texture
+    /// (e.g. CEP "N_Tiger_LaoHu02_D") whose stored resource is the 16-char-truncated
+    /// "N_Tiger_LaoHu02_". Truncating the lookup key here matches the engine so such
+    /// references resolve instead of falling back to a wrong texture. (#2029)
+    /// </summary>
+    private const int MaxResRefLength = 16;
+
+    private static string NormalizeResRef(string resRef)
+    {
+        if (string.IsNullOrEmpty(resRef) || resRef.Length <= MaxResRefLength)
+            return resRef;
+        return resRef.Substring(0, MaxResRefLength);
+    }
 
     private ResourceResult? FindInModule(string resRef, ushort resourceType)
     {

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
@@ -1667,8 +1667,7 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
                     : _textureService.LoadTextureWithKind(texName, materialName, _colorIndices);
                 if (textureData == null)
                 {
-                    UnifiedLogger.LogApplication(LogLevel.INFO,
-                        $"[TexResolve] '{texName}' (len={texName.Length}) -> NULL (will try model fallback) #2029");
+                    UnifiedLogger.LogApplication(LogLevel.DEBUG, $"  Texture '{texName}' returned null");
                     failedTextures.Add(texName);
                     continue;
                 }
@@ -1679,8 +1678,6 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
                 {
                     _textureCache[texName] = texId;
                     if (isPlt) _pltTextureNames.Add(texName);
-                    UnifiedLogger.LogApplication(LogLevel.INFO,
-                        $"[TexResolve] '{texName}' (len={texName.Length}) -> RESOLVED {width}x{height} #2029");
                     UnifiedLogger.LogApplication(LogLevel.DEBUG, $"  Loaded texture '{texName}' ({width}x{height}) -> texId={texId}, isPlt={isPlt}");
                 }
             }

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
@@ -1609,6 +1609,12 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
         var materialByTexture = new Dictionary<string, string>();
         foreach (var mesh in _model.GetMeshNodes())
         {
+            // Only consider meshes that are actually drawn. Render=false bone/internal
+            // meshes carry bitmaps (often the model name, e.g. boar's hidden legs use
+            // 'c_boar') that resolve to a base-game stub no visible surface uses —
+            // loading them wasted work and falsely tripped the base-texture warning. (#2029)
+            if (!mesh.Render || mesh.Vertices.Length == 0 || mesh.Faces.Length == 0)
+                continue;
             if (string.IsNullOrEmpty(mesh.Bitmap))
                 continue;
             var bitmap = mesh.Bitmap.ToLowerInvariant();
@@ -1648,10 +1654,6 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
             $"metal1={_colorIndices.Metal1}, metal2={_colorIndices.Metal2}, cloth1={_colorIndices.Cloth1}, cloth2={_colorIndices.Cloth2}");
 
         var failedTextures = new List<string>();
-        // #1758: for a non-base model (PreferBifTextures=false), note when a texture
-        // resolves from base-game BIF instead of the model's own pack — the preview skin
-        // may then not match the intended asset.
-        bool usedBaseFallback = false;
         foreach (var texName in textureNames)
         {
             if (_textureCache.ContainsKey(texName))
@@ -1665,7 +1667,8 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
                     : _textureService.LoadTextureWithKind(texName, materialName, _colorIndices);
                 if (textureData == null)
                 {
-                    UnifiedLogger.LogApplication(LogLevel.DEBUG, $"  Texture '{texName}' returned null");
+                    UnifiedLogger.LogApplication(LogLevel.INFO,
+                        $"[TexResolve] '{texName}' (len={texName.Length}) -> NULL (will try model fallback) #2029");
                     failedTextures.Add(texName);
                     continue;
                 }
@@ -1676,8 +1679,8 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
                 {
                     _textureCache[texName] = texId;
                     if (isPlt) _pltTextureNames.Add(texName);
-                    if (!_preferBifTextures && _textureService.ResolvesFromBase(texName))
-                        usedBaseFallback = true;
+                    UnifiedLogger.LogApplication(LogLevel.INFO,
+                        $"[TexResolve] '{texName}' (len={texName.Length}) -> RESOLVED {width}x{height} #2029");
                     UnifiedLogger.LogApplication(LogLevel.DEBUG, $"  Loaded texture '{texName}' ({width}x{height}) -> texId={texId}, isPlt={isPlt}");
                 }
             }
@@ -1707,8 +1710,6 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
                     {
                         _textureCache[modelTexture] = fallbackId;
                         if (isPlt) _pltTextureNames.Add(modelTexture);
-                        if (!_preferBifTextures && _textureService.ResolvesFromBase(modelTexture))
-                            usedBaseFallback = true;
                         UnifiedLogger.LogApplication(LogLevel.DEBUG,
                             $"  Loaded model fallback texture '{modelTexture}' ({w}x{h}) -> texId={fallbackId}, isPlt={isPlt}");
                     }
@@ -1727,8 +1728,14 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
             }
         }
 
-        // #1758: notify the host so it can warn that a CEP creature is showing
-        // base-game textures (preview may not match the intended asset).
+        // #1758: warn only when a non-base model's actually-rendered texture resolves from
+        // base-game BIF instead of its own pack. Computed here over the final rendered
+        // texture set — NOT inside the load loop — so the result is deterministic regardless
+        // of which textures were already cached from a previous model. The old in-loop check
+        // skipped cached textures, making the warning flicker on/off across reloads. (#2029)
+        bool usedBaseFallback = !_preferBifTextures
+            && textureNames.Any(t => _textureService.ResolvesFromBase(t));
+
         if (Dispatcher.UIThread.CheckAccess())
             TextureSourceChanged?.Invoke(this, usedBaseFallback);
         else


### PR DESCRIPTION
## Summary

Fixes the dire-tiger "holes" regression (#2029) in the Quartermaster model preview, plus two related false-warning papercuts surfaced during UAT.

## Root cause

Not the skin-mesh heuristic. Aurora caps ResRefs at 16 chars; `GameResourceResolver` looked up the full name. The dire tiger's texture `N_Tiger_LaoHu02_D` (17 chars) is stored truncated as `N_Tiger_LaoHu02_`, so the lookup missed and fell back to a wrong 128×128 texture — the "holes." Aurora works because it truncates the lookup too.

## Fixes

1. **16-char ResRef truncation** (`Radoub.Formats`) — `GameResourceResolver` truncates lookup keys to 16 chars, matching the engine. Any >16-char-referenced resource now resolves. Verified: `n_tiger_laohu02_d` resolves to the real 512×512 DDS (was null). Unit-tested.
2. **False "meshes hidden" status** (Quartermaster) — removed the "N of M meshes hidden (Render=false)" line; those are the model author's intentional bone/internal meshes.
3. **False/intermittent "base-game textures" warning** (`Radoub.UI`) — preview now collects textures only from rendered meshes and computes the warning deterministically (was cache-coupled → flickered).

## Out of scope (routed)

- Dire-tiger **mane** alpha-cutout → #2507
- **Umber hulk** exploded geometry, cobra/snakes → #2400 (skin deformation epic)
- 30-vertex heuristic re-scoping → #2498

## Tests

- Radoub.Formats: 1404 passed (2 new ResRef-truncation tests)
- Radoub.UI: 1162 passed
- Quartermaster: 1274 passed
- UAT: dire tiger body/face/stripes/fangs confirmed correct; boar warning confirmed gone

## Related Issues

- Closes #2029
- Relates to #2507, #2400, #2498

🤖 Generated with [Claude Code](https://claude.com/claude-code)