### PR TITLE
[Quartermaster] Epic: Mesh transparency — hint-less cutout for CEP creatures (#2540)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Radoub.UI 0.2.29-alpha] - 2026-06-22
 **Branch**: `quartermaster/issue-2540-cutout` | **PR**: #2586
 
-### Epic: Mesh transparency — hint-less cutout for CEP creature meshes (#2540)
+### Epic: Mesh transparency — hint-less alpha for creature meshes (#2540)
 
-- Model-preview meshes with no MDL transparency hint now read their cutout silhouette from the texture's own alpha when it is a genuine 0/255 mask — carving alpha-cutout geometry like the CEP dire-tiger mane (#2507) instead of rendering it as an opaque shell. Opaque and graded bodies are untouched. Shared `Radoub.UI` change (Quartermaster, Relique, Reliquary previews).
+- Model-preview meshes with no MDL transparency hint now derive transparency from the texture itself, matching the Aurora engine: a hard 0/1 alpha mask (fur/mane) is alpha-tested as a cutout, a graded alpha (celestial/zodiac creatures, #2435) is alpha-blended, and a PLT skin is always opaque (its alpha is a palette-layer index, not transparency — keeps humanoid heads/bodies solid). Carves the CEP dire-tiger mane (#2507) and renders the zodiac creatures translucent. Shared `Radoub.UI` change (Quartermaster, Relique, Reliquary previews). Known remainder: a body skin that shares a cutout texture can show black patches (#2588).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Radoub.UI 0.2.29-alpha] - 2026-06-22
-**Branch**: `quartermaster/issue-2540-cutout` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2540-cutout` | **PR**: #2586
 
 ### Epic: Mesh transparency — hint-less cutout for CEP creature meshes (#2540)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.29-alpha] - 2026-06-22
+**Branch**: `quartermaster/issue-2540-cutout` | **PR**: #TBD
+
+### Epic: Mesh transparency — hint-less cutout for CEP creature meshes (#2540)
+
+- Model-preview meshes with no MDL transparency hint now read their cutout silhouette from the texture's own alpha when it is a genuine 0/255 mask — carving alpha-cutout geometry like the CEP dire-tiger mane (#2507) instead of rendering it as an opaque shell. Opaque and graded bodies are untouched. Shared `Radoub.UI` change (Quartermaster, Relique, Reliquary previews).
+
+---
+
 ## [Radoub.Formats 0.2.77-alpha / Radoub.UI 0.2.28-alpha] - 2026-06-22
 **Branch**: `radoub/issue-1765` | **PR**: #2585
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -8,9 +8,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ## [0.2.132-alpha] - 2026-06-22
 **Branch**: `quartermaster/issue-2540-cutout` | **PR**: #2586
 
-### Epic: Mesh transparency — cutout for the dire-tiger mane (#2540)
+### Epic: Mesh transparency — hint-less alpha for creature meshes (#2540)
 
-- Alpha-cutout meshes (e.g. the CEP dire-tiger mane, #2507) now carve their silhouette from the texture's 0/255 alpha mask instead of rendering as an opaque shell, even when the MDL carries no transparency hint. Shared-library change — see root CHANGELOG (`Radoub.UI 0.2.29-alpha`).
+- Hint-less creature meshes derive transparency from the texture, matching the engine: fur/mane masks carve as cutouts (dire-tiger mane #2507), celestial/zodiac creatures blend (#2435), and PLT skin stays opaque (humanoid heads/bodies unaffected). Shared-library change — see root CHANGELOG (`Radoub.UI 0.2.29-alpha`). Known remainder: shared body+mane texture can patch the body (#2588).
 
 ---
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.132-alpha] - 2026-06-22
+**Branch**: `quartermaster/issue-2540-cutout` | **PR**: #TBD
+
+### Epic: Mesh transparency — cutout for the dire-tiger mane (#2540)
+
+- Alpha-cutout meshes (e.g. the CEP dire-tiger mane, #2507) now carve their silhouette from the texture's 0/255 alpha mask instead of rendering as an opaque shell, even when the MDL carries no transparency hint. Shared-library change — see root CHANGELOG (`Radoub.UI 0.2.29-alpha`).
+
+---
+
 ## [0.2.131-alpha] - 2026-06-22
 **Branch**: `quartermaster/issue-2582` | **PR**: #2583
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.132-alpha] - 2026-06-22
-**Branch**: `quartermaster/issue-2540-cutout` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2540-cutout` | **PR**: #2586
 
 ### Epic: Mesh transparency — cutout for the dire-tiger mane (#2540)
 

--- a/Radoub.UI/Radoub.UI.Tests/MeshTransparencyTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/MeshTransparencyTests.cs
@@ -82,23 +82,12 @@ public class MeshTransparencyTests
     }
 
     [Fact]
-    public void HintZero_BinaryProfile_IsCutout()
+    public void HintZero_NeverCutoutOrTransparent()
     {
-        // #2540 hint-less fallthrough: CEP creatures (e.g. the dire-tiger mane, #2507) encode
-        // their cutout only in the texture alpha, never in the MDL. A genuinely BINARY profile
-        // is a real 0/255 cutout mask, so it carves even with no hint. This is safe because the
-        // #2507 trap — an opaque _d body with alpha overloaded as a spec value — classifies as
-        // Opaque or Graded by AnalyzeAlphaProfile, NOT Binary, so it never reaches this branch.
-        Assert.Equal(MaterialMode.Cutout,
+        // The #2507 trap: opaque _d body, alpha overloaded as spec. Hint == 0 => stay opaque
+        // even if the texture has a binary or graded alpha channel.
+        Assert.Equal(MaterialMode.Opaque,
             MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Binary));
-    }
-
-    [Fact]
-    public void HintZero_GradedProfile_IsOpaque()
-    {
-        // Graded alpha with no hint stays opaque on the creature path (matches rollnw's
-        // character-class behavior). The zod rat (#2435) is graded but is gated on in-game UAT
-        // before any creature blend path lands, so it must NOT auto-blend here.
         Assert.Equal(MaterialMode.Opaque,
             MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Graded));
     }

