### PR TITLE
[Radoub] Sprint: ITP E2 — Consumers (standardization & handling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Sprint: ITP E2 — Consumers (standardization & handling) (#2562)
 
 - Quartermaster and Relique palette-category combos migrate to the shared Radoub.UI binder, removing the last tool-local copies of populate/select/fallback logic (#2421, #2423).
-- Palette editor gains category add/rename/delete, full undo/redo for reorg gestures, double-click-to-launch a blueprint's editor, and duplicate/nested category-name disambiguation (#2486, #2484, #2485, #2488).
+- Palette editor gains full undo/redo for reorg gestures, double-click-to-launch a blueprint's editor, and duplicate/nested category-name disambiguation (#2484, #2485, #2488). Category authoring (#2486) deferred to #2565.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.25-alpha] - 2026-06-21
+**Branch**: `radoub/issue-2562` | **PR**: #TBD
+
+### Sprint: ITP E2 — Consumers (standardization & handling) (#2562)
+
+- Quartermaster and Relique palette-category combos migrate to the shared Radoub.UI binder, removing the last tool-local copies of populate/select/fallback logic (#2421, #2423).
+- Palette editor gains category add/rename/delete, full undo/redo for reorg gestures, double-click-to-launch a blueprint's editor, and duplicate/nested category-name disambiguation (#2486, #2484, #2485, #2488).
+
+---
+
 ## [Radoub.Formats 0.2.76-alpha / Radoub.UI 0.2.24-alpha] - 2026-06-21
 **Branch**: `radoub/issue-2561` | **PR**: #2563
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Radoub.UI 0.2.25-alpha] - 2026-06-21
-**Branch**: `radoub/issue-2562` | **PR**: #TBD
+**Branch**: `radoub/issue-2562` | **PR**: #2564
 
 ### Sprint: ITP E2 — Consumers (standardization & handling) (#2562)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.129-alpha] - 2026-06-21
+**Branch**: `radoub/issue-2562` | **PR**: #2564
+
+### Refactor: Palette-category combo → shared Radoub.UI binder (#2421)
+
+- The Advanced panel and New Character wizard now use the shared `PaletteCategoryComboBinder` instead of QM-local populate/select glue; duplicate/nested category names are disambiguated centrally (#2488).
+
+---
+
 ## [0.2.128-alpha] - 2026-06-21
 **Branch**: `quartermaster/issue-2540` | **PR**: #2553
 

--- a/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Navigation.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Navigation.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Quartermaster.Services;
 using Radoub.UI.Services;
+using Radoub.UI.Utils;
 
 namespace Quartermaster.Views.Dialogs;
 
@@ -196,8 +197,8 @@ public partial class NewCharacterWizardWindow
 
     private void OnFinishClick(object? sender, RoutedEventArgs e)
     {
-        // Read palette ID from UI before building input
-        _paletteId = (_identityPaletteIdComboBox.SelectedItem is ComboBoxItem item && item.Tag is byte id) ? id : (byte)1;
+        // Read palette ID from UI before building input (shared binder, #2421)
+        _paletteId = PaletteCategoryComboBinder.GetSelectedId(_identityPaletteIdComboBox) ?? 1;
 
         var input = new CharacterCreationService.CharacterCreationInput
         {

--- a/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.axaml.cs
@@ -12,6 +12,7 @@ using Quartermaster.Models;
 using Quartermaster.Services;
 using Quartermaster.Views;
 using Radoub.UI.Services;
+using Radoub.UI.Utils;
 using Radoub.Formats.Services;
 using Radoub.Formats.Settings;
 using Radoub.Formats.Utc;
@@ -606,38 +607,23 @@ public partial class NewCharacterWizardWindow : Window
         AvaloniaXamlLoader.Load(this);
     }
 
+    // Creature fallback when creaturepal.itp yields nothing (the shared DefaultFallback is
+    // item-oriented; creatures default to the Custom bucket, PaletteID 1).
+    private static readonly List<PaletteCategory> CreatureCategoryFallback = new()
+    {
+        new() { Id = 1, Name = "Custom" },
+    };
+
     private void PopulatePaletteCategories()
     {
-        _identityPaletteIdComboBox.Items.Clear();
-
         var categories = _displayService.GetCreaturePaletteCategories().ToList();
+        var sorted = categories.Count > 0
+            ? categories.OrderBy(c => c.Id).ToList()
+            : CreatureCategoryFallback;
 
-        if (categories.Count == 0)
-        {
-            _identityPaletteIdComboBox.Items.Add(new ComboBoxItem { Content = "Custom (1)", Tag = (byte)1 });
-            _identityPaletteIdComboBox.SelectedIndex = 0;
-            return;
-        }
-
-        int defaultIndex = 0;
-        int index = 0;
-        foreach (var category in categories.OrderBy(c => c.Id))
-        {
-            var displayName = !string.IsNullOrEmpty(category.ParentPath)
-                ? $"{category.ParentPath}/{category.Name} ({category.Id})"
-                : $"{category.Name} ({category.Id})";
-
-            _identityPaletteIdComboBox.Items.Add(new ComboBoxItem
-            {
-                Content = displayName,
-                Tag = category.Id
-            });
-
-            if (category.Id == 1) defaultIndex = index;
-            index++;
-        }
-
-        _identityPaletteIdComboBox.SelectedIndex = defaultIndex;
+        // Shared binder owns populate + select (#2421); disambiguates duplicate names (#2488).
+        PaletteCategoryComboBinder.Populate(_identityPaletteIdComboBox, sorted);
+        PaletteCategoryComboBinder.SelectById(_identityPaletteIdComboBox, 1); // default to Custom
     }
 
     private void PopulateFactions()

--- a/Quartermaster/Quartermaster/Views/Panels/AdvancedPanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AdvancedPanel.axaml.cs
@@ -170,7 +170,7 @@ public partial class AdvancedPanel : BasePanelControl
     {
         if (IsLoading || CurrentCreature == null) return;
 
-        var categoryId = ComboBoxHelper.GetSelectedTag<byte>(_paletteCategoryComboBox);
+        var categoryId = PaletteCategoryComboBinder.GetSelectedId(_paletteCategoryComboBox);
         if (categoryId.HasValue)
         {
             CurrentCreature.PaletteID = categoryId.Value;
@@ -325,7 +325,7 @@ public partial class AdvancedPanel : BasePanelControl
                 // If a creature was loaded before the combo populated, re-select its category.
                 if (CurrentCreature != null)
                 {
-                    ComboBoxHelper.SelectByTag(_paletteCategoryComboBox, CurrentCreature.PaletteID);
+                    PaletteCategoryComboBinder.SelectById(_paletteCategoryComboBox, CurrentCreature.PaletteID);
                 }
             });
         }
@@ -441,31 +441,25 @@ public partial class AdvancedPanel : BasePanelControl
         }
     }
 
+    // Creature-specific fallback when creaturepal.itp yields no categories (e.g. game data not
+    // configured). The shared DefaultFallback is item-oriented (Armor/Weapons/Potions); for
+    // creatures the only sane default is the Custom bucket (PaletteID 1).
+    private static readonly System.Collections.Generic.List<PaletteCategory> CreatureCategoryFallback = new()
+    {
+        new() { Id = 1, Name = "Custom" },
+    };
+
     private void PopulatePaletteCategoryCombo(System.Collections.Generic.List<PaletteCategory> categories)
     {
         if (_paletteCategoryComboBox == null) return;
 
-        _paletteCategoryComboBox.Items.Clear();
+        // Shared binder owns populate/select/read-back (#2421). It sorts nothing, so sort by Id
+        // here for stable ordering, and disambiguates duplicate names itself (#2488).
+        var sorted = categories.Count > 0
+            ? categories.OrderBy(c => c.Id).ToList()
+            : CreatureCategoryFallback;
 
-        if (categories.Count == 0)
-        {
-            // Fallback if no categories loaded (e.g., game data not configured)
-            _paletteCategoryComboBox.Items.Add(new ComboBoxItem { Content = "Custom (1)", Tag = (byte)1 });
-            return;
-        }
-
-        foreach (var category in categories.OrderBy(c => c.Id))
-        {
-            var displayName = !string.IsNullOrEmpty(category.ParentPath)
-                ? $"{category.ParentPath}/{category.Name} ({category.Id})"
-                : $"{category.Name} ({category.Id})";
-
-            _paletteCategoryComboBox.Items.Add(new ComboBoxItem
-            {
-                Content = displayName,
-                Tag = category.Id
-            });
-        }
+        PaletteCategoryComboBinder.Populate(_paletteCategoryComboBox, sorted);
     }
 
     public override void LoadCreature(UtcFile? creature)
@@ -485,7 +479,7 @@ public partial class AdvancedPanel : BasePanelControl
         SetTextBox(_templateResRefTextBox, creature.TemplateResRef ?? "");
         SetTextBox(_tagTextBox, creature.Tag ?? "");
         SetTextBox(_commentTextBox, creature.Comment ?? "");
-        ComboBoxHelper.SelectByTag(_paletteCategoryComboBox, creature.PaletteID);
+        PaletteCategoryComboBinder.SelectById(_paletteCategoryComboBox, creature.PaletteID);
 
         // Flags
         SetCheckBox(_plotCheckBox, creature.Plot);
@@ -532,8 +526,8 @@ public partial class AdvancedPanel : BasePanelControl
             _decayTimeComboBox.SelectedIndex = 2; // 5 seconds default
         if (_bodyBagComboBox != null)
             _bodyBagComboBox.SelectedIndex = 0;
-        // Select PaletteID 1 (typically Custom category) by tag, not index
-        ComboBoxHelper.SelectByTag(_paletteCategoryComboBox, (byte)1);
+        // Select PaletteID 1 (typically Custom category) by id, not index
+        PaletteCategoryComboBinder.SelectById(_paletteCategoryComboBox, 1);
 
         // Variables
         ClearVariables();

--- a/Radoub.UI/Radoub.UI.Tests/Undo/PaletteReorgCommandsTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Undo/PaletteReorgCommandsTests.cs
@@ -1,0 +1,249 @@
+using System.Linq;
+using Radoub.Formats.Itp;
+using Radoub.UI.Services.Palette;
+using Radoub.UI.Undo;
+using Xunit;
+
+namespace Radoub.UI.Tests.Undo;
+
+/// <summary>
+/// Inverse commands for the non-delete palette reorg ops (#2484): blueprint move/file, category
+/// add/rename/move. Mirror <see cref="PaletteDeleteCategoryCommandTests"/>: Do applies + snapshots,
+/// Undo reverses, Redo (a second Do) returns to the post-op state, and a throwing refresh
+/// self-rolls-back and reports false (so the undo stack is never poisoned, #2231).
+/// </summary>
+public class PaletteReorgCommandsTests
+{
+    private sealed class FakeGateway : IBlueprintFileGateway
+    {
+        public byte ReadPaletteId(string filePath) => 0;
+        public byte[] ProduceBytesWithPaletteId(string filePath, byte id) => new[] { id };
+        public byte ReadPaletteIdFromBytes(byte[] bytes) => bytes[0];
+    }
+
+    // root: [Misc(9), Weapons(1){ acid_dagger(id1) }]; loose blueprint is uncategorized (id 0).
+    private static (ItpFile itp, LooseFileBlueprintStore store, PaletteCategoryNode misc, PaletteCategoryNode weapons) Build()
+    {
+        var itp = new ItpFile();
+        var misc = new PaletteCategoryNode { Id = 9, Name = "Misc" };
+        var weapons = new PaletteCategoryNode { Id = 1, Name = "Weapons" };
+        weapons.Blueprints.Add(new PaletteBlueprintNode { ResRef = "acid_dagger" });
+        itp.MainNodes.Add(misc);
+        itp.MainNodes.Add(weapons);
+
+        var store = new LooseFileBlueprintStore(new FakeGateway(), new[]
+        {
+            ("acid_dagger", "p/acid_dagger.uti"),
+            ("loose", "p/loose.uti"),
+        });
+        store.SetPaletteId("acid_dagger", 1); // in sync with Weapons
+        // "loose" stays at id 0 -> uncategorized
+        return (itp, store, misc, weapons);
+    }
+
+    // ---- MoveBlueprintCommand (move + file-from-uncategorized via PaletteID) ----
+
+    [Fact]
+    public void MoveBlueprint_Do_stages_new_palette_id()
+    {
+        var (itp, store, misc, _) = Build();
+        var cmd = new PaletteMoveBlueprintCommand(store, "acid_dagger", misc.Id, onChanged: null);
+
+        Assert.True(cmd.Do());
+        Assert.Equal((byte)9, store.GetPaletteId("acid_dagger"));
+        Assert.Equal(PalettePlacementKind.InSync, PaletteReorgMutator.Classify(itp, store, "acid_dagger").Home is { } h && h.Id == 9 ? PalettePlacementKind.InSync : PalettePlacementKind.Uncategorized);
+    }
+
+    [Fact]
+    public void MoveBlueprint_Undo_restores_original_palette_id()
+    {
+        var (_, store, misc, _) = Build();
+        var cmd = new PaletteMoveBlueprintCommand(store, "acid_dagger", misc.Id, onChanged: null);
+        cmd.Do();
+        cmd.Undo();
+        Assert.Equal((byte)1, store.GetPaletteId("acid_dagger"));
+    }
+
+    [Fact]
+    public void MoveBlueprint_files_uncategorized_blueprint_and_undo_returns_it_to_uncategorized()
+    {
+        var (itp, store, _, weapons) = Build();
+        var cmd = new PaletteMoveBlueprintCommand(store, "loose", weapons.Id, onChanged: null);
+
+        Assert.True(cmd.Do());
+        Assert.Equal((byte)1, store.GetPaletteId("loose"));
+
+        cmd.Undo();
+        Assert.Equal((byte)0, store.GetPaletteId("loose"));
+        Assert.Equal(PalettePlacementKind.Uncategorized, PaletteReorgMutator.Classify(itp, store, "loose").Kind);
+    }
+
+    [Fact]
+    public void MoveBlueprint_Do_Undo_Redo_returns_to_moved_state()
+    {
+        var (_, store, misc, _) = Build();
+        var cmd = new PaletteMoveBlueprintCommand(store, "acid_dagger", misc.Id, onChanged: null);
+        cmd.Do();
+        cmd.Undo();
+        cmd.Do(); // redo
+        Assert.Equal((byte)9, store.GetPaletteId("acid_dagger"));
+    }
+
+    [Fact]
+    public void MoveBlueprint_Do_returns_false_and_rolls_back_when_refresh_throws()
+    {
+        var (_, store, misc, _) = Build();
+        var cmd = new PaletteMoveBlueprintCommand(store, "acid_dagger", misc.Id,
+            onChanged: () => throw new System.InvalidOperationException());
+
+        Assert.False(cmd.Do());
+        Assert.Equal((byte)1, store.GetPaletteId("acid_dagger")); // unchanged
+    }
+
+    [Fact]
+    public void MoveBlueprint_Do_returns_false_when_already_in_target()
+    {
+        var (_, store, _, weapons) = Build();
+        var cmd = new PaletteMoveBlueprintCommand(store, "acid_dagger", weapons.Id, onChanged: null);
+        Assert.False(cmd.Do()); // already id 1
+    }
+
+    // ---- RenameCategoryCommand ----
+
+    [Fact]
+    public void Rename_Do_sets_name_and_clears_strref()
+    {
+        var (_, store, _, weapons) = Build();
+        weapons.StrRef = 5432; // standard category with a TLK name
+        var cmd = new PaletteRenameCategoryCommand(weapons, "Blades", onChanged: null);
+
+        Assert.True(cmd.Do());
+        Assert.Equal("Blades", weapons.Name);
+        Assert.Null(weapons.StrRef);
+    }
+
+    [Fact]
+    public void Rename_Undo_restores_name_and_strref()
+    {
+        var (_, _, _, weapons) = Build();
+        weapons.Name = "Weapons";
+        weapons.StrRef = 5432;
+        var cmd = new PaletteRenameCategoryCommand(weapons, "Blades", onChanged: null);
+        cmd.Do();
+        cmd.Undo();
+        Assert.Equal("Weapons", weapons.Name);
+        Assert.Equal((uint)5432, weapons.StrRef);
+    }
+
+    [Fact]
+    public void Rename_Do_returns_false_on_empty_name()
+    {
+        var (_, _, _, weapons) = Build();
+        var cmd = new PaletteRenameCategoryCommand(weapons, "   ", onChanged: null);
+        Assert.False(cmd.Do());
+    }
+
+    [Fact]
+    public void Rename_Do_returns_false_and_rolls_back_when_refresh_throws()
+    {
+        var (_, _, _, weapons) = Build();
+        var cmd = new PaletteRenameCategoryCommand(weapons, "Blades",
+            onChanged: () => throw new System.InvalidOperationException());
+        Assert.False(cmd.Do());
+        Assert.Equal("Weapons", weapons.Name);
+    }
+
+    // ---- AddCategoryCommand ----
+
+    [Fact]
+    public void Add_Do_creates_category_under_parent()
+    {
+        var (itp, _, _, weapons) = Build();
+        var cmd = new PaletteAddCategoryCommand(itp, weapons, "Melee", onChanged: null);
+
+        Assert.True(cmd.Do());
+        Assert.Contains(weapons.Children.OfType<PaletteCategoryNode>(), c => c.Name == "Melee");
+    }
+
+    [Fact]
+    public void Add_Undo_removes_the_created_category()
+    {
+        var (itp, _, _, weapons) = Build();
+        var cmd = new PaletteAddCategoryCommand(itp, weapons, "Melee", onChanged: null);
+        cmd.Do();
+        cmd.Undo();
+        Assert.DoesNotContain(weapons.Children.OfType<PaletteCategoryNode>(), c => c.Name == "Melee");
+    }
+
+    [Fact]
+    public void Add_Do_Undo_Redo_reuses_same_id_and_node()
+    {
+        var (itp, _, _, weapons) = Build();
+        var cmd = new PaletteAddCategoryCommand(itp, weapons, "Melee", onChanged: null);
+        cmd.Do();
+        var created = weapons.Children.OfType<PaletteCategoryNode>().Single(c => c.Name == "Melee");
+        byte firstId = created.Id;
+        cmd.Undo();
+        cmd.Do(); // redo must NOT allocate a new id
+
+        var again = weapons.Children.OfType<PaletteCategoryNode>().Single(c => c.Name == "Melee");
+        Assert.Same(created, again);
+        Assert.Equal(firstId, again.Id);
+    }
+
+    [Fact]
+    public void Add_Do_returns_false_on_empty_name()
+    {
+        var (itp, _, _, weapons) = Build();
+        var cmd = new PaletteAddCategoryCommand(itp, weapons, "  ", onChanged: null);
+        Assert.False(cmd.Do());
+    }
+
+    // ---- MoveCategoryCommand ----
+
+    [Fact]
+    public void MoveCategory_Do_reparents_then_Undo_restores_position()
+    {
+        // Move Misc(9) under Weapons(1); undo returns it to root index 0.
+        var (itp, _, misc, weapons) = Build();
+        var cmd = new PaletteMoveCategoryCommand(itp, misc, weapons, index: 0, onChanged: null);
+
+        Assert.True(cmd.Do());
+        Assert.Contains(weapons.Children, n => ReferenceEquals(n, misc));
+        Assert.DoesNotContain(itp.MainNodes, n => ReferenceEquals(n, misc));
+
+        cmd.Undo();
+        Assert.Same(misc, itp.MainNodes[0]);
+        Assert.DoesNotContain(weapons.Children, n => ReferenceEquals(n, misc));
+    }
+
+    [Fact]
+    public void MoveCategory_Do_returns_false_on_cycle()
+    {
+        // Nesting Weapons into itself is a cycle -> refused.
+        var (itp, _, _, weapons) = Build();
+        var cmd = new PaletteMoveCategoryCommand(itp, weapons, weapons, index: 0, onChanged: null);
+        Assert.False(cmd.Do());
+    }
+
+    [Fact]
+    public void MoveCategory_Do_Undo_Redo_returns_to_moved_state()
+    {
+        var (itp, _, misc, weapons) = Build();
+        var cmd = new PaletteMoveCategoryCommand(itp, misc, weapons, index: 0, onChanged: null);
+        cmd.Do();
+        cmd.Undo();
+        cmd.Do(); // redo
+        Assert.Contains(weapons.Children, n => ReferenceEquals(n, misc));
+    }
+
+    [Fact]
+    public void MoveCategory_Do_returns_false_and_rolls_back_when_refresh_throws()
+    {
+        var (itp, _, misc, weapons) = Build();
+        var cmd = new PaletteMoveCategoryCommand(itp, misc, weapons, index: 0,
+            onChanged: () => throw new System.InvalidOperationException());
+        Assert.False(cmd.Do());
+        Assert.Same(misc, itp.MainNodes[0]); // rolled back to root
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/Utils/PaletteCategoryComboBinderTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Utils/PaletteCategoryComboBinderTests.cs
@@ -77,4 +77,91 @@ public class PaletteCategoryComboBinderTests
 
         Assert.Null(PaletteCategoryComboBinder.GetSelectedId(combo));
     }
+
+    // --- Duplicate/nested name disambiguation (#2488) ---
+
+    [Fact]
+    public void BuildDisplayLabels_UniqueNames_ReturnsBareNames()
+    {
+        var cats = new List<PaletteCategory>
+        {
+            new() { Id = 0, Name = "Containers" },
+            new() { Id = 1, Name = "Doors" },
+        };
+
+        var labels = PaletteCategoryComboBinder.BuildDisplayLabels(cats);
+
+        Assert.Equal(new[] { "Containers", "Doors" }, labels);
+    }
+
+    [Fact]
+    public void BuildDisplayLabels_DuplicateName_WithParentPath_QualifiesByPath()
+    {
+        // CEP case: two "Custom 1" categories under different branches.
+        var cats = new List<PaletteCategory>
+        {
+            new() { Id = 10, Name = "Custom 1", ParentPath = "Weapons" },
+            new() { Id = 20, Name = "Custom 1", ParentPath = "Armor" },
+            new() { Id = 30, Name = "Doors" },
+        };
+
+        var labels = PaletteCategoryComboBinder.BuildDisplayLabels(cats);
+
+        Assert.Equal("Weapons › Custom 1", labels[0]);
+        Assert.Equal("Armor › Custom 1", labels[1]);
+        Assert.Equal("Doors", labels[2]); // unique name stays bare
+    }
+
+    [Fact]
+    public void BuildDisplayLabels_DuplicateName_NoParentPath_QualifiesById()
+    {
+        // Both duplicates are top-level (no ParentPath) — fall back to id suffix.
+        var cats = new List<PaletteCategory>
+        {
+            new() { Id = 41, Name = "Custom 1" },
+            new() { Id = 42, Name = "Custom 1" },
+        };
+
+        var labels = PaletteCategoryComboBinder.BuildDisplayLabels(cats);
+
+        Assert.Equal("Custom 1 (id 41)", labels[0]);
+        Assert.Equal("Custom 1 (id 42)", labels[1]);
+    }
+
+    [Fact]
+    public void BuildDisplayLabels_DuplicateNameAndDuplicatePath_FallsBackToId()
+    {
+        // Pathological: same name AND same parent path — path can't disambiguate, use id.
+        var cats = new List<PaletteCategory>
+        {
+            new() { Id = 7, Name = "Custom 1", ParentPath = "Weapons" },
+            new() { Id = 8, Name = "Custom 1", ParentPath = "Weapons" },
+        };
+
+        var labels = PaletteCategoryComboBinder.BuildDisplayLabels(cats);
+
+        Assert.Equal("Weapons › Custom 1 (id 7)", labels[0]);
+        Assert.Equal("Weapons › Custom 1 (id 8)", labels[1]);
+    }
+
+    [AvaloniaFact]
+    public void Populate_DuplicateNames_UsesDisambiguatedContent()
+    {
+        var combo = new ComboBox();
+        var cats = new List<PaletteCategory>
+        {
+            new() { Id = 10, Name = "Custom 1", ParentPath = "Weapons" },
+            new() { Id = 20, Name = "Custom 1", ParentPath = "Armor" },
+        };
+
+        PaletteCategoryComboBinder.Populate(combo, cats);
+
+        var first = Assert.IsType<ComboBoxItem>(combo.Items[0]);
+        var second = Assert.IsType<ComboBoxItem>(combo.Items[1]);
+        Assert.Equal("Weapons › Custom 1", first.Content);
+        Assert.Equal("Armor › Custom 1", second.Content);
+        // Tags remain the raw PaletteID — disambiguation is display-only (#2488).
+        Assert.Equal((byte)10, first.Tag);
+        Assert.Equal((byte)20, second.Tag);
+    }
 }

--- a/Radoub.UI/Radoub.UI.Tests/Utils/PaletteCategoryComboBinderTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Utils/PaletteCategoryComboBinderTests.cs
@@ -78,10 +78,12 @@ public class PaletteCategoryComboBinderTests
         Assert.Null(PaletteCategoryComboBinder.GetSelectedId(combo));
     }
 
-    // --- Duplicate/nested name disambiguation (#2488) ---
+    // --- Nested/duplicate name display (#2488, #2562) ---
+    // Rule: top-level categories show bare Name; any nested category shows "Parent › Name" so
+    // siblings read consistently. Remaining duplicate *qualified* labels get an "(id N)" suffix.
 
     [Fact]
-    public void BuildDisplayLabels_UniqueNames_ReturnsBareNames()
+    public void BuildDisplayLabels_TopLevelUniqueNames_ReturnsBareNames()
     {
         var cats = new List<PaletteCategory>
         {
@@ -92,6 +94,26 @@ public class PaletteCategoryComboBinderTests
         var labels = PaletteCategoryComboBinder.BuildDisplayLabels(cats);
 
         Assert.Equal(new[] { "Containers", "Doors" }, labels);
+    }
+
+    [Fact]
+    public void BuildDisplayLabels_NestedNames_AlwaysShowParentPath_EvenWhenUnique()
+    {
+        // The reported case: all of Armor's children show the path, not just the duplicated one.
+        var cats = new List<PaletteCategory>
+        {
+            new() { Id = 1, Name = "Armor" },
+            new() { Id = 2, Name = "Clothing", ParentPath = "Armor" },
+            new() { Id = 3, Name = "Light", ParentPath = "Armor" },
+            new() { Id = 4, Name = "Heavy", ParentPath = "Armor" },
+        };
+
+        var labels = PaletteCategoryComboBinder.BuildDisplayLabels(cats);
+
+        Assert.Equal("Armor", labels[0]);            // top level stays bare
+        Assert.Equal("Armor › Clothing", labels[1]);
+        Assert.Equal("Armor › Light", labels[2]);
+        Assert.Equal("Armor › Heavy", labels[3]);
     }
 
     [Fact]
@@ -109,13 +131,13 @@ public class PaletteCategoryComboBinderTests
 
         Assert.Equal("Weapons › Custom 1", labels[0]);
         Assert.Equal("Armor › Custom 1", labels[1]);
-        Assert.Equal("Doors", labels[2]); // unique name stays bare
+        Assert.Equal("Doors", labels[2]); // unique top-level name stays bare
     }
 
     [Fact]
-    public void BuildDisplayLabels_DuplicateName_NoParentPath_QualifiesById()
+    public void BuildDisplayLabels_DuplicateTopLevelName_QualifiesById()
     {
-        // Both duplicates are top-level (no ParentPath) — fall back to id suffix.
+        // Both duplicates are top-level (no ParentPath) — no path to show, fall back to id suffix.
         var cats = new List<PaletteCategory>
         {
             new() { Id = 41, Name = "Custom 1" },

--- a/Radoub.UI/Radoub.UI.Tests/ViewModels/PaletteEditorHostViewModelTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/ViewModels/PaletteEditorHostViewModelTests.cs
@@ -219,4 +219,60 @@ public class PaletteEditorHostViewModelTests
         host.Undo();
         Assert.DoesNotContain(host.ActiveContext!.Palette.GetCategories(), c => c.Name == "X");
     }
+
+    // --- #2484 review fixes: empty-stack no-op + cross-tool lock guard on undo/redo ---
+
+    [Fact]
+    public async Task Undo_or_redo_with_empty_history_does_not_commit()
+    {
+        int commits = 0;
+        var host = MakeHost(commit: _ => { commits++; return new PaletteSaveResult(true, null); });
+        await host.SwitchResourceTypeAsync(PaletteResourceType.Item);
+
+        host.Undo(); // nothing to undo
+        host.Redo(); // nothing to redo
+        Assert.Equal(0, commits); // no disk write on a no-op keystroke
+    }
+
+    [Fact]
+    public async Task Undo_of_blueprint_move_refused_when_blueprint_open_in_another_tool()
+    {
+        // The blueprint is free at move time but gets opened in another tool before the undo.
+        string? lockedBy = null;
+        string? reported = null;
+        int commits = 0;
+        var host = MakeHost(
+            commit: _ => { commits++; return new PaletteSaveResult(true, null); },
+            lockHolder: path => path.EndsWith("bp.uti") ? lockedBy : null);
+        host.SaveFailed += m => reported = m;
+        await host.SwitchResourceTypeAsync(PaletteResourceType.Item);
+
+        host.MoveBlueprintToCategory("bp", Cat(host, 1)); // free -> moves, commit #1
+        Assert.Equal((byte)1, host.ActiveContext!.Store.GetPaletteId("bp"));
+        int commitsAfterMove = commits;
+
+        lockedBy = "Relique"; // another tool opens the blueprint
+        host.Undo();          // must be refused — undo rewrites the file
+
+        Assert.Equal((byte)1, host.ActiveContext.Store.GetPaletteId("bp")); // NOT reverted
+        Assert.Equal(commitsAfterMove, commits);                            // no disk write
+        Assert.Contains("Relique", reported);                              // names the holder
+    }
+
+    [Fact]
+    public async Task Undo_of_blueprint_move_proceeds_once_the_other_tool_releases_the_lock()
+    {
+        string? lockedBy = "Relique";
+        var host = MakeHost(lockHolder: path => path.EndsWith("bp.uti") ? lockedBy : null);
+        await host.SwitchResourceTypeAsync(PaletteResourceType.Item);
+
+        // Move requires the lock free; release it for the move, re-acquire, then release again.
+        lockedBy = null;
+        host.MoveBlueprintToCategory("bp", Cat(host, 1));
+        Assert.Equal((byte)1, host.ActiveContext!.Store.GetPaletteId("bp"));
+
+        lockedBy = null; // tool closed it
+        host.Undo();
+        Assert.Equal((byte)0, host.ActiveContext.Store.GetPaletteId("bp")); // reverted
+    }
 }

--- a/Radoub.UI/Radoub.UI.Tests/ViewModels/PaletteEditorHostViewModelTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/ViewModels/PaletteEditorHostViewModelTests.cs
@@ -121,4 +121,102 @@ public class PaletteEditorHostViewModelTests
         Assert.Equal(2, loads);
         Assert.NotNull(host.ActiveContext);
     }
