### PR TITLE
[Quartermaster] Fix: Part composition data-driven naming + authored MDL position + robe arms (#2541)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.26-alpha] - 2026-06-22
+**Branch**: `quartermaster/issue-2541` | **PR**: #2569
+
+### Part composition: preserve authored mesh position + custom-skeleton bone resolution (#2541)
+
+- `MdlPartComposer` now preserves a body-part mesh's authored local position instead of zeroing it, fixing the head-too-high gap on part-based creature previews (#2161). Part-to-bone attachment best-matches custom-skeleton bones by exact name stem when the conventional `_g` bone is absent, rather than silently grafting at the composite root. Surfaced in Quartermaster (#2398/#2116).
+
+---
+
 ## [Radoub.UI 0.2.25-alpha] - 2026-06-21
 **Branch**: `radoub/issue-2562` | **PR**: #2564
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.130-alpha] - 2026-06-22
+**Branch**: `quartermaster/issue-2541` | **PR**: #TBD
+
+### Fix: Part composition data-driven naming + authored MDL position + robe arms (#2541)
+
+- Part/bone/gender naming becomes data-driven with cross-gender fallback (custom content), the authored part-mesh local position is preserved instead of zeroed (head-too-high #2161), and robe missing/duplicate arms (#2398, #2116) are diagnosed and fixed.
+
+---
+
 ## [0.2.129-alpha] - 2026-06-21
 **Branch**: `radoub/issue-2562` | **PR**: #2564
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.130-alpha] - 2026-06-22
-**Branch**: `quartermaster/issue-2541` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2541` | **PR**: #2569
 
 ### Fix: Part composition data-driven naming + authored MDL position + robe arms (#2541)
 

--- a/Quartermaster/Quartermaster.Tests/CreatureModelResolverTests.cs
+++ b/Quartermaster/Quartermaster.Tests/CreatureModelResolverTests.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+using Quartermaster.Services;
+using Xunit;
+
+namespace Quartermaster.Tests;
+
+/// <summary>
+/// Tests for the pure, GL-free part-resolution chain (#2541 Phase 1a): gender→model-flavor
+/// resolution and the race → same-gender-human → cross-gender fallback chain. These replace
+/// the inline <c>gender == 1 ? 'f' : 'm'</c> literal and the human-only fallback in
+/// <see cref="ModelService.AppendPart"/>.
+/// </summary>
+public class CreatureModelResolverTests
+{
+    // ---- Gender → model flavor (NWN ships only 'm'/'f' body-model flavors) ----
+
+    [Theory]
+    [InlineData(0, 'm', 'f')]  // Male  → primary m, cross f
+    [InlineData(1, 'f', 'm')]  // Female → primary f, cross m
+    [InlineData(2, 'm', 'f')]  // Both   → map to a real flavor (m) + cross-gender fallback
+    [InlineData(3, 'm', 'f')]  // Other  → map to a real flavor (m) + cross-gender fallback
+    [InlineData(4, 'm', 'f')]  // None   → map to a real flavor (m) + cross-gender fallback
+    [InlineData(99, 'm', 'f')] // Unknown/custom → never throw; default to m + cross fallback
+    public void ResolveGenderFlavors_MapsToRealFlavorPlusCross(int gender, char primary, char cross)
+    {
+        var flavors = CreatureModelResolver.ResolveGenderFlavors(gender);
+        Assert.Equal(primary, flavors[0]);
+        Assert.Contains(cross, flavors);
+    }
+
+    // ---- Part resolution chain ----
+
+    [Fact]
+    public void ResolvePart_RaceSpecificModel_PreferredFirst()
+    {
+        var exists = Set("pfe0_head001");
+        var result = CreatureModelResolver.ResolvePart("pfe0", "head", 1, exists);
+
+        Assert.NotNull(result);
+        Assert.Equal("pfe0_head001", result!.ResRef);
+        Assert.Equal(PartResolutionPath.RaceSpecific, result.Path);
+    }
+
+    [Fact]
+    public void ResolvePart_FallsBackToSameGenderHuman()
+    {
+        // Elf female part missing → human female (pfh0) exists.
+        var exists = Set("pfh0_head001");
+        var result = CreatureModelResolver.ResolvePart("pfe0", "head", 1, exists);
+
+        Assert.NotNull(result);
+        Assert.Equal("pfh0_head001", result!.ResRef);
+        Assert.Equal(PartResolutionPath.SameGenderHuman, result.Path);
+    }
+
+    [Fact]
+    public void ResolvePart_FallsBackToOtherGender_WhenSameGenderMissingEverywhere()
+    {
+        // Appearance authored ONLY in male; viewed as female. Today this renders a missing limb.
+        // Cross-gender fallback must find the male race-specific variant.
+        var exists = Set("pme0_head001");
+        var result = CreatureModelResolver.ResolvePart("pfe0", "head", 1, exists);
+
+        Assert.NotNull(result);
+        Assert.Equal("pme0_head001", result!.ResRef);
+        Assert.Equal(PartResolutionPath.CrossGender, result.Path);
+    }
+
+    [Fact]
+    public void ResolvePart_FallsBackToOtherGenderHuman_AsLastResort()
+    {
+        // Only the human male variant exists; creature is a female elf.
+        var exists = Set("pmh0_head001");
+        var result = CreatureModelResolver.ResolvePart("pfe0", "head", 1, exists);
+
+        Assert.NotNull(result);
+        Assert.Equal("pmh0_head001", result!.ResRef);
+        Assert.Equal(PartResolutionPath.CrossGenderHuman, result.Path);
+    }
+
+    [Fact]
+    public void ResolvePart_ReturnsNull_WhenNothingResolves()
+    {
+        var exists = Set(/* nothing */);
+        var result = CreatureModelResolver.ResolvePart("pfe0", "head", 1, exists);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ResolvePart_RaceSpecificBeatsCrossGender_WhenBothExist()
+    {
+        // Both the female-elf and male-elf parts exist — must not jump to cross-gender.
+        var exists = Set("pfe0_head001", "pme0_head001");
+        var result = CreatureModelResolver.ResolvePart("pfe0", "head", 1, exists);
+
+        Assert.Equal("pfe0_head001", result!.ResRef);
+        Assert.Equal(PartResolutionPath.RaceSpecific, result.Path);
+    }
+
+    [Fact]
+    public void ResolvePart_HumanInput_DoesNotDuplicateHumanStep()
+    {
+        // For a human female whose part is missing, the same-gender-human step IS the race step;
+        // resolution should proceed to cross-gender (male human) without a redundant lookup.
+        var exists = Set("pmh0_head001");
+        var result = CreatureModelResolver.ResolvePart("pfh0", "head", 1, exists);
+
+        Assert.NotNull(result);
+        Assert.Equal("pmh0_head001", result!.ResRef);
+        Assert.Equal(PartResolutionPath.CrossGender, result.Path);
+    }
+
+    private static System.Func<string, bool> Set(params string[] existing)
+    {
+        var set = new HashSet<string>(existing, System.StringComparer.OrdinalIgnoreCase);
+        return resref => set.Contains(resref);
+    }
+}

--- a/Quartermaster/Quartermaster.Tests/RobeArmGeometryTests.cs
+++ b/Quartermaster/Quartermaster.Tests/RobeArmGeometryTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Numerics;
+using Quartermaster.Services;
+using Radoub.Formats.Mdl;
+using Xunit;
+
+namespace Quartermaster.Tests;
+
+/// <summary>
+/// Tests for the #2541 Phase 2 narrow carve-out: a robe should only suppress the creature's own
+/// arm parts when the robe actually supplies RENDERABLE arm geometry. Dana's robe
+/// (<c>pfh0_robe005</c>) has all arm bone trimeshes Render=false and an armless torso+legs skin,
+/// so suppressing the creature arms leaves her armless (#2398/#2116). Blanket suppression of
+/// torso/legs is unchanged — this only narrows the arm decision.
+/// </summary>
+public class RobeArmGeometryTests
+{
+    private static MdlTrimeshNode Mesh(string name, bool render, int verts = 10)
+        => new()
+        {
+            Name = name,
+            Render = render,
+            Vertices = verts > 0 ? new Vector3[verts] : Array.Empty<Vector3>(),
+            Faces = Array.Empty<MdlFace>(),
+        };
+
+    private static MdlModel Robe(MdlNode root) => new() { Name = "robe", GeometryRoot = root, IsBinary = true };
+
+    [Fact]
+    public void HasRenderableArmGeometry_True_WhenArmBoneTrimeshRenders()
+    {
+        // pfh0_robe186 shape: bicep/forearm/hand trimeshes are Render=true.
+        var root = new MdlNode { Name = "robe_root" };
+        var torso = new MdlNode { Name = "torso_g", Parent = root };
+        var bicep = Mesh("lbicep_g", render: true);
+        bicep.Parent = torso;
+        torso.Children.Add(bicep);
+        root.Children.Add(torso);
+
+        Assert.True(RobeArmGeometry.HasRenderableArmGeometry(Robe(root)));
+    }
+
+    [Fact]
+    public void HasRenderableArmGeometry_False_WhenAllArmBonesRenderFalse()
+    {
+        // pfh0_robe005 shape: torso+legs skin renders, but every arm bone trimesh is Render=false
+        // and no skin slot is weighted to an arm bone.
+        var root = new MdlNode { Name = "robe_root" };
+        var robeSkin = new MdlSkinNode
+        {
+            Name = "Robe",
+            Render = true,
+            Vertices = new Vector3[364],
+            Faces = Array.Empty<MdlFace>(),
+            // resolved skin bones: legs + torso only — NO arm bones
+            BoneNodeNames = new[] { "lshin_g", "rshin_g", "rthigh_g", "pelvis_g", "lthigh_g", "torso_g" },
+        };
+        robeSkin.Parent = root;
+        root.Children.Add(robeSkin);
+
+        var torso = new MdlNode { Name = "torso_g", Parent = root };
+        var bicepL = Mesh("lbicep_g", render: false);
+        bicepL.Parent = torso;
+        torso.Children.Add(bicepL);
+        var bicepR = Mesh("rbicep_g", render: false);
+        bicepR.Parent = torso;
+        torso.Children.Add(bicepR);
+        root.Children.Add(torso);
+
+        Assert.False(RobeArmGeometry.HasRenderableArmGeometry(Robe(root)));
+    }
+
+    [Fact]
+    public void HasRenderableArmGeometry_True_WhenSkinWeightsAnArmBone()
+    {
+        // A robe whose visible skin IS weighted to arm bones (long-sleeve skin) supplies arms.
+        var root = new MdlNode { Name = "robe_root" };
+        var armSkin = new MdlSkinNode
+        {
+            Name = "arms",
+            Render = true,
+            Vertices = new Vector3[100],
+            Faces = Array.Empty<MdlFace>(),
+            BoneNodeNames = new[] { "torso_g", "lbicep_g", "lforearm_g" },
+        };
+        armSkin.Parent = root;
+        root.Children.Add(armSkin);
+
+        Assert.True(RobeArmGeometry.HasRenderableArmGeometry(Robe(root)));
+    }
+
+    [Fact]
+    public void HasRenderableArmGeometry_False_ForNullOrEmptyRobe()
+    {
+        Assert.False(RobeArmGeometry.HasRenderableArmGeometry(null));
+        Assert.False(RobeArmGeometry.HasRenderableArmGeometry(new MdlModel { GeometryRoot = null }));
+    }
+
+    [Fact]
+    public void HasRenderableArmGeometry_False_WhenOnlyArmlessSkinSurface()
+    {
+        // pfh0_robe005 signature: the sole renderable surface is a skin weighted to torso/legs
+        // but NOT arms → creature must keep its own arms.
+        var root = new MdlNode { Name = "robe_root" };
+        var torsoSkin = new MdlSkinNode
+        {
+            Name = "Robe",
+            Render = true,
+            Vertices = new Vector3[200],
+            Faces = Array.Empty<MdlFace>(),
+            BoneNodeNames = new[] { "torso_g", "pelvis_g", "lthigh_g", "lshin_g" },
+        };
+        torsoSkin.Parent = root;
+        root.Children.Add(torsoSkin);
+
+        Assert.False(RobeArmGeometry.HasRenderableArmGeometry(Robe(root)));
+    }
+
+    [Fact]
+    public void HasRenderableArmGeometry_True_WhenRigidFullBodyDrape()
+    {
+        // pmh0_robe001 signature: a single Render=true rigid 'Robe' TRIMESH that drapes the whole
+        // body (X-span 2x the torso) — it visually covers the arms even with no arm-bone geometry.
+        // Must report true so blanket suppression stays and we don't get duplicate arms (#2398).
+        var root = new MdlNode { Name = "robe_root" };
+        var robeMesh = Mesh("Robe", render: true, verts: 465);
+        robeMesh.Parent = root;
+        root.Children.Add(robeMesh);
+
+        // arm bone trimeshes present but Render=false (animation drivers only)
+        var bicep = Mesh("lbicep_g", render: false);
+        bicep.Parent = root;
+        root.Children.Add(bicep);
+
+        Assert.True(RobeArmGeometry.HasRenderableArmGeometry(Robe(root)));
+    }
+}

--- a/Quartermaster/Quartermaster/Services/CreatureModelResolver.cs
+++ b/Quartermaster/Quartermaster/Services/CreatureModelResolver.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using Radoub.UI.Services;
+
+namespace Quartermaster.Services;
+
+/// <summary>
+/// Which fallback step in the part-resolution chain produced a model. Surfaced so the
+/// caller can log the path taken (custom-content authors need to see when a fallback fired).
+/// </summary>
+public enum PartResolutionPath
+{
+    /// <summary>The creature's own race/gender/phenotype model (e.g. <c>pfe0_head001</c>).</summary>
+    RaceSpecific,
+    /// <summary>Same-gender human reference set (<c>pfh0</c>/<c>pmh0</c>).</summary>
+    SameGenderHuman,
+    /// <summary>The other gender's race-specific model (single-variant appearances).</summary>
+    CrossGender,
+    /// <summary>The other gender's human reference set (last resort).</summary>
+    CrossGenderHuman,
+}
+
+/// <summary>Result of resolving a body-part ResRef: the chosen resref and which path found it.</summary>
+public sealed record PartResolution(string ResRef, PartResolutionPath Path);
+
+/// <summary>
+/// Pure, GL-free, game-data-free resolution of part-based creature model naming (#2541 Phase 1a).
+///
+/// Replaces two hardcoded conventions in <see cref="ModelService"/>:
+/// the <c>gender == 1 ? 'f' : 'm'</c> literal (which silently collapsed every non-1 gender to
+/// male) and the human-only fallback chain in <c>AppendPart</c> (which had no cross-gender step,
+/// so a single-variant appearance viewed as the other gender rendered a missing limb).
+///
+/// NWN ships only <c>m</c>/<c>f</c> body-model flavors — there is no <c>pb</c>/<c>po</c>/<c>pn</c>
+/// prefix — so gender.2da values beyond 0/1 (2=Both, 3=Other, 4=None) map to a real flavor and
+/// rely on the cross-gender fallback to find whichever variant the content actually authored.
+/// </summary>
+public static class CreatureModelResolver
+{
+    /// <summary>
+    /// Resolve a gender value to the ordered list of model flavors to try: the primary flavor
+    /// first, then the other gender as a cross-gender fallback. gender.2da: 0=Male, 1=Female,
+    /// 2=Both, 3=Other, 4=None; only Female maps to <c>f</c>, everything else maps to <c>m</c>
+    /// primary. Never throws on unknown values.
+    /// </summary>
+    public static IReadOnlyList<char> ResolveGenderFlavors(int gender)
+        => gender == 1 ? new[] { 'f', 'm' } : new[] { 'm', 'f' };
+
+    /// <summary>
+    /// Build a creature/mannequin prefix for a flavor + race + phenotype, e.g.
+    /// <c>('f', "e", 0) =&gt; "pfe0"</c>. Race is lowercased.
+    /// </summary>
+    public static string BuildPrefix(char flavor, string race, int phenotype)
+        => $"p{flavor}{race.ToLowerInvariant()}{phenotype}";
+
+    /// <summary>
+    /// Resolve a body-part ResRef from an already-built creature prefix, trying in order:
+    /// race-specific → same-gender human → cross-gender race-specific → cross-gender human.
+    /// Returns the first resref for which <paramref name="modelExists"/> is true, with the path
+    /// taken, or <c>null</c> if none resolve. Pure: no IO, no game-data access.
+    /// </summary>
+    /// <param name="prefix">The creature prefix, e.g. <c>pfe0</c> (p + flavor + race + phenotype).</param>
+    /// <param name="partType">Body part type, e.g. <c>head</c>, <c>chest</c>, <c>bicepl</c>.</param>
+    /// <param name="partNumber">Part variant number (1-based; 0 is handled by the caller).</param>
+    /// <param name="modelExists">Predicate: does a model with this ResRef exist/load?</param>
+    public static PartResolution? ResolvePart(
+        string prefix, string partType, byte partNumber, Func<string, bool> modelExists)
+    {
+        if (string.IsNullOrEmpty(prefix) || prefix.Length < 2)
+            return null;
+
+        var flavor = prefix[1];                 // 'm' or 'f'
+        var crossFlavor = flavor == 'f' ? 'm' : 'f';
+        var racePheno = prefix.Substring(2);    // race + phenotype, e.g. "e0"
+
+        // Each candidate is (resref, path); deduped so a human creature doesn't probe the human
+        // reference set twice (its race step IS the human step).
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (candidatePrefix, path) in EnumerateCandidates(flavor, crossFlavor, racePheno))
+        {
+            var resRef = MdlPartNaming.BuildBodyPartName(candidatePrefix, partType, partNumber);
+            if (!seen.Add(resRef))
+                continue;
+            if (modelExists(resRef))
+                return new PartResolution(resRef, path);
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<(string Prefix, PartResolutionPath Path)> EnumerateCandidates(
+        char flavor, char crossFlavor, string racePheno)
+    {
+        // 1. Race-specific, same gender.
+        yield return ($"p{flavor}{racePheno}", PartResolutionPath.RaceSpecific);
+        // 2. Same-gender human reference set.
+        yield return ($"p{flavor}h0", PartResolutionPath.SameGenderHuman);
+        // 3. Cross-gender, race-specific (single-variant appearances authored in one gender).
+        yield return ($"p{crossFlavor}{racePheno}", PartResolutionPath.CrossGender);
+        // 4. Cross-gender human reference set (last resort).
+        yield return ($"p{crossFlavor}h0", PartResolutionPath.CrossGenderHuman);
+    }
+}

--- a/Quartermaster/Quartermaster/Services/ModelService.cs
+++ b/Quartermaster/Quartermaster/Services/ModelService.cs
@@ -217,16 +217,30 @@ public class ModelService
         // legs AND have no robe to replace them — an empty render (the dana/pmo0 case).
         if (robePartNumber > 0)
             AppendPart(parts, basePrefix, "robe", robePartNumber);
-        bool robeActive = parts.Any(p => p.PartType.Equals("robe", System.StringComparison.OrdinalIgnoreCase));
+        var robeEntry = parts.FirstOrDefault(p => p.PartType.Equals("robe", System.StringComparison.OrdinalIgnoreCase));
+        bool robeActive = robeEntry.ResRef != null;
         if (robePartNumber > 0 && !robeActive)
             UnifiedLogger.LogApplication(LogLevel.WARN,
                 $"LoadPartBasedCreatureModel: robe #{robePartNumber} did not resolve — keeping body parts (no suppression)");
+
+        // #2541 Phase 2: only suppress the creature's arm parts if the robe supplies RENDERABLE
+        // arm geometry. Robes like pfh0_robe005 (Dana) have Render=false arm trimeshes and an
+        // armless torso+legs skin — suppressing the creature arms there leaves the creature with
+        // no arms (#2398/#2116). Torso/legs are always suppressed when a robe is active.
+        bool robeHasRenderableArms = true;
+        if (robeActive)
+        {
+            robeHasRenderableArms = RobeArmGeometry.HasRenderableArmGeometry(LoadModel(robeEntry.ResRef));
+            if (!robeHasRenderableArms)
+                UnifiedLogger.LogApplication(LogLevel.INFO,
+                    $"LoadPartBasedCreatureModel: robe '{robeEntry.ResRef}' has no renderable arm geometry — keeping creature arms");
+        }
 
         // A robe is a near-complete posed body covering torso/pelvis/limbs; skip those individual
         // parts when a robe actually loaded — loading them additively causes z-fighting and gaps.
         void AddPart(string partType, byte partNumber)
         {
-            if (RobePartSuppression.IsSuppressedByRobe(partType, robeActive))
+            if (RobePartSuppression.IsSuppressedByRobe(partType, robeActive, robeHasRenderableArms))
             {
                 UnifiedLogger.LogApplication(LogLevel.INFO,
                     $"LoadPartBasedCreatureModel: skipping '{partType}' (covered by robe #{robePartNumber})");

--- a/Quartermaster/Quartermaster/Services/ModelService.cs
+++ b/Quartermaster/Quartermaster/Services/ModelService.cs
@@ -46,12 +46,15 @@ public class ModelService
 
     /// <summary>
     /// Build the base model prefix for a part-based creature.
-    /// Format: p{gender}{race}{phenotype} (e.g., "pfo0" = playable female, race O, phenotype 0)
+    /// Format: p{gender}{race}{phenotype} (e.g., "pfo0" = playable female, race O, phenotype 0).
+    /// Gender resolves via <see cref="CreatureModelResolver.ResolveGenderFlavors"/> — every value
+    /// other than 1 (Female) uses the male flavor, since NWN ships no other body-model flavors;
+    /// the cross-gender fallback in <see cref="AppendPart"/> covers single-variant content (#2541).
     /// </summary>
     internal static string BuildModelPrefix(int gender, string race, int phenotype)
     {
-        var genderChar = gender == 1 ? 'f' : 'm';
-        return $"p{genderChar}{race.ToLowerInvariant()}{phenotype}";
+        var flavor = CreatureModelResolver.ResolveGenderFlavors(gender)[0];
+        return CreatureModelResolver.BuildPrefix(flavor, race, phenotype);
     }
 
     /// <summary>
@@ -345,9 +348,11 @@ public class ModelService
     }
 
     /// <summary>
-    /// Resolve a body part ResRef with race-specific lookup first, falling back to human
-    /// (pmh0/pfh0). Skips parts with partNumber=0 (none/invisible). Adds the resolved
-    /// (partType, resRef) tuple to the parts list if a model file exists.
+    /// Resolve a body part ResRef through the data-driven fallback chain (#2541):
+    /// race-specific → same-gender human → cross-gender race-specific → cross-gender human.
+    /// Skips parts with partNumber=0 (none/invisible). Adds the resolved (partType, resRef) tuple
+    /// to the parts list if any model file exists, logging which fallback path fired so custom
+    /// content authors can see when a part missed its own race/gender model.
     /// </summary>
     private void AppendPart(List<(string PartType, string ResRef)> parts, string basePrefix, string partType, byte partNumber)
     {
@@ -357,33 +362,25 @@ public class ModelService
             return;
         }
 
-        var raceResRef = MdlPartNaming.BuildBodyPartName(basePrefix, partType, partNumber);
-        if (LoadModel(raceResRef) != null)
+        var resolution = CreatureModelResolver.ResolvePart(
+            basePrefix, partType, partNumber, resRef => LoadModel(resRef) != null);
+
+        if (resolution == null)
         {
-            parts.Add((partType, raceResRef));
+            var attempted = MdlPartNaming.BuildBodyPartName(basePrefix, partType, partNumber);
+            UnifiedLogger.LogApplication(LogLevel.WARN,
+                $"AppendPart: '{attempted}' not found (no race/human/cross-gender fallback resolved)");
             return;
         }
 
-        // Human fallback (pmh0/pfh0). NWN shares many body part models across races
-        // using the human models as the default reference set.
-        if (basePrefix.Length >= 2)
+        if (resolution.Path != PartResolutionPath.RaceSpecific)
         {
-            var genderChar = basePrefix[1];
-            var humanPrefix = $"p{genderChar}h0";
-            if (humanPrefix != basePrefix)
-            {
-                var humanResRef = MdlPartNaming.BuildBodyPartName(humanPrefix, partType, partNumber);
-                if (LoadModel(humanResRef) != null)
-                {
-                    UnifiedLogger.LogApplication(LogLevel.INFO,
-                        $"AppendPart: using human fallback '{humanResRef}' for '{raceResRef}'");
-                    parts.Add((partType, humanResRef));
-                    return;
-                }
-            }
+            var attempted = MdlPartNaming.BuildBodyPartName(basePrefix, partType, partNumber);
+            UnifiedLogger.LogApplication(LogLevel.INFO,
+                $"AppendPart: '{attempted}' missing — using {resolution.Path} fallback '{resolution.ResRef}'");
         }
 
-        UnifiedLogger.LogApplication(LogLevel.WARN, $"AppendPart: '{raceResRef}' not found (no human fallback either)");
+        parts.Add((partType, resolution.ResRef));
     }
 
     /// <summary>

--- a/Quartermaster/Quartermaster/Services/RobeArmGeometry.cs
+++ b/Quartermaster/Quartermaster/Services/RobeArmGeometry.cs
@@ -1,0 +1,102 @@
+using System;
+using Radoub.Formats.Mdl;
+
+namespace Quartermaster.Services;
+
+/// <summary>
+/// Inspects a robe MDL for RENDERABLE arm geometry (#2541 Phase 2). Some robe variants
+/// (e.g. <c>pfh0_robe005</c> — Dana) author their bicep/forearm/hand bone trimeshes as
+/// <c>Render=false</c> and ship only a torso+legs skin with no arm-weighted vertices. When
+/// <see cref="RobePartSuppression"/> strips the creature's own arm parts on the assumption the
+/// robe replaces them, those creatures lose their arms entirely (#2398/#2116).
+///
+/// This predicate lets suppression keep the creature's arm parts when, and only when, the robe
+/// supplies no renderable arm geometry. It is a narrow, evidence-driven carve-out — NOT a general
+/// spatial coverage probe (the reference engines replace the whole body rather than compositing,
+/// so blanket suppression of torso/legs stays the default). For robes that DO render arms
+/// (<c>pfh0_robe186</c>: Render=true arm trimeshes; long-sleeve skins weighted to arm bones) it
+/// returns true and suppression behaves exactly as before — no duplicate arms.
+/// </summary>
+public static class RobeArmGeometry
+{
+    // Substrings identifying an arm-region bone/mesh name (case-insensitive). Aurora arm bones are
+    // lbicep_g/rbicep_g, lforearm_g/rforearm_g, lhand_g/rhand_g, lshoulder_g/rshoulder_g.
+    private static readonly string[] ArmKeywords = { "bicep", "forearm", "hand", "shoul" };
+
+    /// <summary>
+    /// True if <paramref name="robe"/> provides arm coverage. Conservative by design — it returns
+    /// true (suppress creature arms) for everything EXCEPT the specific armless signature, so the
+    /// carve-out stays narrow and blanket suppression remains the default:
+    ///
+    /// <list type="bullet">
+    /// <item>A Render=true arm bone trimesh (<c>*bicep_g</c>/<c>*forearm_g</c>/<c>*hand_g</c>) →
+    /// renders arms directly (e.g. <c>pfh0_robe186</c>).</item>
+    /// <item>A skin mesh weighted to an arm bone → its surface deforms with and covers the arms.</item>
+    /// <item>A renderable rigid <c>Robe</c> trimesh → a full-body drape that visually covers the
+    /// arms even without arm-bone geometry (e.g. <c>pmh0_robe001</c>, X-span 2× the torso).
+    /// Treated as covering to avoid reintroducing duplicate arms.</item>
+    /// </list>
+    ///
+    /// Only the <c>pfh0_robe005</c> signature — the sole renderable surface is a skin weighted to
+    /// torso/legs but NOT arms — reports false, so the creature keeps its own arms (#2398/#2116).
+    /// </summary>
+    public static bool HasRenderableArmGeometry(MdlModel? robe)
+    {
+        var root = robe?.GeometryRoot;
+        if (root == null)
+            return false;
+
+        bool hasRenderableRigidMesh = false;
+        bool hasRenderableSkin = false;
+        bool hasArmCoverage = false;
+
+        void Walk(MdlNode node)
+        {
+            if (node is MdlSkinNode skin)
+            {
+                if (skin.Render && skin.Vertices.Length > 0)
+                {
+                    hasRenderableSkin = true;
+                    foreach (var boneName in skin.BoneNodeNames)
+                    {
+                        if (IsArmName(boneName))
+                            hasArmCoverage = true;
+                    }
+                }
+            }
+            else if (node is MdlTrimeshNode mesh)
+            {
+                if (mesh.Render && mesh.Vertices.Length > 0)
+                {
+                    // A renderable arm bone trimesh covers the arm directly.
+                    if (IsArmName(mesh.Name))
+                        hasArmCoverage = true;
+                    else
+                        // A renderable non-arm-named rigid trimesh is a full-body drape (robe001);
+                        // assume it covers the arms (conservative — keeps blanket suppression).
+                        hasRenderableRigidMesh = true;
+                }
+            }
+
+            foreach (var child in node.Children)
+                Walk(child);
+        }
+        Walk(root);
+
+        // Arms are covered if any explicit arm geometry exists, OR a full-body rigid drape is the
+        // visible surface. Only the skin-only-without-arm-bones case (robe005) returns false.
+        return hasArmCoverage || hasRenderableRigidMesh;
+    }
+
+    private static bool IsArmName(string? name)
+    {
+        if (string.IsNullOrEmpty(name))
+            return false;
+        foreach (var kw in ArmKeywords)
+        {
+            if (name.Contains(kw, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+}

--- a/Quartermaster/Quartermaster/Services/RobePartSuppression.cs
+++ b/Quartermaster/Quartermaster/Services/RobePartSuppression.cs
@@ -18,12 +18,36 @@ namespace Quartermaster.Services;
 /// </summary>
 public static class RobePartSuppression
 {
+    // Parts the robe always replaces when active (torso + legs): the reference engines treat a
+    // robe as a near-total body, so loading these alongside it duplicates geometry.
     private static readonly HashSet<string> RobeCoveredParts = new(StringComparer.OrdinalIgnoreCase)
     {
         "chest", "pelvis", "legl", "legr", "shol", "shor", "bicepl", "bicepr",
         "forel", "forer", "handl", "handr", "shinl", "shinr",
     };
 
-    public static bool IsSuppressedByRobe(string partType, bool robeActive) =>
-        robeActive && !string.IsNullOrEmpty(partType) && RobeCoveredParts.Contains(partType);
+    // Arm-region parts (#2541 Phase 2): suppressed only when the robe supplies RENDERABLE arm
+    // geometry. Some robes (pfh0_robe005 / Dana) have Render=false arm trimeshes and an armless
+    // skin — suppressing these leaves the creature with no arms at all (#2398/#2116).
+    private static readonly HashSet<string> RobeArmParts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "shol", "shor", "bicepl", "bicepr", "forel", "forer", "handl", "handr",
+    };
+
+    /// <summary>
+    /// Whether <paramref name="partType"/> is replaced by an active robe. When the part is an
+    /// arm-region part and <paramref name="robeHasRenderableArms"/> is false, it is NOT suppressed
+    /// (the creature keeps its own arms). Torso/leg parts are always suppressed when a robe is
+    /// active, regardless of the arm signal.
+    /// </summary>
+    public static bool IsSuppressedByRobe(string partType, bool robeActive, bool robeHasRenderableArms = true)
+    {
+        if (!robeActive || string.IsNullOrEmpty(partType) || !RobeCoveredParts.Contains(partType))
+            return false;
+
+        if (!robeHasRenderableArms && RobeArmParts.Contains(partType))
+            return false;
+
+        return true;
+    }
 }

--- a/Radoub.UI/Radoub.UI.Tests/Services/MdlBoneResolverTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/MdlBoneResolverTests.cs
@@ -1,0 +1,85 @@
+using Radoub.Formats.Mdl;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests.Services;
+
+/// <summary>
+/// Tests for MdlBoneResolver (#2541 Phase 1b): the bone-name resolution fallback that lets
+/// part composition attach to a custom skeleton whose bones don't follow the <c>_g</c>
+/// convention, instead of silently grafting the part at the composite root (the creature's feet).
+/// </summary>
+public class MdlBoneResolverTests
+{
+    private static MdlNode Skeleton(params string[] boneNames)
+    {
+        var root = new MdlNode { Name = "rootdummy" };
+        MdlNode parent = root;
+        foreach (var name in boneNames)
+        {
+            var bone = new MdlNode { Name = name };
+            bone.Parent = parent;
+            parent.Children.Add(bone);
+            parent = bone; // chain them so we exercise recursive search
+        }
+        return root;
+    }
+
+    [Fact]
+    public void Resolve_ExactConventionalBone_PreferredFirst()
+    {
+        var root = Skeleton("torso_g", "neck_g", "head_g");
+        var result = MdlBoneResolver.Resolve(root, "head");
+
+        Assert.NotNull(result.Bone);
+        Assert.Equal("head_g", result.Bone!.Name);
+        Assert.False(result.UsedFallback);
+    }
+
+    [Fact]
+    public void Resolve_CustomSkeleton_BestMatchByStem()
+    {
+        // Custom skeleton names the head bone "Head" (no _g). The conventional "head_g" misses;
+        // best-match should still find it by the "head" stem rather than returning null.
+        var root = Skeleton("Torso", "Neck", "Head");
+        var result = MdlBoneResolver.Resolve(root, "head");
+
+        Assert.NotNull(result.Bone);
+        Assert.Equal("Head", result.Bone!.Name);
+        Assert.True(result.UsedFallback);
+    }
+
+    [Fact]
+    public void Resolve_CustomSkeleton_BestMatchForSidedPart()
+    {
+        // "bicepl" -> conventional "lbicep_g". A custom skeleton calls it "L_Bicep".
+        var root = Skeleton("Torso", "L_Bicep", "R_Bicep");
+        var result = MdlBoneResolver.Resolve(root, "bicepl");
+
+        Assert.NotNull(result.Bone);
+        Assert.Equal("L_Bicep", result.Bone!.Name);
+        Assert.True(result.UsedFallback);
+    }
+
+    [Fact]
+    public void Resolve_NoMatch_ReturnsNullBone_NotRoot()
+    {
+        // A skeleton with no head-like bone must NOT silently return the root (feet graft);
+        // it returns a null bone so the caller can log and fall back deliberately.
+        var root = Skeleton("Torso", "Pelvis");
+        var result = MdlBoneResolver.Resolve(root, "head");
+
+        Assert.Null(result.Bone);
+    }
+
+    [Fact]
+    public void Resolve_DoesNotMatchUnrelatedBone()
+    {
+        // "head" must not best-match "headband_g" only if a real head bone is absent — but it
+        // also must not match a clearly-unrelated bone like "pelvis_g".
+        var root = Skeleton("Torso", "Pelvis_g");
+        var result = MdlBoneResolver.Resolve(root, "head");
+
+        Assert.Null(result.Bone);
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/Services/MdlBoneResolverTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/MdlBoneResolverTests.cs
@@ -82,4 +82,28 @@ public class MdlBoneResolverTests
 
         Assert.Null(result.Bone);
     }
+
+    [Fact]
+    public void Resolve_DoesNotSubstringMatchCompoundBone()
+    {
+        // A skeleton with a "headband_g" accessory bone but NO real head bone must NOT graft the
+        // head onto the headband (the substring trap). Exact-stem match is required first.
+        var root = Skeleton("Torso", "headband_g");
+        var result = MdlBoneResolver.Resolve(root, "head");
+
+        Assert.Null(result.Bone);
+    }
+
+    [Fact]
+    public void Resolve_ExactStemBeatsEarlierSubstringMatch()
+    {
+        // "headband" appears BEFORE the real "Head" in traversal order. The matcher must prefer the
+        // exact-stem bone ("Head" -> normalized "head") over the earlier substring hit ("headband").
+        var root = Skeleton("headband", "Head");
+        var result = MdlBoneResolver.Resolve(root, "head");
+
+        Assert.NotNull(result.Bone);
+        Assert.Equal("Head", result.Bone!.Name);
+        Assert.True(result.UsedFallback);
+    }
 }

--- a/Radoub.UI/Radoub.UI.Tests/Services/MdlPartComposerAuthoredPositionTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/MdlPartComposerAuthoredPositionTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Linq;
+using System.Numerics;
+using Radoub.Formats.Common;
+using Radoub.Formats.Mdl;
+using Radoub.TestUtilities.Mocks;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests.Services;
+
+/// <summary>
+/// Tests for #2541 Phase 3: part composition must PRESERVE the authored local Position of a
+/// body-part mesh instead of zeroing it. Real head MDLs author a small nonzero offset on the
+/// trimesh relative to the part root (verified by dump: pmh0_head001g = (0,-0.010,+0.015);
+/// pfh0_head001g danglymesh = (0,-0.0236,-0.0341)); the old <c>Position = Vector3.Zero</c>
+/// discarded it, lifting the head into a visible gap above the neck (#2161).
+/// </summary>
+public class MdlPartComposerAuthoredPositionTests
+{
+    private const float Tolerance = 0.0001f;
+
+    private static MdlModel MakeSkeleton(params (string boneName, Vector3 position)[] bones)
+    {
+        var root = new MdlNode { Name = "skeleton_root", Scale = 1.0f };
+        foreach (var (boneName, position) in bones)
+        {
+            var bone = new MdlNode { Name = boneName, Position = position, Scale = 1.0f, Parent = root };
+            root.Children.Add(bone);
+        }
+        return new MdlModel { Name = "skeleton", GeometryRoot = root, IsBinary = true };
+    }
+
+    /// <summary>Part MDL shaped like a real head part: dummy root at origin, mesh authored at a
+    /// nonzero local offset. <paramref name="makeNode"/> picks trimesh vs danglymesh.</summary>
+    private static MdlModel MakeHeadPart(string name, string meshName, Vector3 meshOffset,
+        Func<MdlTrimeshNode> makeNode)
+    {
+        var root = new MdlNode { Name = $"{name}", Scale = 1.0f };
+        var mesh = makeNode();
+        mesh.Name = meshName;
+        mesh.Position = meshOffset;       // the authored local offset that must survive
+        mesh.Scale = 1.0f;
+        mesh.Vertices = new[] { Vector3.Zero };  // single vertex at mesh-local origin
+        mesh.Faces = Array.Empty<MdlFace>();
+        mesh.Bitmap = "stale";
+        mesh.Parent = root;
+        root.Children.Add(mesh);
+        return new MdlModel { Name = name, GeometryRoot = root, IsBinary = true };
+    }
+
+    private static MockGameDataService Game(params string[] resRefs)
+    {
+        var game = new MockGameDataService(includeSampleData: false);
+        foreach (var r in resRefs)
+            game.SetResource(r, ResourceTypes.Mdl, new byte[] { 0x42 });
+        return game;
+    }
+
+    [Theory]
+    [InlineData(false)] // plain trimesh (male head)
+    [InlineData(true)]  // danglymesh (female head) — must be handled identically
+    public void Compose_PreservesAuthoredMeshOffset_UnderBone(bool dangly)
+    {
+        var bonePos = new Vector3(0, 0, 1.7f);            // head_g world height
+        var authored = new Vector3(0, -0.0236f, -0.0341f); // the female-head offset from the dump
+        var skeleton = MakeSkeleton(("head_g", bonePos));
+        var headPart = MakeHeadPart("pfh0_head001", "head_mesh", authored,
+            () => dangly ? new MdlDanglyNode() : new MdlTrimeshNode());
+
+        var composer = new MdlPartComposer(Game("pfh0", "pfh0_head001"),
+            (resRef, _) => resRef switch
+            {
+                "pfh0" => skeleton,
+                "pfh0_head001" => headPart,
+                _ => null,
+            });
+
+        // adjustSeams: false so we test the raw attachment position, not the seam nudge.
+        var result = composer.Compose("pfh0", new[] { ("head", "pfh0_head001") }, adjustSeams: false);
+
+        Assert.NotNull(result);
+        var mesh = result!.GetMeshNodes().Single();
+        Assert.Equal("head_g", mesh.Parent!.Name);
+
+        // The mesh's world position must be bone + authored offset, NOT just the bone (zeroed).
+        var world = MdlPartComposer.GetMeshWorldTransform(mesh);
+        var worldPos = Vector3.Transform(Vector3.Zero, world);
+
+        var expected = bonePos + authored;
+        Assert.Equal(expected.X, worldPos.X, Tolerance);
+        Assert.Equal(expected.Y, worldPos.Y, Tolerance);
+        Assert.Equal(expected.Z, worldPos.Z, Tolerance);
+    }
+
+    [Fact]
+    public void Compose_ChestAuthoredAtOrigin_SeatsExactlyOnBone()
+    {
+        // Regression guard: chest is authored at origin (dump), so preserving its position must
+        // leave it exactly on the bone — the position fix must not move parts that were already 0.
+        var bonePos = new Vector3(0, 0, 1.0f);
+        var skeleton = MakeSkeleton(("torso_g", bonePos));
+        var chestPart = MakeHeadPart("pmh0_chest001", "chest_mesh", Vector3.Zero,
+            () => new MdlTrimeshNode());
+
+        var composer = new MdlPartComposer(Game("pmh0", "pmh0_chest001"),
+            (resRef, _) => resRef switch
+            {
+                "pmh0" => skeleton,
+                "pmh0_chest001" => chestPart,
+                _ => null,
+            });
+
+        var result = composer.Compose("pmh0", new[] { ("chest", "pmh0_chest001") }, adjustSeams: false);
+
+        var mesh = result!.GetMeshNodes().Single();
+        var worldPos = Vector3.Transform(Vector3.Zero, MdlPartComposer.GetMeshWorldTransform(mesh));
+
+        Assert.Equal(bonePos.X, worldPos.X, Tolerance);
+        Assert.Equal(bonePos.Y, worldPos.Y, Tolerance);
+        Assert.Equal(bonePos.Z, worldPos.Z, Tolerance);
+    }
+}

--- a/Radoub.UI/Radoub.UI/Services/MdlPartBoneMap.cs
+++ b/Radoub.UI/Radoub.UI/Services/MdlPartBoneMap.cs
@@ -87,8 +87,12 @@ public static class MdlBoneResolver
         if (exact != null)
             return new BoneResolution(exact, UsedFallback: false);
 
-        // Best-match: strip the "_g" suffix to get the part stem (e.g. "lbicep", "head"),
-        // normalize away separators/case, and look for a bone whose normalized name contains it.
+        // Best-match: strip the "_g" suffix to get the part stem (e.g. "lbicep", "head"), normalize
+        // away separators/case, and match a bone whose normalized name EQUALS that stem. Equality
+        // (not substring containment) so we never mis-attach to a compound bone whose name merely
+        // contains the stem — "head" must not grab "headband_g", "tail" must not grab "ponytail".
+        // Legitimate custom-skeleton renames ("Head"→head, "L_Bicep"→lbicep) normalize to the exact
+        // stem, so equality still resolves them; only accidental superstrings are excluded.
         var stem = Normalize(StripBoneSuffix(conventional));
         if (stem.Length == 0)
             return new BoneResolution(null, UsedFallback: false);
@@ -99,7 +103,7 @@ public static class MdlBoneResolver
 
     private static MdlNode? FindByNormalizedStem(MdlNode node, string stem)
     {
-        if (Normalize(node.Name).Contains(stem, StringComparison.Ordinal))
+        if (string.Equals(Normalize(node.Name), stem, StringComparison.Ordinal))
             return node;
 
         foreach (var child in node.Children)

--- a/Radoub.UI/Radoub.UI/Services/MdlPartBoneMap.cs
+++ b/Radoub.UI/Radoub.UI/Services/MdlPartBoneMap.cs
@@ -1,3 +1,6 @@
+using System;
+using Radoub.Formats.Mdl;
+
 namespace Radoub.UI.Services;
 
 /// <summary>
@@ -51,4 +54,80 @@ public static class MdlPartNaming
     /// </summary>
     public static string BuildBodyPartName(string prefix, string partType, byte partNumber)
         => $"{prefix}_{partType}{partNumber:D3}";
+}
+
+/// <summary>Result of resolving a part type to a skeleton bone: the bone (or null) and whether
+/// a non-conventional best-match fallback fired (so the caller can log custom-skeleton cases).</summary>
+public readonly record struct BoneResolution(MdlNode? Bone, bool UsedFallback);
+
+/// <summary>
+/// Resolve a body-part type to a skeleton bone (#2541 Phase 1b). Tries the conventional
+/// <c>_g</c> bone name first; if a custom skeleton names its bones differently, falls back to a
+/// conservative best-match on the bone-name stem. Returns a null bone (NOT the root) when nothing
+/// matches, so the caller logs and falls back deliberately rather than silently grafting the part
+/// at the composite root (the creature's feet).
+/// </summary>
+public static class MdlBoneResolver
+{
+    /// <summary>
+    /// Resolve <paramref name="partType"/> to a bone under <paramref name="root"/> using the
+    /// default <see cref="MdlPartBoneMap"/> convention.
+    /// </summary>
+    public static BoneResolution Resolve(MdlNode root, string partType)
+        => ResolveByBoneName(root, MdlPartBoneMap.GetBoneNameForPart(partType));
+
+    /// <summary>
+    /// Resolve a bone under <paramref name="root"/> from an already-mapped conventional bone name
+    /// (e.g. the output of an injected part→bone delegate). Exact match first, then best-match by
+    /// the bone-name stem for custom skeletons.
+    /// </summary>
+    public static BoneResolution ResolveByBoneName(MdlNode root, string conventional)
+    {
+        var exact = MdlPartComposer.FindBoneByName(root, conventional);
+        if (exact != null)
+            return new BoneResolution(exact, UsedFallback: false);
+
+        // Best-match: strip the "_g" suffix to get the part stem (e.g. "lbicep", "head"),
+        // normalize away separators/case, and look for a bone whose normalized name contains it.
+        var stem = Normalize(StripBoneSuffix(conventional));
+        if (stem.Length == 0)
+            return new BoneResolution(null, UsedFallback: false);
+
+        var match = FindByNormalizedStem(root, stem);
+        return new BoneResolution(match, UsedFallback: match != null);
+    }
+
+    private static MdlNode? FindByNormalizedStem(MdlNode node, string stem)
+    {
+        if (Normalize(node.Name).Contains(stem, StringComparison.Ordinal))
+            return node;
+
+        foreach (var child in node.Children)
+        {
+            var found = FindByNormalizedStem(child, stem);
+            if (found != null)
+                return found;
+        }
+        return null;
+    }
+
+    private static string StripBoneSuffix(string boneName)
+        => boneName.EndsWith("_g", StringComparison.OrdinalIgnoreCase)
+            ? boneName.Substring(0, boneName.Length - 2)
+            : boneName;
+
+    /// <summary>Lowercase and drop underscores/spaces so "L_Bicep" and "lbicep" compare equal.</summary>
+    private static string Normalize(string s)
+    {
+        if (string.IsNullOrEmpty(s))
+            return string.Empty;
+        var sb = new System.Text.StringBuilder(s.Length);
+        foreach (var ch in s)
+        {
+            if (ch == '_' || ch == ' ' || ch == '-')
+                continue;
+            sb.Append(char.ToLowerInvariant(ch));
+        }
+        return sb.ToString();
+    }
 }

--- a/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
+++ b/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
@@ -245,9 +245,21 @@ public sealed class MdlPartComposer
             // skeleton model. Attaching to / nudging the cached skeleton would corrupt it for the
             // next render (#1735).
             var boneName = _boneNameForPart(partType);
-            MdlNode? bone = compositeModel.GeometryRoot != null
-                ? FindBoneByName(compositeModel.GeometryRoot, boneName)
-                : null;
+            MdlNode? bone = null;
+            if (compositeModel.GeometryRoot != null)
+            {
+                // #2541 Phase 1b: exact _g convention first, then a conservative best-match for
+                // custom skeletons whose bones don't follow the convention — so the part attaches
+                // near the right joint instead of silently grafting at the composite root (feet).
+                var resolution = MdlBoneResolver.ResolveByBoneName(compositeModel.GeometryRoot, boneName);
+                bone = resolution.Bone;
+                if (resolution.UsedFallback && bone != null)
+                    UnifiedLogger.LogApplication(LogLevel.INFO,
+                        $"MdlPartComposer: part '{partType}' bone '{boneName}' not found — best-matched custom-skeleton bone '{bone.Name}'");
+                else if (bone == null)
+                    UnifiedLogger.LogApplication(LogLevel.WARN,
+                        $"MdlPartComposer: part '{partType}' bone '{boneName}' not found on skeleton — grafting at composite root");
+            }
 
             var fallbackPosition = Vector3.Zero;
             if (bone != null)
@@ -451,9 +463,16 @@ public sealed class MdlPartComposer
             // the grafted subtree under that bone so it sits at back/rear height; fall back to the
             // composite root only if the skeleton lacks the bone (grafting at root would otherwise
             // place the wings at the model origin — i.e. the creature's feet).
-            var attachBone = FindBoneByName(root, tag);
+            // #2541 Phase 1c: exact connector-bone match first, then a best-match for custom
+            // skeletons that name the attach bone differently (e.g. "WingBone") before falling
+            // back to the root.
+            var attachResolution = MdlBoneResolver.ResolveByBoneName(root, tag);
+            var attachBone = attachResolution.Bone;
             var attachParent = attachBone ?? root;
-            if (attachBone == null)
+            if (attachResolution.UsedFallback && attachBone != null)
+                UnifiedLogger.LogApplication(LogLevel.INFO,
+                    $"MdlPartComposer.GraftSupermodel: '{tag}' bone not found — best-matched custom-skeleton bone '{attachBone.Name}'");
+            else if (attachBone == null)
                 UnifiedLogger.LogApplication(LogLevel.WARN,
                     $"MdlPartComposer.GraftSupermodel: no '{tag}' attach bone on skeleton — grafting at root (may mis-place)");
 

--- a/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
+++ b/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
@@ -277,20 +277,26 @@ public sealed class MdlPartComposer
                 // across renders; we set Bitmap/Position/Parent on the CLONE only (#1735).
                 var trimesh = CloneTrimeshShallow(sourceTrimesh);
 
-                // Body part MDL files have geometry at local origin. Body part bitmap fields
-                // often contain stale data from reused file structures — derive the texture
-                // name from the part ResRef instead.
+                // Body part bitmap fields often contain stale data from reused file structures —
+                // derive the texture name from the part ResRef instead.
                 trimesh.Bitmap = partResRef;
 
                 if (bone != null)
                 {
-                    trimesh.Position = Vector3.Zero;
+                    // #2161/#2541 Phase 3: PRESERVE the mesh's authored local Position relative to
+                    // its part root (which aligns with the target bone). Real head parts author a
+                    // small offset here (e.g. pfh0_head001g = −34mm Z); the old unconditional
+                    // Position = Vector3.Zero discarded it, lifting the head into a gap above the
+                    // neck. The MDL is the authority — keep its offset. Parts authored at origin
+                    // (chest, neck) are unaffected since their offset is already zero.
                     trimesh.Parent = bone;
                     bone.Children.Add(trimesh);
                 }
                 else
                 {
-                    trimesh.Position = fallbackPosition;
+                    // No bone resolved: graft at the composite root, offset to where the bone would
+                    // have been so the part lands near its joint rather than at the model origin.
+                    trimesh.Position += fallbackPosition;
                     trimesh.Parent = compositeModel.GeometryRoot;
                     compositeModel.GeometryRoot!.Children.Add(trimesh);
                 }


### PR DESCRIPTION
## Summary

Part composition currently encodes BioWare model/bone/gender naming as string literals and human-tuned magic numbers, breaking custom content and underlying the robe-arm (#2398) and head-too-high (#2161) bugs. Plan: `NonPublic/Plans/2026-06-21-2541-plan.md` (verified current — accounts for #2399/#2400 landing).

Three phases in ascending risk, one PR:

- **Phase 1 — Data-driven naming**: gender resolution + cross-gender model fallback; bone-name resolution fallback for custom skeletons; wing/tail attach-bone literal. Unit-testable, no GL.
- **Phase 3 — Preserve authored MDL position (#2161)**: replace unconditional `trimesh.Position = Vector3.Zero` with the part mesh's authored local position (all `MdlTrimeshNode` subtypes). The female head is authored 34 mm below `head_g`; zeroing creates the visible gap.
- **Phase 2 — Robe arms (#2398/#2116), diagnose-first**: blanket suppression is canonical (the engine replaces the body, it does not composite — per nwnexplorer/rollnw/webviewer). Reproduce on `dananaherin.utc`, instrument, fix the confirmed root cause only.

## Related Issues

- Closes #2541
- Relates to #2398, #2116, #2161 (tracked symptoms; close when this lands)

## Checklist

- [ ] Phase 1: data-driven naming + fallbacks
- [ ] Phase 3: preserve authored MDL position
- [ ] Phase 2: robe-arm diagnosis + fix
- [ ] Tests added/updated
- [ ] CHANGELOG updated with date
- [ ] Manual spot-checks (GL preview — FlaUI can't see the surface)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