--- a/Radoub.UI/Radoub.UI.Tests/MeshTransparencyTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/MeshTransparencyTests.cs
@@ -82,12 +82,23 @@ public class MeshTransparencyTests
     }
 
     [Fact]
-    public void HintZero_NeverCutoutOrTransparent()
+    public void HintZero_BinaryProfile_IsCutout()
     {
-        // The #2507 trap: opaque _d body, alpha overloaded as spec. Hint == 0 => stay opaque
-        // even if the texture has a binary or graded alpha channel.
-        Assert.Equal(MaterialMode.Opaque,
+        // #2540 hint-less fallthrough: CEP creatures (e.g. the dire-tiger mane, #2507) encode
+        // their cutout only in the texture alpha, never in the MDL. A genuinely BINARY profile
+        // is a real 0/255 cutout mask, so it carves even with no hint. This is safe because the
+        // #2507 trap — an opaque _d body with alpha overloaded as a spec value — classifies as
+        // Opaque or Graded by AnalyzeAlphaProfile, NOT Binary, so it never reaches this branch.
+        Assert.Equal(MaterialMode.Cutout,
             MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Binary));
+    }
+
+    [Fact]
+    public void HintZero_GradedProfile_IsOpaque()
+    {
+        // Graded alpha with no hint stays opaque on the creature path (matches rollnw's
+        // character-class behavior). The zod rat (#2435) is graded but is gated on in-game UAT
+        // before any creature blend path lands, so it must NOT auto-blend here.
         Assert.Equal(MaterialMode.Opaque,
             MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Graded));
     }

--- a/Radoub.UI/Radoub.UI.Tests/MeshTransparencyTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/MeshTransparencyTests.cs
@@ -82,14 +82,29 @@ public class MeshTransparencyTests
     }
 
     [Fact]
-    public void HintZero_NeverCutoutOrTransparent()
+    public void HintZero_AlphaBearingTexture_IsTransparent()
     {
-        // The #2507 trap: opaque _d body, alpha overloaded as spec. Hint == 0 => stay opaque
-        // even if the texture has a binary or graded alpha channel.
-        Assert.Equal(MaterialMode.Opaque,
+        // #2540: the real Aurora engine (xoreos modelnode.cpp:505) blends a hint-less mesh iff its
+        // texture has an alpha channel — isTransparent = hasAlpha. Our production decoder yields a
+        // non-Opaque profile (Binary/Graded) exactly when the texture format carries alpha (DXT5 /
+        // 32-bit TGA); a DXT1/24-bit body decodes to Opaque. So a hint-less mesh with a non-Opaque
+        // profile blends. This carves/blends the dire-tiger mane (#2507) and the zodiac creatures
+        // (#2435), matching Aurora. NOTE: blend, not discard — a near-opaque body (alpha~1) blends
+        // to ~itself (no holes), which is why this is safe where a cutout/discard was not.
+        Assert.Equal(MaterialMode.Transparent,
             MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Binary));
-        Assert.Equal(MaterialMode.Opaque,
+        Assert.Equal(MaterialMode.Transparent,
             MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Graded));
+    }
+
+    [Fact]
+    public void HintZero_OpaqueTexture_IsOpaque()
+    {
+        // DXT1 / 24-bit body has no alpha channel -> Opaque profile -> stays opaque (e.g. the dire
+        // tiger's own DXT1 body texture c_cat_dire). The #2507 "punch holes in _d bodies" trap does
+        // not arise: an overloaded _d spec body decodes Opaque here, so it never blends.
+        Assert.Equal(MaterialMode.Opaque,
+            MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Opaque));
     }
 
     [Fact]