+
+    // --- Undo/redo across all reorg gestures (#2484) ---
+
+    [Fact]
+    public async Task MoveBlueprint_is_undoable_and_redoable()
+    {
+        var host = MakeHost();
+        await host.SwitchResourceTypeAsync(PaletteResourceType.Item);
+
+        host.MoveBlueprintToCategory("bp", Cat(host, 1));
+        Assert.Equal((byte)1, host.ActiveContext!.Store.GetPaletteId("bp"));
+        Assert.True(host.ActiveContext.UndoManager.CanUndo);
+
+        host.Undo();
+        Assert.Equal((byte)0, host.ActiveContext.Store.GetPaletteId("bp")); // back to uncategorized
+
+        host.Redo();
+        Assert.Equal((byte)1, host.ActiveContext.Store.GetPaletteId("bp"));
+    }
+
+    [Fact]
+    public async Task AddCategory_is_undoable_and_redoable_with_stable_id()
+    {
+        var host = MakeHost();
+        await host.SwitchResourceTypeAsync(PaletteResourceType.Item);
+
+        Assert.True(host.AddCategory(null, "New Cat"));
+        var added = host.ActiveContext!.Palette.GetCategories().Single(c => c.Name == "New Cat");
+        byte id = added.Id;
+
+        host.Undo();
+        Assert.DoesNotContain(host.ActiveContext.Palette.GetCategories(), c => c.Name == "New Cat");
+
+        host.Redo();
+        var again = host.ActiveContext.Palette.GetCategories().Single(c => c.Name == "New Cat");
+        Assert.Equal(id, again.Id); // redo reuses the same id, never reallocates
+    }
+
+    [Fact]
+    public async Task RenameCategory_is_undoable()
+    {
+        var host = MakeHost();
+        await host.SwitchResourceTypeAsync(PaletteResourceType.Item);
+        var cat = Cat(host, 1);
+        string original = cat.Name!;
+
+        Assert.True(host.RenameCategory(cat, "Renamed"));
+        Assert.Equal("Renamed", cat.Name);
+
+        host.Undo();
+        Assert.Equal(original, cat.Name);
+    }
+
+    [Fact]
+    public async Task MoveCategory_is_undoable()
+    {
+        var host = MakeHost();
+        await host.SwitchResourceTypeAsync(PaletteResourceType.Item);
+        var moved = Cat(host, 2);
+        var parent = Cat(host, 1);
+
+        Assert.True(host.MoveCategory(moved, parent, 0));
+        Assert.Contains(parent.Children, n => ReferenceEquals(n, moved));
+
+        host.Undo();
+        Assert.DoesNotContain(parent.Children, n => ReferenceEquals(n, moved));
+        Assert.Contains(host.ActiveContext!.Palette.MainNodes, n => ReferenceEquals(n, moved));
+    }
+
+    [Fact]
+    public async Task Undo_and_redo_each_commit_to_disk()
+    {
+        int commits = 0;
+        var host = MakeHost(commit: _ => { commits++; return new PaletteSaveResult(true, null); });
+        await host.SwitchResourceTypeAsync(PaletteResourceType.Item);
+
+        host.RenameCategory(Cat(host, 1), "X"); // commit #1
+        host.Undo();                            // commit #2 (persist the revert)
+        host.Redo();                            // commit #3
+        Assert.Equal(3, commits);
+    }
+
+    [Fact]
+    public async Task Reorg_that_self_rolls_back_on_commit_failure_records_no_undo()
+    {
+        // A rename whose commit fails: the op reverts (reload-from-disk) and must leave no undo entry
+        // to replay later.
+        var host = MakeHost(commit: _ => new PaletteSaveResult(false, new Exception("locked")));
+        await host.SwitchResourceTypeAsync(PaletteResourceType.Item);
+
+        bool ok = host.RenameCategory(Cat(host, 1), "X");
+        Assert.False(ok);
+        // The command Do() succeeded (rename applied + forest rebuilt), so it WAS recorded; but the
+        // commit failed and reloaded from disk. The undo stack belongs to the now-replaced context.
+        // Either way, undoing must not throw and must not resurrect "X".
+        host.Undo();
+        Assert.DoesNotContain(host.ActiveContext!.Palette.GetCategories(), c => c.Name == "X");
+    }
 }

