### PR TITLE
[Relique] Fix: Composite weapon parts render misaligned in 3D preview (#2233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.19-alpha] - 2026-06-20
+**Branch**: `relique/issue-2233` | **PR**: #2530
+
+### Fix: Composite weapon part assembly in 3D preview (#2233)
+
+- `MdlPartComposer.ComposeFlat` now grafts each part's whole subtree (preserving dummy-node assembly offsets) instead of flattening to bare trimeshes, so composite weapons assemble correctly. Same connector mechanism benefits Quartermaster's weapon attach.
+
+---
+
 ## [Radoub.UI 0.2.18-alpha] - 2026-06-20
 **Branch**: `quartermaster/issue-2440` | **PR**: #2525
 

--- a/Radoub.UI/Radoub.UI.Tests/Services/MdlPartComposerTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/MdlPartComposerTests.cs
@@ -58,8 +58,23 @@ public class MdlPartComposerTests
     }
 
     private static MdlModel MakePartModel(string name, string meshName, Vector3 vertex)
+        => MakePartModel(name, meshName, vertex, rootOffset: Vector3.Zero);
+
+    /// <summary>
+    /// Build a part MDL shaped like a real composite-weapon part: a dummy root node whose
+    /// <paramref name="rootOffset"/> encodes the assembly position, with the mesh as a child at
+    /// local origin. Aurora glues b/m/t parts using these dummy offsets, so a correct composer
+    /// must preserve them.
+    /// </summary>
+    private static MdlModel MakePartModel(string name, string meshName, Vector3 vertex, Vector3 rootOffset)
     {
-        var root = new MdlNode { Name = $"{name}_root", Orientation = Quaternion.Identity, Scale = 1.0f };
+        var root = new MdlNode
+        {
+            Name = $"{name}_root",
+            Position = rootOffset,
+            Orientation = Quaternion.Identity,
+            Scale = 1.0f,
+        };
         var mesh = new MdlTrimeshNode
         {
             Name = meshName,
@@ -226,6 +241,46 @@ public class MdlPartComposerTests
         Assert.NotNull(result);
         Assert.Equal(3, result!.GetMeshNodes().Count());
         Assert.NotNull(result.GeometryRoot);
+    }
+
+    [Fact]
+    public void ComposeFlat_PreservesDummyParentOffsets()
+    {
+        // Real composite-weapon parts are authored as: dummy root (assembly offset) → mesh at
+        // local origin. Aurora glues b/m/t along the weapon axis using those dummy offsets. A
+        // flatten that reparents only the trimesh discards the offset and collapses every part
+        // to the composite origin (the floating-blade bug, #2233).
+        var bottom = MakePartModel("wdbsw_b_011", "wdbsw_b_mesh", Vector3.Zero, rootOffset: new Vector3(0, 0, -2));
+        var middle = MakePartModel("wdbsw_m_011", "wdbsw_m_mesh", Vector3.Zero, rootOffset: Vector3.Zero);
+        var top = MakePartModel("wdbsw_t_011", "wdbsw_t_mesh", Vector3.Zero, rootOffset: new Vector3(0, 0, 2));
+
+        var game = BuildGameDataWith(("wdbsw_b_011", bottom), ("wdbsw_m_011", middle), ("wdbsw_t_011", top));
+        var composer = new MdlPartComposer(game, (resRef, _) => resRef switch
+        {
+            "wdbsw_b_011" => bottom,
+            "wdbsw_m_011" => middle,
+            "wdbsw_t_011" => top,
+            _ => null,
+        });
+
+        var result = composer.ComposeFlat(new[] { "wdbsw_b_011", "wdbsw_m_011", "wdbsw_t_011" });
+
+        Assert.NotNull(result);
+        var meshes = result!.GetMeshNodes().ToList();
+        Assert.Equal(3, meshes.Count);
+
+        // Each mesh's effective world position must still reflect its part's dummy offset.
+        // The single vertex is at local origin, so its world Z == accumulated parent-chain Z.
+        float WorldZOf(string meshName)
+        {
+            var mesh = meshes.Single(m => m.Name == meshName);
+            var world = MdlPartComposer.GetMeshWorldTransform(mesh);
+            return Vector3.Transform(mesh.Vertices[0], world).Z;
+        }
+
+        Assert.Equal(-2f, WorldZOf("wdbsw_b_mesh"), precision: 3);
+        Assert.Equal(0f, WorldZOf("wdbsw_m_mesh"), precision: 3);
+        Assert.Equal(2f, WorldZOf("wdbsw_t_mesh"), precision: 3);
     }
 
     [Fact]

--- a/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
+++ b/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
@@ -176,20 +176,21 @@ public sealed class MdlPartComposer
         foreach (var resRef in partResRefs)
         {
             var partModel = _modelLoader(resRef, /* withSupermodelAnims */ false);
-            if (partModel == null)
+            if (partModel?.GeometryRoot == null)
             {
                 UnifiedLogger.LogApplication(LogLevel.WARN, $"MdlPartComposer.ComposeFlat: '{resRef}' not loadable");
                 continue;
             }
 
-            foreach (var node in partModel.EnumerateAllNodes())
-            {
-                if (node is MdlTrimeshNode trimesh)
-                {
-                    node.Parent = compositeModel.GeometryRoot;
-                    compositeModel.GeometryRoot!.Children.Add(node);
-                }
-            }
+            // Graft each part's WHOLE subtree (root dummy included) under the composite root,
+            // cloning the hierarchy so per-node transforms survive. Composite-weapon parts are
+            // authored as dummy root (assembly offset) → mesh at local origin; Aurora glues b/m/t
+            // along the weapon axis using those dummy offsets. Flattening to bare trimeshes dropped
+            // the offset and collapsed every part to the origin — the floating-blade bug (#2233).
+            // We clone the part root itself (not just its children, as the robe graft does) because
+            // here the root dummy IS the alignment offset, not a duplicate of a skeleton root.
+            var clone = CloneNode(partModel.GeometryRoot, compositeModel.GeometryRoot);
+            compositeModel.GeometryRoot!.Children.Add(clone);
         }
 
         UpdateCompositeBounds(compositeModel);

--- a/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
+++ b/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
@@ -189,8 +189,18 @@ public sealed class MdlPartComposer
             // the offset and collapsed every part to the origin — the floating-blade bug (#2233).
             // We clone the part root itself (not just its children, as the robe graft does) because
             // here the root dummy IS the alignment offset, not a duplicate of a skeleton root.
-            var clone = CloneNode(partModel.GeometryRoot, compositeModel.GeometryRoot);
-            compositeModel.GeometryRoot!.Children.Add(clone);
+            // Per-part try/catch isolates a malformed part: a bad subtree skips that part and logs,
+            // rather than blanking the whole weapon (mirrors TryAddBodyPart's discipline).
+            try
+            {
+                var clone = CloneNode(partModel.GeometryRoot, compositeModel.GeometryRoot);
+                compositeModel.GeometryRoot!.Children.Add(clone);
+            }
+            catch (Exception ex)
+            {
+                UnifiedLogger.LogApplication(LogLevel.WARN,
+                    $"MdlPartComposer.ComposeFlat: failed to graft '{resRef}': {ex.GetType().Name}: {ex.Message}");
+            }
         }
 
         UpdateCompositeBounds(compositeModel);

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.10.28-alpha] - 2026-06-20
+**Branch**: `relique/issue-2233` | **PR**: #TBD
+
+### Fix: Composite weapon parts render misaligned in 3D preview (#2233)
+
+- Composite weapons (double axes, two-bladed swords) now assemble correctly in the 3D preview — base/middle/top parts snap together instead of floating disjoint.
+
+---
+
 ## [0.10.27-alpha] - 2026-06-20
 **Branch**: `relique/issue-2447` | **PR**: #2526
 

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.10.28-alpha] - 2026-06-20
-**Branch**: `relique/issue-2233` | **PR**: #TBD
+**Branch**: `relique/issue-2233` | **PR**: #2530
 
 ### Fix: Composite weapon parts render misaligned in 3D preview (#2233)
 


