### PR TITLE
[Radoub] Sprint: ITP E1 — Provider (.itp format & search layer)

### DIFF
--- a/.claude/scripts/Get-CacheData.ps1
+++ b/.claude/scripts/Get-CacheData.ps1
@@ -9,6 +9,9 @@
     - issue: Single issue with body (requires -Number)
     - search: Search issues by keyword (requires -Query)
     - comments: Show comments for a single issue (requires -Number)
+    - backlog: Planning view ΓÇö number, age (days since update), labels, title.
+               Filter with -Label (substring match on any label) and/or
+               -Query (regex match on title). Sorted oldest-first.
 
 .PARAMETER Number
     Issue number for single-issue view.
@@ -29,14 +32,16 @@
 
 param(
     [Parameter(Mandatory)]
-    [ValidateSet("status", "summary", "list", "issue", "search", "comments")]
+    [ValidateSet("status", "summary", "list", "issue", "search", "comments", "backlog")]
     [string]$View,
 
     [int]$Number,
 
     [string]$Tool,
 
-    [string]$Query
+    [string]$Query,
+
+    [string]$Label
 )
 
 $CacheFile = Join-Path $PSScriptRoot "..\cache\github-data.json"
@@ -191,6 +196,37 @@ switch ($View) {
             $labels = ($_.labels.nodes.name -join ", ")
             Write-Host "#$($_.number): $($_.title)"
             if ($labels) { Write-Host "  Labels: $labels" }
+        }
+    }
+
+    "backlog" {
+        $issues = $data.issues
+        if ($Tool) {
+            $issues = $issues | Where-Object { $_.labels.nodes.name -contains $Tool }
+        }
+        if ($Label) {
+            $issues = $issues | Where-Object { ($_.labels.nodes.name -join ",") -match $Label }
+        }
+        if ($Query) {
+            $issues = $issues | Where-Object { $_.title -match $Query }
+        }
+
+        $now = Get-Date
+        $rows = $issues | ForEach-Object {
+            $age = [math]::Round(($now - [datetime]$_.updatedAt).TotalDays)
+            [pscustomobject]@{
+                Age    = $age
+                Number = $_.number
+                Labels = ($_.labels.nodes.name -join ", ")
+                Title  = $_.title
+            }
+        } | Sort-Object -Property Age -Descending
+
+        Write-Host "Matched $($rows.Count) issues (oldest first):"
+        Write-Host ""
+        $rows | ForEach-Object {
+            "{0,-7} {1,4}d  {2}" -f "#$($_.Number)", $_.Age, $_.Title
+            "          [$($_.Labels)]"
         }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.Formats 0.2.76-alpha / Radoub.UI 0.2.24-alpha] - 2026-06-21