--- a/Radoub.UI/Radoub.UI.Tests/MeshTransparencyTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/MeshTransparencyTests.cs
@@ -82,17 +82,23 @@ public class MeshTransparencyTests
     }
 
     [Fact]
-    public void HintZero_AlphaBearingTexture_IsTransparent()
+    public void HintZero_BinaryProfile_IsCutout()
     {
-        // #2540: the real Aurora engine (xoreos modelnode.cpp:505) blends a hint-less mesh iff its
-        // texture has an alpha channel — isTransparent = hasAlpha. Our production decoder yields a
-        // non-Opaque profile (Binary/Graded) exactly when the texture format carries alpha (DXT5 /
-        // 32-bit TGA); a DXT1/24-bit body decodes to Opaque. So a hint-less mesh with a non-Opaque
-        // profile blends. This carves/blends the dire-tiger mane (#2507) and the zodiac creatures
-        // (#2435), matching Aurora. NOTE: blend, not discard — a near-opaque body (alpha~1) blends
-        // to ~itself (no holes), which is why this is safe where a cutout/discard was not.
-        Assert.Equal(MaterialMode.Transparent,
+        // #2540: a hint-less mesh with a hard 0/1 alpha mask (fur/mane cards — e.g. the dire-tiger
+        // texture shared by the mane AND the body skin, #2507) is alpha-TESTED with depth write,
+        // not order-dependent blended. The engine's default for alpha-bearing meshes is alpha-test
+        // (xoreos keeps GL_ALPHA_TEST on; behavioral ref only, GPLv3, not copied). Routing the many
+        // overlapping mane/body layers through the depth-mask-off blend pass made them sort-fight
+        // into black triangular shards; Cutout is order-independent and renders clean.
+        Assert.Equal(MaterialMode.Cutout,
             MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Binary));
+    }
+
+    [Fact]
+    public void HintZero_GradedProfile_IsTransparent()
+    {
+        // Genuinely graded alpha with no hint (the zodiac/celestial creatures, #2435 — a real soft
+        // see-through body) blends. Distinct from the binary fur mask above.
         Assert.Equal(MaterialMode.Transparent,
             MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Graded));
     }
@@ -102,7 +108,7 @@ public class MeshTransparencyTests
     {
         // DXT1 / 24-bit body has no alpha channel -> Opaque profile -> stays opaque (e.g. the dire
         // tiger's own DXT1 body texture c_cat_dire). The #2507 "punch holes in _d bodies" trap does
-        // not arise: an overloaded _d spec body decodes Opaque here, so it never blends.
+        // not arise: an overloaded _d spec body decodes Opaque here, so it never blends or carves.
         Assert.Equal(MaterialMode.Opaque,
             MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Opaque));
     }

--- a/Radoub.UI/Radoub.UI/Controls/MeshTransparency.cs
+++ b/Radoub.UI/Radoub.UI/Controls/MeshTransparency.cs
@@ -35,9 +35,13 @@ public enum MaterialMode
 /// rollnw renderer (<c>classify_material</c>): <see cref="MaterialMode"/> is derived from the mesh
 /// <c>Alpha</c> controller, the MDL <c>TransparencyHint</c>, and the texture's <see cref="AlphaProfile"/>.
 ///