--- a/Radoub.UI/Radoub.UI.Tests/ViewModels/PaletteNodeViewModelTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/ViewModels/PaletteNodeViewModelTests.cs
@@ -110,4 +110,40 @@ public class PaletteNodeViewModelTests
         var forest = PaletteNodeViewModel.BuildForest(vm, strRefResolver: _ => null);
         Assert.Contains(forest, n => n.Kind == PaletteNodeKind.Category && n.Name == "[StrRef 99]");
     }
+
+    // --- Full-path tooltip for duplicate/nested name disambiguation (#2488) ---
+
+    [Fact]
+    public void FullPath_TopLevelCategory_IsJustItsName()
+    {
+        var vm = BuildVm();
+        var forest = PaletteNodeViewModel.BuildForest(vm);
+
+        var weapons = forest.Single(n => n.Name == "Weapons");
+        Assert.Equal("Weapons", weapons.FullPath);
+    }
+
+    [Fact]
+    public void FullPath_NestedNode_ChainsAncestorNames()
+    {
+        // Weapons › Custom 1 › a_blade  — the tree nests, so the path makes a repeated
+        // "Custom 1" unambiguous on hover.
+        var itp = new ItpFile();
+        var weapons = new PaletteCategoryNode { Id = 1, Name = "Weapons" };
+        var custom = new PaletteCategoryNode { Id = 5, Name = "Custom 1" };
+        weapons.Children.Add(custom);
+        itp.MainNodes.Add(weapons);
+
+        var store = new LooseFileBlueprintStore(new FakeGateway(), new[] { ("a_blade", "p/a_blade.uti") });
+        store.SetPaletteId("a_blade", 5); // -> Custom 1
+
+        var forest = PaletteNodeViewModel.BuildForest(new PaletteEditorViewModel(itp, store));
+
+        var weaponsVm = forest.Single(n => n.Name == "Weapons");
+        var customVm = weaponsVm.Children.Single(c => c.Name == "Custom 1");
+        var bladeVm = customVm.Children.Single(c => c.Name == "a_blade");
+
+        Assert.Equal("Weapons › Custom 1", customVm.FullPath);
+        Assert.Equal("Weapons › Custom 1 › a_blade", bladeVm.FullPath);
+    }
 }