+**Branch**: `radoub/issue-2561` | **PR**: #TBD
+
+### Sprint: ITP E1 — Provider (.itp format & search layer) (#2561)
+
+- ITP search now recurses nested palette categories so entries filed under a sub-category are found (#2475).
+- ITP Browser gains category-names-first, lazy per-category loading instead of loading thousands of entries upfront (#987).
+
+---
+
 ## [Radoub.UI 0.2.23-alpha] - 2026-06-21
 **Branch**: `radoub/issue-2544` | **PR**: #2554
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Radoub.Formats 0.2.76-alpha / Radoub.UI 0.2.24-alpha] - 2026-06-21
-**Branch**: `radoub/issue-2561` | **PR**: #TBD
+**Branch**: `radoub/issue-2561` | **PR**: #2563
 
 ### Sprint: ITP E1 — Provider (.itp format & search layer) (#2561)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Sprint: ITP E1 — Provider (.itp format & search layer) (#2561)
 
 - ITP search now recurses nested palette categories so entries filed under a sub-category are found (#2475).
-- ITP Browser gains category-names-first, lazy per-category loading instead of loading thousands of entries upfront (#987).
+- Palette cache now records each item's category id; the provider exposes names-first (`GetCategoryNames`) and per-category (`GetCategoryBlueprints`) methods. Data layer only — the folder-tree browser UI follows next sprint (#987).
 
 ---
 

--- a/Quartermaster/Quartermaster/Views/MainWindow.ItemPalette.cs
+++ b/Quartermaster/Quartermaster/Views/MainWindow.ItemPalette.cs
@@ -255,6 +255,7 @@ public partial class MainWindow
                         PropertiesDisplay = propertiesDisplay,
                         BaseItemType = item.BaseItem,
                         BaseValue = item.Cost,
+                        PaletteId = item.PaletteID,
                         Source = gameSource,
                         SourceLocation = !string.IsNullOrEmpty(resourceInfo.SourcePath)
                             ? Path.GetFileName(resourceInfo.SourcePath)

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/ItpSearchProviderTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/ItpSearchProviderTests.cs
@@ -166,4 +166,92 @@ public class ItpSearchProviderTests
         var match = Assert.Single(matches, m => m.Field.Name == "ResRef");
         Assert.False(match.Field.IsReplaceable);
     }
+
+    /// <summary>
+    /// Build an ITP GFF with a category nested under another category (#2280 reader,
+    /// #2475 search). A nested category is a category struct (ID field) inside another
+    /// category's LIST:
+    ///   MAIN
+    ///     └─ Category ID=3, NAME="Weapons"
+    ///         └─ Category ID=4, NAME="Swords"   (nested)
+    ///              └─ Blueprint RESREF="longsword", NAME="Longsword"
+    /// </summary>
+    private static GffFile CreateNestedCategoryItpGff()
+    {
+        var blueprint = new GffStruct { Type = 0 };
+        blueprint.Fields = new List<GffField>
+        {
+            new GffField { Label = "RESREF", Type = GffField.CResRef, Value = "longsword" },
+            new GffField { Label = "NAME", Type = GffField.CExoString, Value = "Longsword" }
+        };
+
+        // Nested category "Swords" (ID=4) containing the blueprint
+        var nested = new GffStruct { Type = 0 };
+        nested.Fields = new List<GffField>
+        {
+            new GffField { Label = "ID", Type = GffField.BYTE, Value = (byte)4 },
+            new GffField { Label = "NAME", Type = GffField.CExoString, Value = "Swords" },
+            new GffField { Label = "LIST", Type = GffField.List, Value = new GffList { Elements = new List<GffStruct> { blueprint } } }
+        };
+
+        // Parent category "Weapons" (ID=3) containing the nested category
+        var parent = new GffStruct { Type = 0 };
+        parent.Fields = new List<GffField>
+        {
+            new GffField { Label = "ID", Type = GffField.BYTE, Value = (byte)3 },
+            new GffField { Label = "NAME", Type = GffField.CExoString, Value = "Weapons" },
+            new GffField { Label = "LIST", Type = GffField.List, Value = new GffList { Elements = new List<GffStruct> { nested } } }
+        };
+
+        var root = new GffStruct { Type = 0xFFFFFFFF };
+        root.Fields = new List<GffField>
+        {
+            new GffField { Label = "MAIN", Type = GffField.List, Value = new GffList { Elements = new List<GffStruct> { parent } } }
+        };
+
+        return new GffFile { FileType = "ITP ", FileVersion = "V3.2", RootStruct = root };
+    }
+
+    [Fact]
+    public void Search_FindsBlueprintNestedUnderSubCategory()
+    {
+        var provider = new ItpSearchProvider();
+        var gff = CreateNestedCategoryItpGff();
+        var criteria = new SearchCriteria { Pattern = "longsword" };
+
+        var matches = provider.Search(gff, criteria);
+
+        Assert.Contains(matches, m =>
+            m.Field.Name == "ResRef" &&
+            m.MatchedText == "longsword");
+    }
+
+    [Fact]
+    public void Search_FindsNestedSubCategoryName()
+    {
+        var provider = new ItpSearchProvider();
+        var gff = CreateNestedCategoryItpGff();
+        var criteria = new SearchCriteria { Pattern = "Swords" };
+
+        var matches = provider.Search(gff, criteria);
+
+        Assert.Contains(matches, m =>
+            m.Field.Name == "Category Name" &&
+            m.MatchedText == "Swords");
+    }
+
+    [Fact]
+    public void Search_NestedBlueprintDisplayPathShowsFullHierarchy()
+    {
+        var provider = new ItpSearchProvider();
+        var gff = CreateNestedCategoryItpGff();
+        var criteria = new SearchCriteria { Pattern = "longsword" };
+
+        var matches = provider.Search(gff, criteria);
+
+        var match = Assert.Single(matches, m => m.Field.Name == "ResRef");
+        var location = match.Location as ItpMatchLocation;
+        Assert.NotNull(location);
+        Assert.Equal("Weapons → Swords → Longsword", location.DisplayPath);
+    }
 }

--- a/Radoub.Formats/Radoub.Formats/Search/Providers/ItpSearchProvider.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Providers/ItpSearchProvider.cs
@@ -91,6 +91,8 @@ public class ItpSearchProvider : SearchProviderBase, IFileSearchProvider
         {
             SearchBlueprint(blueprint, criteria, regex, matches, pathParts);
         }
+        // Recurse into nested categories/branches (#2280 reader, #2475 search).
+        SearchNodes(category.Children, criteria, regex, matches, pathParts);
         pathParts.RemoveAt(pathParts.Count - 1);
     }
 