-/// <para>The decisive rule (the #2507 trap): <c>TransparencyHint == 0</c> never yields Cutout or
-/// Transparent. NWN:EE <c>_d</c> diffuse maps overload the alpha channel as a PBR/spec value, so an
-/// opaque body's alpha must not be consulted — a blanket <c>discard</c> punches holes in it.</para>
+/// <para>Hint-less meshes (#2540): the real Aurora engine blends a mesh with no TransparencyHint
+/// iff its texture has an alpha channel (xoreos <c>modelnode.cpp:505</c>, behavioral reference only
+/// — GPLv3, not copied). Our production decoder yields a non-Opaque <see cref="AlphaProfile"/>
+/// exactly when the texture FORMAT carries alpha (DXT5 / 32-bit TGA); DXT1 / 24-bit bodies decode
+/// fully opaque. So a hint-less non-Opaque mesh blends (mane #2507, zodiac creatures #2435) and a
+/// DXT1 body (incl. the #2507 overloaded-<c>_d</c> trap, which decodes Opaque) stays opaque. This
+/// is blend, not discard: a near-opaque body blends to ~itself, so no holes are punched.</para>
 /// </summary>
 public static class MeshTransparency
 {
@@ -95,9 +99,17 @@ public static class MeshTransparency
         if (alpha < OpaqueAlphaCutoff)
             return MaterialMode.Transparent;
 
-        // No hint => never consult the texture alpha (it may be an overloaded _d/spec channel).
+        // No MDL hint: follow the real Aurora engine (xoreos modelnode.cpp:505 — behavioral
+        // reference only, GPLv3, not copied), which blends a hint-less mesh iff its texture has an
+        // alpha channel: isTransparent = hasAlpha. Our production decoder (TextureService) yields a
+        // non-Opaque profile exactly when the texture FORMAT carries alpha (DXT5 / 32-bit TGA);
+        // a DXT1/24-bit body decodes fully opaque -> Opaque profile. So "profile != Opaque" is our
+        // hasAlpha. This blends the dire-tiger mane (#2507) and the zodiac/celestial creatures
+        // (#2435), matching Aurora, while DXT1 bodies (incl. the #2507 _d-spec trap) stay opaque.
+        // Blend (not discard): a near-opaque body (alpha~1) blends to ~itself, so the ~145 DXT5
+        // animal bodies that classify non-Opaque render visually opaque with no holes.
         if (transparencyHint <= 0)
-            return MaterialMode.Opaque;
+            return profile == AlphaProfile.Opaque ? MaterialMode.Opaque : MaterialMode.Transparent;
 
         // Hint set: the alpha channel is real; its profile decides cutout vs blend.
         return profile switch

--- a/Radoub.UI/Radoub.UI/Controls/MeshTransparency.cs
+++ b/Radoub.UI/Radoub.UI/Controls/MeshTransparency.cs
@@ -35,12 +35,9 @@ public enum MaterialMode
 /// rollnw renderer (<c>classify_material</c>): <see cref="MaterialMode"/> is derived from the mesh
 /// <c>Alpha</c> controller, the MDL <c>TransparencyHint</c>, and the texture's <see cref="AlphaProfile"/>.
 ///
-/// <para>The decisive rule (the #2507 trap): a <c>TransparencyHint == 0</c> mesh is carved as a
-/// Cutout only when its texture is a genuine 0/255 <see cref="AlphaProfile.Binary"/> mask (the
-/// CEP dire-tiger mane convention, #2540). NWN:EE <c>_d</c> diffuse maps overload the alpha channel
-/// as a PBR/spec value, but those classify as <see cref="AlphaProfile.Opaque"/> or
-/// <see cref="AlphaProfile.Graded"/> — never Binary — so an opaque body is never holed. A hint-less
-/// Graded mesh stays Opaque (the zod-rat #2435 blend case is gated on in-game verification).</para>
+/// <para>The decisive rule (the #2507 trap): <c>TransparencyHint == 0</c> never yields Cutout or
+/// Transparent. NWN:EE <c>_d</c> diffuse maps overload the alpha channel as a PBR/spec value, so an
+/// opaque body's alpha must not be consulted — a blanket <c>discard</c> punches holes in it.</para>
 /// </summary>
 public static class MeshTransparency
 {
@@ -98,19 +95,9 @@ public static class MeshTransparency
         if (alpha < OpaqueAlphaCutoff)
             return MaterialMode.Transparent;
 
-        // No MDL hint: CEP creatures encode cutout/transparency only in the texture alpha, not
-        // the MDL (#2540) — e.g. the dire-tiger mane (#2507) has Hint=0 on every mesh. A genuinely
-        // BINARY profile is a real 0/255 cutout mask, so it carves even hint-less. This is safe
-        // because the #2507 trap (an opaque _d body whose alpha is overloaded as a spec value)
-        // classifies as Opaque or Graded by AnalyzeAlphaProfile, never Binary, so it cannot reach
-        // Cutout here. A Graded profile stays Opaque on the creature path (matches rollnw's
-        // character-class behavior); the zod rat (#2435) blend case is gated on in-game UAT.
+        // No hint => never consult the texture alpha (it may be an overloaded _d/spec channel).
         if (transparencyHint <= 0)
-        {
-            return profile == AlphaProfile.Binary
-                ? MaterialMode.Cutout
-                : MaterialMode.Opaque;
-        }
+            return MaterialMode.Opaque;
 
         // Hint set: the alpha channel is real; its profile decides cutout vs blend.
         return profile switch

--- a/Radoub.UI/Radoub.UI/Controls/MeshTransparency.cs
+++ b/Radoub.UI/Radoub.UI/Controls/MeshTransparency.cs
@@ -109,7 +109,18 @@ public static class MeshTransparency
         // Blend (not discard): a near-opaque body (alpha~1) blends to ~itself, so the ~145 DXT5
         // animal bodies that classify non-Opaque render visually opaque with no holes.
         if (transparencyHint <= 0)
-            return profile == AlphaProfile.Opaque ? MaterialMode.Opaque : MaterialMode.Transparent;
+            return profile switch
+            {
+                // Binary 0/1 mask (fur/mane cards like the dire tiger's shared body+mane texture):
+                // alpha-TEST with depth write, NOT order-dependent blend. The engine's default for
+                // alpha-bearing meshes is alpha-test (xoreos keeps GL_ALPHA_TEST on); routing these
+                // through the depth-mask-off blend pass makes the many overlapping mane/body layers
+                // sort-fight into black triangular shards. Cutout is order-independent -> clean.
+                AlphaProfile.Binary => MaterialMode.Cutout,
+                // Genuinely graded alpha (the zodiac/celestial creatures, #2435): a real soft blend.
+                AlphaProfile.Graded => MaterialMode.Transparent,
+                _ => MaterialMode.Opaque,
+            };
 
         // Hint set: the alpha channel is real; its profile decides cutout vs blend.
         return profile switch

--- a/Radoub.UI/Radoub.UI/Controls/MeshTransparency.cs
+++ b/Radoub.UI/Radoub.UI/Controls/MeshTransparency.cs
@@ -35,9 +35,12 @@ public enum MaterialMode
 /// rollnw renderer (<c>classify_material</c>): <see cref="MaterialMode"/> is derived from the mesh
 /// <c>Alpha</c> controller, the MDL <c>TransparencyHint</c>, and the texture's <see cref="AlphaProfile"/>.
 ///
-/// <para>The decisive rule (the #2507 trap): <c>TransparencyHint == 0</c> never yields Cutout or
-/// Transparent. NWN:EE <c>_d</c> diffuse maps overload the alpha channel as a PBR/spec value, so an
-/// opaque body's alpha must not be consulted — a blanket <c>discard</c> punches holes in it.</para>
+/// <para>The decisive rule (the #2507 trap): a <c>TransparencyHint == 0</c> mesh is carved as a
+/// Cutout only when its texture is a genuine 0/255 <see cref="AlphaProfile.Binary"/> mask (the
+/// CEP dire-tiger mane convention, #2540). NWN:EE <c>_d</c> diffuse maps overload the alpha channel
+/// as a PBR/spec value, but those classify as <see cref="AlphaProfile.Opaque"/> or
+/// <see cref="AlphaProfile.Graded"/> — never Binary — so an opaque body is never holed. A hint-less
+/// Graded mesh stays Opaque (the zod-rat #2435 blend case is gated on in-game verification).</para>
 /// </summary>
 public static class MeshTransparency
 {
@@ -95,9 +98,19 @@ public static class MeshTransparency
         if (alpha < OpaqueAlphaCutoff)
             return MaterialMode.Transparent;
 
-        // No hint => never consult the texture alpha (it may be an overloaded _d/spec channel).
+        // No MDL hint: CEP creatures encode cutout/transparency only in the texture alpha, not
+        // the MDL (#2540) — e.g. the dire-tiger mane (#2507) has Hint=0 on every mesh. A genuinely
+        // BINARY profile is a real 0/255 cutout mask, so it carves even hint-less. This is safe
+        // because the #2507 trap (an opaque _d body whose alpha is overloaded as a spec value)
+        // classifies as Opaque or Graded by AnalyzeAlphaProfile, never Binary, so it cannot reach
+        // Cutout here. A Graded profile stays Opaque on the creature path (matches rollnw's
+        // character-class behavior); the zod rat (#2435) blend case is gated on in-game UAT.
         if (transparencyHint <= 0)
-            return MaterialMode.Opaque;
+        {
+            return profile == AlphaProfile.Binary
+                ? MaterialMode.Cutout
+                : MaterialMode.Opaque;
+        }
 
         // Hint set: the alpha channel is real; its profile decides cutout vs blend.
         return profile switch

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
@@ -90,9 +90,19 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
         public Vector3 Centroid;
     }
 
-    // Discard cutoff for Cutout meshes (#2540). 0.5 matches rollnw's default; mid-grey alpha
-    // splits cleanly into kept/discarded for a hard silhouette.
-    private const float CutoutAlphaThreshold = 0.5f;
+    // Discard cutoff for Cutout meshes (#2540). The real engine alpha-tests at GL_GREATER 0.1
+    // (xoreos modelnode.cpp:440, behavioral ref only — GPLv3, not copied), keeping the soft fur
+    // tips of a mane/fur card instead of carving them away. 0.5 (rollnw's hard-silhouette default)
+    // discarded the wispy upper-mane fragments and left black triangular voids behind them; 0.1
+    // keeps the wisps, matching the in-game dire-tiger mane.
+    private const float CutoutAlphaThreshold = 0.1f;
+
+    // Alpha-test floor applied to Transparent meshes during the blend pass (#2540). The engine
+    // keeps GL_ALPHA_TEST on at GL_GREATER 0.1 while blending (xoreos modelnode.cpp:440/770,
+    // behavioral ref only — GPLv3, not copied), so near-zero-alpha fur/mane texels are discarded
+    // before they write colour or sort as ghost layers. This removes the zod-rat emitter
+    // show-through and the dire-tiger mane gaps while still blending the soft fur edges.
+    private const float TransparentAlphaFloor = 0.1f;
 
     private MdlModel? _model;
     private TextureService? _textureService;
@@ -1212,6 +1222,7 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
 
             _shaderManager!.SetUniformInt("meshMode", (int)mode);
             _shaderManager!.SetUniformFloat("alphaThreshold", CutoutAlphaThreshold);
+            _shaderManager!.SetUniformFloat("transparentAlphaFloor", TransparentAlphaFloor);
             _shaderManager!.SetUniformFloat("meshAlpha", drawCall.MeshAlpha);
 
             if (hasTexture)
@@ -1234,15 +1245,20 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
             }
         }
 
