### PR TITLE
[Radoub] Sprint: Shared UI Bug Fix (#2443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.17-alpha] - 2026-06-19
+**Branch**: `radoub/sprint/2443-shared-ui-bugs` | **PR**: #TBD
+
+### Sprint: Shared UI Bug Fix (#2443)
+
+- Theme edits made in Trebuchet now reach running tools on window focus, not just on restart (#2300).
+- Custom Tokens tab text in the shared TokenSelectorWindow is now readable across themes (#2310).
+
+---
+
 ## [Radoub.UI 0.2.16-alpha] - 2026-06-19
 **Branch**: `fence/sprint/2422-2418-shared-ui` | **PR**: #2512
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Radoub.UI 0.2.17-alpha] - 2026-06-19
-**Branch**: `radoub/sprint/2443-shared-ui-bugs` | **PR**: #TBD
+**Branch**: `radoub/sprint/2443-shared-ui-bugs` | **PR**: #2518
 
 ### Sprint: Shared UI Bug Fix (#2443)
 

--- a/Radoub.UI/Radoub.UI.Tests/ThemeManagerActivatedRefreshTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/ThemeManagerActivatedRefreshTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.IO;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Guards #2300: a tool that was already running when Trebuchet *edits* an
+/// existing theme JSON kept a stale cached ThemeManifest forever. The
+/// Activated refresh path (ReloadSettings + ApplySharedTheme) never
+/// re-discovered themes, so ApplyTheme(id) succeeded but applied outdated
+/// colors.
+///
+/// Fix: ApplySharedTheme's effective-id resolution now calls DiscoverThemes()
+/// first. DiscoverThemes honors the catalog cache's mtime check, so it is a
+/// cheap no-op when nothing changed and a rescan the moment Trebuchet
+/// rewrites the JSON.
+/// </summary>
+public class ThemeManagerActivatedRefreshTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _themesDir;
+
+    public ThemeManagerActivatedRefreshTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"RadoubThemeRefresh_{Guid.NewGuid():N}");
+        _themesDir = Path.Combine(_tempDir, "Themes");
+        Directory.CreateDirectory(_themesDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private string WriteTheme(string id, string background)
+    {
+        var path = Path.Combine(_themesDir, $"{id}.json");
+        File.WriteAllText(path, $$"""
+        {
+          "manifest_version": "1.0",
+          "plugin": { "id": "{{id}}", "name": "Test", "type": "theme" },
+          "base_theme": "Light",
+          "colors": { "background": "{{background}}", "text": "#000000" }
+        }
+        """);
+        return path;
+    }
+
+    [Fact]
+    public void RefreshThemeCatalog_PicksUpEditedThemeFile()
+    {
+        const string id = "org.test.editme";
+        var path = WriteTheme(id, "#111111");
+
+        // Test-only ctor with explicit dirs + isolated cache so we never touch
+        // real user themes or the shared catalog cache.
+        var cachePath = Path.Combine(_tempDir, "ThemeCatalog.json");
+        var manager = new ThemeManager("Test", new List<string> { _themesDir }, cachePath);
+        manager.DiscoverThemes();
+
+        var before = manager.GetCachedManifest(id);
+        Assert.NotNull(before);
+        Assert.Equal("#111111", before!.Colors.Background);
+
+        // Trebuchet rewrites the existing theme file with new colors.
+        File.WriteAllText(path, File.ReadAllText(path).Replace("#111111", "#222222"));
+        // Bump the directory mtime so the catalog cache's mtime check invalidates,
+        // mirroring what a real file rewrite does.
+        Directory.SetLastWriteTimeUtc(_themesDir, DateTime.UtcNow.AddMinutes(5));
+
+        // The Activated path's id resolution must re-discover before returning.
+        manager.RefreshThemeCatalog();
+
+        var after = manager.GetCachedManifest(id);
+        Assert.NotNull(after);
+        Assert.Equal("#222222", after!.Colors.Background);
+    }
+}

--- a/Radoub.UI/Radoub.UI/Services/ThemeManager.cs
+++ b/Radoub.UI/Radoub.UI/Services/ThemeManager.cs
@@ -24,6 +24,7 @@ public partial class ThemeManager
     private readonly Dictionary<string, ThemeManifest> _themes = new();
     private ThemeManifest? _currentTheme;
     private readonly string _toolName;
+    private readonly string? _cachePathOverride;
     private const string DefaultThemeId = "org.radoub.theme.light";
 
     /// <summary>
@@ -97,6 +98,30 @@ public partial class ThemeManager
     }
 
     /// <summary>