--- a/Radoub.TestUtilities/Radoub.TestUtilities/Mocks/MockGameDataService.cs
+++ b/Radoub.TestUtilities/Radoub.TestUtilities/Mocks/MockGameDataService.cs
@@ -152,17 +152,24 @@ public class MockGameDataService : IGameDataService
 
     #region Palette Access
 
-    public IEnumerable<PaletteCategory> GetPaletteCategories(ushort resourceType)
+    private readonly Dictionary<ushort, List<PaletteCategory>> _paletteCategories = new();
+
+    /// <summary>
+    /// Seed palette categories for a resource type (fluent, for tests). (#987)
+    /// </summary>
+    public MockGameDataService WithPaletteCategories(ushort resourceType, params PaletteCategory[] categories)
     {
-        // Return empty by default - tests can override if needed
-        return Enumerable.Empty<PaletteCategory>();
+        _paletteCategories[resourceType] = categories.ToList();
+        return this;
     }
 
+    public IEnumerable<PaletteCategory> GetPaletteCategories(ushort resourceType)
+        => _paletteCategories.TryGetValue(resourceType, out var cats)
+            ? cats
+            : Enumerable.Empty<PaletteCategory>();
+
     public string? GetPaletteCategoryName(ushort resourceType, byte categoryId)
-    {
-        // Return null by default - tests can override if needed
-        return null;
-    }
+        => GetPaletteCategories(resourceType).FirstOrDefault(c => c.Id == categoryId)?.Name;
 
     #endregion
 

--- a/Radoub.UI/Radoub.UI.Tests/SharedPaletteCachePropertiesTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/SharedPaletteCachePropertiesTests.cs
@@ -24,4 +24,22 @@ public class SharedPaletteCachePropertiesTests
         var item = new SharedPaletteCacheItem();
         Assert.Equal(string.Empty, item.PropertiesDisplay);
     }
+
+    [Fact]
+    public void PaletteId_RoundTripsThroughJson()
+    {
+        var item = new SharedPaletteCacheItem { ResRef = "longsword", PaletteId = 7 };
+        var json = System.Text.Json.JsonSerializer.Serialize(item);
+        var restored = System.Text.Json.JsonSerializer.Deserialize<SharedPaletteCacheItem>(json)!;
+        Assert.Equal((byte?)7, restored.PaletteId);
+    }
+
+    [Fact]
+    public void PaletteId_NullRoundTripsThroughJson()
+    {
+        var item = new SharedPaletteCacheItem { ResRef = "x", PaletteId = null };
+        var json = System.Text.Json.JsonSerializer.Serialize(item);
+        var restored = System.Text.Json.JsonSerializer.Deserialize<SharedPaletteCacheItem>(json)!;
+        Assert.Null(restored.PaletteId);
+    }
 }

--- a/Radoub.UI/Radoub.UI.Tests/SharedPaletteCacheServiceTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/SharedPaletteCacheServiceTests.cs
@@ -1,5 +1,7 @@
 using Xunit;
+using Radoub.Formats.Common;
 using Radoub.Formats.Services;
+using Radoub.TestUtilities.Mocks;
 using Radoub.UI.Services;
 
 namespace Radoub.UI.Tests;