--- a/Radoub.UI/Radoub.UI/Controls/PaletteEditorControl.axaml
+++ b/Radoub.UI/Radoub.UI/Controls/PaletteEditorControl.axaml
@@ -57,8 +57,10 @@
                 </ControlTheme>
             </TreeView.ItemContainerTheme>
             <TreeView.ItemTemplate>
+                <!-- ToolTip shows the full root-to-here path so repeated/nested names
+                     (CEP "Custom 1") are unambiguous on hover (#2488). -->
                 <TreeDataTemplate ItemsSource="{Binding Children}">
-                    <TextBlock Text="{Binding Name}"/>
+                    <TextBlock Text="{Binding Name}" ToolTip.Tip="{Binding FullPath}"/>
                 </TreeDataTemplate>
             </TreeView.ItemTemplate>
         </TreeView>

--- a/Radoub.UI/Radoub.UI/Controls/PaletteEditorControl.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Controls/PaletteEditorControl.axaml.cs
@@ -14,8 +14,9 @@ namespace Radoub.UI.Controls;
 /// The shared ITP palette editor view (#2477, M3): a resource-type selector, a single tree of
 /// categories with blueprint leaves inline (plus the virtual Uncategorized bucket), drag-drop
 /// reorganization, and save. The control is host-agnostic — Trebuchet (or a future per-tool host)
-/// supplies the <see cref="PaletteEditorHostViewModel"/> via <see cref="Bind"/>. Category
-/// add/rename/delete is deferred (needs a TLK-name decision, #2486); v1 is reorganize-only.
+/// supplies the <see cref="PaletteEditorHostViewModel"/> via <see cref="Bind"/>. Every reorg
+/// gesture is undoable via Ctrl+Z/Y (#2484). Category add/rename buttons in the UI are deferred
+/// (needs a TLK-name decision, #2565); the host VM ops + their inverse commands already exist.
 /// </summary>
 public partial class PaletteEditorControl : UserControl
 {
@@ -41,6 +42,9 @@ public partial class PaletteEditorControl : UserControl
         DragDrop.SetAllowDrop(PaletteTree, true);
         PaletteTree.AddHandler(DragDrop.DropEvent, OnDrop);
         PaletteTree.AddHandler(DragDrop.DragOverEvent, OnDragOver);
+        // Ctrl+Z / Ctrl+Y (and Ctrl+Shift+Z) drive undo/redo across every reorg gesture (#2484).
+        // Tunnel so we get the chord before the TreeView swallows it.
+        AddHandler(KeyDownEvent, OnKeyDown, RoutingStrategies.Tunnel);
         // Tunnel so we see the press before the TreeView consumes it, but we DON'T start the drag
         // here — we only record a candidate, letting normal click/select/expand proceed.
         PaletteTree.AddHandler(PointerPressedEvent, OnTreePointerPressed, RoutingStrategies.Tunnel);
@@ -56,6 +60,19 @@ public partial class PaletteEditorControl : UserControl
         DataContext = host;
         host.SaveFailed += OnSaveFailed;
         RefreshChrome();
+    }
+
+    // Ctrl+Z = undo, Ctrl+Y / Ctrl+Shift+Z = redo. Every reorg gesture is reversible (#2484); the
+    // host re-derives the tree and re-commits to disk on undo/redo.
+    private void OnKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (_host is null) return;
+        bool ctrl = e.KeyModifiers.HasFlag(KeyModifiers.Control);
+        if (!ctrl) return;
+        bool shift = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+
+        if (e.Key == Key.Z && !shift) { _host.Undo(); e.Handled = true; }
+        else if (e.Key == Key.Y || (e.Key == Key.Z && shift)) { _host.Redo(); e.Handled = true; }
     }
 
     private void OnSaveFailed(string message)

--- a/Radoub.UI/Radoub.UI/Controls/PaletteEditorControl.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Controls/PaletteEditorControl.axaml.cs
@@ -45,12 +45,22 @@ public partial class PaletteEditorControl : UserControl
         // Ctrl+Z / Ctrl+Y (and Ctrl+Shift+Z) drive undo/redo across every reorg gesture (#2484).
         // Tunnel so we get the chord before the TreeView swallows it.
         AddHandler(KeyDownEvent, OnKeyDown, RoutingStrategies.Tunnel);
+        // Double-click a blueprint leaf -> raise BlueprintActivated for the host to launch its
+        // editor (#2485). Launch logic stays in the host (Trebuchet), not in Radoub.UI.
+        PaletteTree.AddHandler(DoubleTappedEvent, OnTreeDoubleTapped);
         // Tunnel so we see the press before the TreeView consumes it, but we DON'T start the drag
         // here — we only record a candidate, letting normal click/select/expand proceed.
         PaletteTree.AddHandler(PointerPressedEvent, OnTreePointerPressed, RoutingStrategies.Tunnel);
         PaletteTree.AddHandler(PointerMovedEvent, OnTreePointerMoved, RoutingStrategies.Tunnel);
         PaletteTree.AddHandler(PointerReleasedEvent, OnTreePointerReleased, RoutingStrategies.Tunnel);
     }
+
+    /// <summary>
+    /// Raised when a blueprint leaf is double-clicked (#2485). The argument is the blueprint ResRef;
+    /// the host (Trebuchet) resolves the file path + tool and launches it. Radoub.UI deliberately
+    /// owns no launch logic.
+    /// </summary>
+    public event Action<string>? BlueprintActivated;
 
     /// <summary>Bind the control to its host view-model and owning window (for modal prompts).</summary>
     public void Bind(PaletteEditorHostViewModel host, Window ownerWindow)
@@ -149,6 +159,18 @@ public partial class PaletteEditorControl : UserControl
     private void OnTreePointerReleased(object? sender, PointerReleasedEventArgs e)
     {
         _pendingDragNode = null; // a plain click/release without crossing the threshold: no drag
+    }
+
+    // Double-click a blueprint leaf -> launch its editor (#2485). Categories/branches/Uncategorized
+    // ignore the gesture (they expand/collapse instead). The blueprint node's Name is its ResRef.
+    private void OnTreeDoubleTapped(object? sender, Avalonia.Input.TappedEventArgs e)
+    {
+        if ((e.Source as Control)?.DataContext is not PaletteNodeViewModel node) return;
+        if (node.Kind != PaletteNodeKind.Blueprint) return;
+        if (string.IsNullOrEmpty(node.Name)) return;
+
+        BlueprintActivated?.Invoke(node.Name);
+        e.Handled = true;
     }
 
     private void OnDragOver(object? sender, DragEventArgs e)

--- a/Radoub.UI/Radoub.UI/Controls/PaletteEditorControl.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Controls/PaletteEditorControl.axaml.cs
@@ -77,8 +77,10 @@ public partial class PaletteEditorControl : UserControl
     private void OnKeyDown(object? sender, KeyEventArgs e)
     {
         if (_host is null) return;
-        bool ctrl = e.KeyModifiers.HasFlag(KeyModifiers.Control);
-        if (!ctrl) return;
+        // Require Ctrl WITHOUT Alt: on Windows the AltGr key reports as Ctrl+Alt, so a bare Ctrl
+        // check would fire undo/redo on AltGr+Z/Y chords used to type characters on many layouts.
+        if (!e.KeyModifiers.HasFlag(KeyModifiers.Control) || e.KeyModifiers.HasFlag(KeyModifiers.Alt))
+            return;
         bool shift = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
 
         if (e.Key == Key.Z && !shift) { _host.Undo(); e.Handled = true; }

--- a/Radoub.UI/Radoub.UI/Services/Palette/PaletteReorgMutator.cs
+++ b/Radoub.UI/Radoub.UI/Services/Palette/PaletteReorgMutator.cs
@@ -222,13 +222,39 @@ public static class PaletteReorgMutator
     }
 
     /// <summary>The mutable child list a node parents (category Children, branch Children),
