### PR TITLE
[Quartermaster] Sprint: Character Data + UI Bug Fix (#2440)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Radoub.UI 0.2.18-alpha] - 2026-06-20
 **Branch**: `quartermaster/issue-2440` | **PR**: #2525
 
-### Fix: Portrait browser duplicate guard (#2329)
+### Fix: Portrait browser duplicate guard + larger thumbnails (#2329)
 
 - `PortraitBrowserWindow` now de-duplicates portraits by ResRef (case-insensitive, first-occurrence) before display, so no tool's portrait context can surface the same portrait twice. Quartermaster and Reliquary contexts also dedupe at source.
+- Thumbnails enlarged from 32×40 to 64×80 so portraits are legible in the grid.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.18-alpha] - 2026-06-20
+**Branch**: `quartermaster/issue-2440` | **PR**: #2525
+
+### Fix: Portrait browser duplicate guard (#2329)
+
+- `PortraitBrowserWindow` now de-duplicates portraits by ResRef (case-insensitive, first-occurrence) before display, so no tool's portrait context can surface the same portrait twice. Quartermaster and Reliquary contexts also dedupe at source.
+
+---
+
 ## [Radoub.UI 0.2.17-alpha] - 2026-06-19
 **Branch**: `radoub/sprint/2443-shared-ui-bugs` | **PR**: #2518
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -12,7 +12,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 - Closing the window mid-cache-build no longer freezes the UI — the in-flight palette/HAK scan is cancelled on close (#2299).
 - Feats panel: clearer separation between the row checkbox and the status column so the checkbox's column is unambiguous (#2286).
-- Portrait browser: duplicate portraits removed — the same base portrait used by multiple race/sex variants now lists once (#2329).
+- Portrait browser: duplicate portraits removed and thumbnails enlarged for legibility; the editor's Browse now pre-filters to the creature's race/sex instead of showing all (#2329).
 
 ---
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.126-alpha] - 2026-06-19
-**Branch**: `quartermaster/issue-2440` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2440` | **PR**: #2525
 
 ### Sprint: Character Data + UI Bug Fix (#2440)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.126-alpha] - 2026-06-19
+**Branch**: `quartermaster/issue-2440` | **PR**: #TBD
+
+### Sprint: Character Data + UI Bug Fix (#2440)
+
+- Closing the window mid-cache-build no longer freezes the UI — the in-flight palette/HAK scan is cancelled on close (#2299).
+- Feats panel: clearer separation between the row checkbox and the status column so the checkbox's column is unambiguous (#2286).
+- Portrait browser: duplicate portraits removed — the same base portrait used by multiple race/sex variants now lists once (#2329).
+
+---
+
 ## [0.2.125-alpha] - 2026-06-19
 **Branch**: `quartermaster/issue-2498` | **PR**: #2509
 

--- a/Quartermaster/Quartermaster.Tests/LinkedCtsHolderTests.cs
+++ b/Quartermaster/Quartermaster.Tests/LinkedCtsHolderTests.cs
@@ -1,0 +1,89 @@
+using System.Threading;
+using Quartermaster.Services;
+using Xunit;
+
+namespace Quartermaster.Tests;
+
+/// <summary>
+/// Tests for the palette-cache CTS lifecycle helper (#2299). The bug: closing the
+/// window mid-cache-build disposed the linked CTS without cancelling it first, so the
+/// in-flight scan ran to completion and froze the UI. The helper enforces
+/// Cancel -> Dispose -> null on teardown and on restart.
+/// </summary>
+public class LinkedCtsHolderTests
+{
+    [Fact]
+    public void CancelAndDispose_SignalsCancellationBeforeDisposing()
+    {
+        var holder = new LinkedCtsHolder();
+        var token = holder.Restart(null);
+
+        Assert.False(token.IsCancellationRequested);
+
+        holder.CancelAndDispose();
+
+        // The token captured before teardown must observe cancellation — proves we
+        // Cancel() rather than just Dispose() (the #2299 regression).
+        Assert.True(token.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void CancelAndDispose_IsIdempotent()
+    {
+        var holder = new LinkedCtsHolder();
+        holder.Restart(null);
+
+        holder.CancelAndDispose();
+        // Second call must be a no-op, not a double-dispose throw.
+        holder.CancelAndDispose();
+    }
+
+    [Fact]
+    public void CancelAndDispose_WithNoActiveToken_DoesNotThrow()
+    {
+        var holder = new LinkedCtsHolder();
+        // Never started — teardown must be safe.
+        holder.CancelAndDispose();
+    }
+
+    [Fact]
+    public void Restart_CancelsAndDisposesPreviousToken()
+    {
+        var holder = new LinkedCtsHolder();
+        var first = holder.Restart(null);
+
+        var second = holder.Restart(null);
+
+        Assert.True(first.IsCancellationRequested);
+        Assert.False(second.IsCancellationRequested);
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void Restart_WithParentToken_CancelsWhenParentCancels()
+    {
+        var holder = new LinkedCtsHolder();
+        using var parent = new CancellationTokenSource();
+
+        var token = holder.Restart(parent.Token);
+        Assert.False(token.IsCancellationRequested);
+
+        parent.Cancel();
+
+        Assert.True(token.IsCancellationRequested);
+        holder.CancelAndDispose();
+    }
+
+    [Fact]
+    public void Restart_WithAlreadyCancelledParent_ProducesCancelledToken()
+    {
+        var holder = new LinkedCtsHolder();
+        using var parent = new CancellationTokenSource();
+        parent.Cancel();
+
+        var token = holder.Restart(parent.Token);
+
+        Assert.True(token.IsCancellationRequested);
+        holder.CancelAndDispose();
+    }
+}

--- a/Quartermaster/Quartermaster.Tests/PortraitBrowserContextTests.cs
+++ b/Quartermaster/Quartermaster.Tests/PortraitBrowserContextTests.cs
@@ -76,6 +76,24 @@ public class PortraitBrowserContextTests
     }
 
     [Fact]
+    public void ListPortraits_DuplicateWithDifferingRace_StaysVisibleToAllRaces()
+    {
+        // A repeated BaseResRef whose rows disagree on Race must not be pinned to the
+        // first row's race — otherwise pre-filtering by a creature's race hides a
+        // portrait that other rows mark as valid for that race (#2329 regression guard).
+        var mock = new MockGameDataService(includeSampleData: false);
+        var twoDA = new TwoDAFile { Columns = new() { "BaseResRef", "Race", "Sex" } };
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "po_shared_", "1", "0" } }); // first row: Elf
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "po_shared_", "4", "0" } }); // dup: Half-Elf
+        mock.With2DA("portraits", twoDA);
+
+        var entry = Assert.Single(BuildContext(mock).ListPortraits().ToList());
+
+        // Collapsed to "all races" (-1) so neither race-filter excludes it.
+        Assert.Equal(-1, entry.Race);
+    }
+
+    [Fact]
     public void ListPortraits_KeepsFirstOccurrenceOrder()
     {
         // Dedupe keeps the first row seen and preserves 2DA order.

--- a/Quartermaster/Quartermaster.Tests/PortraitBrowserContextTests.cs
+++ b/Quartermaster/Quartermaster.Tests/PortraitBrowserContextTests.cs
@@ -38,4 +38,58 @@ public class PortraitBrowserContextTests
         Assert.Contains(result, p => p.ResRef == "hu_m_01_");
         Assert.Contains(result, p => p.ResRef == "el_f_02_");
     }
+
+    [Fact]
+    public void ListPortraits_DedupesRepeatedBaseResRef()
+    {
+        // portraits.2da carries the same BaseResRef across multiple rows for
+        // race/sex variants. The browser must list each portrait once (#2329).
+        var mock = new MockGameDataService(includeSampleData: false);
+        var twoDA = new TwoDAFile { Columns = new() { "BaseResRef", "Race", "Sex" } };
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "hu_m_01_", "6", "0" } });
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "hu_m_01_", "4", "0" } }); // dup (half-elf male)
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "hu_m_01_", "5", "0" } }); // dup (half-orc male)
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "el_f_02_", "1", "1" } });
+        mock.With2DA("portraits", twoDA);
+
+        var result = BuildContext(mock).ListPortraits().ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Single(result, p => p.ResRef == "hu_m_01_");
+        Assert.Single(result, p => p.ResRef == "el_f_02_");
+    }
+
+    [Fact]
+    public void ListPortraits_DedupesCaseInsensitively()
+    {
+        // ResRefs are case-insensitive in Aurora; variants differing only in case
+        // must not slip past the dedupe (#2329).
+        var mock = new MockGameDataService(includeSampleData: false);
+        var twoDA = new TwoDAFile { Columns = new() { "BaseResRef", "Race", "Sex" } };
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "hu_m_01_", "6", "0" } });
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "Hu_M_01_", "6", "1" } }); // same ResRef, different case
+        mock.With2DA("portraits", twoDA);
+
+        var result = BuildContext(mock).ListPortraits().ToList();
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void ListPortraits_KeepsFirstOccurrenceOrder()
+    {
+        // Dedupe keeps the first row seen and preserves 2DA order.
+        var mock = new MockGameDataService(includeSampleData: false);
+        var twoDA = new TwoDAFile { Columns = new() { "BaseResRef", "Race", "Sex" } };
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "el_f_02_", "1", "1" } });
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "hu_m_01_", "6", "0" } });
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "el_f_02_", "4", "1" } }); // dup of row 0
+        mock.With2DA("portraits", twoDA);
+
+        var result = BuildContext(mock).ListPortraits().ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("el_f_02_", result[0].ResRef);
+        Assert.Equal("hu_m_01_", result[1].ResRef);
+    }
 }

--- a/Quartermaster/Quartermaster/Services/LinkedCtsHolder.cs
+++ b/Quartermaster/Quartermaster/Services/LinkedCtsHolder.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading;
+
+namespace Quartermaster.Services;
+
+/// <summary>
+/// Owns the lifecycle of a single background-work <see cref="CancellationTokenSource"/>,
+/// optionally linked to a parent token. Enforces the Cancel -> Dispose -> null discipline
+/// (the #2262 FileBrowserPanelBase pattern) so tearing down or restarting the work never
+/// orphans an in-flight scan.
+///
+/// #2299: the palette/HAK cache build was disposed on window close without being cancelled
+/// first, so the close handler waited for the synchronous tail of the scan and the UI froze.
+/// Routing that CTS through this helper guarantees cancellation is signalled before disposal.
+/// </summary>
+public sealed class LinkedCtsHolder
+{
+    private CancellationTokenSource? _cts;
+
+    /// <summary>
+    /// Cancel and dispose any existing source, then create a fresh one (linked to
+    /// <paramref name="parentToken"/> when supplied) and return its token.
+    /// </summary>
+    public CancellationToken Restart(CancellationToken? parentToken)
+    {
+        CancelAndDispose();
+
+        _cts = parentToken.HasValue
+            ? CancellationTokenSource.CreateLinkedTokenSource(parentToken.Value)
+            : new CancellationTokenSource();
+
+        return _cts.Token;
+    }
+
+    /// <summary>
+    /// Cancel the in-flight work and dispose its source. Idempotent and null-safe.
+    /// </summary>
+    public void CancelAndDispose()
+    {
+        if (_cts != null)
+        {
+            _cts.Cancel();
+            _cts.Dispose();
+            _cts = null;
+        }
+    }
+}

--- a/Quartermaster/Quartermaster/Services/QuartermasterPortraitBrowserContext.cs
+++ b/Quartermaster/Quartermaster/Services/QuartermasterPortraitBrowserContext.cs
@@ -36,7 +36,10 @@ public class QuartermasterPortraitBrowserContext : IPortraitBrowserContext
 
         // portraits.2da repeats the same BaseResRef across race/sex variant rows;
         // list each portrait once (#2329). ResRefs are case-insensitive in Aurora.
-        var seen = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
+        // When duplicate rows disagree on Race/Sex, collapse to "all" (-1) so a
+        // creature-race/sex pre-filter can't hide a portrait that a later row marks
+        // as valid for that race/sex (#2329 regression).
+        var indexByResRef = new Dictionary<string, int>(System.StringComparer.OrdinalIgnoreCase);
 
         int rowCount = _gameDataService.Get2DA("portraits")?.RowCount ?? 500;
         for (int i = 0; i < rowCount; i++)
@@ -45,9 +48,6 @@ public class QuartermasterPortraitBrowserContext : IPortraitBrowserContext
             if (IsEmptyCell(baseResRef))
                 continue;
             baseResRef = baseResRef!.Trim();
-
-            if (!seen.Add(baseResRef))
-                continue;
 
             var raceStr = _gameDataService.Get2DAValue("portraits", i, "Race");
             var sexStr = _gameDataService.Get2DAValue("portraits", i, "Sex");
@@ -61,6 +61,19 @@ public class QuartermasterPortraitBrowserContext : IPortraitBrowserContext
             if (!string.IsNullOrEmpty(sexStr) && sexStr != "****")
                 int.TryParse(sexStr, out sex);
 
+            if (indexByResRef.TryGetValue(baseResRef, out var existingIdx))
+            {
+                // Duplicate ResRef: widen the kept entry to "all" on any axis the
+                // rows disagree on, so neither value excludes the portrait.
+                var existing = portraits[existingIdx];
+                if (existing.Race != race)
+                    existing.Race = -1;
+                if (existing.Sex != sex)
+                    existing.Sex = -1;
+                continue;
+            }
+
+            indexByResRef[baseResRef] = portraits.Count;
             portraits.Add(new PortraitEntry
             {
                 Id = (ushort)i,

--- a/Quartermaster/Quartermaster/Services/QuartermasterPortraitBrowserContext.cs
+++ b/Quartermaster/Quartermaster/Services/QuartermasterPortraitBrowserContext.cs
@@ -34,6 +34,10 @@ public class QuartermasterPortraitBrowserContext : IPortraitBrowserContext
     {
         var portraits = new List<PortraitEntry>();
 
+        // portraits.2da repeats the same BaseResRef across race/sex variant rows;
+        // list each portrait once (#2329). ResRefs are case-insensitive in Aurora.
+        var seen = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
+
         int rowCount = _gameDataService.Get2DA("portraits")?.RowCount ?? 500;
         for (int i = 0; i < rowCount; i++)
         {
@@ -41,6 +45,9 @@ public class QuartermasterPortraitBrowserContext : IPortraitBrowserContext
             if (IsEmptyCell(baseResRef))
                 continue;
             baseResRef = baseResRef!.Trim();
+
+            if (!seen.Add(baseResRef))
+                continue;
 
             var raceStr = _gameDataService.Get2DAValue("portraits", i, "Race");
             var sexStr = _gameDataService.Get2DAValue("portraits", i, "Sex");

--- a/Quartermaster/Quartermaster/Views/MainWindow.ItemPalette.cs
+++ b/Quartermaster/Quartermaster/Views/MainWindow.ItemPalette.cs
@@ -28,8 +28,10 @@ public partial class MainWindow
     // HAK scanner for loading items from module-referenced HAK files
     private readonly HakPaletteScannerService _hakScanner = new();
 
-    // Cancellation token for background cache building
-    private CancellationTokenSource? _paletteCacheCts;
+    // Cancellation lifecycle for background cache building (#2299).
+    // Enforces Cancel -> Dispose -> null so a window close mid-build cancels the
+    // in-flight scan instead of waiting on it (the freeze this fixed).
+    private readonly Quartermaster.Services.LinkedCtsHolder _paletteCacheCts = new();
 
     // Track loaded state
     private bool _cachePreWarmed;
@@ -53,12 +55,11 @@ public partial class MainWindow
             return;
         }
 
-        // Link to window cancellation token
-        _paletteCacheCts?.Cancel();
-        _paletteCacheCts = CancellationTokenSource.CreateLinkedTokenSource(windowToken);
+        // Link to window cancellation token (cancels + disposes any prior source)
+        var token = _paletteCacheCts.Restart(windowToken);
 
         // Pre-warm cache in background (non-blocking)
-        _ = PreWarmCacheAsync(_paletteCacheCts.Token);
+        _ = PreWarmCacheAsync(token);
     }
 
     /// <summary>
@@ -488,12 +489,9 @@ public partial class MainWindow
     /// </summary>
     public async Task ClearAndReloadPaletteCacheAsync()
     {
-        // Create new CTS for this operation (links to window CTS if available)
-        _paletteCacheCts?.Cancel();
-        _paletteCacheCts = _windowCts != null
-            ? CancellationTokenSource.CreateLinkedTokenSource(_windowCts.Token)
-            : new CancellationTokenSource();
-        var token = _paletteCacheCts.Token;
+        // Create new CTS for this operation (links to window CTS if available).
+        // Restart cancels + disposes the prior source so it isn't orphaned.
+        var token = _paletteCacheCts.Restart(_windowCts?.Token);
 
         _sharedCacheService.ClearAllCaches();
         _cachePreWarmed = false;

--- a/Quartermaster/Quartermaster/Views/MainWindow.Lifecycle.cs
+++ b/Quartermaster/Quartermaster/Views/MainWindow.Lifecycle.cs
@@ -202,14 +202,16 @@ public partial class MainWindow
             Radoub.UI.Services.ThemeManager.Instance.ThemeApplied -= OnThemeApplied;
             Radoub.UI.Services.FileSessionLockService.ReleaseAllLocks();
 
-            // Cancel all async operations
+            // Cancel all async operations. Cancel the palette cache build FIRST and
+            // explicitly (#2299) so closing mid-build signals the in-flight scan to
+            // stop rather than waiting on its synchronous tail (the UI freeze).
+            _paletteCacheCts.CancelAndDispose();
             _windowCts?.Cancel();
             _windowCts?.Dispose();
 
             SaveWindowPosition();
             _audioService?.Dispose();
             _gameDataService?.Dispose();
-            _paletteCacheCts?.Dispose();
             (_sharedCacheService as IDisposable)?.Dispose();
             (_creaturePaletteCache as IDisposable)?.Dispose();
 

--- a/Quartermaster/Quartermaster/Views/Panels/CharacterPanel.Dialogs.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/CharacterPanel.Dialogs.cs
@@ -49,6 +49,10 @@ public partial class CharacterPanel
             var context = new QuartermasterPortraitBrowserContext(_gameDataService, _itemIconService);
             var browser = PortraitBrowserWindow.Create(context);
 
+            // Pre-filter by the creature's race/gender so the list isn't All/All.
+            if (_currentCreature != null)
+                browser.SetInitialFilters(_currentCreature.Race, _currentCreature.Gender);
+
             var topLevel = TopLevel.GetTopLevel(this);
             if (topLevel is Window parentWindow)
             {

--- a/Quartermaster/Quartermaster/Views/Panels/FeatsPanel.axaml
+++ b/Quartermaster/Quartermaster/Views/Panels/FeatsPanel.axaml
@@ -122,13 +122,14 @@
                         BorderThickness="1,1,1,0"
                         CornerRadius="4,4,0,0"
                         Padding="10,8,25,8">
-                    <Grid ColumnDefinitions="32,35,*,120,100">
+                    <Grid ColumnDefinitions="32,44,16,*,120,100">
                         <TextBlock Grid.Column="0" Text="" FontWeight="SemiBold" FontSize="{DynamicResource FontSizeSmall}"/>
                         <TextBlock Grid.Column="1" Text="Has" FontWeight="SemiBold" FontSize="{DynamicResource FontSizeSmall}" HorizontalAlignment="Center"
                                    ToolTip.Tip="Feat is chosen for creature"/>
-                        <TextBlock Grid.Column="2" Text="Feat Name" FontWeight="SemiBold" FontSize="{DynamicResource FontSizeSmall}"/>
-                        <TextBlock Grid.Column="3" Text="Category" FontWeight="SemiBold" FontSize="{DynamicResource FontSizeSmall}" HorizontalAlignment="Center"/>
-                        <TextBlock Grid.Column="4" Text="Status" FontWeight="SemiBold" FontSize="{DynamicResource FontSizeSmall}" HorizontalAlignment="Center"/>
+                        <!-- Column 2: spacer between the Has checkbox and the feat name -->
+                        <TextBlock Grid.Column="3" Text="Feat Name" FontWeight="SemiBold" FontSize="{DynamicResource FontSizeSmall}"/>
+                        <TextBlock Grid.Column="4" Text="Category" FontWeight="SemiBold" FontSize="{DynamicResource FontSizeSmall}" HorizontalAlignment="Center"/>
+                        <TextBlock Grid.Column="5" Text="" FontWeight="SemiBold" FontSize="{DynamicResource FontSizeSmall}" HorizontalAlignment="Center"/>
                     </Grid>
                 </Border>
 
@@ -153,7 +154,7 @@
                                     BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                                     BorderThickness="0,0,0,1"
                                     ToolTip.Tip="{Binding Description}">
-                                <Grid ColumnDefinitions="32,35,*,120,100">
+                                <Grid ColumnDefinitions="32,44,16,*,120,100">
                                     <!-- Icon -->
                                     <Image Grid.Column="0"
                                            Source="{Binding IconBitmap}"
@@ -172,23 +173,31 @@
                                               ToolTip.Tip="{Binding AssignedTooltip}"
                                               AutomationProperties.AutomationId="FeatAssignedCheckbox"/>
 
+                                    <!-- Separator between the Has checkbox and the feat name (#2286) -->
+                                    <Border Grid.Column="2"
+                                            Width="1"
+                                            Background="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Stretch"
+                                            Margin="0,3"/>
+
                                     <!-- Feat Name -->
-                                    <TextBlock Grid.Column="2"
+                                    <TextBlock Grid.Column="3"
                                                Text="{Binding FeatName}"
                                                VerticalAlignment="Center"
                                                FontSize="{DynamicResource FontSizeNormal}"
                                                Opacity="{Binding TextOpacity}"/>
 
                                     <!-- Category -->
-                                    <TextBlock Grid.Column="3"
+                                    <TextBlock Grid.Column="4"
                                                Text="{Binding CategoryName}"
                                                FontSize="{DynamicResource FontSizeSmall}"
                                                Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                                HorizontalAlignment="Center"
                                                VerticalAlignment="Center"/>
 
-                                    <!-- Status -->
-                                    <TextBlock Grid.Column="4"
+                                    <!-- Status (column header label dropped; colored text alone conveys state, #2286) -->
+                                    <TextBlock Grid.Column="5"
                                                Text="{Binding StatusText}"
                                                FontSize="{DynamicResource FontSizeSmall}"
                                                Foreground="{Binding StatusColor}"

--- a/Radoub.UI/Radoub.UI.Tests/PortraitDedupeTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/PortraitDedupeTests.cs
@@ -55,4 +55,36 @@ public class PortraitDedupeTests
         var result = PortraitBrowserWindow.DedupeByResRef(new List<PortraitEntry>()).ToList();
         Assert.Empty(result);
     }
+
+    [Fact]
+    public void DedupeByResRef_DuplicateWithDifferingRaceOrSex_CollapsesToAll()
+    {
+        // A repeated ResRef whose rows disagree on Race/Sex must not be pinned to the
+        // first row's values, or a race/sex pre-filter would hide it (#2329).
+        var input = new List<PortraitEntry>
+        {
+            P(0, "po_shared_", race: 1, sex: 0),
+            P(1, "po_shared_", race: 4, sex: 1),
+        };
+
+        var result = PortraitBrowserWindow.DedupeByResRef(input).ToList();
+
+        var entry = Assert.Single(result);
+        Assert.Equal(-1, entry.Race);
+        Assert.Equal(-1, entry.Sex);
+    }
+
+    [Fact]
+    public void DedupeByResRef_DuplicateWithMatchingRaceSex_KeepsValues()
+    {
+        var input = new List<PortraitEntry>
+        {
+            P(0, "po_shared_", race: 1, sex: 0),
+            P(1, "po_shared_", race: 1, sex: 0),
+        };
+
+        var entry = Assert.Single(PortraitBrowserWindow.DedupeByResRef(input).ToList());
+        Assert.Equal(1, entry.Race);
+        Assert.Equal(0, entry.Sex);
+    }
 }

--- a/Radoub.UI/Radoub.UI.Tests/PortraitDedupeTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/PortraitDedupeTests.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.Linq;
+using Radoub.UI.Services;
+using Radoub.UI.Views;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Defensive guard for the shared PortraitBrowserWindow (#2329): even if a context
+/// fails to dedupe, the window must not list the same portrait ResRef twice.
+/// Keeps the first occurrence and preserves order; case-insensitive (Aurora ResRefs).
+/// </summary>
+public class PortraitDedupeTests
+{
+    private static PortraitEntry P(ushort id, string resRef, int race = -1, int sex = -1)
+        => new PortraitEntry { Id = id, ResRef = resRef, Race = race, Sex = sex };
+
+    [Fact]
+    public void DedupeByResRef_RemovesRepeats_KeepsFirstInOrder()
+    {
+        var input = new List<PortraitEntry>
+        {
+            P(0, "el_f_02_"),
+            P(1, "hu_m_01_"),
+            P(2, "el_f_02_"), // dup of 0
+            P(3, "hu_m_01_"), // dup of 1
+        };
+
+        var result = PortraitBrowserWindow.DedupeByResRef(input).ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("el_f_02_", result[0].ResRef);
+        Assert.Equal("hu_m_01_", result[1].ResRef);
+        Assert.Equal(0, result[0].Id); // first occurrence kept
+    }
+
+    [Fact]
+    public void DedupeByResRef_IsCaseInsensitive()
+    {
+        var input = new List<PortraitEntry>
+        {
+            P(0, "hu_m_01_"),
+            P(1, "Hu_M_01_"),
+        };
+
+        var result = PortraitBrowserWindow.DedupeByResRef(input).ToList();
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void DedupeByResRef_EmptyInput_ReturnsEmpty()
+    {
+        var result = PortraitBrowserWindow.DedupeByResRef(new List<PortraitEntry>()).ToList();
+        Assert.Empty(result);
+    }
+}

--- a/Radoub.UI/Radoub.UI/Views/PortraitBrowserWindow.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Views/PortraitBrowserWindow.axaml.cs
@@ -281,10 +281,11 @@ public partial class PortraitBrowserWindow : Window
 
     private ListBoxItem CreatePortraitItem(PortraitEntry portrait, out Image image)
     {
-        // Create mini icon (roughly 50% size = ~32x40 for typical NWN portraits).
+        // Thumbnail size for the wrap-grid (#2329): 32x40 was too small to make out
+        // the portrait; 64x80 keeps NWN's ~4:5 portrait aspect and stays compact.
         // Source is left null here and filled in by LoadThumbnailsAsync.
-        const int thumbnailWidth = 32;
-        const int thumbnailHeight = 40;
+        const int thumbnailWidth = 64;
+        const int thumbnailHeight = 80;
 
         image = new Image
         {

--- a/Radoub.UI/Radoub.UI/Views/PortraitBrowserWindow.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Views/PortraitBrowserWindow.axaml.cs
@@ -55,17 +55,31 @@ public partial class PortraitBrowserWindow : Window
 
     /// <summary>
     /// Remove duplicate portraits by ResRef, keeping the first occurrence and
-    /// preserving order. ResRefs are case-insensitive in Aurora. Defensive guard so
-    /// no context can reintroduce the duplicate-portrait bug (#2329).
+    /// preserving order. ResRefs are case-insensitive in Aurora. When duplicates
+    /// disagree on Race/Sex, the kept entry is widened to "all" (-1) on that axis so a
+    /// race/sex filter can't hide a portrait a later row marks valid. Defensive guard
+    /// so no context can reintroduce the duplicate-portrait bug (#2329).
     /// </summary>
     public static IEnumerable<PortraitEntry> DedupeByResRef(IEnumerable<PortraitEntry> portraits)
     {
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var byResRef = new Dictionary<string, PortraitEntry>(StringComparer.OrdinalIgnoreCase);
+        var ordered = new List<PortraitEntry>();
         foreach (var portrait in portraits)
         {
-            if (seen.Add(portrait.ResRef))
-                yield return portrait;
+            if (byResRef.TryGetValue(portrait.ResRef, out var existing))
+            {
+                if (existing.Race != portrait.Race)
+                    existing.Race = -1;
+                if (existing.Sex != portrait.Sex)
+                    existing.Sex = -1;
+                continue;
+            }
+
+            byResRef[portrait.ResRef] = portrait;
+            ordered.Add(portrait);
         }
+
+        return ordered;
     }
 
     /// <summary>

--- a/Radoub.UI/Radoub.UI/Views/PortraitBrowserWindow.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Views/PortraitBrowserWindow.axaml.cs
@@ -54,6 +54,21 @@ public partial class PortraitBrowserWindow : Window
     public int PortraitCount => _allPortraits.Count;
 
     /// <summary>
+    /// Remove duplicate portraits by ResRef, keeping the first occurrence and
+    /// preserving order. ResRefs are case-insensitive in Aurora. Defensive guard so
+    /// no context can reintroduce the duplicate-portrait bug (#2329).
+    /// </summary>
+    public static IEnumerable<PortraitEntry> DedupeByResRef(IEnumerable<PortraitEntry> portraits)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var portrait in portraits)
+        {
+            if (seen.Add(portrait.ResRef))
+                yield return portrait;
+        }
+    }
+
+    /// <summary>
     /// Parameterless constructor for XAML designer.
     /// </summary>
     public PortraitBrowserWindow()
@@ -152,7 +167,9 @@ public partial class PortraitBrowserWindow : Window
         }
 
         UnifiedLogger.LogApplication(LogLevel.INFO, "PortraitBrowser: Loading portraits from context");
-        _allPortraits = _context.ListPortraits().ToList();
+        // Defensive dedupe (#2329): contexts should already list each portrait once,
+        // but guard here so no context can reintroduce duplicate ResRefs into the list.
+        _allPortraits = DedupeByResRef(_context.ListPortraits()).ToList();
 
         var races = new HashSet<int>();
         foreach (var portrait in _allPortraits)

--- a/Reliquary/CHANGELOG.md
+++ b/Reliquary/CHANGELOG.md
@@ -6,6 +6,15 @@ Format based on [Keep a Changelog](https://keepachangelog.com/); versioning via 
 
 ---
 
+## [0.10.2-alpha] - 2026-06-20
+**Branch**: `quartermaster/issue-2440` | **PR**: #2525
+
+### Fix: Portrait browser duplicates (#2329)
+
+- The portrait browser now lists each portrait once; race/sex variant rows in `portraits.2da` that share a base ResRef no longer appear as duplicates. Shared dedupe guard added in `Radoub.UI` (see root CHANGELOG).
+
+---
+
 ## [0.10.1-alpha] - 2026-06-19
 **Branch**: `fence/sprint/2422-2418-shared-ui` | **PR**: #2512
 

--- a/Reliquary/Reliquary.Tests/PortraitBrowserContextTests.cs
+++ b/Reliquary/Reliquary.Tests/PortraitBrowserContextTests.cs
@@ -35,6 +35,22 @@ public class PortraitBrowserContextTests
     }
 
     [Fact]
+    public void ListPortraits_DuplicateWithDifferingRace_CollapsesToAllRaces()
+    {
+        // Duplicate ResRef rows that disagree on Race must collapse to -1 so a
+        // race pre-filter can't hide a portrait a later row marks valid (#2329).
+        var mock = new MockGameDataService(includeSampleData: false);
+        var twoDA = new TwoDAFile { Columns = new() { "BaseResRef", "Race", "Sex" } };
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "po_shared_", "1", "0" } });
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "po_shared_", "4", "0" } });
+        mock.With2DA("portraits", twoDA);
+
+        var entry = Assert.Single(BuildContext(mock).ListPortraits().ToList());
+
+        Assert.Equal(-1, entry.Race);
+    }
+
+    [Fact]
     public void ListPortraits_DedupesCaseInsensitively()
     {
         var mock = new MockGameDataService(includeSampleData: false);

--- a/Reliquary/Reliquary.Tests/PortraitBrowserContextTests.cs
+++ b/Reliquary/Reliquary.Tests/PortraitBrowserContextTests.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+using PlaceableEditor.Services;
+using Radoub.Formats.TwoDA;
+using Radoub.TestUtilities.Mocks;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace PlaceableEditor.Tests;
+
+/// <summary>
+/// Tests for ReliquaryPortraitBrowserContext.ListPortraits dedupe (#2329).
+/// portraits.2da repeats the same BaseResRef across race/sex variant rows; the
+/// browser must list each portrait once. Mirrors Quartermaster's context.
+/// </summary>
+public class PortraitBrowserContextTests
+{
+    private static ReliquaryPortraitBrowserContext BuildContext(MockGameDataService mock)
+        => new ReliquaryPortraitBrowserContext(mock, new ItemIconService(mock));
+
+    [Fact]
+    public void ListPortraits_DedupesRepeatedBaseResRef()
+    {
+        var mock = new MockGameDataService(includeSampleData: false);
+        var twoDA = new TwoDAFile { Columns = new() { "BaseResRef", "Race", "Sex" } };
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "hu_m_01_", "6", "0" } });
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "hu_m_01_", "4", "0" } }); // dup
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "el_f_02_", "1", "1" } });
+        mock.With2DA("portraits", twoDA);
+
+        var result = BuildContext(mock).ListPortraits().ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Single(result, p => p.ResRef == "hu_m_01_");
+        Assert.Single(result, p => p.ResRef == "el_f_02_");
+    }
+
+    [Fact]
+    public void ListPortraits_DedupesCaseInsensitively()
+    {
+        var mock = new MockGameDataService(includeSampleData: false);
+        var twoDA = new TwoDAFile { Columns = new() { "BaseResRef", "Race", "Sex" } };
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "hu_m_01_", "6", "0" } });
+        twoDA.Rows.Add(new TwoDARow { Values = new() { "Hu_M_01_", "6", "1" } }); // same ResRef, different case
+        mock.With2DA("portraits", twoDA);
+
+        var result = BuildContext(mock).ListPortraits().ToList();
+
+        Assert.Single(result);
+    }
+}

--- a/Reliquary/Reliquary/Services/ReliquaryPortraitBrowserContext.cs
+++ b/Reliquary/Reliquary/Services/ReliquaryPortraitBrowserContext.cs
@@ -35,6 +35,10 @@ public class ReliquaryPortraitBrowserContext : IPortraitBrowserContext
     {
         var portraits = new List<PortraitEntry>();
 
+        // portraits.2da repeats the same BaseResRef across race/sex variant rows;
+        // list each portrait once (#2329). ResRefs are case-insensitive in Aurora.
+        var seen = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
+
         int rowCount = _gameDataService.Get2DA("portraits")?.RowCount ?? 500;
         for (int i = 0; i < rowCount; i++)
         {
@@ -42,6 +46,9 @@ public class ReliquaryPortraitBrowserContext : IPortraitBrowserContext
             if (IsEmptyCell(baseResRef))
                 continue;
             baseResRef = baseResRef!.Trim();
+
+            if (!seen.Add(baseResRef))
+                continue;
 
             var raceStr = _gameDataService.Get2DAValue("portraits", i, "Race");
             var sexStr = _gameDataService.Get2DAValue("portraits", i, "Sex");

--- a/Reliquary/Reliquary/Services/ReliquaryPortraitBrowserContext.cs
+++ b/Reliquary/Reliquary/Services/ReliquaryPortraitBrowserContext.cs
@@ -37,7 +37,9 @@ public class ReliquaryPortraitBrowserContext : IPortraitBrowserContext
 
         // portraits.2da repeats the same BaseResRef across race/sex variant rows;
         // list each portrait once (#2329). ResRefs are case-insensitive in Aurora.
-        var seen = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
+        // When duplicate rows disagree on Race/Sex, collapse to "all" (-1) so a
+        // race/sex pre-filter can't hide a portrait a later row marks valid (#2329).
+        var indexByResRef = new Dictionary<string, int>(System.StringComparer.OrdinalIgnoreCase);
 
         int rowCount = _gameDataService.Get2DA("portraits")?.RowCount ?? 500;
         for (int i = 0; i < rowCount; i++)
@@ -46,9 +48,6 @@ public class ReliquaryPortraitBrowserContext : IPortraitBrowserContext
             if (IsEmptyCell(baseResRef))
                 continue;
             baseResRef = baseResRef!.Trim();
-
-            if (!seen.Add(baseResRef))
-                continue;
 
             var raceStr = _gameDataService.Get2DAValue("portraits", i, "Race");
             var sexStr = _gameDataService.Get2DAValue("portraits", i, "Sex");
@@ -62,6 +61,17 @@ public class ReliquaryPortraitBrowserContext : IPortraitBrowserContext
             if (!string.IsNullOrEmpty(sexStr) && sexStr != "****")
                 int.TryParse(sexStr, out sex);
 
+            if (indexByResRef.TryGetValue(baseResRef, out var existingIdx))
+            {
+                var existing = portraits[existingIdx];
+                if (existing.Race != race)
+                    existing.Race = -1;
+                if (existing.Sex != sex)
+                    existing.Sex = -1;
+                continue;
+            }
+
+            indexByResRef[baseResRef] = portraits.Count;
             portraits.Add(new PortraitEntry
             {
                 Id = (ushort)i,


### PR DESCRIPTION
## Summary

Sprint #2440 — three Quartermaster bug fixes (non-rendering), plus two follow-on portrait fixes surfaced during work and a code-review regression fix.

- **#2299** — Closing the window mid-cache-build froze the UI; the in-flight palette/HAK scan is now cancelled on close. Extracted Cancel→Dispose→null into a tested `LinkedCtsHolder` (the #2262 pattern).
- **#2286** — Feats panel: separator + spacing so the 'Has' checkbox column is unambiguous; dropped the confusing 'Status' header word. AXAML-only.
- **#2329** — Portrait browser: dedupe by ResRef (QM + Reliquary contexts + shared `PortraitBrowserWindow` guard); larger 64×80 thumbnails; and the editor's Browse now pre-filters to the creature's race/sex (was All/All — regression vs the wizard path). Duplicate rows that disagree on race/sex collapse to 'all' so the pre-filter can't hide a valid portrait.

Plan: `NonPublic/Plans/2026-06-19-2440-plan.md`.

## Related Issues

- Closes #2299
- Closes #2286
- Closes #2329

## Tests

- Quartermaster 1284, Reliquary 127, Radoub.UI 1208, Radoub.Formats 1442, Radoub.Dictionary 75 — all pass.
- Quartermaster FlaUI smoke: 1 pass.
- New: LinkedCtsHolder (6), portrait dedupe + race/sex-collapse regression tests across all three layers.

## Checklist

- [x] #2299 — close-mid-cache cancellation + tests
- [x] #2286 — checkbox/status spacing
- [x] #2329 — portrait dedupe + thumbnails + race/sex filter + tests
- [x] Tests pass (unit + QM FlaUI smoke)
- [x] CHANGELOG updated (QM + Reliquary + root Radoub.UI)
- [ ] Manual spot-checks (close-freeze, visual layout, portrait list) — pending

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)