-        // Pass 1: opaque + cutout meshes (depth write on, no blend). Defer Transparent meshes
-        // to a sorted blend pass so they composite correctly back-to-front (#2540).
+        // Pass 1: opaque + cutout meshes, depth write ON. Blend is enabled so cutout meshes
+        // (#2540) composite their kept soft fur tips by alpha instead of drawing them as opaque
+        // dark texels (the black mane spots) — depth write stays on so overlapping mane cards are
+        // order-independent and do not sort-fight into shards. Opaque meshes output alpha 1.0, so
+        // blending is a visual no-op for them. Transparent meshes defer to the sorted pass 2.
+        _gl.Enable(EnableCap.Blend);
+        _gl.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
         var transparentCalls = new List<MeshDrawCall>();
         foreach (var drawCall in _meshDrawCalls)
         {
             if (drawCall.IndexCount == 0) continue;
 
             // Route Transparent meshes to pass 2 without drawing them here — pass 1 must not
-            // draw blended geometry (it would write depth and occlude other transparent layers).
+            // draw depth-mask-off blended geometry (it would occlude other transparent layers).
             if (ResolveDrawCall(drawCall).mode == MaterialMode.Transparent)
             {
                 transparentCalls.Add(drawCall);
@@ -1250,6 +1266,7 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
             }
             DrawMesh(drawCall);
         }