-    /// or null for a leaf/blueprint (caller substitutes MAIN root).</summary>
-    private static List<PaletteNode>? ChildListOf(PaletteNode? parent) => parent switch
+    /// or null for a leaf/blueprint (caller substitutes MAIN root). Public so reorg undo commands
+    /// (#2484) can re-insert/remove a node in the same list the mutator uses.</summary>
+    public static List<PaletteNode>? ChildListOf(PaletteNode? parent) => parent switch
     {
         PaletteCategoryNode cat => cat.Children,
         PaletteBranchNode br => br.Children,
         _ => null,
     };
+
+    /// <summary>Locate <paramref name="target"/>'s current parent node (null = MAIN root) and its
+    /// index within that parent's child list, or index -1 if not in the tree. Used by the move-undo
+    /// command (#2484) to capture a category's original position for restore.</summary>
+    public static (PaletteNode? Parent, int Index) LocateChild(ItpFile itp, PaletteNode target)
+    {
+        if (itp == null) throw new ArgumentNullException(nameof(itp));
+        int rootIdx = itp.MainNodes.IndexOf(target);
+        if (rootIdx >= 0) return (null, rootIdx);
+        return LocateChildIn(itp.MainNodes, target);
+    }
+
+    private static (PaletteNode? Parent, int Index) LocateChildIn(List<PaletteNode> nodes, PaletteNode target)
+    {
+        foreach (var node in nodes)
+        {
+            var children = ChildListOf(node);
+            if (children == null) continue;
+            int idx = children.IndexOf(target);
+            if (idx >= 0) return (node, idx);
+            var found = LocateChildIn(children, target);
+            if (found.Index >= 0) return found;
+        }
+        return (null, -1);
+    }
 
     /// <summary>The list that currently holds <paramref name="target"/> (MAIN root or any node's
     /// Children), or null if it is not in the tree.</summary>

--- a/Radoub.UI/Radoub.UI/Undo/PaletteReorgCommands.cs
+++ b/Radoub.UI/Radoub.UI/Undo/PaletteReorgCommands.cs
@@ -33,6 +33,10 @@ public sealed class PaletteMoveBlueprintCommand : IUndoableCommand
 
     public string Description => $"Move '{_resRef}'";
 
+    /// <summary>The blueprint this command moves. The host checks this against the cross-tool file
+    /// lock before undo/redo (the move rewrites the file, same as the forward op — #2484 review).</summary>
+    public string ResRef => _resRef;
+
     public bool Do()
     {
         if (string.IsNullOrEmpty(_resRef) || !_store.Contains(_resRef)) return false;

--- a/Radoub.UI/Radoub.UI/Undo/PaletteReorgCommands.cs
+++ b/Radoub.UI/Radoub.UI/Undo/PaletteReorgCommands.cs
@@ -1,0 +1,213 @@
+using System;
+using Radoub.Formats.Itp;
+using Radoub.UI.Services.Palette;
+
+namespace Radoub.UI.Undo;
+
+// Inverse commands for the non-delete palette reorg ops (#2484), companions to
+// PaletteDeleteCategoryCommand. Each owns its mutate via the pure PaletteReorgMutator, runs the
+// injected refresh with mutate-refresh-rollback on Do (so a throwing refresh self-rolls-back and
+// reports false — the undo stack is never poisoned, #2231), and reverses on Undo. Redo (a second
+// Do) returns to the post-op state.
+
+/// <summary>
+/// Reversible blueprint placement change (move between categories, or file an uncategorized one).
+/// Placement is authoritative on the blueprint's <c>PaletteID</c> (#2477), so this stages the new
+/// id on Do and the captured original id on Undo; the tree reconciles from PaletteIDs on refresh.
+/// </summary>
+public sealed class PaletteMoveBlueprintCommand : IUndoableCommand
+{
+    private readonly IBlueprintPaletteStore _store;
+    private readonly string _resRef;
+    private readonly byte _targetId;
+    private readonly Action? _onChanged;
+    private byte? _originalId;
+
+    public PaletteMoveBlueprintCommand(IBlueprintPaletteStore store, string resRef, byte targetId, Action? onChanged)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _resRef = resRef ?? throw new ArgumentNullException(nameof(resRef));
+        _targetId = targetId;
+        _onChanged = onChanged;
+    }
+
+    public string Description => $"Move '{_resRef}'";
+
+    public bool Do()
+    {
+        if (string.IsNullOrEmpty(_resRef) || !_store.Contains(_resRef)) return false;
+
+        _originalId = _store.GetPaletteId(_resRef); // re-snapshot each Do (Redo re-runs)
+        if (_originalId == _targetId) return false;  // already there — no-op
+        if (!_store.SetPaletteId(_resRef, _targetId)) return false;
+
+        try
+        {
+            _onChanged?.Invoke();
+            return true;
+        }
+        catch
+        {
+            try { if (_originalId is byte id) _store.SetPaletteId(_resRef, id); } catch { /* best-effort */ }
+            return false;
+        }
+    }
+
+    public void Undo()
+    {
+        if (_originalId is byte id) _store.SetPaletteId(_resRef, id);
+        _onChanged?.Invoke();
+    }
+}
+
+/// <summary>Reversible category rename. Captures the old literal name and StrRef; the rename clears
+/// StrRef (a literal name overrides a TLK reference), and Undo restores both.</summary>
+public sealed class PaletteRenameCategoryCommand : IUndoableCommand
+{
+    private readonly PaletteCategoryNode _cat;
+    private readonly string _newName;
+    private readonly Action? _onChanged;
+    private string _oldName = string.Empty;
+    private uint? _oldStrRef;
+
+    public PaletteRenameCategoryCommand(PaletteCategoryNode cat, string newName, Action? onChanged)
+    {
+        _cat = cat ?? throw new ArgumentNullException(nameof(cat));
+        _newName = newName;
+        _onChanged = onChanged;
+    }
+
+    public string Description => $"Rename category to '{_newName}'";
+
+    public bool Do()
+    {
+        _oldName = _cat.Name ?? string.Empty;   // re-snapshot each Do
+        _oldStrRef = _cat.StrRef;
+
+        if (!PaletteReorgMutator.RenameCategory(_cat, _newName)) return false;
+
+        try
+        {
+            _onChanged?.Invoke();
+            return true;
+        }
+        catch
+        {
+            try { _cat.Name = _oldName; _cat.StrRef = _oldStrRef; } catch { /* best-effort */ }
+            return false;
+        }
+    }
+
+    public void Undo()
+    {
+        _cat.Name = _oldName;
+        _cat.StrRef = _oldStrRef;
+        _onChanged?.Invoke();
+    }
+}
+
+/// <summary>Reversible add of a new empty category. The first Do allocates an id via the mutator;
+/// Undo removes the node; Redo re-inserts the SAME node instance (no fresh allocation) so the id is
+/// stable across undo/redo cycles.</summary>
+public sealed class PaletteAddCategoryCommand : IUndoableCommand
+{
+    private readonly ItpFile _itp;
+    private readonly PaletteNode? _parent;
+    private readonly string _name;
+    private readonly Action? _onChanged;
+    private PaletteCategoryNode? _created;
+
+    public PaletteAddCategoryCommand(ItpFile itp, PaletteNode? parent, string name, Action? onChanged)
+    {
+        _itp = itp ?? throw new ArgumentNullException(nameof(itp));
+        _parent = parent;
+        _name = name;
+        _onChanged = onChanged;
+    }
+
+    public string Description => $"Add category '{_name}'";
+
+    public bool Do()
+    {
+        if (_created == null)
+        {
+            // First Do: allocate + create through the mutator (advances the id allocator once).
+            _created = PaletteReorgMutator.AddCategory(_itp, _parent, _name);
+            if (_created == null) return false;
+        }
+        else
+        {
+            // Redo: re-insert the same node instance so its id is never reallocated.
+            (PaletteReorgMutator.ChildListOf(_parent) ?? _itp.MainNodes).Add(_created);
+        }
+
+        try
+        {
+            _onChanged?.Invoke();
+            return true;
+        }
+        catch
+        {
+            try { (PaletteReorgMutator.ChildListOf(_parent) ?? _itp.MainNodes).Remove(_created); } catch { /* best-effort */ }
+            return false;
+        }
+    }
+
+    public void Undo()
+    {
+        if (_created == null) return;
+        (PaletteReorgMutator.ChildListOf(_parent) ?? _itp.MainNodes).Remove(_created);
+        _onChanged?.Invoke();
+    }
+}
+
+/// <summary>Reversible category move/nest. Captures the category's current parent list + index on Do
+/// and moves it back there on Undo. Refuses cycles (delegated to the mutator).</summary>
+public sealed class PaletteMoveCategoryCommand : IUndoableCommand
+{
+    private readonly ItpFile _itp;
+    private readonly PaletteCategoryNode _cat;
+    private readonly PaletteNode? _newParent;
+    private readonly int _index;
+    private readonly Action? _onChanged;
+    private PaletteNode? _oldParent;
+    private int _oldIndex = -1;
+
+    public PaletteMoveCategoryCommand(
+        ItpFile itp, PaletteCategoryNode cat, PaletteNode? newParent, int index, Action? onChanged)
+    {
+        _itp = itp ?? throw new ArgumentNullException(nameof(itp));
+        _cat = cat ?? throw new ArgumentNullException(nameof(cat));
+        _newParent = newParent;
+        _index = index;
+        _onChanged = onChanged;
+    }
+
+    public string Description => $"Move category '{_cat.Name ?? _cat.Id.ToString()}'";
+
+    public bool Do()
+    {
+        // Capture the current location BEFORE the move (Redo re-runs Do from the restored state).
+        (_oldParent, _oldIndex) = PaletteReorgMutator.LocateChild(_itp, _cat);
+        if (_oldIndex < 0) return false; // not in tree
+
+        if (!PaletteReorgMutator.MoveCategory(_itp, _cat, _newParent, _index)) return false;
+
+        try
+        {
+            _onChanged?.Invoke();
+            return true;
+        }
+        catch
+        {
+            try { PaletteReorgMutator.MoveCategory(_itp, _cat, _oldParent, _oldIndex); } catch { /* best-effort */ }
+            return false;
+        }
+    }
+
+    public void Undo()
+    {
+        PaletteReorgMutator.MoveCategory(_itp, _cat, _oldParent, _oldIndex);
+        _onChanged?.Invoke();
+    }
+}

--- a/Radoub.UI/Radoub.UI/Undo/UndoRedoManager.cs
+++ b/Radoub.UI/Radoub.UI/Undo/UndoRedoManager.cs
@@ -22,6 +22,11 @@ public sealed class UndoRedoManager
     public bool CanUndo => _undo.Count > 0;
     public bool CanRedo => _redo.Count > 0;
 
+    /// <summary>Number of commands on the undo stack. Lets a host detect whether an
+    /// <see cref="Execute"/> actually recorded (it pushes exactly one entry on success, none on a
+    /// self-rolled-back command) without an ambiguous <see cref="CanUndo"/> before/after check.</summary>
+    public int UndoCount => _undo.Count;
+
     /// <summary>Description of the command Undo would revert, or null if none.</summary>
     public string? UndoDescription => _undo.Count > 0 ? _undo.Peek().Description : null;
 

--- a/Radoub.UI/Radoub.UI/Undo/UndoRedoManager.cs
+++ b/Radoub.UI/Radoub.UI/Undo/UndoRedoManager.cs
@@ -33,6 +33,13 @@ public sealed class UndoRedoManager
     /// <summary>Description of the command Redo would reapply, or null if none.</summary>
     public string? RedoDescription => _redo.Count > 0 ? _redo.Peek().Description : null;
 