@@ -917,6 +919,97 @@ public class SharedPaletteCacheServiceTests : IDisposable
         // Both .json and .building files should be gone
         Assert.Empty(Directory.GetFiles(_testCacheDir, "*.json"));
         Assert.Empty(Directory.GetFiles(_testCacheDir, "*.building"));
+    }
+
+    #endregion
+
+    #region Category-Aware Provider (#987)
+
+    private SharedPaletteCacheService ServiceWith(params SharedPaletteCacheItem[] items)
+    {
+        foreach (var f in Directory.GetFiles(_testCacheDir, "*.json")) File.Delete(f);
+        var wrapper = new SourcePaletteCacheWrapper { Version = 5, Source = "bif", Items = items.ToList() };
+        File.WriteAllText(Path.Combine(_testCacheDir, "bif.json"),
+            System.Text.Json.JsonSerializer.Serialize(wrapper));
+        return new SharedPaletteCacheService(_testCacheDir);
+    }
+
+    [Fact]
+    public void GetCategoryNames_OnePerCategoryWithCounts()
+    {
+        var svc = ServiceWith(
+            new SharedPaletteCacheItem { ResRef = "a", PaletteId = 1 },
+            new SharedPaletteCacheItem { ResRef = "b", PaletteId = 1 },
+            new SharedPaletteCacheItem { ResRef = "c", PaletteId = 2 });
+        var gd = new MockGameDataService().WithPaletteCategories(ResourceTypes.Uti,
+            new PaletteCategory { Id = 1, Name = "Medium", ParentPath = "Armor" },
+            new PaletteCategory { Id = 2, Name = "Heavy", ParentPath = "Armor" });
+
+        var result = svc.GetCategoryNames(gd, ResourceTypes.Uti);
+
+        Assert.Equal(2, result.Single(c => c.Id == 1).ItemCount);
+        Assert.Equal(1, result.Single(c => c.Id == 2).ItemCount);
+        Assert.Equal("Armor", result.Single(c => c.Id == 1).ParentPath);
+    }
+
+    [Fact]
+    public void GetCategoryNames_TwoSameNameDifferentParentsAreDistinct()
+    {
+        var svc = ServiceWith(
+            new SharedPaletteCacheItem { ResRef = "a", PaletteId = 10 },
+            new SharedPaletteCacheItem { ResRef = "b", PaletteId = 20 });
+        var gd = new MockGameDataService().WithPaletteCategories(ResourceTypes.Uti,
+            new PaletteCategory { Id = 10, Name = "Custom 1", ParentPath = "Armor" },
+            new PaletteCategory { Id = 20, Name = "Custom 1", ParentPath = "Weapons" });
+
+        var result = svc.GetCategoryNames(gd, ResourceTypes.Uti);
+
+        Assert.Equal(2, result.Count(c => c.Name == "Custom 1"));
+        Assert.Contains(result, c => c.Name == "Custom 1" && c.ParentPath == "Armor");
+        Assert.Contains(result, c => c.Name == "Custom 1" && c.ParentPath == "Weapons");
+    }
+
+    [Fact]
+    public void GetCategoryNames_UnmappedPaletteIdGroupsUncategorized()
+    {
+        var svc = ServiceWith(
+            new SharedPaletteCacheItem { ResRef = "a", PaletteId = null },
+            new SharedPaletteCacheItem { ResRef = "b", PaletteId = 99 }); // 99 not in gd
+        var gd = new MockGameDataService().WithPaletteCategories(ResourceTypes.Uti,
+            new PaletteCategory { Id = 1, Name = "Medium", ParentPath = "Armor" });
+
+        var result = svc.GetCategoryNames(gd, ResourceTypes.Uti);
+
+        var uncat = result.Single(c => c.IsUncategorized);
+        Assert.Equal(PaletteCategoryInfo.UncategorizedId, uncat.Id);
+        Assert.Equal(2, uncat.ItemCount);
+    }
+
+    [Fact]
+    public void GetCategoryBlueprints_ReturnsOnlyThatCategorysItems()
+    {
+        var svc = ServiceWith(
+            new SharedPaletteCacheItem { ResRef = "a", PaletteId = 1 },
+            new SharedPaletteCacheItem { ResRef = "b", PaletteId = 1 },
+            new SharedPaletteCacheItem { ResRef = "c", PaletteId = 2 });
+
+        var items = svc.GetCategoryBlueprints(1);
+
+        Assert.Equal(2, items.Count);
+        Assert.All(items, i => Assert.Equal((byte?)1, i.PaletteId));
+    }
+
+    [Fact]
+    public void GetCategoryBlueprints_UncategorizedReturnsNullPaletteIdItems()
+    {
+        var svc = ServiceWith(
+            new SharedPaletteCacheItem { ResRef = "a", PaletteId = null },
+            new SharedPaletteCacheItem { ResRef = "b", PaletteId = 1 });
+
+        var items = svc.GetCategoryBlueprints(PaletteCategoryInfo.UncategorizedId);
+
+        Assert.Single(items);
+        Assert.Equal("a", items[0].ResRef);
     }
 
     #endregion

