### PR TITLE
[Quartermaster] fix: Streaky shading on multi-smoothgroup meshes (#1584 investigation)

### DIFF
--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -8,9 +8,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ## [0.2.133-alpha] - 2026-06-25
 **Branch**: `quartermaster/issue-1584` | **PR**: #2602
 
-### Feature: Tune gamma/contrast in 3D model preview (#1584)
+### Fix: Streaky shading on multi-smoothgroup meshes (#1584 investigation)
 
-- Dark armor/skin no longer washes out to flat gray in the preview — the texture's painted-in shading shows through with deeper blacks, closer to the Aurora toolset. Shared-library change (Radoub.UI shader) — affects all 3D-preview tools.
+- Hands and other multi-smoothgroup meshes that carry valid stored normals no longer render faceted/streaky — they now use their stored normals instead of being recomputed (heads, which lack stored normals, still recompute). Shared-library change (Radoub.UI). Investigation also re-scoped #1584's "gamma/contrast" complaint to a PLT metal-layer shading gap (#2603).
 
 ---
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.133-alpha] - 2026-06-25
+**Branch**: `quartermaster/issue-1584` | **PR**: #TBD
+
+### Feature: Tune gamma/contrast in 3D model preview (#1584)
+
+- Dark armor/skin no longer washes out to flat gray in the preview — the texture's painted-in shading shows through with deeper blacks, closer to the Aurora toolset. Shared-library change (Radoub.UI shader) — affects all 3D-preview tools.
+
+---
+
 ## [0.2.132-alpha] - 2026-06-22
 **Branch**: `quartermaster/issue-2540-cutout` | **PR**: #2586
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.133-alpha] - 2026-06-25
-**Branch**: `quartermaster/issue-1584` | **PR**: #TBD
+**Branch**: `quartermaster/issue-1584` | **PR**: #2602
 
 ### Feature: Tune gamma/contrast in 3D model preview (#1584)
 

--- a/Radoub.UI/Radoub.UI.Tests/MeshNormalSourceTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/MeshNormalSourceTests.cs
@@ -1,0 +1,45 @@
+// Tests for MeshNormalSource (#1584): the normal-source gate must key on whether a usable stored
+// normal set exists, NOT on smoothgroup count. Reproduces the streaky-hand bug where a
+// multi-smoothgroup mesh with valid stored normals was wrongly recomputed.
+
+using Radoub.UI.Controls;
+
+namespace Radoub.UI.Tests;
+
+public class MeshNormalSourceTests
+{
+    [Fact]
+    public void HandWithMultipleSmoothgroupsButValidStoredNormals_UsesStored()
+    {
+        // pmh0_handl001: 186 verts, 186 stored normals, 6 smoothgroups. The old gate recomputed it
+        // (smoothgroup count > 1) and streaked it. It must now use its valid stored normals.
+        Assert.True(MeshNormalSource.UseStoredNormals(vertexCount: 186, storedNormalCount: 186));
+    }
+
+    [Fact]
+    public void HeadWithNoStoredNormals_Recomputes()
+    {
+        // pmh0_head009 / pfh0_head001: stored normals absent (count 0). #2026 recompute must stand.
+        Assert.False(MeshNormalSource.UseStoredNormals(vertexCount: 205, storedNormalCount: 0));
+    }
+
+    [Fact]
+    public void BodyWithSingleSmoothgroupAndStoredNormals_UsesStored()
+    {
+        // pmh0_chest016: 132 verts, 132 stored normals, single smoothgroup — unchanged behaviour.
+        Assert.True(MeshNormalSource.UseStoredNormals(vertexCount: 132, storedNormalCount: 132));
+    }
+
+    [Fact]
+    public void PartialStoredNormalSet_Recomputes()
+    {
+        // A mismatched count is not a usable stored set — recompute rather than index out of range.
+        Assert.False(MeshNormalSource.UseStoredNormals(vertexCount: 100, storedNormalCount: 40));
+    }
+
+    [Fact]
+    public void EmptyMesh_DoesNotUseStored()
+    {
+        Assert.False(MeshNormalSource.UseStoredNormals(vertexCount: 0, storedNormalCount: 0));
+    }
+}