+    /// <summary>The command Undo would revert next, or null if the stack is empty. Lets a host
+    /// inspect the pending command (e.g. to apply a cross-tool lock guard before reverting a write).</summary>
+    public IUndoableCommand? PeekUndo => _undo.Count > 0 ? _undo.Peek() : null;
+
+    /// <summary>The command Redo would reapply next, or null if the redo stack is empty.</summary>
+    public IUndoableCommand? PeekRedo => _redo.Count > 0 ? _redo.Peek() : null;
+
     /// <summary>
     /// Run the command, and only if its <see cref="IUndoableCommand.Do"/> reports success
     /// (returns <c>true</c>) push it onto the undo stack and clear the redo stack. A command that

--- a/Radoub.UI/Radoub.UI/Utils/PaletteCategoryComboBinder.cs
+++ b/Radoub.UI/Radoub.UI/Utils/PaletteCategoryComboBinder.cs
@@ -55,50 +55,45 @@ public static class PaletteCategoryComboBinder
     }
 
     /// <summary>
-    /// Build one display label per category, disambiguating duplicate names (#2488). CEP and
-    /// custom content commonly repeat names like "Custom 1" across branches; a flat combo of
-    /// identical labels is unusable. Rules, applied per category:
+    /// Build one display label per category so nesting is visible and duplicates are
+    /// distinguishable (#2488). Rules, applied per category:
     /// <list type="bullet">
-    /// <item>Name unique in the list → bare <c>Name</c> (unchanged from the simple case).</item>
-    /// <item>Name duplicated, has a <c>ParentPath</c> → <c>"Parent › Name"</c>.</item>
-    /// <item>Name still ambiguous (no path, or same name+path) → append <c>" (id N)"</c>.</item>
+    /// <item>Top-level (no <c>ParentPath</c>) → bare <c>Name</c>, so the common flat palette reads
+    /// cleanly.</item>
+    /// <item>Nested (has a <c>ParentPath</c>) → always <c>"Parent › Name"</c>, even when the name is
+    /// unique, so siblings under one parent read consistently (e.g. all of Armor's children show
+    /// "Armor › …", not just a duplicated one).</item>
+    /// <item>If the resulting label still collides (same name with no path, or identical
+    /// name+path) → append <c>" (id N)"</c>.</item>
     /// </list>
-    /// Disambiguation is display-only — placement is by PaletteID (#2477), so the item Tag stays
-    /// the raw <c>Id</c>. The order of the returned labels matches <paramref name="categories"/>.
+    /// Display-only — placement is by PaletteID (#2477), so the item Tag stays the raw <c>Id</c>.
+    /// The order of the returned labels matches <paramref name="categories"/>.
     /// </summary>
     public static IReadOnlyList<string> BuildDisplayLabels(IReadOnlyList<PaletteCategory> categories)
     {
-        var nameCounts = categories
-            .GroupBy(c => c.Name)
-            .ToDictionary(g => g.Key, g => g.Count());
-
-        // After path-qualification, a "Parent › Name" string can still collide (same name AND
-        // same parent path). Detect those so we can add the id suffix only where it's needed.
-        var qualifiedCounts = new Dictionary<string, int>();
+        // Base label: bare for top-level, path-qualified for nested. Count collisions on this base
+        // so we only add an id suffix where the base label is genuinely ambiguous.
+        var baseLabels = new List<string>(categories.Count);
+        var baseCounts = new Dictionary<string, int>();
         foreach (var cat in categories)
         {
-            var key = PathQualified(cat);
-            qualifiedCounts[key] = qualifiedCounts.TryGetValue(key, out var n) ? n + 1 : 1;
+            var label = BaseLabel(cat);
+            baseLabels.Add(label);
+            baseCounts[label] = baseCounts.TryGetValue(label, out var n) ? n + 1 : 1;
         }
 
         var labels = new List<string>(categories.Count);
-        foreach (var cat in categories)
+        for (int i = 0; i < categories.Count; i++)
         {
-            if (nameCounts[cat.Name] <= 1)
-            {
-                labels.Add(cat.Name); // unique — leave it bare
-                continue;
-            }
-
-            var qualified = PathQualified(cat);
-            // Path disambiguates only if the path-qualified form is itself unique.
-            labels.Add(qualifiedCounts[qualified] <= 1 ? qualified : $"{qualified} (id {cat.Id})");
+            var label = baseLabels[i];
+            labels.Add(baseCounts[label] <= 1 ? label : $"{label} (id {categories[i].Id})");
         }
 
         return labels;
     }
 
-    private static string PathQualified(PaletteCategory cat)
+    // Bare name for a top-level category; "Parent › Name" for a nested one.
+    private static string BaseLabel(PaletteCategory cat)
         => string.IsNullOrEmpty(cat.ParentPath) ? cat.Name : $"{cat.ParentPath} › {cat.Name}";
 
     /// <summary>

--- a/Radoub.UI/Radoub.UI/Utils/PaletteCategoryComboBinder.cs
+++ b/Radoub.UI/Radoub.UI/Utils/PaletteCategoryComboBinder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Avalonia.Controls;
 using Radoub.Formats.Services;
 
@@ -30,7 +31,8 @@ public static class PaletteCategoryComboBinder
 
     /// <summary>
     /// Clear and repopulate the combo from <paramref name="categories"/>. Each item's
-    /// <c>Content</c> is the category name and <c>Tag</c> is the byte <c>Id</c> (so
+    /// <c>Content</c> is the disambiguated display label (see <see cref="BuildDisplayLabels"/>)
+    /// and <c>Tag</c> is the byte <c>Id</c> (so
     /// <see cref="ComboBoxHelper.SelectByTag{T}"/> / <see cref="ComboBoxHelper.GetSelectedTag{T}"/>
     /// work). Falls back to <see cref="DefaultFallback"/> when the list is null/empty.
     /// Returns the list actually loaded (caller can cache it).
@@ -41,15 +43,63 @@ public static class PaletteCategoryComboBinder
 
         if (combo != null)
         {
+            var labels = BuildDisplayLabels(list);
             combo.Items.Clear();
-            foreach (var cat in list)
+            for (int i = 0; i < list.Count; i++)
             {
-                combo.Items.Add(new ComboBoxItem { Content = cat.Name, Tag = cat.Id });
+                combo.Items.Add(new ComboBoxItem { Content = labels[i], Tag = list[i].Id });
             }
         }
 
         return list;
     }
+
+    /// <summary>
+    /// Build one display label per category, disambiguating duplicate names (#2488). CEP and
+    /// custom content commonly repeat names like "Custom 1" across branches; a flat combo of
+    /// identical labels is unusable. Rules, applied per category:
+    /// <list type="bullet">
+    /// <item>Name unique in the list → bare <c>Name</c> (unchanged from the simple case).</item>
+    /// <item>Name duplicated, has a <c>ParentPath</c> → <c>"Parent › Name"</c>.</item>
+    /// <item>Name still ambiguous (no path, or same name+path) → append <c>" (id N)"</c>.</item>
+    /// </list>
+    /// Disambiguation is display-only — placement is by PaletteID (#2477), so the item Tag stays
+    /// the raw <c>Id</c>. The order of the returned labels matches <paramref name="categories"/>.
+    /// </summary>
+    public static IReadOnlyList<string> BuildDisplayLabels(IReadOnlyList<PaletteCategory> categories)
+    {
+        var nameCounts = categories
+            .GroupBy(c => c.Name)
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        // After path-qualification, a "Parent › Name" string can still collide (same name AND
+        // same parent path). Detect those so we can add the id suffix only where it's needed.
+        var qualifiedCounts = new Dictionary<string, int>();
+        foreach (var cat in categories)
+        {
+            var key = PathQualified(cat);
+            qualifiedCounts[key] = qualifiedCounts.TryGetValue(key, out var n) ? n + 1 : 1;
+        }
+
+        var labels = new List<string>(categories.Count);
+        foreach (var cat in categories)
+        {
+            if (nameCounts[cat.Name] <= 1)
+            {
+                labels.Add(cat.Name); // unique — leave it bare
+                continue;
+            }
+
+            var qualified = PathQualified(cat);
+            // Path disambiguates only if the path-qualified form is itself unique.
+            labels.Add(qualifiedCounts[qualified] <= 1 ? qualified : $"{qualified} (id {cat.Id})");
+        }
+
+        return labels;
+    }
+
+    private static string PathQualified(PaletteCategory cat)
+        => string.IsNullOrEmpty(cat.ParentPath) ? cat.Name : $"{cat.ParentPath} › {cat.Name}";
 
     /// <summary>
     /// Select the item whose Tag matches <paramref name="paletteId"/>. If not present, selects the

--- a/Radoub.UI/Radoub.UI/ViewModels/PaletteEditorHostViewModel.cs
+++ b/Radoub.UI/Radoub.UI/ViewModels/PaletteEditorHostViewModel.cs
@@ -196,11 +196,7 @@ public partial class PaletteEditorHostViewModel : ObservableObject
         // Cross-tool guard: the move rewrites the whole blueprint file (read-disk -> set PaletteID
         // -> write). If another running tool (Relique/QM/Fence) holds the file open, abort and warn
         // rather than clobber its in-flight edits.
-        if (ActiveContext.Store.GetFilePath(resRef) is { } path && _lockHolder(path) is { } holder)
-        {
-            SaveFailed?.Invoke($"'{resRef}' is open in {holder}. Close it there, then try again.");
-            return false;
-        }
+        if (IsBlueprintLockedElsewhere(resRef)) return false;
 
         // Placement is by PaletteID; the command stages to.Id and undo restores the old id (#2484).
         if (!ExecuteReorg(new PaletteMoveBlueprintCommand(
@@ -208,6 +204,19 @@ public partial class PaletteEditorHostViewModel : ObservableObject
             return false;
         RevealCategory(to); // focus follows the drop: expand + select the destination
         return true;
+    }
+
+    // True (and raises SaveFailed) when the blueprint is currently open in another tool — moving or
+    // un-moving it would rewrite the file underneath that tool and lose its edits. Used by both the
+    // forward move and undo/redo of a move (#2484 review: undo also writes the file).
+    private bool IsBlueprintLockedElsewhere(string resRef)
+    {
+        if (ActiveContext?.Store.GetFilePath(resRef) is { } path && _lockHolder(path) is { } holder)
+        {
+            SaveFailed?.Invoke($"'{resRef}' is open in {holder}. Close it there, then try again.");
+            return true;
+        }
+        return false;
     }
 
     /// <summary>Add a new empty category under <paramref name="parent"/> (or root when null).
@@ -262,6 +271,32 @@ public partial class PaletteEditorHostViewModel : ObservableObject
         return CommitNow();
     }
 
-    public void Undo() { ActiveContext?.UndoManager.Undo(); RebuildForest(); CommitNow(); }
-    public void Redo() { ActiveContext?.UndoManager.Redo(); RebuildForest(); CommitNow(); }
+    /// <summary>Revert the last reorg and persist the result. No-op (no disk write) when the undo
+    /// stack is empty. Refused when the command would rewrite a blueprint that is open in another
+    /// tool (#2484 review) — the revert is a real file write, same as the forward move.</summary>
+    public void Undo()
+    {
+        if (ActiveContext is null || !ActiveContext.UndoManager.CanUndo) return;
+        if (ActiveContext.UndoManager.PeekUndo is PaletteMoveBlueprintCommand mv
+            && IsBlueprintLockedElsewhere(mv.ResRef))
+            return;
+
+        ActiveContext.UndoManager.Undo();
+        RebuildForest();
+        CommitNow();
+    }
+
+    /// <summary>Reapply the last undone reorg and persist. Same empty-stack and cross-tool-lock
+    /// guards as <see cref="Undo"/>.</summary>
+    public void Redo()
+    {
+        if (ActiveContext is null || !ActiveContext.UndoManager.CanRedo) return;
+        if (ActiveContext.UndoManager.PeekRedo is PaletteMoveBlueprintCommand mv
+            && IsBlueprintLockedElsewhere(mv.ResRef))
+            return;
+
+        ActiveContext.UndoManager.Redo();
+        RebuildForest();
+        CommitNow();
+    }
 }

