### PR TITLE
[Quartermaster] Fix: Robe animations badly off — head detaches during run (#2399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.21-alpha] - 2026-06-21
+**Branch**: `quartermaster/issue-2399` | **PR**: #2545
+
+### Fix: Skinned-mesh deformation in the 3D model preview (#2399)
+
+- Skin meshes (robe bodies, snake coils, etc.) now deform with the animated skeleton instead of staying frozen at bind pose — robe-wearing creatures no longer detach their head/body during animation. New `SkinDeformer` / `SkinMatrixBuilder` apply linear-blend skinning; static (un-animated) models render identically to before.
+
+---
+
+## [Radoub.Formats 0.2.74-alpha] - 2026-06-21
+**Branch**: `quartermaster/issue-2399` | **PR**: #2545
+
+### Fix: Populate skin-mesh bone names for runtime skinning (#2399)
+
+- The binary MDL reader now resolves each skin mesh's bone-slot → bone-node-name table (`BoneNodeNames`) via a post-parse NodeToBoneMap inversion, the bridge skin deformation needs to find its animated bones.
+
+---
+
 ## [Radoub.Formats 0.2.73-alpha] - 2026-06-19
 **Branch**: `parley/sprint/2445-ui-ux` | **PR**: #2519
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.127-alpha] - 2026-06-21
+**Branch**: `quartermaster/issue-2399` | **PR**: #TBD
+
+### Fix: Robe animations badly off — head detaches during run (#2399)
+
+- Robe-wearing creatures (e.g. Dana) no longer distort during animation playback; grafted robe sub-bones now follow the skeleton's animation channels instead of drifting from the head/neck. Shared `Radoub.UI` renderer change.
+
+---
+
 ## [0.2.126-alpha] - 2026-06-19
 **Branch**: `quartermaster/issue-2440` | **PR**: #2525
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -10,7 +10,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ### Fix: Robe animations badly off — head detaches during run (#2399)
 