--- a/Radoub.UI/Radoub.UI.Tests/SharedPaletteCacheServiceTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/SharedPaletteCacheServiceTests.cs
@@ -986,6 +986,22 @@ public class SharedPaletteCacheServiceTests : IDisposable
     }
 
     [Fact]
+    public void GetCategoryNames_DuplicateCategoryIdsDoNotThrow()
+    {
+        // The IGameDataService contract does not guarantee unique category ids.
+        // A non-deduping provider must not crash GetCategoryNames. (#987 review)
+        var svc = ServiceWith(new SharedPaletteCacheItem { ResRef = "a", PaletteId = 5 });
+        var gd = new MockGameDataService().WithPaletteCategories(ResourceTypes.Uti,
+            new PaletteCategory { Id = 5, Name = "First", ParentPath = "Armor" },
+            new PaletteCategory { Id = 5, Name = "Dupe", ParentPath = "Weapons" });
+
+        var result = svc.GetCategoryNames(gd, ResourceTypes.Uti);
+
+        // First occurrence wins; no ArgumentException.
+        Assert.Equal("First", result.Single(c => c.Id == 5).Name);
+    }
+
+    [Fact]
     public void GetCategoryBlueprints_ReturnsOnlyThatCategorysItems()
     {
         var svc = ServiceWith(

--- a/Radoub.UI/Radoub.UI.Tests/SharedPaletteCacheServiceTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/SharedPaletteCacheServiceTests.cs
@@ -50,6 +50,26 @@ public class SharedPaletteCacheServiceTests : IDisposable
         return items;
     }
 
+    #region Version Guard
+
+    [Fact]
+    public void GetAggregatedCache_RejectsV4CacheFile()
+    {
+        var v4Wrapper = new SourcePaletteCacheWrapper
+        {
+            Version = 4,
+            Source = "bif",
+            Items = new List<SharedPaletteCacheItem> { new() { ResRef = "old" } }
+        };
+        File.WriteAllText(Path.Combine(_testCacheDir, "bif.json"),
+            System.Text.Json.JsonSerializer.Serialize(v4Wrapper));
+
+        Assert.Null(_service.GetAggregatedCache());          // no-filter path
+        Assert.False(_service.HasValidSourceCache("bif"));   // validation path
+    }
+
+    #endregion
+
     #region Save and Load
 
     [Fact]

--- a/Radoub.UI/Radoub.UI/Services/HakPaletteScannerService.cs
+++ b/Radoub.UI/Radoub.UI/Services/HakPaletteScannerService.cs
@@ -84,6 +84,7 @@ public class HakPaletteScannerService
                             BaseItemTypeName = string.Empty, // Set by consumer with 2DA lookup
                             BaseItemType = uti.BaseItem,
                             BaseValue = uti.Cost,
+                            PaletteId = uti.PaletteID,
                             Source = GameResourceSource.Hak,
                             SourceLocation = Path.GetFileName(hakPath)
                         });

--- a/Radoub.UI/Radoub.UI/Services/ISharedPaletteCacheService.cs
+++ b/Radoub.UI/Radoub.UI/Services/ISharedPaletteCacheService.cs
@@ -50,6 +50,25 @@ public interface ISharedPaletteCacheService
     List<SharedPaletteCacheItem>? GetAggregatedCache(IEnumerable<string>? activeHakPaths);
 
     /// <summary>