+    /// Test-only constructor: uses the supplied theme directories verbatim
+    /// instead of the real official/shared/user locations, so tests never
+    /// touch the developer's real theme folders.
+    /// </summary>
+    internal ThemeManager(string toolName, IEnumerable<string> themeDirectories, string? cachePathOverride = null)
+    {
+        _toolName = toolName;
+        _themeDirectories.AddRange(themeDirectories);
+        _cachePathOverride = cachePathOverride;
+    }
+
+    /// <summary>
+    /// Test-only accessor: returns the currently cached manifest for an id,
+    /// or null if not discovered.
+    /// </summary>
+    internal ThemeManifest? GetCachedManifest(string themeId)
+    {
+        lock (_lock)
+        {
+            return _themes.TryGetValue(themeId, out var m) ? m : null;
+        }
+    }
+
+    /// <summary>
     /// Initialize theme search directories.
     /// Order of precedence (last wins for same theme ID):
     /// 1. Official themes (shipped with app)
@@ -144,7 +169,9 @@ public partial class ThemeManager
     /// <param name="forceRescan">If true, bypass cache and rescan directories. Use for theme editing.</param>
     public void DiscoverThemes(bool forceRescan = false)
     {
-        var cache = ThemeCatalogCache.ForTool(_toolName);
+        var cache = _cachePathOverride != null
+            ? new ThemeCatalogCache(_cachePathOverride)
+            : ThemeCatalogCache.ForTool(_toolName);
 
         // Try loading from cache (unless forced rescan)
         if (!forceRescan && cache.IsValid(_themeDirectories))
@@ -416,7 +443,21 @@ public partial class ThemeManager
     /// <returns>True if a theme was applied successfully</returns>
     public bool ApplySharedTheme()
     {
+        RefreshThemeCatalog();
         var effectiveThemeId = GetEffectiveThemeId();
         return ApplyTheme(effectiveThemeId);
+    }
+
+    /// <summary>
+    /// Re-discover themes so that edits made to an existing theme JSON by
+    /// Trebuchet are picked up by a tool that has been running since before
+    /// the edit (#2300). DiscoverThemes honors the catalog cache's mtime
+    /// check, so this is a cheap no-op when nothing changed.
+    /// </summary>
+    internal void RefreshThemeCatalog()
+    {
+        // forceRescan: false — the catalog cache's mtime check rescans only
+        // when a theme directory (and thus a theme file) actually changed.
+        DiscoverThemes();
     }
 }

--- a/Radoub.UI/Radoub.UI/Views/TokenSelectorWindow.axaml
+++ b/Radoub.UI/Radoub.UI/Views/TokenSelectorWindow.axaml
@@ -89,6 +89,7 @@
                                  Margin="0,5"
                                  Checked="OnHighlightTypeChanged">
                         <StackPanel Orientation="Horizontal">
+                            <!-- theme-ok: NWN engine renders action highlights green regardless of theme -->
                             <TextBlock Text="Action" FontWeight="Bold" Foreground="#00FF00" Width="80"/>
                             <TextBlock Text="[Character actions]" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
                         </StackPanel>
@@ -106,6 +107,7 @@
                                  Margin="0,5"
                                  Checked="OnHighlightTypeChanged">
                         <StackPanel Orientation="Horizontal">
+                            <!-- theme-ok: NWN engine renders highlight tokens blue regardless of theme -->
                             <TextBlock Text="Highlight" FontWeight="Bold" Foreground="#0080FF" Width="80"/>
                             <TextBlock Text="[Important text]" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
                         </StackPanel>
@@ -117,6 +119,7 @@
                                  Margin="0,5"
                                  Checked="OnHighlightTypeChanged">
                         <StackPanel Orientation="Horizontal">
+                            <!-- theme-ok: NWN engine renders skill-check tokens red regardless of theme -->
                             <TextBlock Text="Skill Check" FontWeight="Bold" Foreground="#FF0000" Width="80"/>
                             <ComboBox x:Name="SkillCheckComboBox" MinWidth="150" Margin="10,0,0,0"
                                       SelectionChanged="OnSkillCheckChanged">
@@ -161,6 +164,7 @@
                                        Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                        FontFamily="Consolas"
                                        FontSize="{DynamicResource FontSizeSmall}"/>
+                            <!-- theme-ok: green is the NWN action-highlight color, fixed regardless of theme -->
                             <TextBlock x:Name="HighlightPreviewFormatted"
                                        Text="[Chef waves]"
                                        TextWrapping="Wrap"

--- a/Radoub.UI/Radoub.UI/Views/TokenSelectorWindow.axaml
+++ b/Radoub.UI/Radoub.UI/Views/TokenSelectorWindow.axaml
@@ -90,7 +90,7 @@
                                  Checked="OnHighlightTypeChanged">
                         <StackPanel Orientation="Horizontal">
                             <TextBlock Text="Action" FontWeight="Bold" Foreground="#00FF00" Width="80"/>