--- a/Radoub.UI/Radoub.UI/ViewModels/PaletteEditorHostViewModel.cs
+++ b/Radoub.UI/Radoub.UI/ViewModels/PaletteEditorHostViewModel.cs
@@ -157,8 +157,9 @@ public partial class PaletteEditorHostViewModel : ObservableObject
     // reloaded from disk so the editor never diverges from the files (which is what produced the
     // earlier save conflict), and SaveFailed is raised.
     //
-    // Undo/redo: delete-with-reparent is reversible (PaletteDeleteCategoryCommand). Reversible undo
-    // for the other ops is tracked in #2484.
+    // Undo/redo: every reorg gesture is reversible (#2484). Each op runs through ExecuteReorg, which
+    // pushes a dedicated inverse IUndoableCommand (blueprint move, category add/rename/move, delete-
+    // with-reparent) onto the active context's UndoManager, then commits to disk on success.
 
     /// <summary>Commit the active palette to disk atomically (reconcile tree + write changed files).
     /// On failure, reload from disk so the editor matches the files, and raise <see cref="SaveFailed"/>.
@@ -201,30 +202,37 @@ public partial class PaletteEditorHostViewModel : ObservableObject
             return false;
         }
 
-        if (!AfterReorg(ActiveContext.ViewModel.SetBlueprintCategory(resRef, to))) return false;
+        // Placement is by PaletteID; the command stages to.Id and undo restores the old id (#2484).
+        if (!ExecuteReorg(new PaletteMoveBlueprintCommand(
+                ActiveContext.Store, resRef, to.Id, onChanged: RebuildForest)))
+            return false;
         RevealCategory(to); // focus follows the drop: expand + select the destination
         return true;
     }
 
-    /// <summary>Add a new empty category under <paramref name="parent"/> (or root when null).</summary>
+    /// <summary>Add a new empty category under <paramref name="parent"/> (or root when null).
+    /// Reversible (#2484).</summary>
     public bool AddCategory(PaletteCategoryNode? parent, string name)
     {
         if (ActiveContext is null) return false;
-        return AfterReorg(ActiveContext.ViewModel.AddCategory(parent, name) != null);
+        return ExecuteReorg(new PaletteAddCategoryCommand(
+            ActiveContext.Palette, parent, name, onChanged: RebuildForest));
     }
 
-    /// <summary>Rename a category.</summary>
+    /// <summary>Rename a category. Reversible (#2484).</summary>
     public bool RenameCategory(PaletteCategoryNode cat, string newName)
     {
         if (ActiveContext is null) return false;
-        return AfterReorg(ActiveContext.ViewModel.RenameCategory(cat, newName));
+        return ExecuteReorg(new PaletteRenameCategoryCommand(cat, newName, onChanged: RebuildForest));
     }
 
-    /// <summary>Move/nest a category to a new parent and index.</summary>
+    /// <summary>Move/nest a category to a new parent and index. Reversible (#2484).</summary>
     public bool MoveCategory(PaletteCategoryNode cat, PaletteNode? newParent, int index)
     {
         if (ActiveContext is null) return false;
-        if (!AfterReorg(ActiveContext.ViewModel.MoveCategory(cat, newParent, index))) return false;
+        if (!ExecuteReorg(new PaletteMoveCategoryCommand(
+                ActiveContext.Palette, cat, newParent, index, onChanged: RebuildForest)))
+            return false;
         if (newParent is PaletteCategoryNode parentCat) RevealCategory(parentCat);
         RevealCategory(cat); // select the moved category itself
         return true;
@@ -235,23 +243,25 @@ public partial class PaletteEditorHostViewModel : ObservableObject
     public bool DeleteCategory(PaletteCategoryNode cat)
     {
         if (ActiveContext is null) return false;
-        bool before = ActiveContext.UndoManager.CanUndo;
-        var cmd = new PaletteDeleteCategoryCommand(
-            ActiveContext.Palette, ActiveContext.Store, cat, onChanged: RebuildForest);
-        ActiveContext.UndoManager.Execute(cmd);
-        // Execute invokes Do() once; if it self-rolled-back the stack is untouched.
-        if (ActiveContext.UndoManager.CanUndo == before && before == false) return false; // no-op
+        return ExecuteReorg(new PaletteDeleteCategoryCommand(
+            ActiveContext.Palette, ActiveContext.Store, cat, onChanged: RebuildForest));
+    }
+
+    /// <summary>
+    /// Run a reversible reorg command through the active undo manager and, if it was recorded (its
+    /// Do succeeded — a self-rolled-back command leaves the stack untouched), commit to disk. The
+    /// command's onChanged is RebuildForest, so the forest is already refreshed by the time we
+    /// commit. Returns true only when the command applied and committed.
+    /// </summary>
+    private bool ExecuteReorg(IUndoableCommand command)
+    {
+        if (ActiveContext is null) return false;
+        int before = ActiveContext.UndoManager.UndoCount;
+        ActiveContext.UndoManager.Execute(command);
+        if (ActiveContext.UndoManager.UndoCount == before) return false; // self-rolled-back / no-op
         return CommitNow();
     }
 
     public void Undo() { ActiveContext?.UndoManager.Undo(); RebuildForest(); CommitNow(); }
     public void Redo() { ActiveContext?.UndoManager.Redo(); RebuildForest(); CommitNow(); }
-
-    // After a VM reorg op: on success rebuild the forest and commit to disk immediately.
-    private bool AfterReorg(bool ok)
-    {
-        if (!ok || ActiveContext is null) return false;
-        RebuildForest();
-        return CommitNow();
-    }
 }

--- a/Radoub.UI/Radoub.UI/ViewModels/PaletteNodeViewModel.cs
+++ b/Radoub.UI/Radoub.UI/ViewModels/PaletteNodeViewModel.cs
@@ -26,7 +26,27 @@ public partial class PaletteNodeViewModel : ObservableObject
     /// <summary>The backing model node, or null for the virtual Uncategorized bucket.</summary>
     public PaletteNode? Model { get; }
 
+    /// <summary>
+    /// Parent node in the tree, or null for a top-level node. Set during <see cref="BuildForest"/>;
+    /// used by <see cref="FullPath"/> to chain ancestor names for the disambiguation tooltip (#2488).
+    /// </summary>
+    public PaletteNodeViewModel? Parent { get; private set; }
+
+    /// <summary>
+    /// Root-to-here name chain, joined with " › " (e.g. "Weapons › Custom 1 › a_blade"). Shown as a
+    /// tooltip so repeated names (CEP "Custom 1") are unambiguous on hover (#2488). A top-level node's
+    /// full path is just its own name.
+    /// </summary>
+    public string FullPath => Parent is null ? Name : $"{Parent.FullPath} › {Name}";
+
     public ObservableCollection<PaletteNodeViewModel> Children { get; } = new();
+
+    /// <summary>Add a child and set its <see cref="Parent"/> back-reference.</summary>
+    private void AddChild(PaletteNodeViewModel child)
+    {
+        child.Parent = this;
+        Children.Add(child);
+    }
 
     [ObservableProperty] private string _name = string.Empty;
     [ObservableProperty] private bool _isExpanded;
@@ -71,7 +91,7 @@ public partial class PaletteNodeViewModel : ObservableObject
 
         var uncategorized = new PaletteNodeViewModel(PaletteNodeKind.Uncategorized, null, "Uncategorized");
         foreach (var resRef in uncategorizedRefs.OrderBy(r => r, StringComparer.OrdinalIgnoreCase))
-            uncategorized.Children.Add(new PaletteNodeViewModel(PaletteNodeKind.Blueprint, null, resRef));
+            uncategorized.AddChild(new PaletteNodeViewModel(PaletteNodeKind.Blueprint, null, resRef));
         forest.Add(uncategorized);
         return forest;
     }
@@ -87,16 +107,16 @@ public partial class PaletteNodeViewModel : ObservableObject
                 // Blueprint leaves come from the pool grouped by PaletteID, not cat.Blueprints.
                 if (byCategoryId.TryGetValue(cat.Id, out var refs))
                     foreach (var resRef in refs.OrderBy(r => r, StringComparer.OrdinalIgnoreCase))
-                        vmNode.Children.Add(new PaletteNodeViewModel(PaletteNodeKind.Blueprint, null, resRef));
+                        vmNode.AddChild(new PaletteNodeViewModel(PaletteNodeKind.Blueprint, null, resRef));
                 foreach (var child in cat.Children)
