### PR TITLE
[Parley] Sprint: UI/UX Enhancements (#2445)

### DIFF
--- a/.claude/scripts/Scratch-Investigate-1.ps1
+++ b/.claude/scripts/Scratch-Investigate-1.ps1
@@ -20,85 +20,27 @@
 #       -File ".claude/scripts/Scratch-Investigate-1.ps1"
 # ---------------------------------------------------------------------------
 
-param(
-    [string] $ModuleDir = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Neverwinter Nights\modules\LNS_DLG'),
-    [int]    $TinyThreshold = 30,
-    [string] $Prefix = 'c_',
-    [int]    $Limit = 0
-)
 $ErrorActionPreference = 'Stop'
 $repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
 $dll = Join-Path $repoRoot 'Radoub.Formats\Radoub.Formats\bin\Debug\net9.0\Radoub.Formats.dll'
 Add-Type -Path $dll
 
-$gameData = [Radoub.Formats.Services.GameDataService]::new()
-if (-not $gameData.IsConfigured) { throw "GameDataService not configured." }
-$gameData.ConfigureModuleHaks($ModuleDir)
+$p = [Radoub.Formats.Tokens.TokenParser]::new()
 
-$mdlType  = [Radoub.Formats.Common.ResourceTypes]::Mdl   # NOTE: never name a var $mdl here —
-$skinType = 'Radoub.Formats.Mdl.MdlSkinNode'             # PS is case-insensitive, $mdl/$MDL collide.
-$reader   = [Radoub.Formats.Mdl.MdlReader]::new()
+# EXACT test lines as given to the user (literal text, NOT escaped bytes).
+# Line 2 contained a literal "\xFF\x00\x00" inside a color tag — reproduce verbatim.
+$line2_literal = 'Step forward, <Lord/Lady>. A <Boy/Girl> like you, raised by a <Brother/Sister> - the <c\xFF\x00\x00>finest</c> youth this town has seen.'
 
-$all = @($gameData.ListResources($mdlType))
-$names = $all | ForEach-Object { $_.ResRef.ToLowerInvariant() } |
-    Where-Object { $Prefix -eq '' -or $_.StartsWith($Prefix) } |
-    Sort-Object -Unique
-if ($Limit -gt 0) { $names = $names | Select-Object -First $Limit }
-"MDL resources: $($all.Count) total, $($names.Count) match prefix '$Prefix'`n"
+# What the color tag would look like with REAL bytes (how it should have been written):
+$realColor = "Step forward, <Lord/Lady>. A <Boy/Girl> like you - the <c$([char]0xFF)$([char]0x00)$([char]0x00)>finest</c> youth."
 
-$scanned = 0; $withSkins = 0; $heuristicSkips = 0
-$divergent = New-Object System.Collections.Generic.List[string]
-$detail    = New-Object System.Collections.Generic.List[string]
-
-foreach ($name in $names) {
-    $bytes = $null
-    try { $bytes = $gameData.FindResource($name, $mdlType) } catch { continue }
-    if ($null -eq $bytes -or $bytes.Length -eq 0) { continue }
-    $model = $null
-    try { $model = $reader.Parse($bytes) } catch { continue }
-    $scanned++
-    $meshes = @($model.GetMeshNodes())
-    if ($meshes.Count -eq 0) { continue }
-
-    $hasSkins = $false
-    $skinBitmaps = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
-    foreach ($m in $meshes) {
-        if (($m.GetType().FullName -eq $skinType) -and $m.Render -and $m.Vertices.Length -gt 0) {
-            $hasSkins = $true
-            if (-not [string]::IsNullOrEmpty($m.Bitmap) -and $m.Bitmap.ToLowerInvariant() -ne 'null') { [void]$skinBitmaps.Add($m.Bitmap) }
-        }
+$cases = @($line2_literal, $realColor)
+foreach ($c in $cases) {
+    Write-Host "IN : $c"
+    Write-Host "OUT: $($p.GetSpeechText($c))"
+    Write-Host "--- segments ---"
+    foreach ($seg in $p.Parse($c)) {
+        "  [{0}] raw='{1}' display='{2}'" -f $seg.GetType().Name, $seg.RawText, $seg.DisplayText
     }
-    if (-not $hasSkins) { continue }
-    $withSkins++
-
-    $diverged = $false
-    foreach ($m in $meshes) {
-        $isSkin = $m.GetType().FullName -eq $skinType
-        $vc = $m.Vertices.Length
-        if (-not $m.Render) { continue }                    # Gate 1: Render flag (first)
-        if ($vc -eq 0 -or $m.Faces.Length -eq 0) { continue }
-        if ($hasSkins -and (-not $isSkin) -and ($vc -lt $TinyThreshold)) {   # Gate 2: heuristic
-            $bmp = $m.Bitmap
-            $hasUnique = (-not [string]::IsNullOrEmpty($bmp)) -and ($bmp.ToLowerInvariant() -ne 'null') -and (-not $skinBitmaps.Contains($bmp))
-            if (-not $hasUnique) {
-                $heuristicSkips++; $diverged = $true
-                $why = if ([string]::IsNullOrEmpty($bmp)) { 'empty bitmap' } elseif ($bmp.ToLowerInvariant() -eq 'null') { 'null bitmap' } else { "shares skin bmp '$bmp'" }
-                $detail.Add(("  {0,-18} mesh '{1}' ({2} verts, {3})" -f $name, $m.Name, $vc, $why))
-            }
-        }
-    }
-    if ($diverged) { $divergent.Add($name) }
-}
-
-"=== CENSUS COMPLETE ==="
-"Models scanned (parsed OK)        : $scanned"
-"Models with skin meshes           : $withSkins"
-"Render=true meshes skipped by heuristic ONLY : $heuristicSkips"
-"Models where heuristic diverges   : $($divergent.Count)"
-""
-if ($heuristicSkips -gt 0) {
-    "Heuristic is LOAD-BEARING: it hides $heuristicSkips Render=true meshes the Render flag misses."
-    "First 30 detail lines:"; $detail | Select-Object -First 30 | ForEach-Object { $_ }
-} else {
-    "Heuristic skipped ZERO Render=true meshes — redundant on this content."
+    Write-Host ""
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.Formats 0.2.73-alpha] - 2026-06-19
+**Branch**: `parley/sprint/2445-ui-ux` | **PR**: #2519
+
+### Feat: TokenParser.GetSpeechText for text-to-speech (#1570)
+
+- New `GetSpeechText` strips markup, keeps highlight/color content, maps name tokens and pronouns to spoken placeholders, and drops custom tokens. Reusable across tools.
+
+---
+
 ## [Radoub.UI 0.2.17-alpha] - 2026-06-19
 **Branch**: `radoub/sprint/2443-shared-ui-bugs` | **PR**: #2518
 

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Parley. One-line highlights per version; full details in 
 ---
 
 ## [0.1.176-alpha] - 2026-06-19
-**Branch**: `parley/sprint/2445-ui-ux` | **PR**: #TBD
+**Branch**: `parley/sprint/2445-ui-ux` | **PR**: #2519
 
 ### Sprint: UI/UX Enhancements (#2445)
 

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Parley. One-line highlights per version; full details in 
 
 - Conversation Simulator: show per-start-entry direct-child coverage alongside subtree coverage (#482)
 - Text-to-Speech: persist simulator toggles and strip markup tags from spoken text (#1570)
+- Fix: Ctrl+D no longer captures the previous node's text into the new node (#2521)
 
 ---
 

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Parley. One-line highlights per version; full details in 
 
 ---
 
+## [0.1.176-alpha] - 2026-06-19
+**Branch**: `parley/sprint/2445-ui-ux` | **PR**: #TBD
+
+### Sprint: UI/UX Enhancements (#2445)
+
+- Conversation Simulator: show per-start-entry direct-child coverage alongside subtree coverage (#482)
+- Text-to-Speech: persist simulator toggles and strip markup tags from spoken text (#1570)
+
+---
+
 ## [0.1.175-alpha] - 2026-06-06
 **Branch**: `parley/issue-2392` | **PR**: #2393
 

--- a/Parley/Parley.Tests/CoverageTrackerDirectCoverageTests.cs
+++ b/Parley/Parley.Tests/CoverageTrackerDirectCoverageTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using DialogEditor.Services;
+using Xunit;
+
+namespace DialogEditor.Tests
+{
+    /// <summary>
+    /// Coverage for the #482 direct-child per-entry metric. The simulator already computes a
+    /// full-subtree per-entry count; #482 adds a parallel DIRECT-child count so the start-entry
+    /// menu can show both. These tests exercise CoverageTracker.GetCoverageStats with both the
+    /// subtree map and the new direct map and assert the two metrics are reported independently.
+    ///
+    /// Each test uses a unique file path so the shared coverage cache does not bleed between
+    /// tests, and clears that path on disposal.
+    /// </summary>
+    public class CoverageTrackerDirectCoverageTests : IDisposable
+    {
+        private readonly CoverageTracker _tracker = new();
+        private readonly List<string> _paths = new();
+
+        private string NewPath()
+        {
+            var p = $"test_{Guid.NewGuid():N}.dlg";
+            _paths.Add(p);
+            return p;
+        }
+
+        public void Dispose()
+        {
+            foreach (var p in _paths)
+            {
+                try { _tracker.ClearCoverage(p); } catch { /* best-effort */ }
+            }
+        }
+
+        [Fact]
+        public void DirectCoverage_CountsOnlyImmediateReplies()
+        {
+            var path = NewPath();
+            // Entry 0 has direct replies R0, R1; subtree additionally includes R2.
+            _tracker.RecordVisitedNode(path, "R0"); // direct + subtree
+            _tracker.RecordVisitedNode(path, "R2"); // subtree only
+
+            var rootEntries = new List<int> { 0 };
+            var subtree = new Dictionary<int, HashSet<int>> { [0] = new() { 0, 1, 2 } };
+            var direct = new Dictionary<int, HashSet<int>> { [0] = new() { 0, 1 } };
+
+            var stats = _tracker.GetCoverageStats(path, totalReplies: 3,
+                rootEntryIndices: rootEntries,
+                repliesPerRootEntry: subtree,
+                directRepliesPerRootEntry: direct);
+
+            Assert.Equal("1/2", stats.GetEntryDirectCoverageText(0)); // R0 visited of {R0,R1}
+            Assert.Equal("2/3", stats.GetEntryCoverageText(0));       // R0,R2 visited of {R0,R1,R2}
+        }
+
+        [Fact]
+        public void DirectCoverage_DiffersFromSubtreeWhenSubtreeIsLarger()
+        {
+            var path = NewPath();
+            var rootEntries = new List<int> { 0 };
+            var subtree = new Dictionary<int, HashSet<int>> { [0] = new() { 0, 1, 2, 3, 4 } };
+            var direct = new Dictionary<int, HashSet<int>> { [0] = new() { 0 } };
+
+            var stats = _tracker.GetCoverageStats(path, totalReplies: 5,
+                rootEntryIndices: rootEntries,
+                repliesPerRootEntry: subtree,
+                directRepliesPerRootEntry: direct);
+
+            Assert.Equal("0/1", stats.GetEntryDirectCoverageText(0));
+            Assert.Equal("0/5", stats.GetEntryCoverageText(0));
+        }
+
+        [Fact]
+        public void DirectCoverage_ZeroDirectReplies_ReportsZeroOverZero()
+        {
+            var path = NewPath();
+            var rootEntries = new List<int> { 0 };
+            var subtree = new Dictionary<int, HashSet<int>> { [0] = new() { 1 } };
+            var direct = new Dictionary<int, HashSet<int>> { [0] = new() };
+
+            var stats = _tracker.GetCoverageStats(path, totalReplies: 1,
+                rootEntryIndices: rootEntries,
+                repliesPerRootEntry: subtree,
+                directRepliesPerRootEntry: direct);
+
+            Assert.Equal("0/0", stats.GetEntryDirectCoverageText(0));
+        }
+
+        [Fact]
+        public void DirectCoverage_AllDirectVisited_CountsFully()
+        {
+            var path = NewPath();
+            _tracker.RecordVisitedNode(path, "R0");
+            _tracker.RecordVisitedNode(path, "R1");
+
+            var rootEntries = new List<int> { 0 };
+            var direct = new Dictionary<int, HashSet<int>> { [0] = new() { 0, 1 } };
+
+            var stats = _tracker.GetCoverageStats(path, totalReplies: 2,
+                rootEntryIndices: rootEntries,
+                repliesPerRootEntry: new Dictionary<int, HashSet<int>> { [0] = new() { 0, 1 } },
+                directRepliesPerRootEntry: direct);
+
+            Assert.Equal("2/2", stats.GetEntryDirectCoverageText(0));
+        }
+
+        [Fact]
+        public void DirectCoverage_AbsentEntry_FallsBackToZeroOverZero()
+        {
+            var path = NewPath();
+            _tracker.RecordVisitedNode(path, "R0");
+
+            var stats = _tracker.GetCoverageStats(path, totalReplies: 1,
+                rootEntryIndices: new List<int> { 0 },
+                repliesPerRootEntry: new Dictionary<int, HashSet<int>> { [0] = new() { 0 } },
+                directRepliesPerRootEntry: new Dictionary<int, HashSet<int>> { [0] = new() { 0 } });
+
+            // Entry 99 was never mapped -> default text.
+            Assert.Equal("0/0", stats.GetEntryDirectCoverageText(99));
+        }
+
+        [Fact]
+        public void DirectCoverage_OmittedMap_LeavesDirectEmptyButSubtreeIntact()
+        {
+            var path = NewPath();
+            _tracker.RecordVisitedNode(path, "R0");
+
+            // Backwards-compat: callers that don't pass the direct map still get subtree coverage.
+            var stats = _tracker.GetCoverageStats(path, totalReplies: 1,
+                rootEntryIndices: new List<int> { 0 },
+                repliesPerRootEntry: new Dictionary<int, HashSet<int>> { [0] = new() { 0 } });
+
+            Assert.Equal("1/1", stats.GetEntryCoverageText(0));
+            Assert.Equal("0/0", stats.GetEntryDirectCoverageText(0)); // empty -> default
+        }
+    }
+}

--- a/Parley/Parley.Tests/Mocks/MockSettingsService.cs
+++ b/Parley/Parley.Tests/Mocks/MockSettingsService.cs
@@ -109,6 +109,12 @@ namespace Parley.Tests.Mocks
         // Conversation Simulator
         public bool SimulatorShowWarnings { get; set; } = true;
 
+        // Conversation Simulator TTS (#1570)
+        public bool SimulatorTtsEnabled { get; set; } = true;
+        public double SimulatorTtsRate { get; set; } = 1.0;
+        public bool SimulatorAutoSpeak { get; set; } = false;
+        public bool SimulatorAutoAdvance { get; set; } = true;
+
         // Script editor settings
         public string ExternalEditorPath { get; set; } = "";
         public List<string> ScriptSearchPaths { get; set; } = new();

--- a/Parley/Parley.Tests/PropertyAutoSaveGuardTests.cs
+++ b/Parley/Parley.Tests/PropertyAutoSaveGuardTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using DialogEditor.Models;
+using DialogEditor.Services;
+using Xunit;
+
+namespace Parley.Tests
+{
+    /// <summary>
+    /// Guards the focus-change auto-save path against cross-node corruption (#2521).
+    ///
+    /// Repro: Ctrl+D creates+selects a new (empty) node DURING a tree refresh. The
+    /// selection-changed handler that repopulates the properties panel early-returns while
+    /// the refresh coordinator is busy, so the shared TextTextBox keeps the PREVIOUS node's
+    /// text. When focus then moves, OnFieldLostFocus -> AutoSaveProperty flushes that stale
+    /// text into the new node. The other save path (SaveCurrentNodeProperties) already has
+    /// the #2382 PropertyFlushGuard; this auto-save path did not.
+    ///
+    /// Guard: AutoSaveProperty must refuse to write when the panel's source node
+    /// (lastPopulatedNode) is not the currently-selected node.
+    /// </summary>
+    public class PropertyAutoSaveGuardTests
+    {
+        private static DialogNode MakeNode(Dialog dialog, DialogNodeType type, string text)
+        {
+            var n = dialog.CreateNode(type)!;
+            n.Text.Add(0, text);
+            dialog.AddNodeInternal(n, type);
+            return n;
+        }
+
+        private static PropertyAutoSaveService MakeService(
+            TextBox textBox,
+            System.Func<DialogNode?> getLastPopulatedNode)
+        {
+            var coordinator = new TreeRefreshCoordinator(
+                populateDialogNodes: _ => { },
+                saveExpansionState: () => new HashSet<DialogNode>(),
+                restoreExpansionState: (_, _) => { },
+                getDialogNodes: () => new ObservableCollection<TreeViewSafeNode>(),
+                getCurrentDialog: () => null,
+                getSelectedNode: () => null,
+                setSelectedNode: _ => { },
+                getFocusedFieldInfo: () => (null, null),
+                restoreFocusedField: (_, _) => { },
+                publishDialogRefreshed: _ => { },
+                scheduleDeferred: action => action());
+
+            return new PropertyAutoSaveService(
+                findControl: name => name == "TextTextBox" ? textBox : null,
+                treeRefreshCoordinator: coordinator,
+                loadScriptPreview: (_, _) => { },
+                clearScriptPreview: _ => { },
+                triggerDebouncedAutoSave: () => { },
+                getLastPopulatedNode: getLastPopulatedNode);
+        }
+
+        [AvaloniaFact]
+        public void AutoSaveProperty_PanelOutOfSyncWithSelection_DoesNotWriteStaleText()
+        {
+            var dialog = new Dialog();
+            var oldNode = MakeNode(dialog, DialogNodeType.Entry, "Previous line");
+            var newNode = MakeNode(dialog, DialogNodeType.Entry, ""); // brand-new empty node
+
+            // TextBox still holds the PREVIOUS node's text (panel never repopulated for newNode).
+            var textBox = new TextBox { Name = "TextTextBox", Text = "Previous line" };
+
+            // Panel was last populated FROM oldNode, but selection is newNode → out of sync.
+            var service = MakeService(textBox, getLastPopulatedNode: () => oldNode);
+
+            var result = service.AutoSaveProperty(new TreeViewSafeNode(newNode), "TextTextBox");
+
+            // The stale text must NOT be captured into the new node.
+            Assert.Equal("", newNode.Text.GetDefault());
+            Assert.False(result.Success);
+        }
+
+        [AvaloniaFact]
+        public void AutoSaveProperty_PanelInSyncWithSelection_WritesText()
+        {
+            var dialog = new Dialog();
+            var node = MakeNode(dialog, DialogNodeType.Entry, "old");
+
+            var textBox = new TextBox { Name = "TextTextBox", Text = "edited" };
+
+            // Panel populated FROM the same node that is selected → safe to flush.
+            var service = MakeService(textBox, getLastPopulatedNode: () => node);
+
+            var result = service.AutoSaveProperty(new TreeViewSafeNode(node), "TextTextBox");
+
+            Assert.Equal("edited", node.Text.GetDefault());
+            Assert.True(result.Success);
+        }
+    }
+}

--- a/Parley/Parley.Tests/SettingsBoolPersistenceTests.cs
+++ b/Parley/Parley.Tests/SettingsBoolPersistenceTests.cs
@@ -107,6 +107,30 @@ namespace DialogEditor.Tests
         [Fact] public void SimulatorShowWarnings_RoundTrips()
             => AssertRoundTrip(s => s.SimulatorShowWarnings = false, s => s.SimulatorShowWarnings, expected: false);
 
+        // Conversation Simulator TTS toggles (#1570)
+        [Fact] public void SimulatorTtsEnabled_RoundTrips()
+            => AssertRoundTrip(s => s.SimulatorTtsEnabled = false, s => s.SimulatorTtsEnabled, expected: false);
+
+        [Fact] public void SimulatorAutoSpeak_RoundTrips()
+            => AssertRoundTrip(s => s.SimulatorAutoSpeak = true, s => s.SimulatorAutoSpeak, expected: true);
+
+        [Fact] public void SimulatorAutoAdvance_RoundTrips()
+            => AssertRoundTrip(s => s.SimulatorAutoAdvance = false, s => s.SimulatorAutoAdvance, expected: false);
+
+        /// <summary>
+        /// TtsRate is a double, so it can't use the bool AssertRoundTrip helper (#1570).
+        /// Flip to a non-default value, persist, reload, assert it survived.
+        /// </summary>
+        [Fact]
+        public void SimulatorTtsRate_RoundTrips()
+        {
+            var writer = NewService();
+            writer.SimulatorTtsRate = 1.75;
+
+            var reader = NewService();
+            Assert.Equal(1.75, reader.SimulatorTtsRate);
+        }
+
         [Fact] public void SoundBrowserIncludeGameResources_RoundTrips()
             => AssertRoundTrip(s => s.SoundBrowserIncludeGameResources = false, s => s.SoundBrowserIncludeGameResources, expected: false);
 

--- a/Parley/Parley/Services/CoverageTracker.cs
+++ b/Parley/Parley/Services/CoverageTracker.cs
@@ -78,47 +78,59 @@ namespace DialogEditor.Services
         /// <param name="totalReplies">Total number of reply nodes in the dialog</param>
         /// <param name="rootEntryIndices">Entry indices that are root entries (conversation starters)</param>
         /// <param name="repliesPerRootEntry">Mapping of root entry index to set of reply indices under that entry</param>
+        /// <param name="directRepliesPerRootEntry">#482: mapping of root entry index to the set of
+        /// its DIRECT child reply indices (not the full subtree). Used for the dual coverage display.</param>
         public CoverageStats GetCoverageStats(
             string filePath,
             int totalReplies = 0,
             IReadOnlyList<int>? rootEntryIndices = null,
-            IReadOnlyDictionary<int, HashSet<int>>? repliesPerRootEntry = null)
+            IReadOnlyDictionary<int, HashSet<int>>? repliesPerRootEntry = null,
+            IReadOnlyDictionary<int, HashSet<int>>? directRepliesPerRootEntry = null)
         {
             var sanitizedPath = SanitizePath(filePath);
 
-            if (!_coverageData.Files.TryGetValue(sanitizedPath, out var fileData))
-            {
-                return new CoverageStats(0, 0, totalReplies, 0, rootEntryIndices?.Count ?? 0, new Dictionary<int, (int visited, int total)>());
-            }
+            // A file with no recorded coverage still reports per-entry totals (all visited=0),
+            // so a never-visited start-entry menu shows "0/N direct, 0/M all" rather than "0/0".
+            var visitedNodeSet = _coverageData.Files.TryGetValue(sanitizedPath, out var fileData)
+                ? fileData.VisitedNodes
+                : new HashSet<string>();
 
             // Count visited replies (keys starting with "R")
-            var visitedReplies = fileData.VisitedNodes.Count(k => k.StartsWith("R"));
+            var visitedReplies = visitedNodeSet.Count(k => k.StartsWith("R"));
 
             // Count visited root entries and per-entry coverage
             var visitedRootEntries = 0;
             var totalRootEntries = rootEntryIndices?.Count ?? 0;
             var perEntryCoverage = new Dictionary<int, (int visited, int total)>();
+            var perEntryDirectCoverage = new Dictionary<int, (int visited, int total)>();
 
             if (rootEntryIndices != null)
             {
                 foreach (var entryIndex in rootEntryIndices)
                 {
                     var key = $"E{entryIndex}";
-                    if (fileData.VisitedNodes.Contains(key))
+                    if (visitedNodeSet.Contains(key))
                     {
                         visitedRootEntries++;
                     }
 
-                    // Calculate per-entry reply coverage
+                    // Calculate per-entry subtree reply coverage
                     if (repliesPerRootEntry != null && repliesPerRootEntry.TryGetValue(entryIndex, out var replyIndices))
                     {
-                        var visitedCount = replyIndices.Count(ri => fileData.VisitedNodes.Contains($"R{ri}"));
+                        var visitedCount = replyIndices.Count(ri => visitedNodeSet.Contains($"R{ri}"));
                         perEntryCoverage[entryIndex] = (visitedCount, replyIndices.Count);
+                    }
+
+                    // #482: per-entry direct-child reply coverage
+                    if (directRepliesPerRootEntry != null && directRepliesPerRootEntry.TryGetValue(entryIndex, out var directIndices))
+                    {
+                        var visitedDirect = directIndices.Count(ri => visitedNodeSet.Contains($"R{ri}"));
+                        perEntryDirectCoverage[entryIndex] = (visitedDirect, directIndices.Count);
                     }
                 }
             }
 
-            return new CoverageStats(fileData.VisitedNodes.Count, visitedReplies, totalReplies, visitedRootEntries, totalRootEntries, perEntryCoverage);
+            return new CoverageStats(visitedNodeSet.Count, visitedReplies, totalReplies, visitedRootEntries, totalRootEntries, perEntryCoverage, perEntryDirectCoverage);
         }
 
         /// <summary>
@@ -284,9 +296,16 @@ namespace DialogEditor.Services
         public int TotalRootEntries { get; }
 
         /// <summary>
-        /// Per-entry coverage: entryIndex -> (visited replies, total replies under that entry)
+        /// Per-entry subtree coverage: entryIndex -> (visited replies, total replies in the
+        /// full subtree reachable from that entry).
         /// </summary>
         public IReadOnlyDictionary<int, (int visited, int total)> PerEntryCoverage { get; }
+
+        /// <summary>
+        /// Per-entry direct-child coverage (#482): entryIndex -> (visited, total) counting only
+        /// the entry's immediate PC reply children, not the full subtree.
+        /// </summary>
+        public IReadOnlyDictionary<int, (int visited, int total)> PerEntryDirectCoverage { get; }
 
         public CoverageStats(
             int visitedNodes,
@@ -294,7 +313,8 @@ namespace DialogEditor.Services
             int totalReplies,
             int visitedRootEntries,
             int totalRootEntries,
-            IReadOnlyDictionary<int, (int visited, int total)> perEntryCoverage)
+            IReadOnlyDictionary<int, (int visited, int total)> perEntryCoverage,
+            IReadOnlyDictionary<int, (int visited, int total)>? perEntryDirectCoverage = null)
         {
             VisitedNodes = visitedNodes;
             VisitedReplies = visitedReplies;
@@ -302,6 +322,8 @@ namespace DialogEditor.Services
             VisitedRootEntries = visitedRootEntries;
             TotalRootEntries = totalRootEntries;
             PerEntryCoverage = perEntryCoverage;
+            PerEntryDirectCoverage = perEntryDirectCoverage
+                ?? new Dictionary<int, (int visited, int total)>();
         }
 
         public bool IsComplete => TotalReplies > 0 && VisitedReplies >= TotalReplies;
@@ -325,6 +347,18 @@ namespace DialogEditor.Services
         public string GetEntryCoverageText(int entryIndex)
         {
             if (PerEntryCoverage.TryGetValue(entryIndex, out var coverage))
+            {
+                return $"{coverage.visited}/{coverage.total}";
+            }
+            return "0/0";
+        }
+
+        /// <summary>
+        /// Get direct-child coverage text for a specific entry (#482), e.g. "2/3".
+        /// </summary>
+        public string GetEntryDirectCoverageText(int entryIndex)
+        {
+            if (PerEntryDirectCoverage.TryGetValue(entryIndex, out var coverage))
             {
                 return $"{coverage.visited}/{coverage.total}";
             }

--- a/Parley/Parley/Services/EditorPreferencesService.cs
+++ b/Parley/Parley/Services/EditorPreferencesService.cs
@@ -31,6 +31,12 @@ namespace DialogEditor.Services
         // Conversation Simulator
         private bool _simulatorShowWarnings = true;
 
+        // Conversation Simulator TTS (#1570) - defaults mirror the simulator VM
+        private bool _simulatorTtsEnabled = true;
+        private double _simulatorTtsRate = 1.0;
+        private bool _simulatorAutoSpeak = false;
+        private bool _simulatorAutoAdvance = true;
+
         // Script editor settings
         // #2357: ExternalEditorPath migrated to shared RadoubSettings.CodeEditorPath (no local field)
         private List<string> _scriptSearchPaths = new List<string>();
@@ -71,6 +77,7 @@ namespace DialogEditor.Services
         public void Initialize(
             bool autoSaveEnabled, int autoSaveDelayMs, int autoSaveIntervalMinutes,
             bool enableNpcTagColoring, bool showDeleteConfirmation, bool simulatorShowWarnings,
+            bool simulatorTtsEnabled, double simulatorTtsRate, bool simulatorAutoSpeak, bool simulatorAutoAdvance,
             string externalEditorPath, List<string> scriptSearchPaths,
             string manifestPath,
             bool enableParameterCache, int maxCachedValuesPerParameter, int maxCachedScripts,
@@ -85,6 +92,10 @@ namespace DialogEditor.Services
             _enableNpcTagColoring = enableNpcTagColoring;
             _showDeleteConfirmation = showDeleteConfirmation;
             _simulatorShowWarnings = simulatorShowWarnings;
+            _simulatorTtsEnabled = simulatorTtsEnabled;
+            _simulatorTtsRate = Math.Clamp(simulatorTtsRate, 0.5, 2.0);
+            _simulatorAutoSpeak = simulatorAutoSpeak;
+            _simulatorAutoAdvance = simulatorAutoAdvance;
 
             // #2357: One-time migration of legacy Parley path values onto shared RadoubSettings.
             // Adopt the legacy value only if the shared value is still empty (mirrors #2295).
@@ -196,6 +207,55 @@ namespace DialogEditor.Services
             set
             {
                 if (SetProperty(ref _simulatorShowWarnings, value))
+                {
+                    SettingsChanged?.Invoke();
+                }
+            }
+        }
+
+        // Conversation Simulator TTS (#1570)
+        public bool SimulatorTtsEnabled
+        {
+            get => _simulatorTtsEnabled;
+            set
+            {
+                if (SetProperty(ref _simulatorTtsEnabled, value))
+                {
+                    SettingsChanged?.Invoke();
+                }
+            }
+        }
+
+        public double SimulatorTtsRate
+        {
+            get => _simulatorTtsRate;
+            set
+            {
+                if (SetProperty(ref _simulatorTtsRate, Math.Clamp(value, 0.5, 2.0)))
+                {
+                    SettingsChanged?.Invoke();
+                }
+            }
+        }
+
+        public bool SimulatorAutoSpeak
+        {
+            get => _simulatorAutoSpeak;
+            set
+            {
+                if (SetProperty(ref _simulatorAutoSpeak, value))
+                {
+                    SettingsChanged?.Invoke();
+                }
+            }
+        }
+
+        public bool SimulatorAutoAdvance
+        {
+            get => _simulatorAutoAdvance;
+            set
+            {
+                if (SetProperty(ref _simulatorAutoAdvance, value))
                 {
                     SettingsChanged?.Invoke();
                 }

--- a/Parley/Parley/Services/Interfaces/ISettingsService.cs
+++ b/Parley/Parley/Services/Interfaces/ISettingsService.cs
@@ -86,6 +86,12 @@ namespace DialogEditor.Services
         // Conversation Simulator
         bool SimulatorShowWarnings { get; set; }
 
+        // Conversation Simulator TTS (#1570)
+        bool SimulatorTtsEnabled { get; set; }
+        double SimulatorTtsRate { get; set; }
+        bool SimulatorAutoSpeak { get; set; }
+        bool SimulatorAutoAdvance { get; set; }
+
         // Script editor settings
         string ExternalEditorPath { get; set; }
         List<string> ScriptSearchPaths { get; set; }

--- a/Parley/Parley/Services/NodeCreationHelper.cs
+++ b/Parley/Parley/Services/NodeCreationHelper.cs
@@ -19,6 +19,7 @@ namespace DialogEditor.Services
         private readonly Func<string, Control?> _findControl;
         private readonly Action _saveCurrentNodeProperties;
         private readonly Action _triggerAutoSave;
+        private readonly Action? _repopulateSelectedNodePanel; // #2521: re-sync panel to the new node
 
         // Debouncing state (Issue #76)
         private DateTime _lastAddNodeTime = DateTime.MinValue;
@@ -29,12 +30,14 @@ namespace DialogEditor.Services
             MainViewModel viewModel,
             Func<string, Control?> findControl,
             Action saveCurrentNodeProperties,
-            Action triggerAutoSave)
+            Action triggerAutoSave,
+            Action? repopulateSelectedNodePanel = null)
         {
             _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
             _findControl = findControl ?? throw new ArgumentNullException(nameof(findControl));
             _saveCurrentNodeProperties = saveCurrentNodeProperties ?? throw new ArgumentNullException(nameof(saveCurrentNodeProperties));
             _triggerAutoSave = triggerAutoSave ?? throw new ArgumentNullException(nameof(triggerAutoSave));
+            _repopulateSelectedNodePanel = repopulateSelectedNodePanel; // #2521
         }
 
         /// <summary>
@@ -81,6 +84,13 @@ namespace DialogEditor.Services
                 // Delay allows tree view selection and properties panel population to complete
                 UnifiedLogger.LogApplication(LogLevel.INFO, "CreateSmartNodeAsync: Waiting for properties panel...");
                 await Task.Delay(200);
+
+                // #2521: The selection-changed handler skips the panel repopulate while the tree
+                // refresh coordinator is busy, so the shared TextBox can still show the PREVIOUS
+                // node's text. Explicitly repopulate the now-selected (empty) new node so the box
+                // is cleared before we focus it — otherwise the stale text is visible (and, absent
+                // the autosave flush guard, would be captured into the new node).
+                _repopulateSelectedNodePanel?.Invoke();
 
                 var textTextBox = _findControl("TextTextBox") as TextBox;
                 if (textTextBox != null)

--- a/Parley/Parley/Services/PropertyAutoSaveService.cs
+++ b/Parley/Parley/Services/PropertyAutoSaveService.cs
@@ -21,6 +21,7 @@ namespace DialogEditor.Services
         private readonly Action<bool> _clearScriptPreview;
         private readonly Action _triggerDebouncedAutoSave;
         private readonly Action<TreeViewSafeNode>? _refreshSiblingValidation; // Issue #609
+        private readonly Func<DialogNode?>? _getLastPopulatedNode; // #2521: panel-source for flush guard
 
         /// <summary>
         /// Property save handlers - maps control names to save actions
@@ -33,7 +34,8 @@ namespace DialogEditor.Services
             Action<string, bool> loadScriptPreview,
             Action<bool> clearScriptPreview,
             Action triggerDebouncedAutoSave,
-            Action<TreeViewSafeNode>? refreshSiblingValidation = null)
+            Action<TreeViewSafeNode>? refreshSiblingValidation = null,
+            Func<DialogNode?>? getLastPopulatedNode = null)
         {
             _findControl = findControl ?? throw new ArgumentNullException(nameof(findControl));
             _treeRefreshCoordinator = treeRefreshCoordinator ?? throw new ArgumentNullException(nameof(treeRefreshCoordinator));
@@ -41,6 +43,7 @@ namespace DialogEditor.Services
             _clearScriptPreview = clearScriptPreview ?? throw new ArgumentNullException(nameof(clearScriptPreview));
             _triggerDebouncedAutoSave = triggerDebouncedAutoSave ?? throw new ArgumentNullException(nameof(triggerDebouncedAutoSave));
             _refreshSiblingValidation = refreshSiblingValidation; // Issue #609: Optional callback for validation refresh
+            _getLastPopulatedNode = getLastPopulatedNode; // #2521: optional panel-source for cross-node flush guard
 
             _propertyHandlers = InitializeHandlers();
         }
@@ -52,6 +55,17 @@ namespace DialogEditor.Services
         {
             if (selectedNode == null)
                 return AutoSaveResult.NotSaved("No node selected");
+
+            // #2521: Refuse to flush when the panel is out of sync with the selection.
+            // Mirrors the #2382 guard on SaveCurrentNodeProperties. In the Ctrl+D path the new
+            // node is selected during a tree refresh that skips the panel repopulate, so the
+            // shared TextBox still holds the previous node's text — flushing here would write
+            // that stale text onto the new node. Only guard when a panel-source is provided.
+            if (_getLastPopulatedNode != null &&
+                !PropertyFlushGuard.ShouldFlush(selectedNode.OriginalNode, _getLastPopulatedNode()))
+            {
+                return AutoSaveResult.NotSaved("Panel out of sync with selection — skipped");
+            }
 
             if (!_propertyHandlers.TryGetValue(propertyName, out var handler))
                 return AutoSaveResult.NotSaved($"Unknown property: {propertyName}");

--- a/Parley/Parley/Services/SettingsService.cs
+++ b/Parley/Parley/Services/SettingsService.cs
@@ -456,6 +456,31 @@ namespace DialogEditor.Services
             set => _editorPreferences.SimulatorShowWarnings = value;
         }
 
+        // Conversation Simulator TTS (#1570)
+        public bool SimulatorTtsEnabled
+        {
+            get => _editorPreferences.SimulatorTtsEnabled;
+            set => _editorPreferences.SimulatorTtsEnabled = value;
+        }
+
+        public double SimulatorTtsRate
+        {
+            get => _editorPreferences.SimulatorTtsRate;
+            set => _editorPreferences.SimulatorTtsRate = value;
+        }
+
+        public bool SimulatorAutoSpeak
+        {
+            get => _editorPreferences.SimulatorAutoSpeak;
+            set => _editorPreferences.SimulatorAutoSpeak = value;
+        }
+
+        public bool SimulatorAutoAdvance
+        {
+            get => _editorPreferences.SimulatorAutoAdvance;
+            set => _editorPreferences.SimulatorAutoAdvance = value;
+        }
+
         public string ExternalEditorPath
         {
             get => _editorPreferences.ExternalEditorPath;
@@ -603,6 +628,10 @@ namespace DialogEditor.Services
                             settings.EnableNpcTagColoring,
                             settings.ShowDeleteConfirmation,
                             settings.SimulatorShowWarnings,
+                            settings.SimulatorTtsEnabled,
+                            settings.SimulatorTtsRate,
+                            settings.SimulatorAutoSpeak,
+                            settings.SimulatorAutoAdvance,
                             SharedPathHelper.ExpandPath(settings.ExternalEditorPath ?? ""),
                             SharedPathHelper.ExpandPaths(settings.ScriptSearchPaths?.ToList() ?? new List<string>()),
                             SharedPathHelper.ExpandPath(settings.ManifestPath ?? ""),
@@ -671,6 +700,10 @@ namespace DialogEditor.Services
                     EnableNpcTagColoring = EnableNpcTagColoring,
                     ShowDeleteConfirmation = ShowDeleteConfirmation,
                     SimulatorShowWarnings = SimulatorShowWarnings,
+                    SimulatorTtsEnabled = SimulatorTtsEnabled,
+                    SimulatorTtsRate = SimulatorTtsRate,
+                    SimulatorAutoSpeak = SimulatorAutoSpeak,
+                    SimulatorAutoAdvance = SimulatorAutoAdvance,
                     // Issue #412: Game paths now stored in shared RadoubSettings
                     NeverwinterNightsPath = "",
                     BaseGameInstallPath = "",
@@ -798,6 +831,11 @@ namespace DialogEditor.Services
 
             // Conversation Simulator settings
             public bool SimulatorShowWarnings { get; set; } = true;
+            // Conversation Simulator TTS (#1570) - defaults mirror the simulator VM
+            public bool SimulatorTtsEnabled { get; set; } = true;
+            public double SimulatorTtsRate { get; set; } = 1.0;
+            public bool SimulatorAutoSpeak { get; set; } = false;
+            public bool SimulatorAutoAdvance { get; set; } = true;
 
             // Radoub tool integration settings
             public string ManifestPath { get; set; } = "";

--- a/Parley/Parley/ViewModels/ConversationSimulatorViewModel.ConversationFlow.cs
+++ b/Parley/Parley/ViewModels/ConversationSimulatorViewModel.ConversationFlow.cs
@@ -84,10 +84,11 @@ namespace DialogEditor.ViewModels
                 var nodeKey = $"E{entryIndex}";
                 var wasVisited = _coverageTracker.IsNodeVisited(_filePath, nodeKey);
 
-                // Show per-entry coverage (e.g., "2/3")
-                var entryCoverage = coverage.GetEntryCoverageText(entryIndex);
+                // #482: Show dual per-entry coverage: direct children + full subtree
+                var directCoverage = coverage.GetEntryDirectCoverageText(entryIndex);
+                var subtreeCoverage = coverage.GetEntryCoverageText(entryIndex);
                 var isEntryComplete = coverage.IsEntryComplete(entryIndex);
-                var coverageIndicator = isEntryComplete ? $" ({entryCoverage})" : $" ({entryCoverage})";
+                var coverageIndicator = $" ({directCoverage} direct, {subtreeCoverage} all)";
 
                 Replies.Add(new ReplyOption
                 {

--- a/Parley/Parley/ViewModels/ConversationSimulatorViewModel.ConversationFlow.cs
+++ b/Parley/Parley/ViewModels/ConversationSimulatorViewModel.ConversationFlow.cs
@@ -146,7 +146,7 @@ namespace DialogEditor.ViewModels
                         _isSpeakingPcReply = true;
                         _pendingReplyToAdvance = reply;
                         var pcVoice = GetVoiceForSpeaker("(PC)");
-                        _ttsService.Speak(pcText, pcVoice, TtsRate);
+                        _ttsService.Speak(_ttsTextParser.GetSpeechText(pcText), pcVoice, TtsRate);
                         return; // Don't advance yet - wait for speech to complete
                     }
                 }

--- a/Parley/Parley/ViewModels/ConversationSimulatorViewModel.CoverageAnalysis.cs
+++ b/Parley/Parley/ViewModels/ConversationSimulatorViewModel.CoverageAnalysis.cs
@@ -32,6 +32,7 @@ namespace DialogEditor.ViewModels
             // Collect root entry indices and map replies per root entry
             _rootEntryIndices.Clear();
             _repliesPerRootEntry.Clear();
+            _directRepliesPerRootEntry.Clear();
 
             foreach (var start in _dialog.Starts)
             {
@@ -42,10 +43,13 @@ namespace DialogEditor.ViewModels
                     {
                         _rootEntryIndices.Add(entryIndex);
 
-                        // Collect all reply indices reachable from this root entry
+                        // Collect all reply indices reachable from this root entry (full subtree)
                         var replyIndices = new HashSet<int>();
                         CollectRepliesUnderNode(start.Node, replyIndices, new HashSet<DialogNode>());
                         _repliesPerRootEntry[entryIndex] = replyIndices;
+
+                        // #482: collect only the entry's DIRECT child reply indices (no recursion)
+                        _directRepliesPerRootEntry[entryIndex] = CollectDirectReplies(start.Node);
                     }
                 }
             }
@@ -61,6 +65,26 @@ namespace DialogEditor.ViewModels
                 $"ConversationSimulator: Analyzed dialog - " +
                 $"totalReplies={_totalReplies}, rootEntries={_rootEntryIndices.Count}, " +
                 $"hasConditionals={hasConditionals}, unreachableSiblings={ShowUnreachableSiblingsWarning}");
+        }
+
+        /// <summary>
+        /// #482: Collect only the immediate child reply indices of an entry node (no recursion).
+        /// </summary>
+        private HashSet<int> CollectDirectReplies(DialogNode entryNode)
+        {
+            var directIndices = new HashSet<int>();
+            foreach (var ptr in entryNode.Pointers)
+            {
+                if (ptr.Node != null && ptr.Type == DialogNodeType.Reply)
+                {
+                    var replyIndex = _dialog.GetNodeIndex(ptr.Node, DialogNodeType.Reply);
+                    if (replyIndex >= 0)
+                    {
+                        directIndices.Add(replyIndex);
+                    }
+                }
+            }
+            return directIndices;
         }
 
         /// <summary>

--- a/Parley/Parley/ViewModels/ConversationSimulatorViewModel.cs
+++ b/Parley/Parley/ViewModels/ConversationSimulatorViewModel.cs
@@ -55,7 +55,8 @@ namespace DialogEditor.ViewModels
         // Coverage
         private int _totalReplies;
         private List<int> _rootEntryIndices = new();
-        private Dictionary<int, HashSet<int>> _repliesPerRootEntry = new(); // entryIndex -> set of reply indices under that root
+        private Dictionary<int, HashSet<int>> _repliesPerRootEntry = new(); // entryIndex -> set of reply indices under that root (full subtree)
+        private Dictionary<int, HashSet<int>> _directRepliesPerRootEntry = new(); // #482: entryIndex -> set of DIRECT child reply indices
 
         // TTS (Issue #479)
         // #1570: TtsEnabled/TtsRate/AutoSpeak/AutoAdvance are now backed by SettingsService for persistence.
@@ -251,7 +252,7 @@ namespace DialogEditor.ViewModels
             private set => SetProperty(ref _showLoopWarning, value);
         }
 
-        public CoverageStats Coverage => _coverageTracker.GetCoverageStats(_filePath, _totalReplies, _rootEntryIndices, _repliesPerRootEntry);
+        public CoverageStats Coverage => _coverageTracker.GetCoverageStats(_filePath, _totalReplies, _rootEntryIndices, _repliesPerRootEntry, _directRepliesPerRootEntry);
 
         public string CoverageDisplay => Coverage.DisplayText;
 

--- a/Parley/Parley/ViewModels/ConversationSimulatorViewModel.cs
+++ b/Parley/Parley/ViewModels/ConversationSimulatorViewModel.cs
@@ -58,11 +58,11 @@ namespace DialogEditor.ViewModels
         private Dictionary<int, HashSet<int>> _repliesPerRootEntry = new(); // entryIndex -> set of reply indices under that root
 
         // TTS (Issue #479)
+        // #1570: TtsEnabled/TtsRate/AutoSpeak/AutoAdvance are now backed by SettingsService for persistence.
         private readonly ITtsService _ttsService;
-        private bool _ttsEnabled = true;
-        private bool _autoSpeak = false;
-        private bool _autoAdvance = true;
-        private double _ttsRate = 1.0;
+        // #1570: strips markup/resolves tokens to clean speech text. Default parser (no user-color
+        // config) matches the on-screen TokenTextBlock, which is also unconfigured here.
+        private readonly Radoub.Formats.Tokens.TokenParser _ttsTextParser = new();
         private Dictionary<string, string> _speakerVoiceAssignments = new();
         private string _pcVoice = "";
         private string _defaultNpcVoice = "";
@@ -265,28 +265,58 @@ namespace DialogEditor.ViewModels
         public ObservableCollection<string> VoiceNames { get; }
         public ObservableCollection<SpeakerVoiceMapping> SpeakerVoiceAssignments { get; }
 
+        // TTS toggles bound to SettingsService for persistence across sessions (#1570)
         public bool TtsEnabled
         {
-            get => _ttsEnabled;
-            set => SetProperty(ref _ttsEnabled, value);
+            get => _settings.SimulatorTtsEnabled;
+            set
+            {
+                if (_settings.SimulatorTtsEnabled != value)
+                {
+                    _settings.SimulatorTtsEnabled = value;
+                    OnPropertyChanged(nameof(TtsEnabled));
+                }
+            }
         }
 
         public double TtsRate
         {
-            get => _ttsRate;
-            set => SetProperty(ref _ttsRate, Math.Clamp(value, 0.5, 2.0));
+            get => _settings.SimulatorTtsRate;
+            set
+            {
+                var clamped = Math.Clamp(value, 0.5, 2.0);
+                if (_settings.SimulatorTtsRate != clamped)
+                {
+                    _settings.SimulatorTtsRate = clamped;
+                    OnPropertyChanged(nameof(TtsRate));
+                }
+            }
         }
 
         public bool AutoSpeak
         {
-            get => _autoSpeak;
-            set => SetProperty(ref _autoSpeak, value);
+            get => _settings.SimulatorAutoSpeak;
+            set
+            {
+                if (_settings.SimulatorAutoSpeak != value)
+                {
+                    _settings.SimulatorAutoSpeak = value;
+                    OnPropertyChanged(nameof(AutoSpeak));
+                }
+            }
         }
 
         public bool AutoAdvance
         {
-            get => _autoAdvance;
-            set => SetProperty(ref _autoAdvance, value);
+            get => _settings.SimulatorAutoAdvance;
+            set
+            {
+                if (_settings.SimulatorAutoAdvance != value)
+                {
+                    _settings.SimulatorAutoAdvance = value;
+                    OnPropertyChanged(nameof(AutoAdvance));
+                }
+            }
         }
 
         /// <summary>
@@ -320,7 +350,7 @@ namespace DialogEditor.ViewModels
 
             // Get the voice for the current speaker
             var voiceName = GetVoiceForSpeaker(NpcSpeaker);
-            _ttsService.Speak(NpcText, voiceName, TtsRate);
+            _ttsService.Speak(_ttsTextParser.GetSpeechText(NpcText), voiceName, TtsRate);
             OnPropertyChanged(nameof(TtsSpeaking));
         }
 