+    /// Category-names-first: group the aggregated cache by PaletteId and join each
+    /// group to its category (name + parent path) from GameDataService. Returns one
+    /// descriptor per category that has cached items, plus an "Uncategorized" bucket
+    /// for items with no/unmapped PaletteId. No item payload. (#987)
+    /// </summary>
+    IReadOnlyList<PaletteCategoryInfo> GetCategoryNames(
+        Radoub.Formats.Services.IGameDataService gameData,
+        ushort resourceType,
+        IEnumerable<string>? activeHakPaths = null);
+
+    /// <summary>
+    /// Lazy per-category fetch: aggregated-cache items whose PaletteId == categoryId.
+    /// Pass PaletteCategoryInfo.UncategorizedId for the no-PaletteId bucket. (#987)
+    /// </summary>
+    IReadOnlyList<SharedPaletteCacheItem> GetCategoryBlueprints(
+        int categoryId,
+        IEnumerable<string>? activeHakPaths = null);
+
+    /// <summary>
     /// Clear the in-memory aggregated cache (forces reload from disk).
     /// </summary>
     void InvalidateAggregatedCache();

--- a/Radoub.UI/Radoub.UI/Services/PaletteCategoryInfo.cs
+++ b/Radoub.UI/Radoub.UI/Services/PaletteCategoryInfo.cs
@@ -1,0 +1,19 @@
+namespace Radoub.UI.Services;
+
+/// <summary>
+/// A palette category plus how many cached items fall under it. Returned by
+/// ISharedPaletteCacheService.GetCategoryNames (names-first, no item payload).
+/// Id is int (not byte) so the Uncategorized sentinel (-1) cannot collide with a
+/// real byte category id (0 is the real "Miscellaneous" category). (#987)
+/// </summary>
+public class PaletteCategoryInfo
+{
+    public const int UncategorizedId = -1;
+
+    public int Id { get; init; }
+    public required string Name { get; init; }
+    public string? ParentPath { get; init; }
+    public int ItemCount { get; init; }
+
+    public bool IsUncategorized => Id == UncategorizedId;
+}

--- a/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheItem.cs
+++ b/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheItem.cs
@@ -18,6 +18,13 @@ public class SharedPaletteCacheItem
     public uint BaseValue { get; set; }
 
     /// <summary>
+    /// Leaf palette category id (PaletteID from the blueprint). Null when the
+    /// UTI parse failed or the cache predates v5. Category name/path are resolved
+    /// at read time from GameDataService, not stored here. (#987)
+    /// </summary>
+    public byte? PaletteId { get; set; }
+
+    /// <summary>
     /// Which game resource bucket this item came from (Bif/Override/Hak/Module). Persisted so the
     /// palette filter can distinguish all four sources (#1995). Replaces the former bool IsStandard.
     /// </summary>

--- a/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheService.cs
+++ b/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheService.cs
@@ -12,7 +12,7 @@ namespace Radoub.UI.Services;
 /// </summary>
 public class SharedPaletteCacheService : ISharedPaletteCacheService, IDisposable
 {
-    private const int CacheVersion = 4; // v4: Source enum replaces bool IsStandard (#1995); v3: Added SourceLocation
+    private const int CacheVersion = 5; // v5: PaletteId per item for category grouping (#987); v4: Source enum (#1995); v3: SourceLocation
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheService.cs
+++ b/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheService.cs
@@ -357,7 +357,11 @@ public class SharedPaletteCacheService : ISharedPaletteCacheService, IDisposable
         IEnumerable<string>? activeHakPaths = null)
     {
         var items = GetAggregatedCache(activeHakPaths) ?? new List<SharedPaletteCacheItem>();
-        var categories = gameData.GetPaletteCategories(resourceType).ToDictionary(c => c.Id);
+        // First occurrence wins. The IGameDataService contract does not guarantee
+        // unique category ids, so don't let a non-deduping provider throw. (#987)
+        var categories = gameData.GetPaletteCategories(resourceType)
+            .GroupBy(c => c.Id)
+            .ToDictionary(g => g.Key, g => g.First());
 
         var result = new List<PaletteCategoryInfo>();
         int uncategorized = 0;

--- a/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheService.cs
+++ b/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheService.cs
@@ -351,6 +351,65 @@ public class SharedPaletteCacheService : ISharedPaletteCacheService, IDisposable
         }
     }
 