--- a/Radoub.UI/Radoub.UI/Controls/MeshNormalSource.cs
+++ b/Radoub.UI/Radoub.UI/Controls/MeshNormalSource.cs
@@ -1,0 +1,37 @@
+// Decides where a mesh's render normals come from: the MDL's stored per-vertex normals, or a
+// smoothgroup-aware recompute (SmoothGroupNormals). Extracted from ModelPreviewGLControl so the
+// decision is unit-testable without the GL pipeline.
+//
+// History (#2026, #1584):
+//   #2026 added a recompute path for part-based HEADS, whose stored per-vertex normals are
+//   absent/unreliable (2002-era BioWare mirrored-half compiler output). The original gate keyed on
+//   smoothgroup COUNT (`distinctSmoothgroups <= 1`) as a proxy — but that misfired on hands, which
+//   legitimately carry MULTIPLE smoothgroups AND a full, valid set of stored normals. They were
+//   wrongly recomputed and rendered with faceted/streaky shading (#1584 investigation).
+//
+//   The real signal is simply whether the mesh HAS a usable stored normal set. Evidence from the
+//   game models: heads (pmh0_head*, pfh0_head*) have ZERO stored vertex normals, so the recompute
+//   is forced anyway; hands (pmh0_handl001) and bodies carry one normal per vertex. Keying on
+//   presence (not smoothgroup count) keeps the head behaviour identical while letting hands and
+//   multi-smoothgroup bodies use their authored normals.
+
+using Radoub.Formats.Mdl;
+
+namespace Radoub.UI.Controls;
+
+public static class MeshNormalSource
+{
+    /// <summary>
+    /// True when the mesh's stored per-vertex normals should be used as-is; false when normals must
+    /// be recomputed from smoothgroups (the mesh has no usable stored normal set).
+    /// </summary>
+    /// <param name="vertexCount">Mesh vertex count.</param>
+    /// <param name="storedNormalCount">Length of the mesh's stored normal array.</param>
+    public static bool UseStoredNormals(int vertexCount, int storedNormalCount)
+    {
+        // A usable stored set has exactly one normal per vertex. Heads (#2026) have zero stored
+        // normals and fall through to the smoothgroup recompute; hands/bodies have a full set and
+        // use it, regardless of how many smoothgroups the mesh declares (#1584).
+        return vertexCount > 0 && storedNormalCount == vertexCount;
+    }
+}

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
@@ -776,16 +776,14 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
                 TransparencyHint = mesh.TransparencyHint
             };
 
-            // #2026: Pick normal source based on how the mesh encodes hard
-            // edges. Multi-smoothgroup meshes (heads) use SurfaceId bitmasks;
-            // stored per-vertex normals are unreliable BioWare-compiler
-            // output. Single-smoothgroup meshes (bodies) encode hard edges
-            // by duplicating vertices with different stored normals, so the
-            // stored data IS the source of truth.
-            var distinctSmoothgroups = new HashSet<int>();
-            foreach (var face in mesh.Faces) distinctSmoothgroups.Add(face.SurfaceId);
-            bool hasStoredNormals = mesh.Normals != null && mesh.Normals.Length == mesh.Vertices.Length;
-            bool useStoredNormals = distinctSmoothgroups.Count <= 1 && hasStoredNormals;
+            // #2026/#1584: Pick normal source by whether the mesh carries a usable stored normal
+            // set. Heads (pmh0_head*, pfh0_head*) ship with ZERO stored vertex normals — the 2002
+            // BioWare mirrored-half compiler omitted them — so they fall through to the smoothgroup
+            // recompute. Hands and bodies carry one valid normal per vertex and must use it, even
+            // when the mesh declares multiple smoothgroups (the old smoothgroup-count gate wrongly
+            // recomputed hands and rendered them faceted/streaky, #1584).
+            bool useStoredNormals = MeshNormalSource.UseStoredNormals(
+                mesh.Vertices.Length, mesh.Normals?.Length ?? 0);
 
             Vector3[] cornerNormals;
             if (useStoredNormals)


### PR DESCRIPTION
## Summary

Investigation of #1584 ("tune gamma/contrast") found the original gamma framing was a **misdiagnosis**. The real causes are different, and this PR delivers the one fix that is tested and ready now.

**What this PR ships**: a fix for streaky/faceted shading on multi-smoothgroup meshes (hands, bodies). The old normal-source gate keyed on smoothgroup count and wrongly recomputed normals for meshes that carry valid stored normals. Heads (zero stored normals) still recompute, preserving #2026.

## Investigation outcome (#1584 re-scoped)

The "too red / washed / low-contrast" armor was traced — with full evidence — to QM rendering PLT **metal layers** (Metal1/Metal2) flat, with no metallic environment/specular shading. Aurora renders the same Metal2=red as dark gunmetal via an env-map blended under the diffuse; QM's flat palette lookup shows it bright red. Gamma is not the lever.

- Real fix filed as **#2603** (metallic env-map shading for PLT metal layers).
- Full root-cause writeup: `NonPublic/Quartermaster/Research/1584-investigation-notes.md`.
- Gamma/lighting tuning explored during investigation was reverted — not the fix.

## Related

- Relates to #1584 (re-scoped — true fix is #2603)
- #2603 metal-layer metallic shading (the real #1584 successor)
- #2601 missing shoulder/belt armor parts (found during investigation)

## Tests

- `MeshNormalSourceTests` 5/5 + `SmoothGroupNormalsTests` 8/8 = 13/13 pass, no regression ✅
- Radoub.UI builds clean ✅

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