+        _gl.Disable(EnableCap.Blend);
 
         // Pass 2: transparent meshes, sorted back-to-front, alpha-blended, depth writes off so
         // overlapping translucent layers don't cull each other. Depth TEST stays on so opaque

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
@@ -1071,7 +1071,7 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
         _gl.ClearColor(0.2f, 0.2f, 0.3f, 1.0f);
         _gl.Clear((uint)(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit));
         _gl.Enable(EnableCap.DepthTest);
-        _gl.DepthFunc(DepthFunction.Less);  // Ensure proper depth comparison
+        _gl.DepthFunc(DepthFunction.Less);  // Opaque geometry: strict Less avoids coplanar z-fighting.
         _gl.Viewport(0, 0, (uint)width, (uint)height);
 
         // Check for any GL errors after basic setup
@@ -1245,28 +1245,36 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
             }
         }
 
-        // Pass 1: opaque + cutout meshes, depth write ON. Blend is enabled so cutout meshes
-        // (#2540) composite their kept soft fur tips by alpha instead of drawing them as opaque
-        // dark texels (the black mane spots) — depth write stays on so overlapping mane cards are
-        // order-independent and do not sort-fight into shards. Opaque meshes output alpha 1.0, so
-        // blending is a visual no-op for them. Transparent meshes defer to the sorted pass 2.
-        _gl.Enable(EnableCap.Blend);
-        _gl.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
+        // Pass 1a: opaque meshes only, depth write ON, depth func Less (set above), no blend.
+        // Strict Less is required for normal opaque/part-composited geometry (e.g. armored
+        // humanoids) — LEQUAL there causes coplanar-face z-fighting. Cutout and Transparent meshes
+        // are deferred so they never run under the opaque depth-func.
+        var cutoutCalls = new List<MeshDrawCall>();
         var transparentCalls = new List<MeshDrawCall>();
         foreach (var drawCall in _meshDrawCalls)
         {
             if (drawCall.IndexCount == 0) continue;
-
-            // Route Transparent meshes to pass 2 without drawing them here — pass 1 must not
-            // draw depth-mask-off blended geometry (it would occlude other transparent layers).
-            if (ResolveDrawCall(drawCall).mode == MaterialMode.Transparent)
-            {
-                transparentCalls.Add(drawCall);
-                continue;
-            }
+            var mode = ResolveDrawCall(drawCall).mode;
+            if (mode == MaterialMode.Transparent) { transparentCalls.Add(drawCall); continue; }
+            if (mode == MaterialMode.Cutout) { cutoutCalls.Add(drawCall); continue; }
             DrawMesh(drawCall);
         }