@@ -436,7 +466,7 @@ namespace DialogEditor.ViewModels
             if (AutoSpeak && TtsAvailable && TtsEnabled && !string.IsNullOrWhiteSpace(NpcText))
             {
                 var npcVoice = GetVoiceForSpeaker(NpcSpeaker);
-                _ttsService.Speak(NpcText, npcVoice, TtsRate);
+                _ttsService.Speak(_ttsTextParser.GetSpeechText(NpcText), npcVoice, TtsRate);
                 // Auto-advance will be triggered by OnTtsSpeakCompleted when speech finishes
             }
             else if (AutoAdvance && Replies.Count == 1 && !_isSelectingRootEntry)

--- a/Parley/Parley/Views/MainWindow.axaml.cs
+++ b/Parley/Parley/Views/MainWindow.axaml.cs
@@ -142,7 +142,8 @@ namespace DialogEditor.Views
                 loadScriptPreview: (script, isCondition) => _ = LoadScriptPreviewAsync(script, isCondition),
                 clearScriptPreview: ClearScriptPreview,
                 triggerDebouncedAutoSave: TriggerDebouncedAutoSave,
-                refreshSiblingValidation: RefreshSiblingValidation); // Issue #609
+                refreshSiblingValidation: RefreshSiblingValidation, // Issue #609
+                getLastPopulatedNode: () => _lastPopulatedNode); // #2521: cross-node flush guard
             _services.ParameterUI = new ScriptParameterUIManager(
                 findControl: this.FindControl<Control>,
                 setStatusMessage: msg => _viewModel.StatusMessage = msg,
@@ -155,7 +156,14 @@ namespace DialogEditor.Views
                 viewModel: _viewModel,
                 findControl: this.FindControl<Control>,
                 saveCurrentNodeProperties: SaveCurrentNodeProperties,
-                triggerAutoSave: TriggerDebouncedAutoSave);
+                triggerAutoSave: TriggerDebouncedAutoSave,
+                // #2521: re-sync the panel to the newly-created node after the refresh, since the
+                // selection-changed populate is skipped while the refresh coordinator is busy.
+                repopulateSelectedNodePanel: () =>
+                {
+                    if (_selectedNode != null && _selectedNode is not TreeViewRootNode)
+                        PopulatePropertiesPanel(_selectedNode);
+                });
             // #1791: GameData not yet initialized — wired in ConnectGameDataServices() after deferred init
             _services.ResourceBrowser = new ResourceBrowserManager(
                 audioService: _services.Audio,

--- a/Radoub.Formats/Radoub.Formats.Tests/TokenParserTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/TokenParserTests.cs
@@ -341,6 +341,105 @@ public class TokenParserTests
 
     #endregion
 
+    #region GetSpeechText Tests (#1570)
+
+    [Fact]
+    public void GetSpeechText_PlainText_ReturnsUnchanged()
+    {
+        Assert.Equal("Hello, world!", _parser.GetSpeechText("Hello, world!"));
+    }
+
+    [Fact]
+    public void GetSpeechText_NullOrEmpty_ReturnsEmpty()
+    {
+        Assert.Equal("", _parser.GetSpeechText(""));
+        Assert.Equal("", _parser.GetSpeechText(null!));
+    }
+
+    [Fact]
+    public void GetSpeechText_HighlightToken_KeepsInnerContentDropsTags()
+    {
+        // Decided: read inner content, strip markup tags
+        Assert.Equal("[Chef waves] Welcome!",
+            _parser.GetSpeechText("<StartAction>[Chef waves]</Start> Welcome!"));
+    }
+
+    [Fact]
+    public void GetSpeechText_ColorToken_KeepsInnerContentDropsTags()
+    {
+        var text = "<c\xFF\x00\x00>red text</c> here";
+        Assert.Equal("red text here", _parser.GetSpeechText(text));
+    }
+
+    [Fact]
+    public void GetSpeechText_UserColorToken_KeepsInnerContent()
+    {
+        var config = new UserColorConfig
+        {
+            CloseToken = "<CUSTOM1000>",
+            Colors = new Dictionary<string, string> { ["Red"] = "<CUSTOM1001>" },
+            ColorHexValues = new Dictionary<string, string> { ["Red"] = "#FF0000" }
+        };
+        var parser = new TokenParser(config);
+        Assert.Equal("alert", parser.GetSpeechText("<CUSTOM1001>alert<CUSTOM1000>"));
+    }
+
+    [Fact]
+    public void GetSpeechText_NameTokens_MapToAdventurer()
+    {
+        Assert.Equal("Hello Adventurer!", _parser.GetSpeechText("Hello <FirstName>!"));
+        Assert.Equal("Adventurer", _parser.GetSpeechText("<LastName>"));
+        Assert.Equal("Adventurer", _parser.GetSpeechText("<FullName>"));
+        Assert.Equal("Adventurer", _parser.GetSpeechText("<PlayerName>"));
+    }
+
+    [Theory]
+    [InlineData("He/She", "they")]
+    [InlineData("he/she", "they")]
+    [InlineData("Him/Her", "them")]
+    [InlineData("him/her", "them")]
+    [InlineData("His/Her", "their")]
+    [InlineData("his/her", "their")]
+    [InlineData("His/Hers", "their")]
+    [InlineData("his/hers", "their")]
+    public void GetSpeechText_PronounTokens_MapToNeutral(string token, string spoken)
+    {
+        Assert.Equal($"and {spoken} said", _parser.GetSpeechText($"and <{token}> said"));
+    }
+
+    [Theory]
+    [InlineData("Class")]
+    [InlineData("Race")]
+    [InlineData("Level")]
+    [InlineData("Boy/Girl")]
+    public void GetSpeechText_UnmappedStandardToken_FallsBackToTokenName(string token)
+    {
+        Assert.Equal(token, _parser.GetSpeechText($"<{token}>"));
+    }
+
+    [Fact]
+    public void GetSpeechText_CustomToken_IsDropped()
+    {
+        Assert.Equal("a b", _parser.GetSpeechText("a <CUSTOM5>b"));
+    }
+
+    [Fact]
+    public void GetSpeechText_StrayEndFragment_SpokenAsPlainText()
+    {
+        // Parse() leaves unmatched tags as plain text; GetSpeechText speaks them as-is.
+        // This test pins the chosen behavior so it is intentional.
+        Assert.Equal("hello <End> there", _parser.GetSpeechText("hello <End> there"));
+    }
+
+    [Fact]
+    public void GetSpeechText_MixedContent_ResolvesEachSegment()
+    {
+        var text = "Hello <FirstName>! <StartAction>[waves]</Start> good <he/she>.";
+        Assert.Equal("Hello Adventurer! [waves] good they.", _parser.GetSpeechText(text));
+    }
+
+    #endregion
+
     #region Token Definitions Tests
 
     [Fact]

--- a/Radoub.Formats/Radoub.Formats.Tests/TokenParserTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/TokenParserTests.cs
@@ -411,10 +411,53 @@ public class TokenParserTests
     [InlineData("Class")]
     [InlineData("Race")]
     [InlineData("Level")]
-    [InlineData("Boy/Girl")]
-    public void GetSpeechText_UnmappedStandardToken_FallsBackToTokenName(string token)
+    [InlineData("Deity")]
+    [InlineData("GameMonth")]
+    [InlineData("Alignment")]
+    public void GetSpeechText_DescriptiveStandardToken_FallsBackToTokenName(string token)
     {
+        // Descriptive (non-gendered) tokens are intentionally unmapped -> literal.
         Assert.Equal(token, _parser.GetSpeechText($"<{token}>"));
+    }
+
+    [Theory]
+    [InlineData("Boy/Girl", "child")]
+    [InlineData("boy/girl", "child")]
+    [InlineData("Brother/Sister", "sibling")]
+    [InlineData("Lad/Lass", "youth")]
+    [InlineData("Lord/Lady", "noble")]
+    [InlineData("lord/lady", "noble")]
+    [InlineData("Man/Woman", "person")]
+    [InlineData("Male/Female", "person")]
+    [InlineData("Master/Mistress", "master")]
+    [InlineData("Mister/Missus", "mister")]
+    [InlineData("Sir/Madam", "friend")]
+    [InlineData("bitch/bastard", "wretch")]
+    public void GetSpeechText_GenderedNounTokens_MapToNeutralNoun(string token, string spoken)
+    {
+        Assert.Equal($"Well met, {spoken}.", _parser.GetSpeechText($"Well met, <{token}>."));
+    }
+
+    [Fact]
+    public void GetSpeechText_AllGenderedStandardTokens_AreMapped()
+    {
+        // Guard: every gendered name/pronoun/noun token resolves to something OTHER than its
+        // literal token name, so none accidentally falls through to being read aloud verbatim.
+        string[] gendered =
+        {
+            "FirstName", "LastName", "FullName", "PlayerName",
+            "He/She", "he/she", "Him/Her", "him/her", "His/Her", "his/her", "His/Hers", "his/hers",
+            "Boy/Girl", "boy/girl", "Brother/Sister", "brother/sister", "Lad/Lass", "lad/lass",
+            "Lord/Lady", "lord/lady", "Man/Woman", "man/woman", "Male/Female", "male/female",
+            "Master/Mistress", "master/mistress", "Mister/Missus", "mister/missus",
+            "Sir/Madam", "sir/madam", "bitch/bastard"
+        };
+        foreach (var token in gendered)
+        {
+            var spoken = _parser.GetSpeechText($"<{token}>");
+            Assert.NotEqual(token, spoken);
+            Assert.False(string.IsNullOrWhiteSpace(spoken), $"{token} produced empty speech");
+        }
     }
 
     [Fact]

--- a/Radoub.Formats/Radoub.Formats/Tokens/TokenDefinitions.cs
+++ b/Radoub.Formats/Radoub.Formats/Tokens/TokenDefinitions.cs
@@ -124,6 +124,33 @@ public static class TokenDefinitions
         new(StandardTokens, StringComparer.Ordinal);
 
     /// <summary>
+    /// Spoken-text placeholders for standard tokens, used by TTS in the Conversation Simulator
+    /// where there is no real game character to resolve tokens against (#1570).
+    /// This is presentation data for a preview feature, NOT 2DA game data.
+    /// Name tokens speak as "Adventurer"; gender pronoun tokens speak as neutral forms.
+    /// Tokens not in this map fall back to their literal token name.
+    /// Keys are case-exact (StandardTokenSet uses ordinal comparison).
+    /// </summary>
+    public static readonly Dictionary<string, string> SpeechPlaceholders = new(StringComparer.Ordinal)
+    {
+        // Name tokens
+        ["FirstName"] = "Adventurer",
+        ["LastName"] = "Adventurer",
+        ["FullName"] = "Adventurer",
+        ["PlayerName"] = "Adventurer",
+
+        // Pronoun tokens -> neutral spoken forms (both case variants)
+        ["He/She"] = "they",
+        ["he/she"] = "they",
+        ["Him/Her"] = "them",
+        ["him/her"] = "them",
+        ["His/Her"] = "their",
+        ["his/her"] = "their",
+        ["His/Hers"] = "their",
+        ["his/hers"] = "their"
+    };
+
+    /// <summary>
     /// Check if a token name is a standard Aurora token.
     /// </summary>
     public static bool IsStandardToken(string tokenName)

--- a/Radoub.Formats/Radoub.Formats/Tokens/TokenDefinitions.cs
+++ b/Radoub.Formats/Radoub.Formats/Tokens/TokenDefinitions.cs
@@ -127,8 +127,9 @@ public static class TokenDefinitions
     /// Spoken-text placeholders for standard tokens, used by TTS in the Conversation Simulator
     /// where there is no real game character to resolve tokens against (#1570).
     /// This is presentation data for a preview feature, NOT 2DA game data.
-    /// Name tokens speak as "Adventurer"; gender pronoun tokens speak as neutral forms.
-    /// Tokens not in this map fall back to their literal token name.
+    /// Name tokens speak as "Adventurer"; gender pronoun/noun tokens speak as neutral forms.
+    /// Descriptive tokens (Class, Race, Level, time, alignment, etc.) are intentionally NOT
+    /// mapped here and fall back to their literal token name.
     /// Keys are case-exact (StandardTokenSet uses ordinal comparison).
     /// </summary>
     public static readonly Dictionary<string, string> SpeechPlaceholders = new(StringComparer.Ordinal)
@@ -147,7 +148,28 @@ public static class TokenDefinitions
         ["His/Her"] = "their",
         ["his/her"] = "their",
         ["His/Hers"] = "their",
-        ["his/hers"] = "their"
+        ["his/hers"] = "their",
+
+        // Gendered noun pairs -> generic neutral nouns (both case variants)
+        ["Boy/Girl"] = "child",
+        ["boy/girl"] = "child",
+        ["Brother/Sister"] = "sibling",
+        ["brother/sister"] = "sibling",
+        ["Lad/Lass"] = "youth",
+        ["lad/lass"] = "youth",
+        ["Lord/Lady"] = "noble",
+        ["lord/lady"] = "noble",
+        ["Man/Woman"] = "person",
+        ["man/woman"] = "person",
+        ["Male/Female"] = "person",
+        ["male/female"] = "person",
+        ["Master/Mistress"] = "master",
+        ["master/mistress"] = "master",
+        ["Mister/Missus"] = "mister",
+        ["mister/missus"] = "mister",
+        ["Sir/Madam"] = "friend",
+        ["sir/madam"] = "friend",
+        ["bitch/bastard"] = "wretch"
     };
 
     /// <summary>