-                            <TextBlock Text="[Character actions]" Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"/>
+                            <TextBlock Text="[Character actions]" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
                         </StackPanel>
                     </RadioButton>
 
@@ -107,7 +107,7 @@
                                  Checked="OnHighlightTypeChanged">
                         <StackPanel Orientation="Horizontal">
                             <TextBlock Text="Highlight" FontWeight="Bold" Foreground="#0080FF" Width="80"/>
-                            <TextBlock Text="[Important text]" Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"/>
+                            <TextBlock Text="[Important text]" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
                         </StackPanel>
                     </RadioButton>
 
@@ -158,7 +158,7 @@
                             <TextBlock x:Name="HighlightPreviewRaw"
                                        Text="&lt;StartAction&gt;[Chef waves]&lt;/Start&gt;"
                                        TextWrapping="Wrap"
-                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                        FontFamily="Consolas"
                                        FontSize="{DynamicResource FontSizeSmall}"/>
                             <TextBlock x:Name="HighlightPreviewFormatted"
@@ -183,7 +183,7 @@
 
                     <!-- Info Text -->
                     <TextBlock Grid.Row="0" TextWrapping="Wrap" Margin="0,0,0,10"
-                               Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}" FontSize="{DynamicResource FontSizeSmall}">
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" FontSize="{DynamicResource FontSizeSmall}">
                         User-defined custom tokens. Configure in ~/Radoub/custom-tokens.json
                     </TextBlock>
 
@@ -207,9 +207,9 @@
                                     <!-- Tag preview -->
                                     <TextBlock Grid.Column="1"
                                                Text="{Binding TagPreview}"
-                                               Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                                FontFamily="Consolas"
-                                               FontSize="{DynamicResource FontSizeXSmall}"
+                                               FontSize="{DynamicResource FontSizeSmall}"
                                                VerticalAlignment="Center"/>
                                 </Grid>
                             </DataTemplate>
@@ -221,7 +221,7 @@
                                Text="No custom tokens defined. Add tokens to ~/Radoub/custom-tokens.json"
                                TextWrapping="Wrap"
                                HorizontalAlignment="Center" VerticalAlignment="Center"
-                               Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                IsVisible="True"/>
 
                     <!-- Preview -->
@@ -233,7 +233,7 @@
                             <TextBlock x:Name="CustomTokenPreviewText"
                                        Text="Select a token"
                                        TextWrapping="Wrap"
-                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                        FontFamily="Consolas"
                                        FontSize="{DynamicResource FontSizeSmall}"/>
                         </StackPanel>
@@ -252,7 +252,7 @@
 
                     <!-- Info Text -->
                     <TextBlock Grid.Row="0" TextWrapping="Wrap" Margin="0,0,0,10"
-                               Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}" FontSize="{DynamicResource FontSizeSmall}">
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" FontSize="{DynamicResource FontSizeSmall}">
                         Custom color tokens require matching SetCustomToken() calls in your module scripts.
                         Configure colors in ~/Radoub/token-colors.json
                     </TextBlock>
@@ -286,9 +286,9 @@
                                     <!-- Token preview -->
                                     <TextBlock Grid.Column="2"
                                                Text="{Binding OpenToken}"
-                                               Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                                FontFamily="Consolas"
-                                               FontSize="{DynamicResource FontSizeXSmall}"
+                                               FontSize="{DynamicResource FontSizeSmall}"
                                                VerticalAlignment="Center"/>
                                 </Grid>
                             </DataTemplate>
@@ -304,7 +304,7 @@
                             <TextBlock x:Name="ColorPreviewRaw"
                                        Text="Select a color"
                                        TextWrapping="Wrap"
-                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                        FontFamily="Consolas"
                                        FontSize="{DynamicResource FontSizeSmall}"/>
                             <TextBlock x:Name="ColorPreviewSample"


### PR DESCRIPTION
## Summary

Two cross-tool bugs in the shared Radoub.UI layer.

- **#2300** — Theme edits in Trebuchet don't reach running tools on focus. `ApplySharedTheme()` (called from each tool's `OnMainWindowActivated`) never re-discovers themes, so a tool keeps its stale cached `ThemeManifest` after Trebuchet rewrites an existing theme JSON. Fix direction (a): call `DiscoverThemes()` on the refresh path — the catalog cache's mtime check rescans only when the file actually changed.
- **#2310** — Custom Tokens tab text in the shared `TokenSelectorWindow` is unreadable because text Foreground uses `SystemControlForegroundBaseMediumLowBrush` (mapped to the theme *border* color). Switch to a real text brush.

Note: #2280 (third listed sprint item) was already closed/completed separately.

## Related Issues

- Closes #2300
- Closes #2310
- Part of sprint #2443

## Checklist

- [ ] Implementation complete
- [ ] Tests added/updated
- [ ] CHANGELOG updated with date
- [ ] Documentation updated (if needed)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)