-        _gl.Disable(EnableCap.Blend);
+
+        // Pass 1b: cutout meshes (#2540), depth write ON + blend + depth func LEQUAL. LEQUAL is
+        // scoped to ONLY these fur/mane cards: it lets equal-depth fragments of overlapping cards
+        // both draw so the layered mane fills without dark gaps, while the kept soft tips composite
+        // by alpha (no black opaque texels). Depth write on keeps it order-independent (no shards).
+        // Restored to Less after so it cannot leak into the transparent pass or the next frame.
+        if (cutoutCalls.Count > 0)
+        {
+            _gl.DepthFunc(DepthFunction.Lequal);
+            _gl.Enable(EnableCap.Blend);
+            _gl.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
+            foreach (var drawCall in cutoutCalls)
+                DrawMesh(drawCall);
+            _gl.Disable(EnableCap.Blend);
+            _gl.DepthFunc(DepthFunction.Less);
+        }
 
         // Pass 2: transparent meshes, sorted back-to-front, alpha-blended, depth writes off so
         // overlapping translucent layers don't cull each other. Depth TEST stays on so opaque
@@ -1829,7 +1837,14 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
                 if (texId != 0)
                 {
                     _textureCache[texName] = texId;
-                    _textureAlphaProfile[texName] = MeshTransparency.AnalyzeAlphaProfile(pixels, width, height);
+                    // PLT skin (player/part-based heads, bodies) is opaque by definition (#2540): a
+                    // PLT's "alpha" byte is a palette-LAYER index (skin/hair/tattoo selector), NOT
+                    // transparency. The engine never treats it as transparent — and scanning the
+                    // rendered RGBA would mis-read those palette-derived alphas as a cutout/blend,
+                    // wrongly carving solid humanoid heads (the gnome-head regression). Force Opaque.
+                    _textureAlphaProfile[texName] = isPlt
+                        ? AlphaProfile.Opaque
+                        : MeshTransparency.AnalyzeAlphaProfile(pixels, width, height);
                     if (isPlt) _pltTextureNames.Add(texName);
                     UnifiedLogger.LogApplication(LogLevel.DEBUG, $"  Loaded texture '{texName}' ({width}x{height}) -> texId={texId}, isPlt={isPlt}");
                 }
@@ -1859,7 +1874,11 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
                     if (fallbackId != 0)
                     {
                         _textureCache[modelTexture] = fallbackId;
-                        _textureAlphaProfile[modelTexture] = MeshTransparency.AnalyzeAlphaProfile(px, w, h);
+                        // PLT skin alpha is a palette-layer index, never transparency (#2540) — force
+                        // Opaque so a PLT body/head is never carved or blended (see primary site above).
+                        _textureAlphaProfile[modelTexture] = isPlt
+                            ? AlphaProfile.Opaque
+                            : MeshTransparency.AnalyzeAlphaProfile(px, w, h);
                         if (isPlt) _pltTextureNames.Add(modelTexture);
                         UnifiedLogger.LogApplication(LogLevel.DEBUG,
                             $"  Loaded model fallback texture '{modelTexture}' ({w}x{h}) -> texId={fallbackId}, isPlt={isPlt}");

--- a/Radoub.UI/Radoub.UI/Controls/OpenGLShaderManager.cs
+++ b/Radoub.UI/Radoub.UI/Controls/OpenGLShaderManager.cs
@@ -68,6 +68,9 @@ uniform vec3 flatColor;
 uniform int meshMode;
 uniform float alphaThreshold;
 uniform float meshAlpha;
+// Alpha-test floor for Transparent meshes (#2540): fragments at/below this are discarded before
+// blending, matching the engine's GL_ALPHA_TEST staying on during the transparent pass.
+uniform float transparentAlphaFloor;
 
 // Debug visualisation modes (#2026 investigation):
 //   0 = normal rendering
@@ -146,6 +149,16 @@ void main()
         discard;
     }
 