--- a/Radoub.Formats/Radoub.Formats/Tokens/TokenParser.cs
+++ b/Radoub.Formats/Radoub.Formats/Tokens/TokenParser.cs
@@ -88,6 +88,48 @@ public class TokenParser
         return string.Concat(segments.Select(s => s.DisplayText));
     }
 
+    /// <summary>
+    /// Parse text and return a clean string suitable for text-to-speech (#1570).
+    /// Markup tags are stripped, the inner content of highlight/color tokens is kept,
+    /// standard tokens are replaced with spoken placeholders (e.g. FirstName -> "Adventurer",
+    /// pronouns -> they/them/their) or their literal name when unmapped, and custom tokens
+    /// are dropped. Stray/unmatched tag fragments are left as plain text and spoken as-is.
+    /// </summary>
+    /// <remarks>
+    /// UserColorToken segments are only produced when this parser was constructed with a
+    /// UserColorConfig. On a default parser, custom-color pairs become dropped CustomTokens
+    /// with their inner text as plain text — the words are still spoken, only color markup is lost.
+    /// </remarks>
+    /// <param name="text">Text to convert to speech</param>
+    /// <returns>Clean speech text</returns>
+    public string GetSpeechText(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return string.Empty;
+
+        var sb = new System.Text.StringBuilder();
+        foreach (var segment in Parse(text))
+        {
+            switch (segment)
+            {
+                case StandardToken std:
+                    sb.Append(TokenDefinitions.SpeechPlaceholders.TryGetValue(std.TokenName, out var spoken)
+                        ? spoken
+                        : std.TokenName);
+                    break;
+                case CustomToken:
+                    // No spoken value; drop.
+                    break;
+                default:
+                    // PlainText, Highlight, Color, UserColor -> inner/display content.
+                    sb.Append(segment.DisplayText);
+                    break;
+            }
+        }
+
+        return sb.ToString();
+    }
+
     private void ProcessHighlightTokens(string text, List<TokenSegment> segments, bool[] processed)
     {
         foreach (Match match in HighlightTokenRegex.Matches(text))


### PR DESCRIPTION
## Summary

Parley UI/UX sprint clearing long-standing Conversation Simulator debt. Scoped to Parley — #218 (keyboard-shortcut config UI) was rescoped to a Radoub-wide feature and dropped from this sprint.

## Work Items

- [ ] #482 — Conversation Simulator: add per-start-entry direct-child reply coverage alongside the existing full-subtree count (dual display)
- [ ] #1570 — Text-to-Speech: persist the 4 simulator toggles (enabled/rate/auto-speak/auto-advance) and strip markup tags from spoken text (keep content; name → "Adventurer", pronouns → they/their)

## Related Issues

- Closes #482
- Closes #1570
- Relates to #218 (rescoped to Radoub-wide; tracked separately)

## Checklist

- [ ] Implementation complete
- [ ] Tests added/updated
- [ ] CHANGELOG updated with date
- [ ] Documentation updated (if needed)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)