### PR TITLE
[Radoub] Sprint: Dependabot Dependency Updates (#2589)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "nbgv": {
-      "version": "3.9.50",
+      "version": "3.10.85",
       "commands": [
         "nbgv"
       ],

--- a/.github/workflows/ci-flake-soak.yml
+++ b/.github/workflows/ci-flake-soak.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0  # NBGV needs full history
 

--- a/.github/workflows/radoub-pr-checks.yml
+++ b/.github/workflows/radoub-pr-checks.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0  # NBGV needs full history
 
@@ -48,7 +48,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
 
@@ -122,7 +122,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
 

--- a/.github/workflows/radoub-release.yml
+++ b/.github/workflows/radoub-release.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
 
@@ -389,7 +389,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
 

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Parse tag
         id: tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Build Infrastructure] - 2026-06-24
+**Branch**: `radoub/issue-2589` | **PR**: #2589
+
+### Sprint: Dependabot Dependency Updates (#2589)
+
+- Bump `actions/checkout` from v6 to v7 across all CI workflows (#2589).
+- Bump `Nerdbank.GitVersioning` and the `nbgv` CLI tool from 3.9.50 to 3.10.85 (#2590, #2591).
+
+Build-time/CI only — no runtime behavior change.
+
+---
+
 ## [Radoub.UI 0.2.30-alpha] - 2026-06-24
 **Branch**: `radoub/issue-2557` | **PR**: #2593
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,7 +41,7 @@
     <PackageVersion Include="WeCantSpell.Hunspell" Version="7.0.1" />
 
     <!-- Versioning -->
-    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.10.85" />
 
     <!-- Misc -->
     <PackageVersion Include="AvaloniaGraphControl" Version="0.7.0" />


### PR DESCRIPTION
## Summary

Consolidated dependabot dependency updates:

| Package | From | To | Risk |
|---------|------|----|------|
| actions/checkout (GH Action) | v6 | v7 | Low |
| Nerdbank.GitVersioning (NuGet) | 3.9.50 | 3.10.85 | Low |
| nbgv (CLI tool) | 3.9.50 | 3.10.85 | Low |

Supersedes dependabot PRs: #2589, #2590, #2591

`Nerdbank.GitVersioning` and `nbgv` are the same package (MSBuild + CLI) and were bumped together to stay in sync. `actions/checkout@v7` is an ESM/major bump that also blocks fork-PR checkout for `pull_request_target`/`workflow_run` (security improvement); applied to all 7 workflow references.

## Test Results

- Build: ✅ 0 errors, 17 warnings (all pre-existing, unrelated to bumps)
- Unit tests: ✅ 6,126 passed, 1 skipped, 0 failed (10 assemblies)
- Integration tests (FlaUI): not run — dependency bumps don't touch UI

## Risk Assessment

All low-risk infrastructure/CI bumps. `nbgv`/`Nerdbank.GitVersioning` are build-time versioning only (no runtime surface). `actions/checkout` is CI-only.

## Checklist

- [x] Build passes
- [x] Unit tests pass
- [x] CHANGELOG updated
- [ ] Close superseded dependabot PRs after merge (#2589, #2590, #2591)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