+    // Transparent (#2540): the real engine renders blended meshes with GL_ALPHA_TEST still
+    // enabled (xoreos modelnode.cpp:770, glAlphaFunc GL_GREATER 0.1 — behavioral ref only,
+    // GPLv3, not copied). Discarding the near-zero-alpha fragments before the blend stops fully
+    // transparent fur/mane texels from writing colour, sorting as ghost layers, or letting
+    // geometry behind a translucent body bleed through (the zod-rat emitter show-through and the
+    // dire-tiger mane gaps). Soft edges (alpha above the floor) still blend.
+    if (meshMode == 2 && (texAlpha * meshAlpha) < transparentAlphaFloor) {
+        discard;
+    }
+
     vec3 result = (ambient + diffuse) * baseColor;
 
     // Gamma correction: NWN textures are sRGB; a mild midtone lift matches the
@@ -153,10 +166,13 @@ void main()
     // PBR _d diffuse maps); 1/1.1 keeps only a slight lift without bleaching (#1762).
     result = pow(result, vec3(1.0 / 1.1));
 
-    // Output alpha (#2540): opaque/cutout write 1.0 (cutout already discarded its holes);
-    // transparent (mode 2) writes the texel alpha scaled by the mesh Alpha controller so the
-    // blend pass (Sprint 4) gets the right coverage.
-    float outAlpha = (meshMode == 2) ? (texAlpha * meshAlpha) : 1.0;
+    // Output alpha (#2540): Opaque (mode 0) writes 1.0. Cutout (mode 1) and Transparent (mode 2)
+    // both write the texel alpha (× mesh Alpha controller). The cutout pass blends with depth-write
+    // ON: discarding below the floor removes the void, while letting the kept soft fur tips
+    // composite by their real alpha stops them rendering as opaque dark texels (the black mane
+    // spots). Depth-write on keeps it order-independent so overlapping mane cards do not sort-fight
+    // into shards — this is the engine's alpha-test + alpha-blend combination.
+    float outAlpha = (meshMode == 0) ? 1.0 : (texAlpha * meshAlpha);
     FragColor = vec4(result, outAlpha);
 }
 ";


### PR DESCRIPTION
## Summary

Hint-less mesh transparency for the model preview, matching the Aurora engine (xoreos behavioral reference). A creature mesh with no MDL `transparencyhint` now derives transparency from the texture itself:

- **Fur/mane (hard 0/1 alpha mask)** → alpha-test cutout (0.1 floor, blend kept tips, depth-write on, `LEQUAL` scoped to cutout meshes). Carves the CEP dire-tiger mane (#2507).
- **Graded alpha (celestial/zodiac creatures)** → alpha-blend. Renders the zodiac creatures translucent (#2435).
- **PLT skin** → always opaque. A PLT's alpha is a palette-layer index, not transparency — keeps humanoid heads/bodies solid (fixes the gnome-head regression).

## Why / Investigation

The engine never classifies transparency from raw texture-alpha content; it reads the resource type + material. The systemic fix mirrors that: PLT = opaque by definition, format/profile decides cutout vs blend. Heuristic approaches (mirrored normals, soft-fraction, format-alone) were each tested against the full creature population and rejected. Full trace in `NonPublic/Quartermaster/Research/2026-06-22-2540-actual-transparency-source.md`.

## Tests

- Radoub.UI MeshTransparency: 16/16
- Full suite (Formats + UI + Dictionary + Quartermaster): 4140 passed, 0 failed ✅
- Privacy scan: pass. Code review: clean.
- Visually confirmed in QM: gnome solid, lion solid, zodiac translucent, tiger mane carved.

## Related

- Closes #2507 (dire-tiger mane — mane now carves)
- Relates to #2435 (zodiac/celestial creatures now blend)
- Relates to #2540 (epic)
- Known remainder filed: #2588 (shared body+mane texture can patch the body skin), #2587 (appearance-list UI gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
