### PR TITLE
[Relique] Sprint: 3D Preview Rendering (#2446)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.20-alpha] - 2026-06-20
+**Branch**: `relique/issue-2446` | **PR**: #2532
+
+### Feat: Gendered mannequin for item 3D preview (#2407)
+
+- New `MannequinPrefix.ForGender` helper and a settable `ItemModelResolver.ArmorMannequinPrefix` let blueprint editors swap the armor preview body between male (`pmh0`) and female (`pfh0`) at runtime.
+
+---
+
 ## [Radoub.UI 0.2.19-alpha] - 2026-06-20
 **Branch**: `relique/issue-2233` | **PR**: #2530
 

--- a/Radoub.UI/Radoub.UI.Tests/Services/ItemModelResolverTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/ItemModelResolverTests.cs
@@ -124,6 +124,49 @@ public class ItemModelResolverTests
     }
 
     [Fact]
+    public void Resolve_Armor_FemaleMannequinPrefix_ReturnsFemaleBodyPartResRefs()
+    {
+        var game = BuildGameData();
+        // Female mannequin prefix is pfh0 (playable female human, phenotype 0)
+        game.SetResource("pfh0_chest005", ResourceTypes.Mdl, new byte[] { 1 });
+        game.SetResource("pfh0_pelvis002", ResourceTypes.Mdl, new byte[] { 1 });
+
+        var resolver = new ItemModelResolver(BuildBaseItemService(game), game, "pfh0");
+        var uti = new UtiFile
+        {
+            BaseItem = 3,
+            ArmorParts = new()
+            {
+                ["Torso"] = 5,
+                ["Pelvis"] = 2,
+            },
+        };
+
+        var result = resolver.Resolve(uti);
+
+        Assert.True(result.HasModel);
+        Assert.Contains("pfh0_chest005", result.MdlResRefs);
+        Assert.Contains("pfh0_pelvis002", result.MdlResRefs);
+    }
+
+    [Fact]
+    public void ArmorMannequinPrefix_SetAtRuntime_AffectsNextResolve()
+    {
+        var game = BuildGameData();
+        game.SetResource("pmh0_chest005", ResourceTypes.Mdl, new byte[] { 1 });
+        game.SetResource("pfh0_chest005", ResourceTypes.Mdl, new byte[] { 1 });
+
+        var resolver = new ItemModelResolver(BuildBaseItemService(game), game);
+        var uti = new UtiFile { BaseItem = 3, ArmorParts = new() { ["Torso"] = 5 } };
+
+        Assert.Contains("pmh0_chest005", resolver.Resolve(uti).MdlResRefs);
+
+        resolver.ArmorMannequinPrefix = "pfh0";
+
+        Assert.Contains("pfh0_chest005", resolver.Resolve(uti).MdlResRefs);
+    }
+
+    [Fact]
     public void Resolve_Armor_PartialPartsExist_DropsMissingAndKeepsRest()
     {
         var game = BuildGameData();

--- a/Radoub.UI/Radoub.UI.Tests/Services/MannequinPrefixTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/MannequinPrefixTests.cs
@@ -1,0 +1,30 @@
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests.Services;
+
+/// <summary>
+/// The mannequin prefix selects the body the armor/clothing preview is composed on.
+/// Gender lives in the prefix (pmh0 male / pfh0 female), race=h, phenotype=0.
+/// Mirrors Quartermaster's ModelService.BuildModelPrefix gender rule (#2407).
+/// </summary>
+public class MannequinPrefixTests
+{
+    [Fact]
+    public void ForGender_Male_ReturnsMalePrefix()
+    {
+        Assert.Equal("pmh0", MannequinPrefix.ForGender(0));
+    }
+
+    [Fact]
+    public void ForGender_Female_ReturnsFemalePrefix()
+    {
+        Assert.Equal("pfh0", MannequinPrefix.ForGender(1));
+    }
+
+    [Fact]
+    public void ForGender_UnknownGender_DefaultsToMale()
+    {
+        Assert.Equal("pmh0", MannequinPrefix.ForGender(99));
+    }
+}

--- a/Radoub.UI/Radoub.UI/Services/ItemModelResolver.cs
+++ b/Radoub.UI/Radoub.UI/Services/ItemModelResolver.cs
@@ -29,7 +29,12 @@ public sealed class ItemModelResolver
 {
     private readonly BaseItemTypeService _baseItemTypeService;
     private readonly IGameDataService _gameDataService;
-    private readonly string _armorMannequinPrefix;
+
+    /// <summary>
+    /// Mannequin body prefix for armor part resolution (e.g. "pmh0" male / "pfh0" female).
+    /// Mutable so the editor can swap the preview gender at runtime (#2407).
+    /// </summary>
+    public string ArmorMannequinPrefix { get; set; }
 
     private static readonly Dictionary<string, string> ArmorPartKeyToMdlSuffix =
         new(StringComparer.OrdinalIgnoreCase)
@@ -62,7 +67,7 @@ public sealed class ItemModelResolver
     {
         _baseItemTypeService = baseItemTypeService;
         _gameDataService = gameDataService;
-        _armorMannequinPrefix = armorMannequinPrefix;
+        ArmorMannequinPrefix = armorMannequinPrefix;
     }
 
     public ItemModelResolution Resolve(UtiFile uti)
@@ -140,7 +145,7 @@ public sealed class ItemModelResolver
             if (!ArmorPartKeyToMdlSuffix.TryGetValue(key, out var suffix))
                 continue;
 
-            var resRef = $"{_armorMannequinPrefix}_{suffix}{partNumber:D3}".ToLowerInvariant();
+            var resRef = $"{ArmorMannequinPrefix}_{suffix}{partNumber:D3}".ToLowerInvariant();
             if (ResourceExists(resRef))
                 found.Add(resRef);
         }

--- a/Radoub.UI/Radoub.UI/Services/MannequinPrefix.cs
+++ b/Radoub.UI/Radoub.UI/Services/MannequinPrefix.cs
@@ -1,0 +1,16 @@
+namespace Radoub.UI.Services;
+
+/// <summary>
+/// Builds the body-model prefix the armor/clothing preview is composed on. Blueprint
+/// editors (Relique) have no creature context, so a fixed human-phenotype-0 mannequin is
+/// used and only the gender varies. Gender lives in the prefix (pmh0 male / pfh0 female),
+/// mirroring Quartermaster's ModelService.BuildModelPrefix rule (#2407).
+/// </summary>
+public static class MannequinPrefix
+{
+    public const string Male = "pmh0";
+    public const string Female = "pfh0";
+
+    /// <summary>gender==1 → female (pfh0); anything else → male (pmh0).</summary>
+    public static string ForGender(int gender) => gender == 1 ? Female : Male;
+}

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.10.29-alpha] - 2026-06-20
+**Branch**: `relique/issue-2446` | **PR**: #TBD
+
+### Sprint: 3D Preview Rendering (#2446)
+
+- Enlarge/responsive 3D preview viewport for full-body armor (#2408).
+- Drag-to-rotate, rotate/zoom buttons in 3D preview (#2409).
+- Gender-specific clothing/armor models in preview, persisted in settings (#2407).
+
+---
+
 ## [0.10.28-alpha] - 2026-06-20
 **Branch**: `relique/issue-2233` | **PR**: #2530
 

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Enlarge/responsive 3D preview viewport for full-body armor (#2408).
 - Drag-to-rotate, rotate/zoom buttons in 3D preview (#2409).
 - Gender-specific clothing/armor models in preview, persisted in settings (#2407).
+- Fix: changing a composite-weapon model part no longer crashes the preview (#2533).
 
 ---
 

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.10.29-alpha] - 2026-06-20
-**Branch**: `relique/issue-2446` | **PR**: #TBD
+**Branch**: `relique/issue-2446` | **PR**: #2532
 
 ### Sprint: 3D Preview Rendering (#2446)
 

--- a/Relique/Relique.Tests/Services/ItemPreviewControllerTests.cs
+++ b/Relique/Relique.Tests/Services/ItemPreviewControllerTests.cs
@@ -36,14 +36,16 @@ public class ItemPreviewControllerTests
         public bool PlaceholderVisible { get; private set; }
         public int LoadCount { get; private set; }
         public int ClearCount { get; private set; }
+        public bool LastGendered { get; private set; }
         public (int metal1, int metal2, int cloth1, int cloth2, int leather1, int leather2)? LastArmorColors { get; private set; }
         public int ArmorColorsCallCount { get; private set; }
         public Quaternion LastModelRootOrientation { get; private set; } = Quaternion.Identity;
 
-        public void SetModel(MdlModel model)
+        public void SetModel(MdlModel model, bool gendered)
         {
             CurrentModel = model;
             LastModelRootOrientation = model.GeometryRoot?.Orientation ?? Quaternion.Identity;
+            LastGendered = gendered;
             PlaceholderVisible = false;
             LoadCount++;
         }
@@ -121,6 +123,22 @@ public class ItemPreviewControllerTests
         // Test mode: pump debounce manually via FlushDebounce()
         var controller = new ItemPreviewController(resolver, composer, renderer, baseItemSvc, debounceManually: true);
         return (renderer, controller, game);
+    }
+
+    private static (FakePreviewRenderer renderer, ItemPreviewController controller, ItemModelResolver resolver, MockGameDataService game)
+        BuildControllerWithResolver(System.Action<MockGameDataService>? setupResources = null, string mannequinPrefix = "pmh0")
+    {
+        var game = BuildGameData();
+        setupResources?.Invoke(game);
+
+        var baseItemSvc = new BaseItemTypeService(game);
+        var resolver = new ItemModelResolver(baseItemSvc, game, mannequinPrefix);
+        var composer = new MdlPartComposer(game, (resRef, _) => MakePartModel(resRef));
+        var renderer = new FakePreviewRenderer();
+
+        var controller = new ItemPreviewController(
+            resolver, composer, renderer, baseItemSvc, mannequinPrefix, debounceManually: true);
+        return (renderer, controller, resolver, game);
     }
 
     // ----- Tests -----
@@ -238,6 +256,68 @@ public class ItemPreviewControllerTests
         Assert.Equal(2, renderer.LastArmorColors.Value.cloth2);
         Assert.Equal(3, renderer.LastArmorColors.Value.leather1);
         Assert.Equal(4, renderer.LastArmorColors.Value.leather2);
+    }
+
+    [Fact]
+    public void Bind_Armor_FemalePrefix_LoadsFemaleBodyParts()
+    {
+        var (renderer, controller, _, _) = BuildControllerWithResolver(g =>
+        {
+            g.SetResource("pfh0_chest005", ResourceTypes.Mdl, new byte[] { 1 });
+            g.SetResource("pfh0_pelvis002", ResourceTypes.Mdl, new byte[] { 1 });
+        }, mannequinPrefix: "pfh0");
+        var uti = new UtiFile { BaseItem = 3 };
+        uti.ArmorParts["Torso"] = 5;
+        uti.ArmorParts["Pelvis"] = 2;
+        var vm = new ItemViewModel(uti);
+
+        controller.BindViewModel(vm);
+        controller.FlushDebounce();
+
+        // Composer was asked for the female-prefixed parts; mesh names carry the resRef.
+        Assert.NotNull(renderer.CurrentModel);
+        Assert.True(renderer.LastGendered); // armor → gender toggle is meaningful
+        var meshNames = renderer.CurrentModel!.GetMeshNodes().Select(n => n.Name).ToList();
+        Assert.Contains(meshNames, n => n.Contains("pfh0_chest005"));
+    }
+
+    [Fact]
+    public void Bind_SimpleWeapon_IsNotGendered()
+    {
+        var (renderer, controller, _, _) = BuildControllerWithResolver(g =>
+            g.SetResource("w_swrd_005", ResourceTypes.Mdl, new byte[] { 1 }));
+        var vm = new ItemViewModel(new UtiFile { BaseItem = 0, ModelPart1 = 5 });
+
+        controller.BindViewModel(vm);
+        controller.FlushDebounce();
+
+        Assert.NotNull(renderer.CurrentModel);
+        Assert.False(renderer.LastGendered); // weapon → no gender toggle
+    }
+
+    [Fact]
+    public void SetArmorMannequinPrefix_SwapsGenderAndReloads()
+    {
+        var (renderer, controller, _, _) = BuildControllerWithResolver(g =>
+        {
+            g.SetResource("pmh0_chest005", ResourceTypes.Mdl, new byte[] { 1 });
+            g.SetResource("pfh0_chest005", ResourceTypes.Mdl, new byte[] { 1 });
+        }, mannequinPrefix: "pmh0");
+        var uti = new UtiFile { BaseItem = 3 };
+        uti.ArmorParts["Torso"] = 5;
+        var vm = new ItemViewModel(uti);
+
+        controller.BindViewModel(vm);
+        controller.FlushDebounce();
+        var maleNames = renderer.CurrentModel!.GetMeshNodes().Select(n => n.Name).ToList();
+        Assert.Contains(maleNames, n => n.Contains("pmh0_chest005"));
+
+        controller.SetArmorMannequinPrefix("pfh0");
+        Assert.True(controller.HasPendingUpdate);
+        controller.FlushDebounce();
+
+        var femaleNames = renderer.CurrentModel!.GetMeshNodes().Select(n => n.Name).ToList();
+        Assert.Contains(femaleNames, n => n.Contains("pfh0_chest005"));
     }
 
     [Fact]

--- a/Relique/Relique.Tests/Services/ModelPartResyncDeciderTests.cs
+++ b/Relique/Relique.Tests/Services/ModelPartResyncDeciderTests.cs
@@ -1,0 +1,31 @@
+using ItemEditor.Services;
+using Xunit;
+
+namespace ItemEditor.Tests.Services;
+
+/// <summary>
+/// A composite-weapon model-part ComboBox must NOT be rebuilt (Items.Clear + repopulate)
+/// while its own SelectionChanged is executing — doing so leaves stale selection state that
+/// crashes deep in the Avalonia render loop with no catchable exception (#2533).
+///
+/// The undo apply-action re-syncs the combos so undo/redo keeps the UI in sync, but that
+/// re-sync is only safe (and only needed) when the value changed programmatically. When the
+/// user's live selection drives the change, the combo already shows the new value, so the
+/// re-sync must be skipped.
+/// </summary>
+public class ModelPartResyncDeciderTests
+{
+    [Fact]
+    public void ShouldResyncCombos_DuringLiveSelection_ReturnsFalse()
+    {
+        // User just picked a part in the combo — rebuilding it now is the crash.
+        Assert.False(ModelPartResyncDecider.ShouldResyncCombos(selectionInProgress: true));
+    }
+
+    [Fact]
+    public void ShouldResyncCombos_ProgrammaticChange_ReturnsTrue()
+    {
+        // Undo/redo changed the value behind the UI — the combo must be re-synced.
+        Assert.True(ModelPartResyncDecider.ShouldResyncCombos(selectionInProgress: false));
+    }
+}

--- a/Relique/Relique.Tests/SettingsServiceTests.cs
+++ b/Relique/Relique.Tests/SettingsServiceTests.cs
@@ -62,4 +62,22 @@ public class SettingsServiceTests
     {
         Assert.True(SettingsService.Instance.OpenInEditorAfterCreate);
     }
+
+    [Fact]
+    public void PreviewGender_RoundTripsValue()
+    {
+        var settings = SettingsService.Instance;
+        var original = settings.PreviewGender;
+        try
+        {
+            settings.PreviewGender = 1;
+            Assert.Equal(1, settings.PreviewGender);
+            settings.PreviewGender = 0;
+            Assert.Equal(0, settings.PreviewGender);
+        }
+        finally
+        {
+            settings.PreviewGender = original;
+        }
+    }
 }

--- a/Relique/Relique/Services/IItemPreviewRenderer.cs
+++ b/Relique/Relique/Services/IItemPreviewRenderer.cs
@@ -10,8 +10,12 @@ namespace ItemEditor.Services;
 /// </summary>
 public interface IItemPreviewRenderer
 {
-    /// <summary>Hand the renderer a composed model to display.</summary>
-    void SetModel(MdlModel model);
+    /// <summary>
+    /// Hand the renderer a composed model to display. <paramref name="gendered"/> is true
+    /// for armor/clothing whose body parts vary by mannequin gender, so the renderer can
+    /// surface the male/female toggle only when it is meaningful (#2407).
+    /// </summary>
+    void SetModel(MdlModel model, bool gendered);
 
     /// <summary>Hide the model and show the "No 3D model" placeholder.</summary>
     void Clear();

--- a/Relique/Relique/Services/ItemPreviewController.cs
+++ b/Relique/Relique/Services/ItemPreviewController.cs
@@ -43,7 +43,7 @@ public sealed class ItemPreviewController
     private readonly MdlPartComposer _composer;
     private readonly IItemPreviewRenderer _renderer;
     private readonly BaseItemTypeService _baseItemTypeService;
-    private readonly string _armorMannequinPrefix;
+    private string _armorMannequinPrefix;
     private readonly bool _debounceManually;
 
     /// <summary>
@@ -70,10 +70,36 @@ public sealed class ItemPreviewController
         _renderer = renderer;
         _baseItemTypeService = baseItemTypeService;
         _armorMannequinPrefix = armorMannequinPrefix;
+        // Keep the resolver in sync with the controller's starting gender so the first
+        // armor resolve uses the persisted prefix, not the resolver's own default (#2407).
+        _resolver.ArmorMannequinPrefix = armorMannequinPrefix;
         _debounceManually = debounceManually;
     }
 
     public bool HasPendingUpdate => _pendingUpdate;
+
+    /// <summary>
+    /// Current mannequin body prefix used to compose armor/clothing previews
+    /// (e.g. "pmh0" male / "pfh0" female).
+    /// </summary>
+    public string ArmorMannequinPrefix => _armorMannequinPrefix;
+
+    /// <summary>
+    /// Swap the preview gender by changing the mannequin body prefix and re-triggering a
+    /// reload. No-op if the prefix is unchanged or no item is bound. (#2407)
+    /// </summary>
+    public void SetArmorMannequinPrefix(string prefix)
+    {
+        if (string.IsNullOrEmpty(prefix) || prefix == _armorMannequinPrefix)
+            return;
+
+        _armorMannequinPrefix = prefix;
+        _resolver.ArmorMannequinPrefix = prefix;
+
+        // Only a bound armor item needs a reload; flag it and let the debounce flush.
+        if (_viewModel != null)
+            _pendingUpdate = true;
+    }
 
     public void BindViewModel(ItemViewModel? vm)
     {
@@ -168,7 +194,9 @@ public sealed class ItemPreviewController
 
             ApplyTrophyRotationIfHeldWeapon(uti, composed);
 
-            _renderer.SetModel(composed);
+            // Only armor (ModelType 3) composes on the gendered mannequin body; the toggle
+            // is meaningless for weapons/layered clothing (#2407).
+            _renderer.SetModel(composed, gendered: resolution.HasArmorParts);
 
             if (resolution.HasColorFields)
             {

--- a/Relique/Relique/Services/ModelPartResyncDecider.cs
+++ b/Relique/Relique/Services/ModelPartResyncDecider.cs
@@ -1,0 +1,21 @@
+namespace ItemEditor.Services;
+
+/// <summary>
+/// Decides whether the model-part ComboBoxes may be rebuilt during a model-part change.
+///
+/// Composite-weapon part combos are populated with Items; rebuilding a combo
+/// (Items.Clear + repopulate) from inside its own SelectionChanged leaves stale selection
+/// state that crashes the Avalonia render loop with no catchable exception (#2533). The undo
+/// apply-action re-syncs the combos so undo/redo keeps the UI in sync, but that re-sync is
+/// only safe — and only necessary — for programmatic value changes. When the user's live
+/// selection drives the change the combo already reflects the new value, so the rebuild must
+/// be skipped to avoid the re-entrancy.
+/// </summary>
+public static class ModelPartResyncDecider
+{
+    /// <summary>
+    /// True when the combos may be rebuilt. False while a live ComboBox SelectionChanged is
+    /// in progress (the rebuild would re-enter the active control).
+    /// </summary>
+    public static bool ShouldResyncCombos(bool selectionInProgress) => !selectionInProgress;
+}

--- a/Relique/Relique/Services/SettingsService.cs
+++ b/Relique/Relique/Services/SettingsService.cs
@@ -37,6 +37,9 @@ public class SettingsService : BaseToolSettingsService<SettingsService.SettingsD
     // Wizard settings
     private bool _openInEditorAfterCreate = true;
 
+    // 3D preview settings
+    private int _previewGender; // 0 = male (pmh0), 1 = female (pfh0)
+
     private SettingsService()
     {
         MigrateLegacySettings();
@@ -85,18 +88,31 @@ public class SettingsService : BaseToolSettingsService<SettingsService.SettingsD
         set { if (SetProperty(ref _openInEditorAfterCreate, value)) SaveSettings(); }
     }
 
+    /// <summary>
+    /// Last-chosen gender for the 3D armor/clothing preview mannequin.
+    /// 0 = male (pmh0), 1 = female (pfh0). Persists across sessions (#2407).
+    /// </summary>
+    public int PreviewGender
+    {
+        get => _previewGender;
+        set { if (SetProperty(ref _previewGender, value)) SaveSettings(); }
+    }
+
     protected override void LoadToolSettings(SettingsData settings)
     {
         _openInEditorAfterCreate = settings.OpenInEditorAfterCreate;
+        _previewGender = settings.PreviewGender;
     }
 
     protected override void SaveToolSettings(SettingsData settings)
     {
         settings.OpenInEditorAfterCreate = OpenInEditorAfterCreate;
+        settings.PreviewGender = PreviewGender;
     }
 
     public class SettingsData : BaseSettingsData
     {
         public bool OpenInEditorAfterCreate { get; set; } = true;
+        public int PreviewGender { get; set; } // 0 = male
     }
 }

--- a/Relique/Relique/Views/MainWindow.EditorPopulation.cs
+++ b/Relique/Relique/Views/MainWindow.EditorPopulation.cs
@@ -484,7 +484,12 @@ public partial class MainWindow
             if (_isLoading || _itemViewModel == null) return;
             if (combo.SelectedItem is ComboBoxItem item && item.Tag is int rowIdx)
             {
-                setter((byte)System.Math.Clamp(rowIdx, 0, 255));
+                // Mark the change as live-selection-driven so the undo apply-action does NOT
+                // rebuild this combo's Items mid-SelectionChanged — that re-entrancy crashes
+                // the render loop for composite weapons (#2533).
+                _modelPartSelectionInProgress = true;
+                try { setter((byte)System.Math.Clamp(rowIdx, 0, 255)); }
+                finally { _modelPartSelectionInProgress = false; }
             }
         });
         var lostFocusHandler = new System.EventHandler<RoutedEventArgs>((_, _) =>

--- a/Relique/Relique/Views/MainWindow.ItemPreview.cs
+++ b/Relique/Relique/Views/MainWindow.ItemPreview.cs
@@ -46,8 +46,10 @@ public partial class MainWindow
 
         _previewResolver = new ItemModelResolver(baseItemSvc, _gameDataService);
 
-        _previewRendererAdapter = new RendererAdapter(ItemPreviewGL, ItemPreviewPlaceholder, ItemPreviewControls);
+        _previewRendererAdapter = new RendererAdapter(ItemPreviewGL, ItemPreviewPlaceholder, ItemPreviewControls, ItemPreviewInputSurface);
         ItemPreviewGL.SetTextureService(_previewTextureService);
+
+        WirePreviewInput();
 
         _previewController = new ItemPreviewController(
             _previewResolver,
@@ -105,6 +107,8 @@ public partial class MainWindow
         _previewDebounceTimer?.Stop();
         _previewDebounceTimer = null;
 
+        UnwirePreviewInput();
+
         _previewController?.Unbind();
         _previewController = null;
 
@@ -134,6 +138,121 @@ public partial class MainWindow
     private void OnItemPreviewResetClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         => ItemPreviewGL.ResetView();
 
+    // --- Rotate / zoom button handlers (#2409, match Quartermaster) ---
+
+    private void OnItemPreviewRotateLeftClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        => ItemPreviewGL.Rotate(-0.3f);
+
+    private void OnItemPreviewRotateRightClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        => ItemPreviewGL.Rotate(0.3f);
+
+    private void OnItemPreviewZoomInClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        => ItemPreviewGL.Zoom *= 1.2f;
+
+    private void OnItemPreviewZoomOutClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        => ItemPreviewGL.Zoom /= 1.2f;
+
+    // --- Pointer / wheel / key input forwarding (#2409, match Quartermaster #2124) ---
+    // Wired on the transparent input-surface Border overlaying the GL control.
+
+    private PreviewDragMode _previewDragMode = PreviewDragMode.None;
+    private Avalonia.Point _previewLastPointer;
+
+    private void WirePreviewInput()
+    {
+        ItemPreviewInputSurface.PointerPressed += OnPreviewPointerPressed;
+        ItemPreviewInputSurface.PointerMoved += OnPreviewPointerMoved;
+        ItemPreviewInputSurface.PointerReleased += OnPreviewPointerReleased;
+        ItemPreviewInputSurface.PointerWheelChanged += OnPreviewWheel;
+        ItemPreviewInputSurface.KeyDown += OnPreviewKeyDown;
+    }
+
+    private void UnwirePreviewInput()
+    {
+        ItemPreviewInputSurface.PointerPressed -= OnPreviewPointerPressed;
+        ItemPreviewInputSurface.PointerMoved -= OnPreviewPointerMoved;
+        ItemPreviewInputSurface.PointerReleased -= OnPreviewPointerReleased;
+        ItemPreviewInputSurface.PointerWheelChanged -= OnPreviewWheel;
+        ItemPreviewInputSurface.KeyDown -= OnPreviewKeyDown;
+    }
+
+    private void OnPreviewPointerPressed(object? sender, Avalonia.Input.PointerPressedEventArgs e)
+    {
+        var props = e.GetCurrentPoint(ItemPreviewInputSurface).Properties;
+        bool shift = (e.KeyModifiers & Avalonia.Input.KeyModifiers.Shift) != 0;
+
+        _previewDragMode = PreviewDragModeDecider.Decide(
+            props.IsLeftButtonPressed, props.IsMiddleButtonPressed, shift);
+        if (_previewDragMode == PreviewDragMode.None) return;
+
+        _previewLastPointer = e.GetPosition(ItemPreviewInputSurface);
+        ItemPreviewInputSurface.Focus();
+        e.Pointer.Capture(ItemPreviewInputSurface);
+        e.Handled = true;
+    }
+
+    private void OnPreviewPointerMoved(object? sender, Avalonia.Input.PointerEventArgs e)
+    {
+        if (_previewDragMode == PreviewDragMode.None) return;
+
+        var pos = e.GetPosition(ItemPreviewInputSurface);
+        double dx = pos.X - _previewLastPointer.X;
+        double dy = pos.Y - _previewLastPointer.Y;
+        _previewLastPointer = pos;
+
+        if (_previewDragMode == PreviewDragMode.Rotate)
+            ItemPreviewGL.RotateByPixels(dx, dy);
+        else if (_previewDragMode == PreviewDragMode.Pan)
+            ItemPreviewGL.PanByPixels(dx, dy);
+    }
+
+    private void OnPreviewPointerReleased(object? sender, Avalonia.Input.PointerReleasedEventArgs e)
+    {
+        if (_previewDragMode != PreviewDragMode.None)
+        {
+            _previewDragMode = PreviewDragMode.None;
+            e.Pointer.Capture(null);
+            e.Handled = true;
+        }
+    }
+
+    private void OnPreviewWheel(object? sender, Avalonia.Input.PointerWheelEventArgs e)
+    {
+        var pos = e.GetPosition(ItemPreviewGL); // unproject uses GL viewport coords
+        ItemPreviewGL.ZoomAtCursorPixels(pos, e.Delta.Y);
+        e.Handled = true;
+    }
+
+    private void OnPreviewKeyDown(object? sender, Avalonia.Input.KeyEventArgs e)
+    {
+        const float rotStep = 0.1f;
+        switch (e.Key)
+        {
+            case Avalonia.Input.Key.Left:
+            case Avalonia.Input.Key.A:
+                ItemPreviewGL.Rotate(-rotStep, 0);
+                break;
+            case Avalonia.Input.Key.Right:
+            case Avalonia.Input.Key.D:
+                ItemPreviewGL.Rotate(rotStep, 0);
+                break;
+            case Avalonia.Input.Key.Up:
+            case Avalonia.Input.Key.W:
+                ItemPreviewGL.Rotate(0, -rotStep);
+                break;
+            case Avalonia.Input.Key.Down:
+            case Avalonia.Input.Key.S:
+                ItemPreviewGL.Rotate(0, rotStep);
+                break;
+            case Avalonia.Input.Key.Home:
+                ItemPreviewGL.ResetView();
+                break;
+            default:
+                return;
+        }
+        e.Handled = true;
+    }
+
     /// <summary>
     /// Adapter that drives the live <see cref="ModelPreviewGLControl"/> from
     /// <see cref="IItemPreviewRenderer"/> calls. Toggles the placeholder and view-controls
@@ -144,18 +263,21 @@ public partial class MainWindow
         private readonly ModelPreviewGLControl _gl;
         private readonly Control _placeholder;
         private readonly Control _viewControls;
+        private readonly Control _inputSurface;
 
-        public RendererAdapter(ModelPreviewGLControl gl, Control placeholder, Control viewControls)
+        public RendererAdapter(ModelPreviewGLControl gl, Control placeholder, Control viewControls, Control inputSurface)
         {
             _gl = gl;
             _placeholder = placeholder;
             _viewControls = viewControls;
+            _inputSurface = inputSurface;
         }
 
         public void SetModel(MdlModel model)
         {
             _gl.Model = model;
             _gl.IsVisible = true;
+            _inputSurface.IsVisible = true;
             _placeholder.IsVisible = false;
             _viewControls.IsVisible = true;
         }
@@ -164,6 +286,7 @@ public partial class MainWindow
         {
             _gl.Model = null;
             _gl.IsVisible = false;
+            _inputSurface.IsVisible = false;
             _placeholder.IsVisible = true;
             _viewControls.IsVisible = false;
         }

--- a/Relique/Relique/Views/MainWindow.ItemPreview.cs
+++ b/Relique/Relique/Views/MainWindow.ItemPreview.cs
@@ -46,16 +46,30 @@ public partial class MainWindow
 
         _previewResolver = new ItemModelResolver(baseItemSvc, _gameDataService);
 
-        _previewRendererAdapter = new RendererAdapter(ItemPreviewGL, ItemPreviewPlaceholder, ItemPreviewControls, ItemPreviewInputSurface);
+        _previewRendererAdapter = new RendererAdapter(ItemPreviewGL, ItemPreviewPlaceholder, ItemPreviewControls, ItemPreviewInputSurface, ItemPreviewGenderPanel);
         ItemPreviewGL.SetTextureService(_previewTextureService);
 
         WirePreviewInput();
+
+        // Restore the persisted preview gender so armor/clothing composes on the last-used
+        // mannequin body across sessions (#2407).
+        int persistedGender = SettingsService.Instance.PreviewGender;
+        string mannequinPrefix = MannequinPrefix.ForGender(persistedGender);
 
         _previewController = new ItemPreviewController(
             _previewResolver,
             _previewComposer,
             _previewRendererAdapter,
-            baseItemSvc);
+            baseItemSvc,
+            mannequinPrefix);
+
+        // Reflect the persisted gender in the toggle without firing the change handler.
+        _suppressGenderHandler = true;
+        if (persistedGender == 1)
+            ItemPreviewFemaleRadio.IsChecked = true;
+        else
+            ItemPreviewMaleRadio.IsChecked = true;
+        _suppressGenderHandler = false;
 
         _previewDebounceTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(PreviewDebounceMs) };
         _previewDebounceTimer.Tick += (_, _) =>
@@ -137,6 +151,19 @@ public partial class MainWindow
 
     private void OnItemPreviewResetClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         => ItemPreviewGL.ResetView();
+
+    // --- Gender toggle (#2407) ---
+
+    private bool _suppressGenderHandler;
+
+    private void OnItemPreviewGenderChanged(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (_suppressGenderHandler || _previewController == null) return;
+
+        int gender = ItemPreviewFemaleRadio.IsChecked == true ? 1 : 0;
+        SettingsService.Instance.PreviewGender = gender;
+        _previewController.SetArmorMannequinPrefix(MannequinPrefix.ForGender(gender));
+    }
 
     // --- Rotate / zoom button handlers (#2409, match Quartermaster) ---
 
@@ -264,22 +291,25 @@ public partial class MainWindow
         private readonly Control _placeholder;
         private readonly Control _viewControls;
         private readonly Control _inputSurface;
+        private readonly Control _genderPanel;
 
-        public RendererAdapter(ModelPreviewGLControl gl, Control placeholder, Control viewControls, Control inputSurface)
+        public RendererAdapter(ModelPreviewGLControl gl, Control placeholder, Control viewControls, Control inputSurface, Control genderPanel)
         {
             _gl = gl;
             _placeholder = placeholder;
             _viewControls = viewControls;
             _inputSurface = inputSurface;
+            _genderPanel = genderPanel;
         }
 
-        public void SetModel(MdlModel model)
+        public void SetModel(MdlModel model, bool gendered)
         {
             _gl.Model = model;
             _gl.IsVisible = true;
             _inputSurface.IsVisible = true;
             _placeholder.IsVisible = false;
             _viewControls.IsVisible = true;
+            _genderPanel.IsVisible = gendered;
         }
 
         public void Clear()
@@ -289,6 +319,7 @@ public partial class MainWindow
             _inputSurface.IsVisible = false;
             _placeholder.IsVisible = true;
             _viewControls.IsVisible = false;
+            _genderPanel.IsVisible = false;
         }
 
         public void SetArmorColors(int metal1, int metal2, int cloth1, int cloth2, int leather1, int leather2)

--- a/Relique/Relique/Views/MainWindow.Undo.cs
+++ b/Relique/Relique/Views/MainWindow.Undo.cs
@@ -2,6 +2,7 @@ using System;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using ItemEditor.Services;
 using Radoub.UI.Undo;
 
 namespace ItemEditor.Views;
@@ -82,6 +83,10 @@ public partial class MainWindow
     /// <summary>True while undo/redo drives a model-part change (re-entrancy guard, #2231).</summary>
     private bool _suppressModelPartUndo;
 
+    /// <summary>True while a live model-part ComboBox SelectionChanged is applying its change,
+    /// so the undo apply-action skips rebuilding the combo it is firing from (#2533).</summary>
+    private bool _modelPartSelectionInProgress;
+
     /// <summary>
     /// Record a model-part change through undo (#2231). The combo is not bound to the VM, so when the
     /// selection handler fires <paramref name="getter"/> still returns the pre-change value — captured
@@ -100,9 +105,13 @@ public partial class MainWindow
             try
             {
                 setter(v);
-                // Re-sync the combos + icon preview to the model (undo/redo path). _isLoading guards
-                // the repopulate from re-recording via its own handlers.
-                if (_currentItem != null)
+                // Re-sync the combos + icon preview to the model so undo/redo keeps the UI in
+                // sync. Skip this while a live combo SelectionChanged is in progress — rebuilding
+                // the combo's Items from inside its own event re-enters the active control and
+                // crashes the render loop for composite weapons (#2533). On the live path the
+                // combo already shows the chosen value, so no re-sync is needed.
+                if (_currentItem != null
+                    && ModelPartResyncDecider.ShouldResyncCombos(_modelPartSelectionInProgress))
                 {
                     var wasLoading = _isLoading;
                     _isLoading = true;

--- a/Relique/Relique/Views/MainWindow.axaml
+++ b/Relique/Relique/Views/MainWindow.axaml
@@ -551,9 +551,11 @@
                                 </StackPanel>
 
                                 <!-- Right column: 3D preview + view controls (#1908 PR3b).
-                                     Responsive viewport (#2408): fills the column and grows with the
-                                     window so full-body armor displays usably; MinWidth/MinHeight keep
-                                     small held-item previews above a usable floor. -->
+                                     Responsive viewport (#2408): width fills the column (3* share +
+                                     Stretch) so full-body armor displays usably; MinWidth/MinHeight keep
+                                     small held-item previews above a usable floor. Height is a larger
+                                     fixed default (the StackPanel does not stretch children vertically);
+                                     fully responsive height tracked in #2538. -->
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <Border BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
                                             BorderThickness="1" CornerRadius="2"

--- a/Relique/Relique/Views/MainWindow.axaml
+++ b/Relique/Relique/Views/MainWindow.axaml
@@ -348,7 +348,7 @@
 
                             <!-- Appearance (collapsible, conditional on base item type) -->
                             <Expander x:Name="AppearanceExpander" Header="Appearance" IsExpanded="True" IsVisible="False" Margin="0,0,0,8">
-                                <Grid ColumnDefinitions="*,16,Auto" Margin="0,4,0,0">
+                                <Grid ColumnDefinitions="2*,16,3*" Margin="0,4,0,0">
                                 <StackPanel Grid.Column="0" Spacing="8">
 
                                     <!-- Icon Preview + Browse Button -->
@@ -550,11 +550,15 @@
 
                                 </StackPanel>
 
-                                <!-- Right column: 3D preview + view controls (#1908 PR3b) -->
-                                <StackPanel Grid.Column="2" Width="280" Spacing="6">
+                                <!-- Right column: 3D preview + view controls (#1908 PR3b).
+                                     Responsive viewport (#2408): fills the column and grows with the
+                                     window so full-body armor displays usably; MinWidth/MinHeight keep
+                                     small held-item previews above a usable floor. -->
+                                <StackPanel Grid.Column="2" Spacing="6">
                                     <Border BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
                                             BorderThickness="1" CornerRadius="2"
-                                            Width="280" Height="280">
+                                            HorizontalAlignment="Stretch"
+                                            MinWidth="280" MinHeight="280" Height="380">
                                         <Grid>
                                             <controls:ModelPreviewGLControl x:Name="ItemPreviewGL"
                                                                             IsVisible="False"/>

--- a/Relique/Relique/Views/MainWindow.axaml
+++ b/Relique/Relique/Views/MainWindow.axaml
@@ -562,6 +562,12 @@
                                         <Grid>
                                             <controls:ModelPreviewGLControl x:Name="ItemPreviewGL"
                                                                             IsVisible="False"/>
+                                            <!-- Transparent input surface so pointer/wheel events always hit-test
+                                                 (OpenGlControlBase has no Background). Mirrors QM (#2124). -->
+                                            <Border x:Name="ItemPreviewInputSurface"
+                                                    Background="Transparent"
+                                                    Focusable="True"
+                                                    IsVisible="False"/>
                                             <TextBlock x:Name="ItemPreviewPlaceholder"
                                                        Text="No 3D model for this item type"
                                                        HorizontalAlignment="Center"
@@ -572,13 +578,23 @@
                                                        Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
                                         </Grid>
                                     </Border>
-                                    <UniformGrid x:Name="ItemPreviewControls" Columns="5" IsVisible="False">
-                                        <Button Content="F" ToolTip.Tip="Front view" Click="OnItemPreviewFrontClick" Padding="6,2"/>
-                                        <Button Content="B" ToolTip.Tip="Back view" Click="OnItemPreviewBackClick" Padding="6,2"/>
-                                        <Button Content="L" ToolTip.Tip="Left view" Click="OnItemPreviewLeftClick" Padding="6,2"/>
-                                        <Button Content="R" ToolTip.Tip="Right view" Click="OnItemPreviewRightClick" Padding="6,2"/>
-                                        <Button Content="↺" ToolTip.Tip="Reset view" Click="OnItemPreviewResetClick" Padding="6,2"/>
-                                    </UniformGrid>
+                                    <!-- Rotate/zoom + view presets (#2409). Drag-to-rotate, ↺/↻ rotate,
+                                         +/- zoom, wheel zoom, arrow/WASD keys — all match Quartermaster. -->
+                                    <StackPanel x:Name="ItemPreviewControls" IsVisible="False" Spacing="4">
+                                        <UniformGrid Columns="5">
+                                            <Button Content="↺" ToolTip.Tip="Rotate left" Click="OnItemPreviewRotateLeftClick" Padding="6,2"/>
+                                            <Button Content="↻" ToolTip.Tip="Rotate right" Click="OnItemPreviewRotateRightClick" Padding="6,2"/>
+                                            <Button Content="+" ToolTip.Tip="Zoom in" Click="OnItemPreviewZoomInClick" Padding="6,2"/>
+                                            <Button Content="−" ToolTip.Tip="Zoom out" Click="OnItemPreviewZoomOutClick" Padding="6,2"/>
+                                            <Button Content="⟲" ToolTip.Tip="Reset view" Click="OnItemPreviewResetClick" Padding="6,2"/>
+                                        </UniformGrid>
+                                        <UniformGrid Columns="4">
+                                            <Button Content="F" ToolTip.Tip="Front view" Click="OnItemPreviewFrontClick" Padding="6,2"/>
+                                            <Button Content="B" ToolTip.Tip="Back view" Click="OnItemPreviewBackClick" Padding="6,2"/>
+                                            <Button Content="L" ToolTip.Tip="Left view" Click="OnItemPreviewLeftClick" Padding="6,2"/>
+                                            <Button Content="R" ToolTip.Tip="Right view" Click="OnItemPreviewRightClick" Padding="6,2"/>
+                                        </UniformGrid>
+                                    </StackPanel>
                                 </StackPanel>
                                 </Grid>
                             </Expander>

--- a/Relique/Relique/Views/MainWindow.axaml
+++ b/Relique/Relique/Views/MainWindow.axaml
@@ -594,6 +594,22 @@
                                             <Button Content="L" ToolTip.Tip="Left view" Click="OnItemPreviewLeftClick" Padding="6,2"/>
                                             <Button Content="R" ToolTip.Tip="Right view" Click="OnItemPreviewRightClick" Padding="6,2"/>
                                         </UniformGrid>
+                                        <!-- Gender toggle for armor/clothing mannequin (#2407). Editor-only
+                                             (UTI has no gender field); persisted in settings. -->
+                                        <StackPanel x:Name="ItemPreviewGenderPanel"
+                                                    Orientation="Horizontal" Spacing="6"
+                                                    HorizontalAlignment="Center" IsVisible="False">
+                                            <TextBlock Text="Body:" VerticalAlignment="Center"
+                                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                                            <RadioButton x:Name="ItemPreviewMaleRadio" Content="Male"
+                                                         GroupName="PreviewGender" IsChecked="True"
+                                                         Click="OnItemPreviewGenderChanged"
+                                                         ToolTip.Tip="Preview armor/clothing on a male body"/>
+                                            <RadioButton x:Name="ItemPreviewFemaleRadio" Content="Female"
+                                                         GroupName="PreviewGender"
+                                                         Click="OnItemPreviewGenderChanged"
+                                                         ToolTip.Tip="Preview armor/clothing on a female body"/>
+                                        </StackPanel>
                                     </StackPanel>
                                 </StackPanel>
                                 </Grid>


### PR DESCRIPTION
## Summary

3D-preview rendering enhancements for Relique (sprint #2446). Bug #2233 shipped earlier via PR #2530; this PR covers the remaining viewport/camera/gender work plus a composite-weapon crash fix surfaced during testing.

## Work Items

- [x] #2233 — Composite weapon parts render misaligned (done in PR #2530)
- [x] #2408 — Responsive 3D preview viewport for full-body armor
- [x] #2409 — Drag-to-rotate + rotate/zoom buttons (wheel zoom, arrow/WASD keys)
- [x] #2407 — Gender-specific clothing/armor models in preview (persisted in settings)
- [x] #2533 — Fix: changing a composite-weapon model part crashed the preview

## Related Issues

- Closes #2446, #2407, #2408, #2409, #2533
- Follow-up tech debt: #2534 (thin-spike centering), #2538 (responsive height + adopt shared ModelPreviewPanel)
- Shares camera/extract work with Reliquary #2430

## Tests

- Unit (local, Windows): **3099 passed, 0 failed** (Relique 368, Radoub.UI 1214, Formats/Dictionary)
- FlaUI smoke (Relique): **3 passed, 0 failed**
- TDD for #2407 and #2533 (failing test first → implement → green)
- Code review: 0 correctness findings; cleanup deferred to #2538

## Checklist

- [x] Implementation complete
- [x] Tests added/updated
- [x] CHANGELOG updated (Relique 0.10.29-alpha; root Radoub.UI 0.2.20-alpha)
- [x] Manual spot-checks verified (gender toggle, drag/rotate, composite-part crash fix)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)