-- Robe-wearing creatures (e.g. Dana) no longer distort during animation playback; grafted robe sub-bones now follow the skeleton's animation channels instead of drifting from the head/neck. Shared `Radoub.UI` renderer change.
+- Robe-wearing creatures (e.g. Dana) no longer distort during animation playback; the robe body now deforms with the animated skeleton. Shared-library fix — see root CHANGELOG (`Radoub.UI 0.2.21-alpha`, `Radoub.Formats 0.2.74-alpha`).
 
 ---
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.127-alpha] - 2026-06-21
-**Branch**: `quartermaster/issue-2399` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2399` | **PR**: #2545
 
 ### Fix: Robe animations badly off — head detaches during run (#2399)
 

--- a/Radoub.Formats/Radoub.Formats.Tests/Mdl/SkinBoneResolverTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Mdl/SkinBoneResolverTests.cs
@@ -1,0 +1,55 @@
+using System.Numerics;
+using Radoub.Formats.Mdl;
+using Xunit;
+
+namespace Radoub.Formats.Tests.Mdl;
+
+/// <summary>
+/// Tests for SkinBoneResolver — maps a skin mesh's per-vertex bone SLOT indices to the
+/// animated bone NODE NAMES, via NodeToBoneMap inverted against the model's depth-first node
+/// order. Empirically validated against pfh0_robe003 (slot 5 → torso_g, slot 9 → lbicep_g, ...).
+/// </summary>
+public class SkinBoneResolverTests
+{
+    private static MdlNode Node(string name) => new() { Name = name };
+
+    [Fact]
+    public void ResolveBoneNames_MapsSlotToNodeNameViaNodeToBoneMap()
+    {
+        // Depth-first node order (index → name). NodeToBoneMap[i] = bone slot for node i (or -1).
+        // Mirrors the validated pfh0_robe003 case in miniature:
+        //   node[0]=root(-1), node[1]=rootdummy(-1), node[2]=torso_g(slot1), node[3]=pelvis_g(slot0)
+        var nodes = new[] { Node("root"), Node("rootdummy"), Node("torso_g"), Node("pelvis_g") };
+        var nodeToBoneMap = new short[] { -1, -1, 1, 0 };
+        int boneCount = 2;
+
+        var names = SkinBoneResolver.ResolveBoneNames(nodes, nodeToBoneMap, boneCount);
+
+        Assert.Equal(2, names.Length);
+        Assert.Equal("pelvis_g", names[0]); // slot 0
+        Assert.Equal("torso_g", names[1]);  // slot 1
+    }
+
+    [Fact]
+    public void ResolveBoneNames_SlotWithNoNode_IsEmptyString()
+    {
+        var nodes = new[] { Node("root"), Node("torso_g") };
+        var nodeToBoneMap = new short[] { -1, 0 };
+        int boneCount = 3; // slots 1 and 2 have no node referencing them
+
+        var names = SkinBoneResolver.ResolveBoneNames(nodes, nodeToBoneMap, boneCount);
+
+        Assert.Equal("torso_g", names[0]);
+        Assert.Equal(string.Empty, names[1]);
+        Assert.Equal(string.Empty, names[2]);
+    }
+
+    [Fact]
+    public void ResolveBoneNames_EmptyMap_ReturnsAllEmpty()
+    {
+        var names = SkinBoneResolver.ResolveBoneNames(new[] { Node("root") }, System.Array.Empty<short>(), 2);
+
+        Assert.Equal(2, names.Length);
+        Assert.All(names, n => Assert.Equal(string.Empty, n));
+    }
+}

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader.cs
@@ -196,6 +196,7 @@ public partial class MdlBinaryReader
         if (rootNodeOffset != uint.MaxValue)
         {
             model.GeometryRoot = ParseNode(rootNodeOffset);
+            ResolveSkinBoneNames(model);
         }
 
         var animArrayBufferOffset = PointerToModelOffset(animArrayOffset);
@@ -205,5 +206,35 @@ public partial class MdlBinaryReader
         }
 
         return model;
+    }
+
+    /// <summary>
+    /// Post-parse pass (#2399): populate every skin mesh's <see cref="MdlSkinNode.BoneNodeNames"/>
+    /// (slot → bone node name) by inverting its NodeToBoneMap against the model's depth-first node
+    /// order. ParseNode assigns node indices depth-first (root first), matching the file's
+    /// NodeToBoneMap indexing. Without this the renderer has no slot→bone bridge for skinning.
+    /// </summary>
+    private static void ResolveSkinBoneNames(MdlModel model)
+    {
+        if (model.GeometryRoot == null) return;
+
+        var depthFirst = new List<MdlNode>();
+        CollectDepthFirst(model.GeometryRoot, depthFirst);
+
+        foreach (var node in depthFirst)
+        {
+            if (node is MdlSkinNode skin && skin.NodeToBoneMap.Length > 0 && skin.BoneQuaternions.Length > 0)
+            {
+                skin.BoneNodeNames = SkinBoneResolver.ResolveBoneNames(
+                    depthFirst, skin.NodeToBoneMap, skin.BoneQuaternions.Length);
+            }
+        }
+    }
+
+    private static void CollectDepthFirst(MdlNode node, List<MdlNode> acc)
+    {
+        acc.Add(node);
+        foreach (var child in node.Children)
+            CollectDepthFirst(child, acc);
     }
 }

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlStructures.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlStructures.cs
@@ -202,8 +202,16 @@ public class MdlSkinNode : MdlTrimeshNode
     /// <summary>Bone weight data per vertex (up to 4 bones per vertex).</summary>
     public MdlBoneWeight[] BoneWeights { get; set; } = Array.Empty<MdlBoneWeight>();
 
-    /// <summary>Bone node name references.</summary>
+    /// <summary>Bone node name references (slot → bone node name).</summary>
     public string[] BoneNodeNames { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Direct slot → bone node references, resolved when the mesh is composited (#2399). Takes
+    /// precedence over <see cref="BoneNodeNames"/> at render time because a composite can contain
+    /// multiple bones sharing a name (the skeleton's torso_g and a grafted robe's torso_g); a
+    /// name lookup is ambiguous, the reference is not. Null/empty entries fall back to name lookup.
+    /// </summary>
+    public MdlNode?[] BoneNodes { get; set; } = Array.Empty<MdlNode?>();
 
     /// <summary>Quaternion rotations for bones.</summary>
     public Quaternion[] BoneQuaternions { get; set; } = Array.Empty<Quaternion>();

--- a/Radoub.Formats/Radoub.Formats/Mdl/SkinBoneResolver.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/SkinBoneResolver.cs
@@ -1,0 +1,37 @@
+namespace Radoub.Formats.Mdl;
+
+/// <summary>
+/// Resolves a skin mesh's bone-SLOT indices to bone NODE NAMES.
+///
+/// A skin mesh weights each vertex to up to four bone <em>slots</em> (indices into the
+/// Q/T inverse-bind arrays). The only bridge from slot to the animated bone is
+/// <c>NodeToBoneMap</c>: for node <c>i</c> in the model's depth-first node order,
+/// <c>NodeToBoneMap[i]</c> is that node's bone slot (or -1 if the node is not a bone).
+/// Inverting that map yields slot → node name, which the renderer looks up in the animation
+/// pose to drive skin deformation (#2399 / R1).
+/// </summary>
+public static class SkinBoneResolver
+{
+    /// <summary>
+    /// Build a slot → bone-node-name table. <paramref name="depthFirstNodes"/> must be the
+    /// model's nodes in the same depth-first order the binary reader assigned indices in
+    /// <paramref name="nodeToBoneMap"/> (root at index 0). Slots with no referencing node get
+    /// <see cref="string.Empty"/>.
+    /// </summary>
+    public static string[] ResolveBoneNames(
+        IReadOnlyList<MdlNode> depthFirstNodes, short[] nodeToBoneMap, int boneCount)
+    {
+        var names = new string[boneCount];
+        for (int i = 0; i < names.Length; i++)
+            names[i] = string.Empty;
+
+        for (int nodeIndex = 0; nodeIndex < nodeToBoneMap.Length && nodeIndex < depthFirstNodes.Count; nodeIndex++)
+        {
+            int slot = nodeToBoneMap[nodeIndex];
+            if (slot >= 0 && slot < boneCount)
+                names[slot] = depthFirstNodes[nodeIndex].Name;
+        }
+
+        return names;
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/MdlPartComposerRobeTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/MdlPartComposerRobeTests.cs
@@ -97,4 +97,43 @@ public class MdlPartComposerRobeTests
         Assert.NotNull(coat);
         Assert.IsType<MdlSkinNode>(coat); // clone preserves skin type (#1989)
     }
+
+    /// <summary>
+    /// After grafting, a robe skin's BoneNodes must point at the ROBE's grafted bone clones, not
+    /// the skeleton's same-named bones — otherwise skin deformation uses the wrong bind and the
+    /// robe explodes under animation (#2399). The robe and skeleton both have a "torso_g".
+    /// </summary>
+    [Fact]
+    public void Robe_BindsSkinBonesToGraftedClones_NotSkeletonBones()
+    {
+        var skeleton = BuildSkeleton();
+        var robe = BuildRobe();
+        // Give the coat skin a slot→name table referencing torso_g (a name the skeleton ALSO owns).
+        var coatSrc = (MdlSkinNode)FindChild(robe.GeometryRoot!, "coat")!;
+        coatSrc.BoneNodeNames = new[] { "torso_g" };
+        coatSrc.NodeToBoneMap = new short[] { -1, 0 }; // not used by composer, present for realism
+        coatSrc.BoneQuaternions = new System.Numerics.Quaternion[1];
+        coatSrc.BoneTranslations = new Vector3[1];
+
+        var composer = MakeComposer(skeleton, robe);
+        var composite = composer.Compose("pmh0", new[] { ("robe", "pmh0_robe186") }, adjustSeams: false);
+
+        var coat = (MdlSkinNode)MdlPartComposer.FindBoneByName(composite!.GeometryRoot!, "coat")!;
+        Assert.Single(coat.BoneNodes);
+        var boundTorso = coat.BoneNodes[0];
+        Assert.NotNull(boundTorso);
+
+        // The bound torso_g must be the robe's grafted clone (a mesh — robe authored torso_g as a
+        // mesh), NOT the skeleton's torso_g bone node. Decisive discriminator: type differs.
+        Assert.IsAssignableFrom<MdlTrimeshNode>(boundTorso);
+        Assert.False(boundTorso!.GetType() == typeof(MdlNode),
+            "skin bound to the skeleton's plain bone node instead of the robe's grafted torso_g");
+    }
+
+    private static MdlNode? FindChild(MdlNode node, string name)
+    {
+        if (node.Name == name) return node;
+        foreach (var c in node.Children) { var r = FindChild(c, name); if (r != null) return r; }
+        return null;
+    }
 }

--- a/Radoub.UI/Radoub.UI.Tests/Services/SkinDeformerTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/SkinDeformerTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Numerics;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests.Services;
+
+/// <summary>
+/// Tests for SkinDeformer — pure linear-blend-skinning math (no GL).
+///
+/// Skinning identity (verified against rollnw + our own parsed bind data, #2399):
+///   inverseBind[slot] = inverse(boneBindWorld) * meshBindWorld
+///   skin[slot]        = boneAnimWorld * inverseBind[slot]
+///   v_world           = Σ wᵢ · (skin[slotᵢ] · v_local)
+/// At bind pose (boneAnimWorld == boneBindWorld) every skin[slot] == meshBindWorld, so an
+/// un-animated skin renders exactly at its current static bind-pose position — the regression
+/// invariant that protects creatures already rendering correctly.
+/// </summary>
+public class SkinDeformerTests
+{
+    [Fact]
+    public void BlendVertex_SingleBoneIdentitySkin_ReturnsVertexUnchanged()
+    {
+        var vertex = new Vector3(1, 2, 3);
+        var skinMatrices = new[] { Matrix4x4.Identity };
+        var weight = new SkinDeformer.VertexWeights(
+            bone0: 0, weight0: 1f, bone1: -1, weight1: 0f, bone2: -1, weight2: 0f, bone3: -1, weight3: 0f);
+
+        var result = SkinDeformer.BlendVertex(vertex, weight, skinMatrices);
+
+        Assert.Equal(1f, result.X, 5);
+        Assert.Equal(2f, result.Y, 5);
+        Assert.Equal(3f, result.Z, 5);
+    }
+
+    [Fact]
+    public void BuildSkinMatrix_AtBindPose_EqualsMeshBindWorld()
+    {
+        // A bone offset from the mesh; at bind pose the animated bone world == bind bone world.
+        var boneBindWorld = Matrix4x4.CreateRotationZ(0.7f) * Matrix4x4.CreateTranslation(2, 1, 3);
+        var meshBindWorld = Matrix4x4.CreateTranslation(5, 0, 0);
+
+        var inverseBind = SkinDeformer.BuildInverseBind(boneBindWorld, meshBindWorld);
+        // boneAnimWorld == boneBindWorld (no animation) → skin must collapse to meshBindWorld.
+        var skin = SkinDeformer.BuildSkinMatrix(boneBindWorld, inverseBind);
+
+        AssertMatrixApproxEqual(meshBindWorld, skin);
+    }
+
+    [Fact]
+    public void BlendVertex_BindPose_LeavesVertexAtBindWorldPosition()
+    {
+        // Full pipeline at bind pose: a vertex blended through a bone must land where the static
+        // mesh bind-pose transform would put it (the regression invariant for #2399).
+        var boneBindWorld = Matrix4x4.CreateRotationX(0.4f) * Matrix4x4.CreateTranslation(1, 2, 3);
+        var meshBindWorld = Matrix4x4.CreateRotationY(0.2f) * Matrix4x4.CreateTranslation(-1, 0, 4);
+        var localVertex = new Vector3(0.5f, -0.3f, 0.9f);
+
+        var inverseBind = SkinDeformer.BuildInverseBind(boneBindWorld, meshBindWorld);
+        var skin = new[] { SkinDeformer.BuildSkinMatrix(boneBindWorld, inverseBind) };
+        var w = new SkinDeformer.VertexWeights(0, 1f, -1, 0f, -1, 0f, -1, 0f);
+
+        var deformed = SkinDeformer.BlendVertex(localVertex, w, skin);
+        var staticBind = Vector3.Transform(localVertex, meshBindWorld);
+
+        Assert.Equal(staticBind.X, deformed.X, 4);
+        Assert.Equal(staticBind.Y, deformed.Y, 4);
+        Assert.Equal(staticBind.Z, deformed.Z, 4);
+    }
+
+    [Fact]
+    public void BlendVertex_AnimatedBone_MovesVertexByBoneDelta()
+    {
+        // bone and mesh share bind world (identity) so inverseBind == identity; then animate the
+        // bone by a pure +Z translation. A fully-weighted vertex must move by exactly that delta.
+        var boneBindWorld = Matrix4x4.Identity;
+        var meshBindWorld = Matrix4x4.Identity;
+        var boneAnimWorld = Matrix4x4.CreateTranslation(0, 0, 10);
+
+        var inverseBind = SkinDeformer.BuildInverseBind(boneBindWorld, meshBindWorld);
+        var skin = new[] { SkinDeformer.BuildSkinMatrix(boneAnimWorld, inverseBind) };
+        var w = new SkinDeformer.VertexWeights(0, 1f, -1, 0f, -1, 0f, -1, 0f);
+
+        var deformed = SkinDeformer.BlendVertex(new Vector3(1, 2, 3), w, skin);
+
+        Assert.Equal(1f, deformed.X, 4);
+        Assert.Equal(2f, deformed.Y, 4);
+        Assert.Equal(13f, deformed.Z, 4); // 3 + 10
+    }
+
+    [Fact]
+    public void BlendVertex_TwoBonesHalfWeight_AveragesTransforms()
+    {
+        // Vertex weighted 50/50 between an unmoved bone and a +10Z bone → moves +5Z.
+        var skin = new[]
+        {
+            Matrix4x4.Identity,
+            Matrix4x4.CreateTranslation(0, 0, 10),
+        };
+        var w = new SkinDeformer.VertexWeights(0, 0.5f, 1, 0.5f, -1, 0f, -1, 0f);
+
+        var deformed = SkinDeformer.BlendVertex(new Vector3(0, 0, 0), w, skin);
+
+        Assert.Equal(0f, deformed.X, 4);
+        Assert.Equal(0f, deformed.Y, 4);
+        Assert.Equal(5f, deformed.Z, 4);
+    }
+
+    [Fact]
+    public void BlendNormal_RotationOnlySkin_RotatesNormalIgnoringTranslation()
+    {
+        // A skin matrix with a 90° Z rotation AND a translation; the normal must rotate but NOT
+        // pick up the translation (normals are direction vectors).
+        var skin = new[] { Matrix4x4.CreateRotationZ(MathF.PI / 2f) * Matrix4x4.CreateTranslation(100, 0, 0) };
+        var w = new SkinDeformer.VertexWeights(0, 1f, -1, 0f, -1, 0f, -1, 0f);
+
+        var n = SkinDeformer.BlendNormal(new Vector3(1, 0, 0), w, skin);
+
+        // +X rotated 90° about Z → +Y; translation ignored.
+        Assert.Equal(0f, n.X, 4);
+        Assert.Equal(1f, n.Y, 4);
+        Assert.Equal(0f, n.Z, 4);
+    }
+
+    private static void AssertMatrixApproxEqual(Matrix4x4 expected, Matrix4x4 actual)
+    {
+        Assert.Equal(expected.M11, actual.M11, 4);
+        Assert.Equal(expected.M12, actual.M12, 4);
+        Assert.Equal(expected.M13, actual.M13, 4);
+        Assert.Equal(expected.M21, actual.M21, 4);
+        Assert.Equal(expected.M22, actual.M22, 4);
+        Assert.Equal(expected.M23, actual.M23, 4);
+        Assert.Equal(expected.M31, actual.M31, 4);
+        Assert.Equal(expected.M32, actual.M32, 4);
+        Assert.Equal(expected.M33, actual.M33, 4);
+        Assert.Equal(expected.M41, actual.M41, 4);
+        Assert.Equal(expected.M42, actual.M42, 4);
+        Assert.Equal(expected.M43, actual.M43, 4);
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/Services/SkinDeformerTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/SkinDeformerTests.cs
@@ -134,6 +134,62 @@ public class SkinDeformerTests
     }
 
     [Fact]
+    public void BlendVertex_WeightsSumLessThanOne_NormalizesToFullPosition()
+    {
+        // Weights summing to 0.5 must still place the vertex at the full bone position, not half
+        // way to the origin. Matches nwn_mdl_webviewer (divides by totalW when |sum-1|>0.01).
+        var skin = new[] { Matrix4x4.CreateTranslation(0, 0, 4) };
+        var w = new SkinDeformer.VertexWeights(0, 0.5f, -1, 0f, -1, 0f, -1, 0f); // sum = 0.5
+
+        var deformed = SkinDeformer.BlendVertex(new Vector3(0, 0, 0), w, skin);
+
+        Assert.Equal(0f, deformed.X, 4);
+        Assert.Equal(0f, deformed.Y, 4);
+        Assert.Equal(4f, deformed.Z, 4); // normalized: 0.5*4 / 0.5 = 4, not 2
+    }
+
+    [Fact]
+    public void BlendVertex_ZeroTotalWeight_ReturnsUntransformedVertex()
+    {
+        // No valid influence (all weights 0 / bones out of range) must NOT collapse the vertex to
+        // the world origin (the spike-to-origin artifact). Return the input vertex unchanged so the
+        // caller can place it via the rigid bind transform.
+        var skin = new[] { Matrix4x4.CreateTranslation(0, 0, 4) };
+        var w = new SkinDeformer.VertexWeights(-1, 0f, -1, 0f, -1, 0f, -1, 0f);
+
+        var deformed = SkinDeformer.BlendVertex(new Vector3(1, 2, 3), w, skin);
+
+        Assert.Equal(1f, deformed.X, 4);
+        Assert.Equal(2f, deformed.Y, 4);
+        Assert.Equal(3f, deformed.Z, 4);
+    }
+
+    [Fact]
+    public void BlendVertex_NaNWeight_IsSkipped()
+    {
+        // A NaN weight must be ignored, not propagate NaN into the result (weight <= 0 is false for
+        // NaN, so an explicit IsNaN guard is required).
+        var skin = new[] { Matrix4x4.CreateTranslation(0, 0, 4), Matrix4x4.CreateTranslation(0, 0, 8) };
+        var w = new SkinDeformer.VertexWeights(0, float.NaN, 1, 1f, -1, 0f, -1, 0f);
+
+        var deformed = SkinDeformer.BlendVertex(new Vector3(0, 0, 0), w, skin);
+
+        Assert.False(float.IsNaN(deformed.X) || float.IsNaN(deformed.Y) || float.IsNaN(deformed.Z));
+        Assert.Equal(8f, deformed.Z, 4); // only the valid weight-1 slot contributes
+    }
+
+    [Fact]
+    public void HasInfluence_DistinguishesWeightedFromUnweighted()
+    {
+        var skin = new[] { Matrix4x4.Identity, Matrix4x4.Identity };
+        Assert.True(SkinDeformer.HasInfluence(new SkinDeformer.VertexWeights(0, 1f, -1, 0f, -1, 0f, -1, 0f), skin.Length));
+        Assert.False(SkinDeformer.HasInfluence(new SkinDeformer.VertexWeights(-1, 0f, -1, 0f, -1, 0f, -1, 0f), skin.Length));
+        Assert.False(SkinDeformer.HasInfluence(new SkinDeformer.VertexWeights(0, float.NaN, -1, 0f, -1, 0f, -1, 0f), skin.Length));
+        // bone index out of range for the matrix array → no influence
+        Assert.False(SkinDeformer.HasInfluence(new SkinDeformer.VertexWeights(5, 1f, -1, 0f, -1, 0f, -1, 0f), skin.Length));
+    }
+
+    [Fact]
     public void BlendNormal_RotationOnlySkin_RotatesNormalIgnoringTranslation()
     {
         // A skin matrix with a 90° Z rotation AND a translation; the normal must rotate but NOT

--- a/Radoub.UI/Radoub.UI.Tests/Services/SkinDeformerTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/SkinDeformerTests.cs
@@ -107,6 +107,33 @@ public class SkinDeformerTests
     }
 
     [Fact]
+    public void BlendVertex_AnimatedRotationWithOffsetBone_MatchesColumnVectorReference()
+    {
+        // Order-sensitive case (the #2399 distortion bug): a bone offset from origin, rotated by
+        // the animation, with a non-trivial mesh bind. The deformed vertex must equal the
+        // canonical skin transform world = boneAnimWorld · inverse(boneBindWorld) · meshBindWorld · v
+        // (column-vector form). A swapped multiply order passes bind-pose but fails here.
+        var boneBindWorld = Matrix4x4.CreateRotationZ(0.3f) * Matrix4x4.CreateTranslation(0, 0, 1);
+        var meshBindWorld = Matrix4x4.CreateTranslation(0.5f, 0, 0.2f);
+        var boneAnimWorld = Matrix4x4.CreateRotationX(0.6f) * Matrix4x4.CreateTranslation(0, 0, 1);
+        var localVertex = new Vector3(0.4f, 0.1f, -0.2f);
+
+        var inverseBind = SkinDeformer.BuildInverseBind(boneBindWorld, meshBindWorld);
+        var skin = new[] { SkinDeformer.BuildSkinMatrix(boneAnimWorld, inverseBind) };
+        var w = new SkinDeformer.VertexWeights(0, 1f, -1, 0f, -1, 0f, -1, 0f);
+        var deformed = SkinDeformer.BlendVertex(localVertex, w, skin);
+
+        // Reference: row-vector composition v · meshBindWorld · inverse(boneBindWorld) · boneAnimWorld.
+        Matrix4x4.Invert(boneBindWorld, out var boneBindInv);
+        var refMat = meshBindWorld * boneBindInv * boneAnimWorld;
+        var expected = Vector3.Transform(localVertex, refMat);
+
+        Assert.Equal(expected.X, deformed.X, 4);
+        Assert.Equal(expected.Y, deformed.Y, 4);
+        Assert.Equal(expected.Z, deformed.Z, 4);
+    }
+
+    [Fact]
     public void BlendNormal_RotationOnlySkin_RotatesNormalIgnoringTranslation()
     {
         // A skin matrix with a 90° Z rotation AND a translation; the normal must rotate but NOT

--- a/Radoub.UI/Radoub.UI.Tests/Services/SkinMatrixBuilderTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/SkinMatrixBuilderTests.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.Numerics;
+using Radoub.Formats.Mdl;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests.Services;
+
+/// <summary>
+/// Tests for SkinMatrixBuilder — resolves a skin mesh's per-slot skin matrices from the
+/// composed bone hierarchy + animation pose (#2399). Bridges parser data (BoneNodeNames,
+/// the skin mesh node) to SkinDeformer's pure math.
+/// </summary>
+public class SkinMatrixBuilderTests
+{
+    // Build a minimal composite: root → bone(named) → skin(child of root).
+    private static (MdlSkinNode skin, MdlNode root) BuildRig(
+        Vector3 bonePos, string boneName, Vector3 meshPos)
+    {
+        var root = new MdlNode { Name = "root", Scale = 1f, Orientation = Quaternion.Identity };
+        var bone = new MdlNode { Name = boneName, Position = bonePos, Scale = 1f, Orientation = Quaternion.Identity, Parent = root };
+        root.Children.Add(bone);
+        var skin = new MdlSkinNode
+        {
+            Name = "skinbody",
+            Position = meshPos,
+            Scale = 1f,
+            Orientation = Quaternion.Identity,
+            Parent = root,
+            BoneNodeNames = new[] { boneName },
+        };
+        root.Children.Add(skin);
+        return (skin, root);
+    }
+
+    [Fact]
+    public void Build_NoPose_SkinMatrixEqualsMeshBindWorld()
+    {
+        var (skin, root) = BuildRig(new Vector3(0, 0, 1), "torso_g", new Vector3(2, 0, 0));
+
+        var matrices = SkinMatrixBuilder.Build(skin, root, pose: null);
+
+        // At bind pose, slot 0's skin matrix must equal the mesh's bind-world transform.
+        var meshBindWorld = ModelViewController.GetWorldTransform(skin, null);
+        Assert.Single(matrices);
+        AssertMatrixApprox(meshBindWorld, matrices[0]);
+    }
+
+    [Fact]
+    public void Build_WithBonePose_AppliesAnimatedDelta()
+    {
+        var (skin, root) = BuildRig(new Vector3(0, 0, 1), "torso_g", new Vector3(0, 0, 0));
+
+        // Animate torso_g: translate +5 on Z (pose Position replaces the bone's bind position).
+        var pose = new Dictionary<string, ModelViewController.NodePose>
+        {
+            ["torso_g"] = new ModelViewController.NodePose(
+                HasPosition: true, Position: new Vector3(0, 0, 6),
+                HasOrientation: false, Orientation: Quaternion.Identity,
+                HasScale: false, Scale: 1f),
+        };
+
+        var matrices = SkinMatrixBuilder.Build(skin, root, pose);
+
+        // A vertex at local origin, fully weighted to slot 0, should move from bind (z=0) to
+        // bind + (animated bone delta). Bone bind z=1, animated z=6 → delta +5.
+        var w = new SkinDeformer.VertexWeights(0, 1f, -1, 0f, -1, 0f, -1, 0f);
+        var deformed = SkinDeformer.BlendVertex(Vector3.Zero, w, matrices);
+        Assert.Equal(0f, deformed.X, 4);
+        Assert.Equal(0f, deformed.Y, 4);
+        Assert.Equal(5f, deformed.Z, 4);
+    }
+
+    [Fact]
+    public void Build_MissingBone_SlotFallsBackToMeshBindWorld()
+    {
+        var (skin, root) = BuildRig(new Vector3(0, 0, 1), "torso_g", new Vector3(1, 1, 1));
+        skin.BoneNodeNames = new[] { "nonexistent_bone" };
+
+        var matrices = SkinMatrixBuilder.Build(skin, root, pose: null);
+
+        // Unknown bone → keep the mesh at its static bind-world position (no crash, no collapse).
+        var meshBindWorld = ModelViewController.GetWorldTransform(skin, null);
+        AssertMatrixApprox(meshBindWorld, matrices[0]);
+    }
+
+    private static void AssertMatrixApprox(Matrix4x4 e, Matrix4x4 a)
+    {
+        Assert.Equal(e.M11, a.M11, 4); Assert.Equal(e.M22, a.M22, 4); Assert.Equal(e.M33, a.M33, 4);
+        Assert.Equal(e.M41, a.M41, 4); Assert.Equal(e.M42, a.M42, 4); Assert.Equal(e.M43, a.M43, 4);
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/Services/SkinMatrixBuilderTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/SkinMatrixBuilderTests.cs
@@ -72,6 +72,44 @@ public class SkinMatrixBuilderTests
     }
 
     [Fact]
+    public void Build_DuplicateBoneNamesInComposite_UsesBoundBoneReference()
+    {
+        // Composite with TWO "torso_g" nodes at different positions (skeleton's + robe's grafted).
+        // The skin must deform against its OWN bound bone, not whichever name-match comes first.
+        var root = new MdlNode { Name = "composite_root", Scale = 1f, Orientation = Quaternion.Identity };
+
+        // Skeleton's torso_g — the WRONG one (different position). Comes first in depth-first order.
+        var skeletonTorso = new MdlNode { Name = "torso_g", Position = new Vector3(0, 0, 5), Scale = 1f, Orientation = Quaternion.Identity, Parent = root };
+        root.Children.Add(skeletonTorso);
+
+        // Robe's grafted torso_g — the RIGHT one.
+        var robeTorso = new MdlNode { Name = "torso_g", Position = new Vector3(0, 0, 1), Scale = 1f, Orientation = Quaternion.Identity, Parent = root };
+        root.Children.Add(robeTorso);
+
+        var skin = new MdlSkinNode
+        {
+            Name = "Robe", Position = Vector3.Zero, Scale = 1f, Orientation = Quaternion.Identity, Parent = root,
+            BoneNodeNames = new[] { "torso_g" },
+            BoneNodes = new MdlNode?[] { robeTorso }, // explicitly bound to the robe's bone
+        };
+        root.Children.Add(skin);
+
+        // Animate torso_g by +10Z (both name-matches share the pose; only the bind differs).
+        var pose = new Dictionary<string, ModelViewController.NodePose>
+        {
+            ["torso_g"] = new ModelViewController.NodePose(true, new Vector3(0, 0, 11), false, Quaternion.Identity, false, 1f),
+        };
+
+        var matrices = SkinMatrixBuilder.Build(skin, root, pose);
+
+        // Bound bone robeTorso: bind z=1, anim z=11 → delta +10. A torso-weighted vertex at origin
+        // must move +10, NOT +6 (which the skeleton's z=5 bone would give).
+        var w = new SkinDeformer.VertexWeights(0, 1f, -1, 0f, -1, 0f, -1, 0f);
+        var deformed = SkinDeformer.BlendVertex(Vector3.Zero, w, matrices);
+        Assert.Equal(10f, deformed.Z, 4);
+    }
+
+    [Fact]
     public void Build_MissingBone_SlotFallsBackToMeshBindWorld()
     {
         var (skin, root) = BuildRig(new Vector3(0, 0, 1), "torso_g", new Vector3(1, 1, 1));

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
@@ -1391,8 +1391,23 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
                         var vw = new SkinDeformer.VertexWeights(
                             bw.Bone0, bw.Weight0, bw.Bone1, bw.Weight1,
                             bw.Bone2, bw.Weight2, bw.Bone3, bw.Weight3);
-                        worldPos = SkinDeformer.BlendVertex(localVertex, vw, skinMatrices);
-                        worldNormal = Vector3.Normalize(SkinDeformer.BlendNormal(localNormal, vw, skinMatrices));
+                        bool hasInfluence = SkinDeformer.HasInfluence(vw, skinMatrices.Length);
+                        if (hasInfluence)
+                        {
+                            worldPos = SkinDeformer.BlendVertex(localVertex, vw, skinMatrices);
+                            worldNormal = Vector3.Normalize(SkinDeformer.BlendNormal(localNormal, vw, skinMatrices));
+                        }
+                        else
+                        {
+                            // No valid bone influence — place at the rigid bind-world position (the
+                            // mesh's own transform) instead of letting it sit at the local origin.
+                            worldPos = hasWorldTransform
+                                ? ModelViewController.TransformPosition(localVertex, worldTransform)
+                                : localVertex;
+                            worldNormal = hasWorldTransform
+                                ? ModelViewController.TransformNormal(localNormal, worldTransform)
+                                : localNormal;
+                        }
                     }
                     else
                     {

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
@@ -1263,11 +1263,23 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
             bool isSkinMesh = mesh is Radoub.Formats.Mdl.MdlSkinNode;
 
             // All meshes: apply full hierarchy world transform.
-            // Skin mesh vertices (m_pavVerts) are in bind-pose space — same treatment as trimesh.
-            // m_aQBoneRefInv/m_aTBoneRefInv are inverse bind-pose matrices for runtime animation, not static display.
             var pose = GetCurrentPose();
             var worldTransform = ModelViewController.GetWorldTransform(mesh, pose);
             bool hasWorldTransform = worldTransform != Matrix4x4.Identity;
+
+            // Skin meshes (#2399 / R1): deform each vertex by its bone weights instead of applying
+            // the single node transform. Without this the skin body renders frozen at bind pose
+            // while bone-driven parts animate (robe head detaches, snakes stay flat). At bind pose
+            // every skin matrix collapses to the mesh bind-world transform, so static creatures are
+            // unaffected. Falls back to the rigid path if bone data is missing.
+            Matrix4x4[]? skinMatrices = null;
+            if (mesh is Radoub.Formats.Mdl.MdlSkinNode skinNode
+                && skinNode.BoneNodeNames.Length > 0
+                && skinNode.BoneWeights.Length == mesh.Vertices.Length
+                && _model?.GeometryRoot != null)
+            {
+                skinMatrices = SkinMatrixBuilder.Build(skinNode, _model.GeometryRoot, pose);
+            }
 
             // Count NaN vertices - we'll skip them during rendering
             var nanVertexIndices = new HashSet<int>();
@@ -1368,15 +1380,30 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
                     }
 
                     var localVertex = mesh.Vertices[vs[c]];
-                    var worldPos = hasWorldTransform
-                        ? ModelViewController.TransformPosition(localVertex, worldTransform)
-                        : localVertex;
-                    cornerPositions[ci] = worldPos;
-
                     var localNormal = cornerNormals[ci];
-                    var worldNormal = hasWorldTransform
-                        ? ModelViewController.TransformNormal(localNormal, worldTransform)
-                        : localNormal;
+
+                    Vector3 worldPos, worldNormal;
+                    if (skinMatrices != null)
+                    {
+                        // Bone-weighted deformation: position blended through the skin matrices,
+                        // normal rotated by the same blend (matched to vs[c] for stored normals).
+                        var bw = ((Radoub.Formats.Mdl.MdlSkinNode)mesh).BoneWeights[vs[c]];
+                        var vw = new SkinDeformer.VertexWeights(
+                            bw.Bone0, bw.Weight0, bw.Bone1, bw.Weight1,
+                            bw.Bone2, bw.Weight2, bw.Bone3, bw.Weight3);
+                        worldPos = SkinDeformer.BlendVertex(localVertex, vw, skinMatrices);
+                        worldNormal = Vector3.Normalize(SkinDeformer.BlendNormal(localNormal, vw, skinMatrices));
+                    }
+                    else
+                    {
+                        worldPos = hasWorldTransform
+                            ? ModelViewController.TransformPosition(localVertex, worldTransform)
+                            : localVertex;
+                        worldNormal = hasWorldTransform
+                            ? ModelViewController.TransformNormal(localNormal, worldTransform)
+                            : localNormal;
+                    }
+                    cornerPositions[ci] = worldPos;
                     cornerNormalsWorld[ci] = worldNormal;
 
                     if (hasUVs)

--- a/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
+++ b/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
@@ -462,6 +462,7 @@ public sealed class MdlPartComposer
             // mechanism as the robe graft (#1989). Apply WING_TAIL_SCALE to each grafted child's
             // root so the whole wing/tail subtree scales as a unit.
             int grafted = 0;
+            var graftedClones = new List<MdlNode>();
             foreach (var child in partModel.GeometryRoot.Children)
             {
                 var clone = CloneNode(child, attachParent);
@@ -473,8 +474,14 @@ public sealed class MdlPartComposer
                 // with the model resref points the renderer at a non-existent texture → grey wings.
                 TagSubtreeMeshes(clone, tag, meshPartTypes);
                 attachParent.Children.Add(clone);
+                graftedClones.Add(clone);
                 grafted++;
             }
+
+            // Bind any skin meshes in the wing/tail subtree to their OWN grafted bones (#2399), so a
+            // wing/tail skin whose bone name collides with a skeleton bone resolves correctly rather
+            // than to the same-named body bone at render time.
+            BindSkinBonesWithinSubtrees(graftedClones);
 
             MergeSupermodelAnimationsByName(compositeModel, partModel);
 

--- a/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
+++ b/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
@@ -335,16 +335,61 @@ public sealed class MdlPartComposer
         // Graft the part root's CHILDREN (skip the part's own root dummy, whose translation
         // duplicates the skeleton root's). Each child subtree is cloned with hierarchy intact.
         int grafted = 0;
+        var graftedClones = new List<MdlNode>();
         foreach (var child in partModel.GeometryRoot.Children)
         {
             var clone = CloneNode(child, root);
             ApplyPartBitmap(clone, partResRef, partType, meshPartTypes);
             root.Children.Add(clone);
+            graftedClones.Add(clone);
             grafted++;
         }
 
+        // Bind each grafted skin's bones to the ROBE's grafted bone clones (#2399). The composite
+        // also contains the skeleton's same-named bones; a render-time name lookup would be
+        // ambiguous and pick the wrong bind, exploding the skin under animation. Resolve names only
+        // within this part's grafted subtrees.
+        BindSkinBonesWithinSubtrees(graftedClones);
+
         UnifiedLogger.LogApplication(LogLevel.INFO,
             $"MdlPartComposer: grafted full-body part '{partType}' ({partResRef}) — {grafted} subtree(s)");
+    }
+
+    /// <summary>
+    /// Resolve every skin mesh's BoneNodeNames to direct node references (<see
+    /// cref="MdlSkinNode.BoneNodes"/>) using only the nodes within <paramref name="graftedRoots"/>
+    /// (this part's grafted subtrees), so a skin binds to its own part's bones and not a
+    /// same-named skeleton bone elsewhere in the composite (#2399).
+    /// </summary>
+    private static void BindSkinBonesWithinSubtrees(IReadOnlyList<MdlNode> graftedRoots)
+    {
+        // Build a name → node index over just the grafted nodes (first match wins, depth-first).
+        var byName = new Dictionary<string, MdlNode>(StringComparer.OrdinalIgnoreCase);
+        var skins = new List<MdlSkinNode>();
+        void Walk(MdlNode n)
+        {
+            if (!byName.ContainsKey(n.Name))
+                byName[n.Name] = n;
+            if (n is MdlSkinNode skin)
+                skins.Add(skin);
+            foreach (var c in n.Children)
+                Walk(c);
+        }
+        foreach (var r in graftedRoots)
+            Walk(r);
+
+        foreach (var skin in skins)
+        {
+            if (skin.BoneNodeNames.Length == 0)
+                continue;
+            var bones = new MdlNode?[skin.BoneNodeNames.Length];
+            for (int slot = 0; slot < bones.Length; slot++)
+            {
+                var name = skin.BoneNodeNames[slot];
+                bones[slot] = !string.IsNullOrEmpty(name) && byName.TryGetValue(name, out var node) ? node : null;
+            }
+            skin.BoneNodes = bones;
+        }
     }
 
     /// <summary>Set the texture name + record the part type on every mesh in a grafted subtree.</summary>

--- a/Radoub.UI/Radoub.UI/Services/SkinDeformer.cs
+++ b/Radoub.UI/Radoub.UI/Services/SkinDeformer.cs
@@ -1,0 +1,90 @@
+// Pure linear-blend-skinning math for MDL skin meshes (#2399 / R1).
+// GL-free and dependency-light so the per-vertex blend and the skin-matrix build are unit-testable.
+
+using System.Numerics;
+
+namespace Radoub.UI.Services;
+
+/// <summary>
+/// Linear-blend-skinning helper. Deforms skin-mesh vertices by blending per-bone transforms,
+/// so a skin body follows its animated skeleton instead of staying frozen at bind pose.
+///
+/// Skinning identity:
+///   inverseBind[slot] = inverse(boneBindWorld) · meshBindWorld
+///   skin[slot]        = boneAnimWorld · inverseBind[slot]
+///   v_world           = Σ wᵢ · (skin[slotᵢ] · v_local)
+/// </summary>
+public static class SkinDeformer
+{
+    /// <summary>Up-to-4 bone-slot indices + weights for one vertex.</summary>
+    public readonly record struct VertexWeights(
+        int bone0, float weight0,
+        int bone1, float weight1,
+        int bone2, float weight2,
+        int bone3, float weight3);
+
+    /// <summary>
+    /// inverseBind[slot] = inverse(boneBindWorld) · meshBindWorld.
+    /// Recomputed from the bind-pose hierarchy (the stored QBoneRefInv/TBoneRefInv are not
+    /// trusted). If <paramref name="boneBindWorld"/> is non-invertible, falls back to identity
+    /// so the slot contributes the raw mesh-bind transform rather than NaNs.
+    /// </summary>
+    public static Matrix4x4 BuildInverseBind(Matrix4x4 boneBindWorld, Matrix4x4 meshBindWorld)
+    {
+        if (!Matrix4x4.Invert(boneBindWorld, out var boneBindInv))
+            boneBindInv = Matrix4x4.Identity;
+        return Matrix4x4.Multiply(boneBindInv, meshBindWorld);
+    }
+
+    /// <summary>
+    /// skin[slot] = boneAnimWorld · inverseBind[slot]. At bind pose (boneAnimWorld ==
+    /// boneBindWorld) this collapses to meshBindWorld, leaving the vertex at its static position.
+    /// </summary>
+    public static Matrix4x4 BuildSkinMatrix(Matrix4x4 boneAnimWorld, Matrix4x4 inverseBind)
+        => Matrix4x4.Multiply(boneAnimWorld, inverseBind);
+
+    /// <summary>
+    /// Blend a local-space vertex by its bone weights against the per-slot skin matrices.
+    /// Bone indices &lt; 0, out of range, or with non-positive weight are skipped.
+    /// </summary>
+    public static Vector3 BlendVertex(Vector3 vertex, VertexWeights w, Matrix4x4[] skinMatrices)
+    {
+        var result = Vector3.Zero;
+
+        void Accumulate(int bone, float weight)
+        {
+            if (weight <= 0f || bone < 0 || bone >= skinMatrices.Length) return;
+            result += weight * Vector3.Transform(vertex, skinMatrices[bone]);
+        }
+
+        Accumulate(w.bone0, w.weight0);
+        Accumulate(w.bone1, w.weight1);
+        Accumulate(w.bone2, w.weight2);
+        Accumulate(w.bone3, w.weight3);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Blend a local-space normal by its bone weights against the per-slot skin matrices, using
+    /// only the rotation/scale component (translation is ignored — normals are directions). The
+    /// result is NOT normalized; callers normalize after.
+    /// </summary>
+    public static Vector3 BlendNormal(Vector3 normal, VertexWeights w, Matrix4x4[] skinMatrices)
+    {
+        var result = Vector3.Zero;
+
+        void Accumulate(int bone, float weight)
+        {
+            if (weight <= 0f || bone < 0 || bone >= skinMatrices.Length) return;
+            result += weight * Vector3.TransformNormal(normal, skinMatrices[bone]);
+        }
+
+        Accumulate(w.bone0, w.weight0);
+        Accumulate(w.bone1, w.weight1);
+        Accumulate(w.bone2, w.weight2);
+        Accumulate(w.bone3, w.weight3);
+
+        return result;
+    }
+}

--- a/Radoub.UI/Radoub.UI/Services/SkinDeformer.cs
+++ b/Radoub.UI/Radoub.UI/Services/SkinDeformer.cs
@@ -24,24 +24,27 @@ public static class SkinDeformer
         int bone3, float weight3);
 
     /// <summary>
-    /// inverseBind[slot] = inverse(boneBindWorld) · meshBindWorld.
-    /// Recomputed from the bind-pose hierarchy (the stored QBoneRefInv/TBoneRefInv are not
-    /// trusted). If <paramref name="boneBindWorld"/> is non-invertible, falls back to identity
-    /// so the slot contributes the raw mesh-bind transform rather than NaNs.
+    /// inverseBind[slot] = meshBindWorld · inverse(boneBindWorld) (System.Numerics row-vector
+    /// order). Maps a skin-local vertex into the bone's local frame: first to model bind space via
+    /// the mesh's bind transform, then into the bone's frame via the inverse bone bind. Recomputed
+    /// from the bind-pose hierarchy (the stored QBoneRefInv/TBoneRefInv are not trusted). If the
+    /// bone bind is non-invertible, falls back so the slot contributes meshBindWorld, not NaNs.
+    /// Verified against nwn_mdl_webviewer's CPU skinning (#2399).
     /// </summary>
     public static Matrix4x4 BuildInverseBind(Matrix4x4 boneBindWorld, Matrix4x4 meshBindWorld)
     {
         if (!Matrix4x4.Invert(boneBindWorld, out var boneBindInv))
             boneBindInv = Matrix4x4.Identity;
-        return Matrix4x4.Multiply(boneBindInv, meshBindWorld);
+        return Matrix4x4.Multiply(meshBindWorld, boneBindInv);
     }
 
     /// <summary>
-    /// skin[slot] = boneAnimWorld · inverseBind[slot]. At bind pose (boneAnimWorld ==
-    /// boneBindWorld) this collapses to meshBindWorld, leaving the vertex at its static position.
+    /// skin[slot] = inverseBind[slot] · boneAnimWorld (row-vector order, so a vertex transforms as
+    /// v · meshBind · inverse(boneBind) · boneAnim). At bind pose (boneAnimWorld == boneBindWorld)
+    /// this collapses to meshBindWorld, leaving an un-animated vertex at its static bind position.
     /// </summary>
     public static Matrix4x4 BuildSkinMatrix(Matrix4x4 boneAnimWorld, Matrix4x4 inverseBind)
-        => Matrix4x4.Multiply(boneAnimWorld, inverseBind);
+        => Matrix4x4.Multiply(inverseBind, boneAnimWorld);
 
     /// <summary>
     /// Blend a local-space vertex by its bone weights against the per-slot skin matrices.

--- a/Radoub.UI/Radoub.UI/Services/SkinDeformer.cs
+++ b/Radoub.UI/Radoub.UI/Services/SkinDeformer.cs
@@ -1,6 +1,7 @@
 // Pure linear-blend-skinning math for MDL skin meshes (#2399 / R1).
 // GL-free and dependency-light so the per-vertex blend and the skin-matrix build are unit-testable.
 
+using System;
 using System.Numerics;
 
 namespace Radoub.UI.Services;
@@ -47,17 +48,36 @@ public static class SkinDeformer
         => Matrix4x4.Multiply(inverseBind, boneAnimWorld);
 
     /// <summary>
+    /// True if at least one bone slot has a positive, non-NaN weight referencing a valid matrix
+    /// index. Lets the renderer route influence-less vertices to the rigid bind transform instead
+    /// of <see cref="BlendVertex"/> (which would return the un-worlded local vertex).
+    /// </summary>
+    public static bool HasInfluence(VertexWeights w, int skinMatrixCount)
+    {
+        bool Valid(int bone, float weight) =>
+            !float.IsNaN(weight) && weight > 0f && bone >= 0 && bone < skinMatrixCount;
+        return Valid(w.bone0, w.weight0) || Valid(w.bone1, w.weight1)
+            || Valid(w.bone2, w.weight2) || Valid(w.bone3, w.weight3);
+    }
+
+    /// <summary>
     /// Blend a local-space vertex by its bone weights against the per-slot skin matrices.
-    /// Bone indices &lt; 0, out of range, or with non-positive weight are skipped.
+    /// Bone indices &lt; 0, out of range, NaN, or with non-positive weight are skipped. The result is
+    /// normalized by the total contributing weight (so weights that don't sum to 1 still land at the
+    /// full bone position, matching nwn_mdl_webviewer). If no slot contributes, returns the input
+    /// vertex unchanged so the caller can place it via the rigid bind transform — never collapses to
+    /// the origin.
     /// </summary>
     public static Vector3 BlendVertex(Vector3 vertex, VertexWeights w, Matrix4x4[] skinMatrices)
     {
         var result = Vector3.Zero;
+        float totalWeight = 0f;
 
         void Accumulate(int bone, float weight)
         {
-            if (weight <= 0f || bone < 0 || bone >= skinMatrices.Length) return;
+            if (float.IsNaN(weight) || weight <= 0f || bone < 0 || bone >= skinMatrices.Length) return;
             result += weight * Vector3.Transform(vertex, skinMatrices[bone]);
+            totalWeight += weight;
         }
 
         Accumulate(w.bone0, w.weight0);
@@ -65,22 +85,30 @@ public static class SkinDeformer
         Accumulate(w.bone2, w.weight2);
         Accumulate(w.bone3, w.weight3);
 
+        if (totalWeight <= 1e-6f)
+            return vertex; // no influence — leave at bind (caller applies the rigid transform)
+        if (MathF.Abs(totalWeight - 1f) > 0.01f)
+            result /= totalWeight;
         return result;
     }
 
     /// <summary>
     /// Blend a local-space normal by its bone weights against the per-slot skin matrices, using
-    /// only the rotation/scale component (translation is ignored — normals are directions). The
-    /// result is NOT normalized; callers normalize after.
+    /// only the rotation/scale component (translation is ignored — normals are directions). Same
+    /// skip rules as <see cref="BlendVertex"/>. Returns the input normal unchanged if no slot
+    /// contributes (so the caller's Normalize never sees a zero vector → NaN). NOT normalized
+    /// otherwise; callers normalize after.
     /// </summary>
     public static Vector3 BlendNormal(Vector3 normal, VertexWeights w, Matrix4x4[] skinMatrices)
     {
         var result = Vector3.Zero;
+        float totalWeight = 0f;
 
         void Accumulate(int bone, float weight)
         {
-            if (weight <= 0f || bone < 0 || bone >= skinMatrices.Length) return;
+            if (float.IsNaN(weight) || weight <= 0f || bone < 0 || bone >= skinMatrices.Length) return;
             result += weight * Vector3.TransformNormal(normal, skinMatrices[bone]);
+            totalWeight += weight;
         }
 
         Accumulate(w.bone0, w.weight0);
@@ -88,6 +116,6 @@ public static class SkinDeformer
         Accumulate(w.bone2, w.weight2);
         Accumulate(w.bone3, w.weight3);
 
-        return result;
+        return totalWeight <= 1e-6f ? normal : result;
     }
 }

--- a/Radoub.UI/Radoub.UI/Services/SkinMatrixBuilder.cs
+++ b/Radoub.UI/Radoub.UI/Services/SkinMatrixBuilder.cs
@@ -1,0 +1,80 @@
+// Builds per-bone-slot skin matrices for an MDL skin mesh from the composed bone hierarchy
+// and the active animation pose (#2399 / R1). Bridges parser data to SkinDeformer's pure math.
+
+using System.Collections.Generic;
+using System.Numerics;
+using Radoub.Formats.Mdl;
+
+namespace Radoub.UI.Services;
+
+/// <summary>
+/// Resolves the per-slot skin matrices for a skin mesh:
+///   skin[slot] = boneAnimWorld · inverse(boneBindWorld) · meshBindWorld
+/// where the bone for each slot is found by name (<see cref="MdlSkinNode.BoneNodeNames"/>) in
+/// the composed hierarchy. Slots whose bone can't be resolved fall back to the mesh bind-world
+/// transform, leaving those vertices at their static bind-pose position rather than collapsing.
+/// </summary>
+public static class SkinMatrixBuilder
+{
+    /// <summary>
+    /// Build the slot → skin matrix array for <paramref name="skin"/>. <paramref name="root"/> is
+    /// the composed model root used to resolve bone nodes by name. <paramref name="pose"/> is the
+    /// active animation pose (null/empty → bind pose, skin matrices collapse to meshBindWorld).
+    /// </summary>
+    public static Matrix4x4[] Build(
+        MdlSkinNode skin,
+        MdlNode root,
+        IReadOnlyDictionary<string, ModelViewController.NodePose>? pose)
+    {
+        int boneCount = skin.BoneNodeNames.Length;
+        var matrices = new Matrix4x4[boneCount];
+
+        // The skin mesh's own bind-pose world transform — the static position every vertex sits at
+        // when un-deformed. Computed without pose so it is the true bind reference.
+        var meshBindWorld = ModelViewController.GetWorldTransform(skin, null);
+
+        // Cache bone-node lookups by name (a skin may weight many slots to the same bone).
+        var boneByName = new Dictionary<string, MdlNode?>(System.StringComparer.OrdinalIgnoreCase);
+
+        for (int slot = 0; slot < boneCount; slot++)
+        {
+            var boneName = skin.BoneNodeNames[slot];
+            if (string.IsNullOrEmpty(boneName))
+            {
+                matrices[slot] = meshBindWorld;
+                continue;
+            }
+
+            if (!boneByName.TryGetValue(boneName, out var bone))
+            {
+                bone = FindNode(root, boneName);
+                boneByName[boneName] = bone;
+            }
+
+            if (bone == null)
+            {
+                matrices[slot] = meshBindWorld;
+                continue;
+            }
+
+            var boneBindWorld = ModelViewController.GetWorldTransform(bone, null);
+            var boneAnimWorld = ModelViewController.GetWorldTransform(bone, pose);
+            var inverseBind = SkinDeformer.BuildInverseBind(boneBindWorld, meshBindWorld);
+            matrices[slot] = SkinDeformer.BuildSkinMatrix(boneAnimWorld, inverseBind);
+        }
+
+        return matrices;
+    }
+
+    private static MdlNode? FindNode(MdlNode node, string name)
+    {
+        if (string.Equals(node.Name, name, System.StringComparison.OrdinalIgnoreCase))
+            return node;
+        foreach (var child in node.Children)
+        {
+            var found = FindNode(child, name);
+            if (found != null) return found;
+        }
+        return null;
+    }
+}

--- a/Radoub.UI/Radoub.UI/Services/SkinMatrixBuilder.cs
+++ b/Radoub.UI/Radoub.UI/Services/SkinMatrixBuilder.cs
@@ -8,10 +8,13 @@ using Radoub.Formats.Mdl;
 namespace Radoub.UI.Services;
 
 /// <summary>
-/// Resolves the per-slot skin matrices for a skin mesh:
-///   skin[slot] = boneAnimWorld · inverse(boneBindWorld) · meshBindWorld
-/// where the bone for each slot is found by name (<see cref="MdlSkinNode.BoneNodeNames"/>) in
-/// the composed hierarchy. Slots whose bone can't be resolved fall back to the mesh bind-world
+/// Resolves the per-slot skin matrices for a skin mesh. In System.Numerics row-vector order
+/// (a vertex transforms as v · skin[slot]):
+///   skin[slot] = meshBindWorld · inverse(boneBindWorld) · boneAnimWorld
+/// (built as <c>BuildSkinMatrix(boneAnimWorld, BuildInverseBind(boneBindWorld, meshBindWorld))</c>).
+/// Bones are resolved per slot — preferring the direct <see cref="MdlSkinNode.BoneNodes"/> reference
+/// set at composite time, falling back to name (<see cref="MdlSkinNode.BoneNodeNames"/>) in the
+/// composed hierarchy. Slots whose bone can't be resolved fall back to the mesh bind-world
 /// transform, leaving those vertices at their static bind-pose position rather than collapsing.
 /// </summary>
 public static class SkinMatrixBuilder

--- a/Radoub.UI/Radoub.UI/Services/SkinMatrixBuilder.cs
+++ b/Radoub.UI/Radoub.UI/Services/SkinMatrixBuilder.cs
@@ -38,17 +38,25 @@ public static class SkinMatrixBuilder
 
         for (int slot = 0; slot < boneCount; slot++)
         {
-            var boneName = skin.BoneNodeNames[slot];
-            if (string.IsNullOrEmpty(boneName))
-            {
-                matrices[slot] = meshBindWorld;
-                continue;
-            }
+            // Prefer a direct bone reference (set at composite time) — a composite can hold two
+            // bones with the same name, so a name lookup is ambiguous and the wrong bind explodes
+            // the skin under animation (#2399). Fall back to name lookup for non-composited skins.
+            MdlNode? bone = slot < skin.BoneNodes.Length ? skin.BoneNodes[slot] : null;
 
-            if (!boneByName.TryGetValue(boneName, out var bone))
+            if (bone == null)
             {
-                bone = FindNode(root, boneName);
-                boneByName[boneName] = bone;
+                var boneName = skin.BoneNodeNames[slot];
+                if (string.IsNullOrEmpty(boneName))
+                {
+                    matrices[slot] = meshBindWorld;
+                    continue;
+                }
+
+                if (!boneByName.TryGetValue(boneName, out bone))
+                {
+                    bone = FindNode(root, boneName);
+                    boneByName[boneName] = bone;
+                }
             }
 
             if (bone == null)


### PR DESCRIPTION
## Summary

Fixes robe-wearing creature animation playback. Currently a robe's grafted sub-bones (`torso_g`, `rbicep_g`, etc.) are not driven by the skeleton's animation channels, so during animations (e.g. run) the head/neck animate while the robe body stays static — the head detaches and the body distorts.

Root cause is R1 in the model-rendering systemic review: skin/grafted parts aren't posed from the skeleton's animated bone transforms. Repro: Dana (`dananaherin.utc`, robe equipped) → Appearance preview → play run animation.

Shared `Radoub.UI` renderer change — regression coverage needed against creatures that currently animate acceptably.

## Related Issues

- Closes #2399
- Relates to #2400 (epic), #2126, #2139

## Checklist

- [ ] Implementation complete
- [ ] Tests added/updated
- [ ] CHANGELOG updated with date
- [ ] Documentation updated (if needed)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)