### PR DESCRIPTION
## Summary

Composite weapons (ModelType 2 — double axes, two-bladed swords) rendered with their base/middle/top (b/m/t) MDL parts visually disjoint in the 3D preview — blades floated off the haft.

**Root cause**: `MdlPartComposer.ComposeFlat` flattened each part MDL, re-parenting only the trimeshes under the synthetic composite root and discarding the dummy parent nodes whose `Position` encodes the b/m/t assembly offset. Every part collapsed to the composite origin.

**Fix**: Graft each part's whole subtree via `CloneNode` (the proven robe/wing path), preserving the offset chain the GL renderer walks for world transforms. A per-part try/catch isolates a malformed part instead of blanking the whole weapon.

## Related Issues

- Closes #2233
- Parent sprint: #2446 (3D Preview Rendering)

## Cross-Tool Note

Same connector mechanism drives Quartermaster's creature weapon attach and the shared Radoub.UI preview — a correct `ComposeFlat` benefits QM too (no QM code change in this PR).

## Tests

- TDD: added `ComposeFlat_PreservesDummyParentOffsets` (failed before, passes after).
- Unit: Relique + shared (Radoub.UI/Formats/Dictionary) — **3088 passed, 0 failed**.
- FlaUI: Relique Smoke — **3 passed** (load/launch path healthy).
- Manual: composite axe assembles correctly in the live preview (user-verified).
- Privacy ✅ · Tech debt ✅ (no large files) · Code review applied (per-part fault isolation).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)