-                    vmNode.Children.Add(BuildNode(child, byCategoryId, strRefResolver));
+                    vmNode.AddChild(BuildNode(child, byCategoryId, strRefResolver));
                 return vmNode;
             }
             case PaletteBranchNode br:
             {
                 var vmNode = new PaletteNodeViewModel(PaletteNodeKind.Branch, br, DisplayName(br, strRefResolver));
                 foreach (var child in br.Children)
-                    vmNode.Children.Add(BuildNode(child, byCategoryId, strRefResolver));
+                    vmNode.AddChild(BuildNode(child, byCategoryId, strRefResolver));
                 return vmNode;
             }
             default:

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.10.30-alpha] - 2026-06-21
+**Branch**: `radoub/issue-2562` | **PR**: #2564
+
+### Refactor: Palette-category combo → shared Radoub.UI binder (#2423)
+
+- The main editor and New Item wizard now use the shared `PaletteCategoryComboBinder` instead of Relique-local populate/select/fallback code; the `_isLoading` dirty guard (#2385) is preserved and duplicate/nested names are disambiguated centrally (#2488).
+
+---
+
 ## [0.10.29-alpha] - 2026-06-20
 **Branch**: `relique/issue-2446` | **PR**: #2532
 

--- a/Relique/Relique/Views/MainWindow.EditorPopulation.cs
+++ b/Relique/Relique/Views/MainWindow.EditorPopulation.cs
@@ -194,17 +194,9 @@ public partial class MainWindow
         try
         {
             _isLoading = true;
-            for (int i = 0; i < PaletteCategoryComboBox.Items.Count; i++)
-            {
-                if (PaletteCategoryComboBox.Items[i] is ComboBoxItem item && item.Tag is byte id && id == paletteId)
-                {
-                    PaletteCategoryComboBox.SelectedIndex = i;
-                    return;
-                }
-            }
-            // Not found — select first item if available
-            if (PaletteCategoryComboBox.Items.Count > 0)
-                PaletteCategoryComboBox.SelectedIndex = 0;
+            // Shared binder owns the select-by-id (#2423); the _isLoading wrapper stays so the
+            // imperative selection does not mark a freshly-loaded document dirty (#2385).
+            Radoub.UI.Utils.PaletteCategoryComboBinder.SelectById(PaletteCategoryComboBox, paletteId);
         }
         finally
         {
@@ -215,7 +207,7 @@ public partial class MainWindow
     private void OnPaletteCategorySelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
         if (_isLoading || _itemViewModel == null) return;
-        if (PaletteCategoryComboBox.SelectedItem is ComboBoxItem item && item.Tag is byte id)
+        if (Radoub.UI.Utils.PaletteCategoryComboBinder.GetSelectedId(PaletteCategoryComboBox) is byte id)
         {
             if (_itemViewModel.PaletteID == id) return;
 

--- a/Relique/Relique/Views/MainWindow.Lifecycle.cs
+++ b/Relique/Relique/Views/MainWindow.Lifecycle.cs
@@ -132,38 +132,13 @@ public partial class MainWindow
 
     private void LoadPaletteCategories(System.Collections.Generic.List<PaletteCategory>? categories)
     {
-        _paletteCategories.Clear();
-        PaletteCategoryComboBox.Items.Clear();
-
-        if (categories != null && categories.Count > 0)
-        {
-            _paletteCategories = categories;
-        }
-        else
-        {
-            _paletteCategories = GetHardcodedPaletteCategories();
-        }
-
-        foreach (var cat in _paletteCategories)
-        {
-            PaletteCategoryComboBox.Items.Add(new Avalonia.Controls.ComboBoxItem
-            {
-                Content = cat.Name,
-                Tag = cat.Id
-            });
-        }
-    }
-
-    private static System.Collections.Generic.List<PaletteCategory> GetHardcodedPaletteCategories()
-    {
-        return new System.Collections.Generic.List<PaletteCategory>
-        {
-            new() { Id = 0, Name = "Miscellaneous" },
-            new() { Id = 1, Name = "Armor" },
-            new() { Id = 2, Name = "Weapons" },
-            new() { Id = 3, Name = "Potions" },
-            new() { Id = 4, Name = "Other" },
-        };
+        // Shared binder owns populate + fallback (#2423). Its DefaultFallback (Misc/Armor/Weapons/
+        // Potions/Other) matches Relique's old hardcoded list exactly, and it disambiguates
+        // duplicate/nested names (#2488). It returns the list actually loaded (real or fallback)
+        // so we cache the same source the combo shows.
+        _paletteCategories = Radoub.UI.Utils.PaletteCategoryComboBinder
+            .Populate(PaletteCategoryComboBox, categories)
+            .ToList();
     }
 
     // --- Item Browser Panel ---

--- a/Relique/Relique/Views/MainWindow.Lifecycle.cs
+++ b/Relique/Relique/Views/MainWindow.Lifecycle.cs
@@ -134,11 +134,8 @@ public partial class MainWindow
     {
         // Shared binder owns populate + fallback (#2423). Its DefaultFallback (Misc/Armor/Weapons/
         // Potions/Other) matches Relique's old hardcoded list exactly, and it disambiguates
-        // duplicate/nested names (#2488). It returns the list actually loaded (real or fallback)
-        // so we cache the same source the combo shows.
-        _paletteCategories = Radoub.UI.Utils.PaletteCategoryComboBinder
-            .Populate(PaletteCategoryComboBox, categories)
-            .ToList();
+        // duplicate/nested names (#2488).
+        Radoub.UI.Utils.PaletteCategoryComboBinder.Populate(PaletteCategoryComboBox, categories);
     }
 
     // --- Item Browser Panel ---

--- a/Relique/Relique/Views/MainWindow.axaml.cs
+++ b/Relique/Relique/Views/MainWindow.axaml.cs
@@ -25,7 +25,6 @@ public partial class MainWindow : Window, INotifyPropertyChanged
     private readonly DocumentState _documentState = new("Relique");
     private IGameDataService? _gameDataService;
     private List<BaseItemTypeInfo>? _baseItemTypes;
-    private List<PaletteCategory> _paletteCategories = new();
     private ItemPropertyService? _itemPropertyService;
     private readonly PropertyCategoryService _categoryService = new();
     private ItemStatisticsService? _itemStatisticsService;

--- a/Relique/Relique/Views/NewItemWizardWindow.axaml.cs
+++ b/Relique/Relique/Views/NewItemWizardWindow.axaml.cs
@@ -90,15 +90,10 @@ public partial class NewItemWizardWindow : Window
 
     private void PopulatePaletteCategories()
     {
-        PaletteCategoryComboBox.Items.Clear();
-        foreach (var cat in _paletteCategories)
-        {
-            PaletteCategoryComboBox.Items.Add(new ComboBoxItem
-            {
-                Content = cat.Name,
-                Tag = cat.Id
-            });
-        }
+        // Shared binder owns populate (#2423); the wizard keeps its own data source + fallback
+        // (Standard/Custom 1-3) by passing the already-loaded list. Binder disambiguates
+        // duplicate names (#2488). Wizard default selection is the first item.
+        Radoub.UI.Utils.PaletteCategoryComboBinder.Populate(PaletteCategoryComboBox, _paletteCategories);
         if (PaletteCategoryComboBox.Items.Count > 0)
             PaletteCategoryComboBox.SelectedIndex = 0;
     }
@@ -571,10 +566,8 @@ public partial class NewItemWizardWindow : Window
             var finalResRef = BlueprintNamingService.ResolveResRefConflict(
                 resRef, r => File.Exists(Path.Combine(saveDir, r + ".uti")));
 
-            // Get palette category
-            byte paletteId = 0;
-            if (PaletteCategoryComboBox.SelectedItem is ComboBoxItem catItem && catItem.Tag is byte catId)
-                paletteId = catId;
+            // Get palette category (shared binder, #2423)
+            byte paletteId = Radoub.UI.Utils.PaletteCategoryComboBinder.GetSelectedId(PaletteCategoryComboBox) ?? 0;
 
             // Create UTI file
             var uti = new UtiFile

--- a/Trebuchet/Trebuchet.Tests/PaletteToolDispatchTests.cs
+++ b/Trebuchet/Trebuchet.Tests/PaletteToolDispatchTests.cs
@@ -1,0 +1,22 @@
+using Radoub.UI.Services.Palette;
+using RadoubLauncher.Controls;
+using Xunit;
+
+namespace Trebuchet.Tests;
+
+/// <summary>
+/// The palette editor double-click dispatch (#2485): each blueprint resource type launches the
+/// correct Radoub tool (.uti→Relique, .utc→Quartermaster, .utp→Reliquary, .utm→Fence).
+/// </summary>
+public class PaletteToolDispatchTests
+{
+    [Theory]
+    [InlineData(PaletteResourceType.Item, "Relique")]
+    [InlineData(PaletteResourceType.Creature, "Quartermaster")]
+    [InlineData(PaletteResourceType.Placeable, "Reliquary")]
+    [InlineData(PaletteResourceType.Store, "Fence")]
+    public void ToolNameFor_maps_each_type_to_its_editor(PaletteResourceType type, string expected)
+    {
+        Assert.Equal(expected, PaletteToolDispatch.ToolNameFor(type));
+    }
+}

--- a/Trebuchet/Trebuchet/Controls/PaletteEditorPanel.axaml.cs
+++ b/Trebuchet/Trebuchet/Controls/PaletteEditorPanel.axaml.cs
@@ -44,7 +44,27 @@ public partial class PaletteEditorPanel : UserControl
             _host.StrRefResolver = _tlkService.ResolveStrRef;
 
         Editor.Bind(_host, parentWindow);
+        Editor.BlueprintActivated += OnBlueprintActivated; // double-click -> launch editor (#2485)
         RefreshVisibility();
+    }
+
+    // Double-click on a blueprint leaf: resolve its file path + owning tool and launch it on that
+    // file. Reuses ToolLauncherService (same path Marlinspike dispatch uses). The shared editor owns
+    // no launch logic — it only told us which ResRef was activated.
+    private void OnBlueprintActivated(string resRef)
+    {
+        if (_host?.ActiveContext is not { } ctx) return;
+        if (ctx.Store.GetFilePath(resRef) is not { } filePath || string.IsNullOrEmpty(filePath))
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN, $"Palette: no file path for '{resRef}', cannot launch.");
+            return;
+        }
+        if (PaletteToolDispatch.ToolNameFor(ctx.Type) is not { } tool)
+            return;
+
+        bool launched = ToolLauncherService.Instance.LaunchToolWithFile(tool, filePath);
+        if (!launched)
+            UnifiedLogger.LogApplication(LogLevel.WARN, $"Palette: could not launch {tool} for '{resRef}'.");
     }
 
     /// <summary>Called by the host when the working module changes. Reloads (or clears) the editor.</summary>

--- a/Trebuchet/Trebuchet/Controls/PaletteToolDispatch.cs
+++ b/Trebuchet/Trebuchet/Controls/PaletteToolDispatch.cs
@@ -1,0 +1,21 @@
+using Radoub.UI.Services.Palette;
+
+namespace RadoubLauncher.Controls;
+
+/// <summary>
+/// Maps a palette editor resource type to the Radoub tool that edits that blueprint type, for
+/// double-click-to-launch dispatch (#2485). Pure + internal so the mapping is unit-testable without
+/// instantiating the UserControl. Mirrors Marlinspike's resource-type → tool dispatch.
+/// </summary>
+internal static class PaletteToolDispatch
+{
+    /// <summary>The tool name for a palette resource type, or null if none maps.</summary>
+    public static string? ToolNameFor(PaletteResourceType type) => type switch
+    {
+        PaletteResourceType.Item      => "Relique",
+        PaletteResourceType.Creature  => "Quartermaster",
+        PaletteResourceType.Placeable => "Reliquary",
+        PaletteResourceType.Store     => "Fence",
+        _ => null,
+    };
+}


### PR DESCRIPTION
## Summary

ITP E2 — the consumer half of the palette epic (#2302). E1 (#2561) shipped the provider/data layer; this sprint standardizes how tools consume it and improves the palette editor's handling.

## Sprint Scope

Standardization:
- [x] #2421 — Quartermaster palette-category combo → shared Radoub.UI binder
- [x] #2423 — Relique palette-category combo → shared Radoub.UI binder

Better handling (palette editor):
- [x] #2484 — Undo/redo for blueprint move/file + category add/rename/move (Ctrl+Z/Y)
- [x] #2485 — Double-click a blueprint to launch its editor
- [x] #2488 — Disambiguate duplicate/nested category names (combo full-path labels + tree tooltip)

Deferred: #2486 (category add/rename/delete authoring) → #2565 (TLK StrRef rename out of scope for E2).

## Follow-ups filed

- #2565 — category authoring (TLK-blocked)
- #2566 — searchable/filterable category picker (priority-high; CEP lists are long)
- #2567 — Browse (…) tree picker (low priority)
- #2568 — tech-debt: palette reorg/undo cleanup (dedup, bare-catch logging)

## Pre-merge

- Code review (high effort): 2 confirmed correctness bugs found + fixed on-branch (undo bypassed the cross-tool file-lock guard; undo/redo committed unconditionally), 1 hardening (AltGr), dead field removed, cleanup → #2568.
- Unit tests: all 10 projects green — Radoub.UI 1312, Quartermaster 1284, Relique 368, Trebuchet 308 (+ Formats/Dictionary/others). 6123+ total.
- FlaUI (Trebuchet + QM + Relique): the only failures are pre-existing launch/realization timing flakes on tabs outside this diff (Build & Test tab, QM cold-launch smoke); palette-relevant nav passed.

## Related Issues

- Closes #2562

🤖 Generated with [Claude Code](https://claude.com/claude-code)