+    public IReadOnlyList<PaletteCategoryInfo> GetCategoryNames(
+        Radoub.Formats.Services.IGameDataService gameData,
+        ushort resourceType,
+        IEnumerable<string>? activeHakPaths = null)
+    {
+        var items = GetAggregatedCache(activeHakPaths) ?? new List<SharedPaletteCacheItem>();
+        var categories = gameData.GetPaletteCategories(resourceType).ToDictionary(c => c.Id);
+
+        var result = new List<PaletteCategoryInfo>();
+        int uncategorized = 0;
+
+        foreach (var group in items.GroupBy(i => i.PaletteId))
+        {
+            if (group.Key is byte id && categories.TryGetValue(id, out var cat))
+            {
+                result.Add(new PaletteCategoryInfo
+                {
+                    Id = id,
+                    Name = cat.Name,
+                    ParentPath = cat.ParentPath,
+                    ItemCount = group.Count()
+                });
+            }
+            else
+            {
+                uncategorized += group.Count();
+            }
+        }
+
+        if (uncategorized > 0)
+        {
+            result.Add(new PaletteCategoryInfo
+            {
+                Id = PaletteCategoryInfo.UncategorizedId,
+                Name = "Uncategorized",
+                ParentPath = null,
+                ItemCount = uncategorized
+            });
+        }
+
+        return result;
+    }
+
+    public IReadOnlyList<SharedPaletteCacheItem> GetCategoryBlueprints(
+        int categoryId,
+        IEnumerable<string>? activeHakPaths = null)
+    {
+        var items = GetAggregatedCache(activeHakPaths) ?? new List<SharedPaletteCacheItem>();
+
+        if (categoryId == PaletteCategoryInfo.UncategorizedId)
+            return items.Where(i => i.PaletteId == null).ToList();
+
+        if (categoryId < byte.MinValue || categoryId > byte.MaxValue)
+            return new List<SharedPaletteCacheItem>();
+
+        var target = (byte)categoryId;
+        return items.Where(i => i.PaletteId == target).ToList();
+    }
+
     public void InvalidateAggregatedCache()
     {
         _lock.EnterWriteLock();


### PR DESCRIPTION
## Summary

Sprint **ITP E1 — Provider (`.itp` format & search layer)**. Two items, both data/provider-layer only — no browser UI this sprint (the folder-tree UI is next sprint's consumer work).

Parent epic: #2302. Relates to #2280 (nested-category reader, merged).

## Work Items

- [x] #2475 — `ItpSearchProvider` now recurses nested palette categories (`SearchCategory` walked only `Blueprints`, never `Children`). 3 nested-category fixture tests added.
- [x] #987 — Category-aware palette cache (provider layer): `SharedPaletteCacheItem` gains `PaletteId`; cache bumped v4→v5; `PaletteId` captured in both build paths; `GetCategoryNames` / `GetCategoryBlueprints` added to `ISharedPaletteCacheService`, resolving category name/parent-path by reusing `GameDataService` (no new tree-walker). Same-named categories under different parents stay distinct (display disambiguation). `MockGameDataService` gained a `WithPaletteCategories` test builder.

## Acceptance Criteria

- [x] ITP search recurses nested categories; nested-category fixture test added
- [x] Provider exposes category-names-first + per-category fetch
- [x] Round-trip / provider tests pass
- [x] Root `CHANGELOG.md` updated (Radoub.Formats / Radoub.UI)

## Tests

- Canonical runner (Quartermaster + shared, unit-only): **4084 passed, 0 failed** (Radoub.Formats, Radoub.UI, Radoub.Dictionary, Quartermaster).
- Privacy scan: pass. Tech-debt: 800+ warning only (no file >1000).
- Code review (local): one latent crash found (duplicate category id → `ToDictionary` throw) and fixed (first-wins `GroupBy`).
- No UI changed → FlaUI not run (provider/data-layer sprint).

## Related Issues

- Closes #2475
- Closes #987

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
