### PR TITLE
[Radoub] Sprint: Tech-Debt — Tooling, CI & Workflow Hygiene

### DIFF
--- a/.claude/commands/pre-merge.md
+++ b/.claude/commands/pre-merge.md
@@ -32,7 +32,9 @@ This prevents running pre-merge with local changes that aren't reflected in the 
 ### Step 0b: Check for Unpushed Commits
 
 ```bash
-git log origin/$(git branch --show-current)..HEAD --oneline
+# Range syntax (origin/<branch>..HEAD) trips the Bash sandbox path-traversal guard (#2468).
+# Use cherry, which takes two refs as separate args and emits one line per unpushed commit (prefixed '+').
+git cherry -v "origin/$(git branch --show-current)" HEAD
 ```
 
 **If output is not empty**:
@@ -90,7 +92,9 @@ If no PR exists, warn and stop.
 ### Step 2: Analyze Changes
 
 ```bash
-git diff main...HEAD --name-only
+# Triple-dot range (main...HEAD) trips the Bash sandbox path-traversal guard (#2468).
+# Equivalent: diff from the merge-base, computed as a separate two-arg diff.
+git diff --name-only "$(git merge-base main HEAD)" HEAD
 ```
 
 **Determine tool and test scope**:
@@ -109,7 +113,8 @@ git diff main...HEAD --name-only
 
 Check if ANY changed files match UI patterns:
 ```bash
-git diff main...HEAD --name-only | grep -E '\.(axaml|axaml\.cs)$|/Views/|/Controls/|/Dialogs/'
+# See #2468: avoid triple-dot range syntax; diff from the merge-base instead.
+git diff --name-only "$(git merge-base main HEAD)" HEAD | grep -E '\.(axaml|axaml\.cs)$|/Views/|/Controls/|/Dialogs/'
 ```
 
 **UI test auto-trigger rules**:

--- a/.claude/scripts/Refresh-GitHubCache.ps1
+++ b/.claude/scripts/Refresh-GitHubCache.ps1
@@ -167,7 +167,7 @@ $prTotalCount = $prData.data.repository.pullRequests.totalCount
 
 # --- Calculate summary statistics ---
 $labelCounts = @{}
-$toolLabels = @("parley", "quartermaster", "manifest", "fence", "radoub", "Trebuchet")
+$toolLabels = @("parley", "quartermaster", "manifest", "fence", "radoub", "Trebuchet", "relique", "reliquary", "marlinspike")
 $typeLabels = @("bug", "enhancement", "epic", "sprint", "tech-debt", "documentation", "refactor", "testing", "research")
 
 foreach ($issue in $allIssues) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Workflow Tooling] - 2026-06-25
-**Branch**: `radoub/issue-2559` | **PR**: #TBD
+**Branch**: `radoub/issue-2559` | **PR**: #2604
 
 ### Sprint: Tech-Debt — Tooling, CI & Workflow Hygiene (#2559)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Workflow Tooling] - 2026-06-25
+**Branch**: `radoub/issue-2559` | **PR**: #TBD
+
+### Sprint: Tech-Debt — Tooling, CI & Workflow Hygiene (#2559)
+
+- Audit theme-scan baseline drift, 16 → 21 hardcoded values (#2278).
+- Consolidate duplicated/trivial unit tests across suites (#2464).
+- Fix sandbox denial of git range syntax in pre-merge/post-merge (#2468).
+- Evaluate selective GitHub auto-merge for low-UI-risk PRs (#2471).
+- Refresh stale tool-label list in Refresh-GitHubCache (relique/reliquary/marlinspike) (#2473).
+
+---
+
 ## [Radoub.Formats 0.2.78-alpha] - 2026-06-24
 **Branch**: `radoub/issue-2558` | **PR**: #2600
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [Workflow Tooling] - 2026-06-25
+## [Workflow Tooling] - 2026-06-27
 **Branch**: `radoub/issue-2559` | **PR**: #2604
 
 ### Sprint: Tech-Debt — Tooling, CI & Workflow Hygiene (#2559)
 
-- Audit theme-scan baseline drift, 16 → 21 hardcoded values (#2278).
-- Consolidate duplicated/trivial unit tests across suites (#2464).
-- Fix sandbox denial of git range syntax in pre-merge/post-merge (#2468).
-- Evaluate selective GitHub auto-merge for low-UI-risk PRs (#2471).
+- Triage theme-scan to a clean 0 baseline; every hit suppressed with a reasoned `theme-ok` (no real drift found) (#2278).
+- Consolidate unit tests: shared `ToolSettingsServiceTestBase` across 5 tools and ~45 search-provider facts collapsed into theories (#2464).
+- Fix sandbox denial of git range syntax in `/pre-merge` (merge-base/cherry equivalents) (#2468).
 - Refresh stale tool-label list in Refresh-GitHubCache (relique/reliquary/marlinspike) (#2473).
+- Evaluate selective GitHub auto-merge (#2471) — recommendation only; blocked on adding required status checks to the branch ruleset first.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -551,6 +551,12 @@ ls -la d:/LOM/workspace/Radoub/some/path/
 - Backslashes in paths (escaping issues)
 - `cmd /c` commands (quoting problems)
 - `grep` with regex alternation `\|` (use PowerShell search instead)
+- **Git range syntax** (`main...HEAD`, `origin/<branch>..HEAD`) — the dot-dot/triple-dot
+  patterns trip the Bash sandbox path-traversal guard and get denied (#2468). Use non-range
+  equivalents:
+  - `git diff main...HEAD` → `git diff "$(git merge-base main HEAD)" HEAD`
+  - `git log origin/<branch>..HEAD` (list unpushed commits) → `git cherry -v "origin/<branch>" HEAD`
+  - `git rev-list --count origin/<branch>..HEAD` → `git rev-list --count HEAD --not "origin/<branch>"`
 
 ### PowerShell Script Patterns
 

--- a/Fence/Fence.Tests/SettingsServiceTests.cs
+++ b/Fence/Fence.Tests/SettingsServiceTests.cs
@@ -1,162 +1,53 @@
 using MerchantEditor.Services;
+using Radoub.TestUtilities.Bases;
 using Radoub.TestUtilities.Helpers;
 
 namespace Fence.Tests;
 
+/// <summary>
+/// Tests for Fence's SettingsService. The shared singleton/window/recent-files/log-retention
+/// contract lives in <see cref="ToolSettingsServiceTestBase{TService}"/> (#2464); only
+/// Fence-specific behavior (panel widths, visibility, async recent-file validation) is below.
+/// </summary>
 [Collection("SettingsService")]
-public class SettingsServiceTests : IDisposable
+public class SettingsServiceTests : ToolSettingsServiceTestBase<SettingsService>
 {
-    private readonly string _tempDir;
+    protected override string SettingsEnvironmentVariable => "FENCE_SETTINGS_DIR";
+    protected override string ToolDirPrefix => "Fence";
+    protected override string RecentFileExtension => ".utm";
 
-    public SettingsServiceTests()
-    {
-        // Create isolated temp directory for each test
-        _tempDir = Path.Combine(Path.GetTempPath(), "FenceTests", Guid.NewGuid().ToString());
-        Directory.CreateDirectory(_tempDir);
+    protected override SettingsService GetInstance() => SettingsService.Instance;
+    protected override void ResetSingleton() => SingletonTestHelper.ResetSingleton<SettingsService>();
 
-        // Reset singleton and configure via environment variable
-        SingletonTestHelper.ResetSingleton<SettingsService>();
-        SingletonTestHelper.ConfigureSettingsDirectory("FENCE_SETTINGS_DIR", _tempDir);
-    }
+    protected override double GetWindowWidth(SettingsService s) => s.WindowWidth;
+    protected override void SetWindowWidth(SettingsService s, double v) => s.WindowWidth = v;
+    protected override double GetWindowHeight(SettingsService s) => s.WindowHeight;
+    protected override void SetWindowHeight(SettingsService s, double v) => s.WindowHeight = v;
+    protected override IReadOnlyList<string> GetRecentFiles(SettingsService s) => s.RecentFiles;
+    protected override void AddRecentFile(SettingsService s, string path) => s.AddRecentFile(path);
+    protected override int GetMaxRecentFiles(SettingsService s) => s.MaxRecentFiles;
+    protected override void SetMaxRecentFiles(SettingsService s, int v) => s.MaxRecentFiles = v;
+    protected override int GetLogRetentionSessions(SettingsService s) => s.LogRetentionSessions;
+    protected override void SetLogRetentionSessions(SettingsService s, int v) => s.LogRetentionSessions = v;
 
-    public void Dispose()
-    {
-        SingletonTestHelper.ResetSingleton<SettingsService>();
-        SingletonTestHelper.ConfigureSettingsDirectory("FENCE_SETTINGS_DIR", null);
-        try
-        {
-            if (Directory.Exists(_tempDir))
-                Directory.Delete(_tempDir, recursive: true);
-        }
-        catch
-        {
-            // Ignore cleanup errors in tests
-        }
-    }
-
-    [Fact]
-    public void Instance_ReturnsNonNull()
-    {
-        // Act
-        var instance = SettingsService.Instance;
-
-        // Assert
-        Assert.NotNull(instance);
-    }
-
-    [Fact]
-    public void Instance_ReturnsSameInstance()
-    {
-        // Act
-        var instance1 = SettingsService.Instance;
-        var instance2 = SettingsService.Instance;
-
-        // Assert
-        Assert.Same(instance1, instance2);
-    }
-
-    [Fact]
-    public void WindowWidth_ClampedToMinimum()
-    {
-        // Arrange
-        var settings = SettingsService.Instance;
-
-        // Act
-        settings.WindowWidth = 100; // Below minimum
-
-        // Assert
-        Assert.Equal(600, settings.WindowWidth);
-    }
-
-    [Fact]
-    public void WindowHeight_ClampedToMinimum()
-    {
-        // Arrange
-        var settings = SettingsService.Instance;
-
-        // Act
-        settings.WindowHeight = 100; // Below minimum
-
-        // Assert
-        Assert.Equal(400, settings.WindowHeight);
-    }
+    // ---- Fence-specific ----
 
     [Fact]
     public void LeftPanelWidth_ClampedToRange()
     {
-        // Arrange
-        var settings = SettingsService.Instance;
+        var settings = GetInstance();
 
-        // Act & Assert - below minimum
         settings.LeftPanelWidth = 100;
         Assert.Equal(250, settings.LeftPanelWidth);
 
-        // Act & Assert - above maximum
         settings.LeftPanelWidth = 800;
         Assert.Equal(700, settings.LeftPanelWidth);
     }
 
     [Fact]
-    public void RecentFiles_InitiallyEmpty()
-    {
-        // Arrange
-        var settings = SettingsService.Instance;
-
-        // Assert
-        Assert.Empty(settings.RecentFiles);
-    }
-
-    [Fact]
-    public void ClearRecentFiles_EmptiesList()
-    {
-        // Arrange
-        var settings = SettingsService.Instance;
-        var testFile = Path.Combine(_tempDir, "test.utm");
-        File.WriteAllText(testFile, "");
-        settings.AddRecentFile(testFile);
-        Assert.NotEmpty(settings.RecentFiles);
-
-        // Act
-        settings.ClearRecentFiles();
-
-        // Assert
-        Assert.Empty(settings.RecentFiles);
-    }
-
-    [Fact]
-    public void MaxRecentFiles_ClampedToRange()
-    {
-        // Arrange
-        var settings = SettingsService.Instance;
-
-        // Act & Assert - below minimum
-        settings.MaxRecentFiles = 0;
-        Assert.Equal(1, settings.MaxRecentFiles);
-
-        // Act & Assert - above maximum
-        settings.MaxRecentFiles = 50;
-        Assert.Equal(20, settings.MaxRecentFiles);
-    }
-
-    [Fact]
-    public void LogRetentionSessions_ClampedToRange()
-    {
-        // Arrange
-        var settings = SettingsService.Instance;
-
-        // Act & Assert - below minimum
-        settings.LogRetentionSessions = 0;
-        Assert.Equal(1, settings.LogRetentionSessions);
-
-        // Act & Assert - above maximum
-        settings.LogRetentionSessions = 20;
-        Assert.Equal(10, settings.LogRetentionSessions);
-    }
-
-    [Fact]
     public void RightPanelWidth_ClampedToRange()
     {
-        var settings = SettingsService.Instance;
+        var settings = GetInstance();
 
         settings.RightPanelWidth = 100;
         Assert.Equal(250, settings.RightPanelWidth);
@@ -168,7 +59,7 @@ public class SettingsServiceTests : IDisposable
     [Fact]
     public void StoreBrowserPanelWidth_ClampedToRange()
     {
-        var settings = SettingsService.Instance;
+        var settings = GetInstance();
 
         settings.StoreBrowserPanelWidth = 50;
         Assert.Equal(150, settings.StoreBrowserPanelWidth);
@@ -180,7 +71,7 @@ public class SettingsServiceTests : IDisposable
     [Fact]
     public void ItemDetailsPanelWidth_ClampedToRange()
     {
-        var settings = SettingsService.Instance;
+        var settings = GetInstance();
 
         settings.ItemDetailsPanelWidth = 50;
         Assert.Equal(180, settings.ItemDetailsPanelWidth);
@@ -192,23 +83,19 @@ public class SettingsServiceTests : IDisposable
     [Fact]
     public void StoreBrowserPanelVisible_DefaultTrue()
     {
-        var settings = SettingsService.Instance;
-
-        Assert.True(settings.StoreBrowserPanelVisible);
+        Assert.True(GetInstance().StoreBrowserPanelVisible);
     }
 
     [Fact]
     public void ItemDetailsPanelVisible_DefaultTrue()
     {
-        var settings = SettingsService.Instance;
-
-        Assert.True(settings.ItemDetailsPanelVisible);
+        Assert.True(GetInstance().ItemDetailsPanelVisible);
     }
 
     [Fact]
     public void PanelVisible_SetToFalse_Persists()
     {
-        var settings = SettingsService.Instance;
+        var settings = GetInstance();
 
         settings.StoreBrowserPanelVisible = false;
         Assert.False(settings.StoreBrowserPanelVisible);
@@ -218,29 +105,42 @@ public class SettingsServiceTests : IDisposable
     }
 
     [Fact]
+    public void ClearRecentFiles_EmptiesList()
+    {
+        var settings = GetInstance();
+        var testFile = Path.Combine(TestSettingsDir, "test.utm");
+        File.WriteAllText(testFile, "");
+        settings.AddRecentFile(testFile);
+        Assert.NotEmpty(settings.RecentFiles);
+
+        settings.ClearRecentFiles();
+
+        Assert.Empty(settings.RecentFiles);
+    }
+
+    [Fact]
     public async Task ValidateRecentFilesAsync_RemovesMissingFiles()
     {
-        var settings = SettingsService.Instance;
+        var settings = GetInstance();
 
-        // Add a file that exists and one that doesn't
-        var existingFile = Path.Combine(_tempDir, "exists.utm");
+        var existingFile = Path.Combine(TestSettingsDir, "exists.utm");
         File.WriteAllText(existingFile, "");
         settings.AddRecentFile(existingFile);
-        settings.AddRecentFile(Path.Combine(_tempDir, "missing.utm"));
+        settings.AddRecentFile(Path.Combine(TestSettingsDir, "missing.utm"));
 
         await settings.ValidateRecentFilesAsync();
 
         var recent = settings.RecentFiles;
         Assert.Contains(existingFile, recent);
-        Assert.DoesNotContain(Path.Combine(_tempDir, "missing.utm"), recent);
+        Assert.DoesNotContain(Path.Combine(TestSettingsDir, "missing.utm"), recent);
     }
 
     [Fact]
     public async Task ValidateRecentFilesAsync_AllFilesExist_NoChange()
     {
-        var settings = SettingsService.Instance;
-        var file1 = Path.Combine(_tempDir, "file1.utm");
-        var file2 = Path.Combine(_tempDir, "file2.utm");
+        var settings = GetInstance();
+        var file1 = Path.Combine(TestSettingsDir, "file1.utm");
+        var file2 = Path.Combine(TestSettingsDir, "file2.utm");
         File.WriteAllText(file1, "");
         File.WriteAllText(file2, "");
         settings.AddRecentFile(file1);
@@ -254,7 +154,7 @@ public class SettingsServiceTests : IDisposable
     [Fact]
     public async Task ValidateRecentFilesAsync_EmptyList_DoesNotThrow()
     {
-        var settings = SettingsService.Instance;
+        var settings = GetInstance();
 
         var exception = await Record.ExceptionAsync(() => settings.ValidateRecentFilesAsync());
 
@@ -264,14 +164,13 @@ public class SettingsServiceTests : IDisposable
     [Fact]
     public void Settings_PersistAcrossReload()
     {
-        var settings = SettingsService.Instance;
+        var settings = GetInstance();
         settings.LeftPanelWidth = 500;
         settings.RightPanelWidth = 350;
         settings.StoreBrowserPanelVisible = false;
 
-        // Reset and reload
-        SingletonTestHelper.ResetSingleton<SettingsService>();
-        var reloaded = SettingsService.Instance;
+        ResetSingleton();
+        var reloaded = GetInstance();
 
         Assert.Equal(500, reloaded.LeftPanelWidth);
         Assert.Equal(350, reloaded.RightPanelWidth);

--- a/Fence/Fence.Tests/SettingsServiceTests.cs
+++ b/Fence/Fence.Tests/SettingsServiceTests.cs
@@ -33,6 +33,14 @@ public class SettingsServiceTests : ToolSettingsServiceTestBase<SettingsService>
     // ---- Fence-specific ----
 
     [Fact]
+    public void RecentFiles_InitiallyEmpty()
+    {
+        // A freshly-isolated SettingsService must start with no MRU entries
+        // (guards against default seeding or settings-dir isolation bleed).
+        Assert.Empty(GetInstance().RecentFiles);
+    }
+
+    [Fact]
     public void LeftPanelWidth_ClampedToRange()
     {
         var settings = GetInstance();

--- a/Manifest/Manifest.Tests/SettingsServiceTests.cs
+++ b/Manifest/Manifest.Tests/SettingsServiceTests.cs
@@ -1,77 +1,56 @@
-using System.ComponentModel;
 using Manifest.Services;
 using Radoub.Formats.Logging;
+using Radoub.TestUtilities.Bases;
 using Radoub.TestUtilities.Helpers;
 using Xunit;
 
 namespace Manifest.Tests;
 
 /// <summary>
-/// Tests for SettingsService.
-/// Uses isolated temp directory via MANIFEST_SETTINGS_DIR environment variable.
+/// Tests for Manifest's SettingsService. The shared singleton/window/recent-files/log-retention
+/// contract lives in <see cref="ToolSettingsServiceTestBase{TService}"/> (#2464); only
+/// Manifest-specific behavior (corrupt-JSON recovery, full round-trip, tree panel, MRU ordering,
+/// PropertyChanged) is below.
 /// </summary>
-public class SettingsServiceTests : IDisposable
+public class SettingsServiceTests : ToolSettingsServiceTestBase<SettingsService>
 {
-    private readonly string _testSettingsDir;
+    protected override string SettingsEnvironmentVariable => "MANIFEST_SETTINGS_DIR";
+    protected override string ToolDirPrefix => "Manifest";
+    protected override string RecentFileExtension => ".jrl";
+    protected override double ExpectedMinWindowWidth => 400;
+    protected override double ExpectedMinWindowHeight => 300;
 
-    public SettingsServiceTests()
-    {
-        // Create isolated temp directory for each test run
-        _testSettingsDir = Path.Combine(Path.GetTempPath(), $"Manifest_Tests_{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_testSettingsDir);
+    protected override SettingsService GetInstance() => SettingsService.Instance;
+    protected override void ResetSingleton() => SingletonTestHelper.ResetSingleton<SettingsService>();
 
-        // Reset singleton and configure via environment variable
-        SingletonTestHelper.ResetSingleton<SettingsService>();
-        SingletonTestHelper.ConfigureSettingsDirectory("MANIFEST_SETTINGS_DIR", _testSettingsDir);
-    }
+    protected override double GetWindowWidth(SettingsService s) => s.WindowWidth;
+    protected override void SetWindowWidth(SettingsService s, double v) => s.WindowWidth = v;
+    protected override double GetWindowHeight(SettingsService s) => s.WindowHeight;
+    protected override void SetWindowHeight(SettingsService s, double v) => s.WindowHeight = v;
+    protected override IReadOnlyList<string> GetRecentFiles(SettingsService s) => s.RecentFiles;
+    protected override void AddRecentFile(SettingsService s, string path) => s.AddRecentFile(path);
+    protected override int GetMaxRecentFiles(SettingsService s) => s.MaxRecentFiles;
+    protected override void SetMaxRecentFiles(SettingsService s, int v) => s.MaxRecentFiles = v;
+    protected override int GetLogRetentionSessions(SettingsService s) => s.LogRetentionSessions;
+    protected override void SetLogRetentionSessions(SettingsService s, int v) => s.LogRetentionSessions = v;
 
-    public void Dispose()
-    {
-        // Reset singleton and clear env var
-        SingletonTestHelper.ResetSingleton<SettingsService>();
-        SingletonTestHelper.ConfigureSettingsDirectory("MANIFEST_SETTINGS_DIR", null);
-
-        // Clean up temp directory
-        try
-        {
-            if (Directory.Exists(_testSettingsDir))
-                Directory.Delete(_testSettingsDir, recursive: true);
-        }
-        catch
-        {
-            // Ignore cleanup failures
-        }
-    }
-
-    [Fact]
-    public void Instance_ReturnsSameInstance()
-    {
-        var instance1 = SettingsService.Instance;
-        var instance2 = SettingsService.Instance;
-
-        Assert.Same(instance1, instance2);
-    }
+    // ---- Manifest-specific ----
 
     [Fact]
     public void SharedSettings_ReturnsRadoubSettings()
     {
-        var sharedSettings = SettingsService.SharedSettings;
-
-        Assert.NotNull(sharedSettings);
+        Assert.NotNull(SettingsService.SharedSettings);
     }
 
     [Fact]
     public void LoadSettings_CorruptedJson_ReturnsDefaults()
     {
-        // Arrange - write corrupted JSON
-        var settingsFile = Path.Combine(_testSettingsDir, "ManifestSettings.json");
+        var settingsFile = Path.Combine(TestSettingsDir, "ManifestSettings.json");
         File.WriteAllText(settingsFile, "{ invalid json [[[");
 
-        // Act - reset and reload
-        SingletonTestHelper.ResetSingleton<SettingsService>();
-        var service = SettingsService.Instance;
+        ResetSingleton();
+        var service = GetInstance();
 
-        // Assert - should have default values
         Assert.Equal(1000, service.WindowWidth);
         Assert.Equal(700, service.WindowHeight);
     }
@@ -79,8 +58,7 @@ public class SettingsServiceTests : IDisposable
     [Fact]
     public void SaveSettings_RoundTrip_PreservesAllValues()
     {
-        // Arrange
-        var service = SettingsService.Instance;
+        var service = GetInstance();
         service.WindowWidth = 1200;
         service.WindowHeight = 800;
         service.WindowMaximized = true;
@@ -89,11 +67,9 @@ public class SettingsServiceTests : IDisposable
         service.CurrentLogLevel = LogLevel.DEBUG;
         service.SpellCheckEnabled = false;
 
-        // Act - reset and reload
-        SingletonTestHelper.ResetSingleton<SettingsService>();
-        var reloaded = SettingsService.Instance;
+        ResetSingleton();
+        var reloaded = GetInstance();
 
-        // Assert
         Assert.Equal(1200, reloaded.WindowWidth);
         Assert.Equal(800, reloaded.WindowHeight);
         Assert.True(reloaded.WindowMaximized);
@@ -104,29 +80,13 @@ public class SettingsServiceTests : IDisposable
     }
 
     [Fact]
-    public void WindowDimensions_Invalid_UseDefaults()
-    {
-        var service = SettingsService.Instance;
-
-        // WindowWidth minimum is 400
-        service.WindowWidth = 100;
-        Assert.True(service.WindowWidth >= 400);
-
-        // WindowHeight minimum is 300
-        service.WindowHeight = 100;
-        Assert.True(service.WindowHeight >= 300);
-    }
-
-    [Fact]
     public void TreePanelWidth_EnforcesRange()
     {
-        var service = SettingsService.Instance;
+        var service = GetInstance();
 
-        // Minimum is 150
         service.TreePanelWidth = 50;
         Assert.True(service.TreePanelWidth >= 150);
 
-        // Maximum is 600
         service.TreePanelWidth = 800;
         Assert.True(service.TreePanelWidth <= 600);
     }
@@ -134,47 +94,41 @@ public class SettingsServiceTests : IDisposable
     [Fact]
     public void RecentFiles_Cleanup_RemovesMissingFiles()
     {
-        // Arrange - create a temp file then delete it
-        var tempFile = Path.Combine(_testSettingsDir, "test.jrl");
+        var tempFile = Path.Combine(TestSettingsDir, "test.jrl");
         File.WriteAllText(tempFile, "test");
 
-        var service = SettingsService.Instance;
+        var service = GetInstance();
         service.AddRecentFile(tempFile);
         Assert.Contains(tempFile, service.RecentFiles);
 
-        // Delete the file
         File.Delete(tempFile);
 
-        // Act - reset and reload (cleanup happens on load)
-        SingletonTestHelper.ResetSingleton<SettingsService>();
-        var reloaded = SettingsService.Instance;
+        ResetSingleton();
+        var reloaded = GetInstance();
 
-        // Assert - missing file should be removed
         Assert.DoesNotContain(tempFile, reloaded.RecentFiles);
     }
 
     [Fact]
     public void RecentFiles_MaxCount_TrimsList()
     {
-        var service = SettingsService.Instance;
+        var service = GetInstance();
         service.MaxRecentFiles = 3;
 
-        // Create and add more files than max
         for (int i = 0; i < 5; i++)
         {
-            var tempFile = Path.Combine(_testSettingsDir, $"test{i}.jrl");
+            var tempFile = Path.Combine(TestSettingsDir, $"test{i}.jrl");
             File.WriteAllText(tempFile, "test");
             service.AddRecentFile(tempFile);
         }
 
-        // Assert - should only keep MaxRecentFiles
         Assert.True(service.RecentFiles.Count <= 3);
     }
 
     [Fact]
     public void PropertyChanged_Fires_OnValueChange()
     {
-        var service = SettingsService.Instance;
+        var service = GetInstance();
         var changedProperties = new List<string>();
 
         service.PropertyChanged += (sender, e) =>
@@ -183,63 +137,26 @@ public class SettingsServiceTests : IDisposable
                 changedProperties.Add(e.PropertyName);
         };
 
-        // Act
         service.WindowWidth = 1100;
 
-        // Assert
         Assert.Contains("WindowWidth", changedProperties);
-    }
-
-    [Fact]
-    public void LogRetentionSessions_EnforcesRange()
-    {
-        var service = SettingsService.Instance;
-
-        // Minimum is 1
-        service.LogRetentionSessions = 0;
-        Assert.True(service.LogRetentionSessions >= 1);
-
-        // Maximum is 10
-        service.LogRetentionSessions = 100;
-        Assert.True(service.LogRetentionSessions <= 10);
-    }
-
-    [Fact]
-    public void MaxRecentFiles_EnforcesRange()
-    {
-        var service = SettingsService.Instance;
-
-        // Minimum is 1
-        service.MaxRecentFiles = 0;
-        Assert.True(service.MaxRecentFiles >= 1);
-
-        // Maximum is 20
-        service.MaxRecentFiles = 100;
-        Assert.True(service.MaxRecentFiles <= 20);
     }
 
     [Fact]
     public void AddRecentFile_MovesExistingToFront()
     {
-        var service = SettingsService.Instance;
+        var service = GetInstance();
 
-        // Create test files
-        var file1 = Path.Combine(_testSettingsDir, "first.jrl");
-        var file2 = Path.Combine(_testSettingsDir, "second.jrl");
+        var file1 = Path.Combine(TestSettingsDir, "first.jrl");
+        var file2 = Path.Combine(TestSettingsDir, "second.jrl");
         File.WriteAllText(file1, "test");
         File.WriteAllText(file2, "test");
 
-        // Add files
         service.AddRecentFile(file1);
         service.AddRecentFile(file2);
-
-        // file2 should be first now
         Assert.Equal(file2, service.RecentFiles[0]);
 
-        // Re-add file1
         service.AddRecentFile(file1);
-
-        // file1 should now be first
         Assert.Equal(file1, service.RecentFiles[0]);
     }
 }

--- a/Quartermaster/Quartermaster.Tests/GameDataWarnOnceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/GameDataWarnOnceTests.cs
@@ -11,39 +11,36 @@ public class GameDataWarnOnceTests
     }
 
     [Fact]
-    public void Warn_FirstCallEmits_SecondCallSilent()
+    public void Warn_FirstCallRecordsKey_SecondCallStaysRecorded()
     {
-        // Side-effect is to UnifiedLogger; we exercise the dedup logic via the
-        // public surface — repeated calls with the same key must not throw or
-        // re-add to the underlying set.
-        GameDataWarnOnce.Warn("skill_42", "First");
-        GameDataWarnOnce.Warn("skill_42", "Second"); // should be silent
+        Assert.False(GameDataWarnOnce.HasSeen("skill_42"));
 
-        // No exception thrown is the assertion; we just want to confirm the
-        // happy-path doesn't blow up on dup keys.
-        Assert.True(true);
+        GameDataWarnOnce.Warn("skill_42", "First");
+        Assert.True(GameDataWarnOnce.HasSeen("skill_42"));
+
+        // Second call with the same key is a silent no-op; the key remains recorded.
+        GameDataWarnOnce.Warn("skill_42", "Second");
+        Assert.True(GameDataWarnOnce.HasSeen("skill_42"));
     }
 
     [Fact]
-    public void Warn_DifferentKeysEachFire()
+    public void Warn_DistinctKeysAreTrackedIndependently()
     {
-        // Each distinct key gets its own first-fire — no cross-contamination.
         GameDataWarnOnce.Warn("a", "msg-a");
         GameDataWarnOnce.Warn("b", "msg-b");
-        GameDataWarnOnce.Warn("c", "msg-c");
 
-        // Re-warn should still be silent for a,b,c
-        GameDataWarnOnce.Warn("a", "msg-a-2");
-        Assert.True(true);
+        Assert.True(GameDataWarnOnce.HasSeen("a"));
+        Assert.True(GameDataWarnOnce.HasSeen("b"));
+        Assert.False(GameDataWarnOnce.HasSeen("c"));
     }
 
     [Fact]
     public void ResetForTests_ClearsSeenSet()
     {
         GameDataWarnOnce.Warn("reset_key", "first");
+        Assert.True(GameDataWarnOnce.HasSeen("reset_key"));
+
         GameDataWarnOnce.ResetForTests();
-        // After reset, the same key fires again — confirmed by absence of exceptions.
-        GameDataWarnOnce.Warn("reset_key", "first-again");
-        Assert.True(true);
+        Assert.False(GameDataWarnOnce.HasSeen("reset_key"));
     }
 }

--- a/Quartermaster/Quartermaster.Tests/SettingsServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/SettingsServiceTests.cs
@@ -1,90 +1,47 @@
 using Quartermaster.Services;
+using Radoub.TestUtilities.Bases;
 using Radoub.TestUtilities.Helpers;
 
 namespace Quartermaster.Tests;
 
 /// <summary>
-/// Tests for SettingsService.
-/// Uses isolated temp directory to avoid corrupting user settings.
+/// Tests for Quartermaster's SettingsService. The shared singleton/window/recent-files/
+/// log-retention contract lives in <see cref="ToolSettingsServiceTestBase{TService}"/> (#2464);
+/// only Quartermaster-specific behavior (panel width, ValidationLevel) is below.
 /// </summary>
-public class SettingsServiceTests : IDisposable
+public class SettingsServiceTests : ToolSettingsServiceTestBase<SettingsService>
 {
-    private readonly string _testSettingsDir;
+    protected override string SettingsEnvironmentVariable => "QUARTERMASTER_SETTINGS_DIR";
+    protected override string ToolDirPrefix => "Quartermaster";
+    protected override string RecentFileExtension => ".utc";
 
-    public SettingsServiceTests()
-    {
-        // Create isolated temp directory for each test run
-        _testSettingsDir = Path.Combine(Path.GetTempPath(), $"Quartermaster_Tests_{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_testSettingsDir);
+    protected override SettingsService GetInstance() => SettingsService.Instance;
+    protected override void ResetSingleton() => SingletonTestHelper.ResetSingleton<SettingsService>();
 
-        // Reset singleton and configure via environment variable
-        SingletonTestHelper.ResetSingleton<SettingsService>();
-        SingletonTestHelper.ConfigureSettingsDirectory("QUARTERMASTER_SETTINGS_DIR", _testSettingsDir);
-    }
+    protected override double GetWindowWidth(SettingsService s) => s.WindowWidth;
+    protected override void SetWindowWidth(SettingsService s, double v) => s.WindowWidth = v;
+    protected override double GetWindowHeight(SettingsService s) => s.WindowHeight;
+    protected override void SetWindowHeight(SettingsService s, double v) => s.WindowHeight = v;
+    protected override IReadOnlyList<string> GetRecentFiles(SettingsService s) => s.RecentFiles;
+    protected override void AddRecentFile(SettingsService s, string path) => s.AddRecentFile(path);
+    protected override int GetMaxRecentFiles(SettingsService s) => s.MaxRecentFiles;
+    protected override void SetMaxRecentFiles(SettingsService s, int v) => s.MaxRecentFiles = v;
+    protected override int GetLogRetentionSessions(SettingsService s) => s.LogRetentionSessions;
+    protected override void SetLogRetentionSessions(SettingsService s, int v) => s.LogRetentionSessions = v;
 
-    public void Dispose()
-    {
-        // Reset singleton and clear env var
-        SingletonTestHelper.ResetSingleton<SettingsService>();
-        SingletonTestHelper.ConfigureSettingsDirectory("QUARTERMASTER_SETTINGS_DIR", null);
-
-        // Clean up temp directory
-        try
-        {
-            if (Directory.Exists(_testSettingsDir))
-                Directory.Delete(_testSettingsDir, recursive: true);
-        }
-        catch
-        {
-            // Ignore cleanup failures
-        }
-    }
-
-    [Fact]
-    public void Instance_ReturnsSameInstance()
-    {
-        var instance1 = SettingsService.Instance;
-        var instance2 = SettingsService.Instance;
-
-        Assert.Same(instance1, instance2);
-    }
+    // ---- Quartermaster-specific ----
 
     [Fact]
     public void SharedSettings_ReturnsRadoubSettings()
     {
-        var sharedSettings = SettingsService.SharedSettings;
-
-        Assert.NotNull(sharedSettings);
-    }
-
-    [Fact]
-    public void WindowWidth_EnforcesMinimum()
-    {
-        var service = SettingsService.Instance;
-
-        // WindowWidth should not go below 600
-        service.WindowWidth = 100;
-
-        Assert.True(service.WindowWidth >= 600);
-    }
-
-    [Fact]
-    public void WindowHeight_EnforcesMinimum()
-    {
-        var service = SettingsService.Instance;
-
-        // WindowHeight should not go below 400
-        service.WindowHeight = 100;
-
-        Assert.True(service.WindowHeight >= 400);
+        Assert.NotNull(SettingsService.SharedSettings);
     }
 
     [Fact]
     public void LeftPanelWidth_EnforcesRange()
     {
-        var service = SettingsService.Instance;
+        var service = GetInstance();
 
-        // LeftPanelWidth should be between 200 and 600
         service.LeftPanelWidth = 100;
         Assert.True(service.LeftPanelWidth >= 200);
 
@@ -93,83 +50,16 @@ public class SettingsServiceTests : IDisposable
     }
 
     [Fact]
-    public void MaxRecentFiles_EnforcesRange()
-    {
-        var service = SettingsService.Instance;
-
-        // MaxRecentFiles should be between 1 and 20
-        service.MaxRecentFiles = 0;
-        Assert.True(service.MaxRecentFiles >= 1);
-
-        service.MaxRecentFiles = 100;
-        Assert.True(service.MaxRecentFiles <= 20);
-    }
-
-    [Fact]
-    public void RecentFiles_ReturnsListCopy()
-    {
-        var service = SettingsService.Instance;
-
-        var list1 = service.RecentFiles;
-        var list2 = service.RecentFiles;
-
-        // Each call should return a new list (defensive copy)
-        Assert.NotSame(list1, list2);
-    }
-
-    [Fact]
-    public void LogRetentionSessions_EnforcesRange()
-    {
-        var service = SettingsService.Instance;
-
-        // LogRetentionSessions should be between 1 and 10
-        service.LogRetentionSessions = 0;
-        Assert.True(service.LogRetentionSessions >= 1);
-
-        service.LogRetentionSessions = 100;
-        Assert.True(service.LogRetentionSessions <= 10);
-    }
-
-    [Fact]
-    public void AddRecentFile_AddsToList()
-    {
-        var service = SettingsService.Instance;
-
-        // Create a temp file that exists
-        var tempFile = Path.Combine(_testSettingsDir, "test.utc");
-        File.WriteAllText(tempFile, "test");
-
-        service.AddRecentFile(tempFile);
-
-        Assert.Contains(tempFile, service.RecentFiles);
-    }
-
-    [Fact]
-    public void Settings_PersistAcrossReload()
-    {
-        // Set some values
-        var service = SettingsService.Instance;
-        service.WindowWidth = 1000;
-
-        // Reset and reload
-        SingletonTestHelper.ResetSingleton<SettingsService>();
-
-        var reloaded = SettingsService.Instance;
-
-        Assert.Equal(1000, reloaded.WindowWidth);
-    }
-
-    [Fact]
     public void ValidationLevel_LegacyWarningValue_MigratesToNone()
     {
         // #1882: The old Warning=1 tier was removed. Persisted settings with
         // Warning (1) must migrate to None since TN allowed everything CE allows.
-        var settingsFile = Path.Combine(_testSettingsDir, "QuartermasterSettings.json");
+        var settingsFile = Path.Combine(TestSettingsDir, "QuartermasterSettings.json");
         File.WriteAllText(settingsFile,
             "{ \"ValidationLevel\": 1, \"WindowWidth\": 1024, \"WindowHeight\": 768 }");
 
-        SingletonTestHelper.ResetSingleton<SettingsService>();
-        var service = SettingsService.Instance;
+        ResetSingleton();
+        var service = GetInstance();
 
         Assert.Equal(ValidationLevel.None, service.ValidationLevel);
     }
@@ -178,8 +68,8 @@ public class SettingsServiceTests : IDisposable
     public void ValidationLevel_DefaultValue_IsNone()
     {
         // #1882: Default is now None (CE) — permissive, matches prior TN default intent
-        SingletonTestHelper.ResetSingleton<SettingsService>();
-        var service = SettingsService.Instance;
+        ResetSingleton();
+        var service = GetInstance();
 
         Assert.Equal(ValidationLevel.None, service.ValidationLevel);
     }
@@ -187,11 +77,11 @@ public class SettingsServiceTests : IDisposable
     [Fact]
     public void ValidationLevel_StrictValue_PreservedAcrossReload()
     {
-        var service = SettingsService.Instance;
+        var service = GetInstance();
         service.ValidationLevel = ValidationLevel.Strict;
 
-        SingletonTestHelper.ResetSingleton<SettingsService>();
-        var reloaded = SettingsService.Instance;
+        ResetSingleton();
+        var reloaded = GetInstance();
 
         Assert.Equal(ValidationLevel.Strict, reloaded.ValidationLevel);
     }

--- a/Quartermaster/Quartermaster/Services/GameDataWarnOnce.cs
+++ b/Quartermaster/Quartermaster/Services/GameDataWarnOnce.cs
@@ -29,4 +29,9 @@ public static class GameDataWarnOnce
     /// Test seam — clears the set of already-seen keys.
     /// </summary>
     internal static void ResetForTests() => _seen.Clear();
+
+    /// <summary>
+    /// Test seam — true if <paramref name="key"/> has already fired (and would now be silent).
+    /// </summary>
+    internal static bool HasSeen(string key) => _seen.ContainsKey(key);
 }

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.DataLoading.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.DataLoading.cs
@@ -179,9 +179,9 @@ public partial class AppearancePanel
             if (armorColors != null)
             {
                 _modelPreviewGL.SetArmorColors(
-                    armorColors.Value.metal1, armorColors.Value.metal2,
-                    armorColors.Value.cloth1, armorColors.Value.cloth2,
-                    armorColors.Value.leather1, armorColors.Value.leather2);
+                    armorColors.Value.metal1, armorColors.Value.metal2, // theme-ok: nullable-tuple .Value, not Avalonia Colors enum
+                    armorColors.Value.cloth1, armorColors.Value.cloth2, // theme-ok: nullable-tuple .Value, not Avalonia Colors enum
+                    armorColors.Value.leather1, armorColors.Value.leather2); // theme-ok: nullable-tuple .Value, not Avalonia Colors enum
             }
 
             // Texture-source policy (#1758): load the model first, then prefer BIF

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
@@ -313,6 +313,7 @@
                             <Border x:Name="ModelPreviewInputSurface"
                                     Background="Transparent"
                                     Focusable="True"/>
+                            <!-- theme-ok: translucent black scrim must read over arbitrary 3D GL preview content, not theme-recolored -->
                             <Border x:Name="PreviewStateOverlay"
                                     HorizontalAlignment="Right"
                                     VerticalAlignment="Top"

--- a/Quartermaster/Quartermaster/Views/Panels/SpellsPanel.SummaryBuilders.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/SpellsPanel.SummaryBuilders.cs
@@ -770,7 +770,7 @@ public partial class SpellsPanel
                 Text = "No metamagic feats",
                 FontStyle = Avalonia.Media.FontStyle.Italic,
                 Foreground = this.FindResource("SystemControlForegroundBaseMediumBrush") as IBrush
-                             ?? Brushes.Gray,
+                             ?? Brushes.Gray, // theme-ok: fallback when themed brush resource is unavailable
                 FontSize = this.FindResource("FontSizeNormal") as double? ?? 14
             };
             _metaMagicContentPanel.Children.Add(noFeatsText);

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/AreSearchProviderTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/AreSearchProviderTests.cs
@@ -45,88 +45,23 @@ public class AreSearchProviderTests
         Assert.Contains(matches, m => m.Field.Name == "Name" && m.MatchedText == "Waterdeep");
     }
 
-    [Fact]
-    public void Search_FindsTag()
+    [Theory]
+    [InlineData("AR_MARKET", "Tag")]
+    [InlineData("ar_market", "ResRef")]
+    [InlineData("Chapter 2", "Comments")]
+    [InlineData("ar_enter_mrkt", "OnEnter")]
+    [InlineData("ar_exit_mrkt", "OnExit")]
+    [InlineData("ar_hb_mrkt", "OnHeartbeat")]
+    [InlineData("ar_ud_mrkt", "OnUserDefined")]
+    public void Search_FindsFieldByPattern(string pattern, string expectedFieldName)
     {
         var provider = new AreSearchProvider();
         var gff = AreToGff(CreateTestAre());
-        var criteria = new SearchCriteria { Pattern = "AR_MARKET" };
+        var criteria = new SearchCriteria { Pattern = pattern };
 
         var matches = provider.Search(gff, criteria);
 
-        Assert.Contains(matches, m => m.Field.Name == "Tag");
-    }
-
-    [Fact]
-    public void Search_FindsResRef()
-    {
-        var provider = new AreSearchProvider();
-        var gff = AreToGff(CreateTestAre());
-        var criteria = new SearchCriteria { Pattern = "ar_market" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "ResRef");
-    }
-
-    [Fact]
-    public void Search_FindsComments()
-    {
-        var provider = new AreSearchProvider();
-        var gff = AreToGff(CreateTestAre());
-        var criteria = new SearchCriteria { Pattern = "Chapter 2" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Comments");
-    }
-
-    [Fact]
-    public void Search_FindsOnEnter()
-    {
-        var provider = new AreSearchProvider();
-        var gff = AreToGff(CreateTestAre());
-        var criteria = new SearchCriteria { Pattern = "ar_enter_mrkt" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "OnEnter");
-    }
-
-    [Fact]
-    public void Search_FindsOnExit()
-    {
-        var provider = new AreSearchProvider();
-        var gff = AreToGff(CreateTestAre());
-        var criteria = new SearchCriteria { Pattern = "ar_exit_mrkt" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "OnExit");
-    }
-
-    [Fact]
-    public void Search_FindsOnHeartbeat()
-    {
-        var provider = new AreSearchProvider();
-        var gff = AreToGff(CreateTestAre());
-        var criteria = new SearchCriteria { Pattern = "ar_hb_mrkt" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "OnHeartbeat");
-    }
-
-    [Fact]
-    public void Search_FindsOnUserDefined()
-    {
-        var provider = new AreSearchProvider();
-        var gff = AreToGff(CreateTestAre());
-        var criteria = new SearchCriteria { Pattern = "ar_ud_mrkt" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "OnUserDefined");
+        Assert.Contains(matches, m => m.Field.Name == expectedFieldName);
     }
 
     [Fact]

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/DlgSearchProviderTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/DlgSearchProviderTests.cs
@@ -110,40 +110,24 @@ public class DlgSearchProviderTests
             m.Location is DlgMatchLocation loc && loc.NodeType == DlgNodeType.Reply);
     }
 
-    [Fact]
-    public void Search_FindsSpeaker()
+    [Theory]
+    [InlineData("LOUIS_ROMAIN", "Speaker")]
+    [InlineData("gc_check_quest", "Action Script")]
+    [InlineData("q_main_plot", "Action Params")]
+    [InlineData("gc_end_conv", "End Conversation")]
+    [InlineData("gc_abort", "End Conversation Abort")]
+    [InlineData("vo_louis", "Sound")]
+    [InlineData("q_main_plot", "Quest")]
+    [InlineData("Opening line", "Comment")]
+    public void Search_FindsFieldByPattern(string pattern, string expectedFieldName)
     {
         var provider = new DlgSearchProvider();
         var gff = DlgToGff(CreateTestDlg());
-        var criteria = new SearchCriteria { Pattern = "LOUIS_ROMAIN" };
+        var criteria = new SearchCriteria { Pattern = pattern };
 
         var matches = provider.Search(gff, criteria);
 
-        Assert.Contains(matches, m => m.Field.Name == "Speaker");
-    }
-
-    [Fact]
-    public void Search_FindsActionScript()
-    {
-        var provider = new DlgSearchProvider();
-        var gff = DlgToGff(CreateTestDlg());
-        var criteria = new SearchCriteria { Pattern = "gc_check_quest" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Action Script");
-    }
-
-    [Fact]
-    public void Search_FindsActionParams()
-    {
-        var provider = new DlgSearchProvider();
-        var gff = DlgToGff(CreateTestDlg());
-        var criteria = new SearchCriteria { Pattern = "q_main_plot" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Action Params");
+        Assert.Contains(matches, m => m.Field.Name == expectedFieldName);
     }
 
     [Fact]
@@ -185,66 +169,6 @@ public class DlgSearchProviderTests
         Assert.Contains(matches, m =>
             m.Field.Name == "Condition Params" &&
             m.Location is DlgMatchLocation loc && loc.NodeType == DlgNodeType.StartingLink);
-    }
-
-    [Fact]
-    public void Search_FindsEndConversationScript()
-    {
-        var provider = new DlgSearchProvider();
-        var gff = DlgToGff(CreateTestDlg());
-        var criteria = new SearchCriteria { Pattern = "gc_end_conv" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "End Conversation");
-    }
-
-    [Fact]
-    public void Search_FindsEndConverAbortScript()
-    {
-        var provider = new DlgSearchProvider();
-        var gff = DlgToGff(CreateTestDlg());
-        var criteria = new SearchCriteria { Pattern = "gc_abort" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "End Conversation Abort");
-    }
-
-    [Fact]
-    public void Search_FindsSound()
-    {
-        var provider = new DlgSearchProvider();
-        var gff = DlgToGff(CreateTestDlg());
-        var criteria = new SearchCriteria { Pattern = "vo_louis" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Sound");
-    }
-
-    [Fact]
-    public void Search_FindsQuest()
-    {
-        var provider = new DlgSearchProvider();
-        var gff = DlgToGff(CreateTestDlg());
-        var criteria = new SearchCriteria { Pattern = "q_main_plot" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Quest");
-    }
-
-    [Fact]
-    public void Search_FindsComment()
-    {
-        var provider = new DlgSearchProvider();
-        var gff = DlgToGff(CreateTestDlg());
-        var criteria = new SearchCriteria { Pattern = "Opening line" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Comment");
     }
 
     [Fact]

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/JrlSearchProviderTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/JrlSearchProviderTests.cs
@@ -72,28 +72,19 @@ public class JrlSearchProviderTests
         return GffReader.Read(bytes);
     }
 
-    [Fact]
-    public void Search_FindsCategoryName()
+    [Theory]
+    [InlineData("Lost Amulet", "Category Name")]
+    [InlineData("q_main_plot", "Category Tag")]
+    [InlineData("Act I", "Comment")]
+    public void Search_FindsFieldByPattern(string pattern, string expectedFieldName)
     {
         var provider = new JrlSearchProvider();
         var gff = JrlToGff(CreateTestJrl());
-        var criteria = new SearchCriteria { Pattern = "Lost Amulet" };
+        var criteria = new SearchCriteria { Pattern = pattern };
 
         var matches = provider.Search(gff, criteria);
 
-        Assert.Contains(matches, m => m.Field.Name == "Category Name");
-    }
-
-    [Fact]
-    public void Search_FindsCategoryTag()
-    {
-        var provider = new JrlSearchProvider();
-        var gff = JrlToGff(CreateTestJrl());
-        var criteria = new SearchCriteria { Pattern = "q_main_plot" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Category Tag");
+        Assert.Contains(matches, m => m.Field.Name == expectedFieldName);
     }
 
     [Fact]
@@ -106,18 +97,6 @@ public class JrlSearchProviderTests
         var matches = provider.Search(gff, criteria);
 
         Assert.Contains(matches, m => m.Field.Name == "Entry Text" && m.MatchedText == "Louis Romain");
-    }
-
-    [Fact]
-    public void Search_FindsComment()
-    {
-        var provider = new JrlSearchProvider();
-        var gff = JrlToGff(CreateTestJrl());
-        var criteria = new SearchCriteria { Pattern = "Act I" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Comment");
     }
 
     [Fact]

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/UtcSearchProviderTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/UtcSearchProviderTests.cs
@@ -68,112 +68,27 @@ public class UtcSearchProviderTests
         Assert.Contains(matches, m => m.Field.Name == "First Name" && m.MatchedText == "Louis Romain");
     }
 
-    [Fact]
-    public void Search_FindsLastName()
+    [Theory]
+    [InlineData("the Merchant", "Last Name")]
+    [InlineData("western coast", "Description")]
+    [InlineData("LOUIS_ROMAIN", "Tag")]
+    [InlineData("louis_romain", "Template ResRef")]
+    [InlineData("Main quest", "Comment")]
+    [InlineData("Illuskan", "Subrace")]
+    [InlineData("Waukeen", "Deity")]
+    [InlineData("louis_conv", "Conversation")]
+    [InlineData("nw_c2_default5", "ScriptAttacked")]
+    [InlineData("nBossState", "Local Variables")]
+    [InlineData("lost amulet", "Local Variables")]
+    public void Search_FindsFieldByPattern(string pattern, string expectedFieldName)
     {
         var provider = new UtcSearchProvider();
         var gff = UtcToGff(CreateTestUtc());
-        var criteria = new SearchCriteria { Pattern = "the Merchant" };
+        var criteria = new SearchCriteria { Pattern = pattern };
 
         var matches = provider.Search(gff, criteria);
 
-        Assert.Contains(matches, m => m.Field.Name == "Last Name");
-    }
-
-    [Fact]
-    public void Search_FindsDescription()
-    {
-        var provider = new UtcSearchProvider();
-        var gff = UtcToGff(CreateTestUtc());
-        var criteria = new SearchCriteria { Pattern = "western coast" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Description");
-    }
-
-    [Fact]
-    public void Search_FindsTag()
-    {
-        var provider = new UtcSearchProvider();
-        var gff = UtcToGff(CreateTestUtc());
-        var criteria = new SearchCriteria { Pattern = "LOUIS_ROMAIN" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Tag");
-    }
-
-    [Fact]
-    public void Search_FindsTemplateResRef()
-    {
-        var provider = new UtcSearchProvider();
-        var gff = UtcToGff(CreateTestUtc());
-        var criteria = new SearchCriteria { Pattern = "louis_romain" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Template ResRef");
-    }
-
-    [Fact]
-    public void Search_FindsComment()
-    {
-        var provider = new UtcSearchProvider();
-        var gff = UtcToGff(CreateTestUtc());
-        var criteria = new SearchCriteria { Pattern = "Main quest" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Comment");
-    }
-
-    [Fact]
-    public void Search_FindsSubrace()
-    {
-        var provider = new UtcSearchProvider();
-        var gff = UtcToGff(CreateTestUtc());
-        var criteria = new SearchCriteria { Pattern = "Illuskan" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Subrace");
-    }
-
-    [Fact]
-    public void Search_FindsDeity()
-    {
-        var provider = new UtcSearchProvider();
-        var gff = UtcToGff(CreateTestUtc());
-        var criteria = new SearchCriteria { Pattern = "Waukeen" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Deity");
-    }
-
-    [Fact]
-    public void Search_FindsConversation()
-    {
-        var provider = new UtcSearchProvider();
-        var gff = UtcToGff(CreateTestUtc());
-        var criteria = new SearchCriteria { Pattern = "louis_conv" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Conversation");
-    }
-
-    [Fact]
-    public void Search_FindsScriptFields()
-    {
-        var provider = new UtcSearchProvider();
-        var gff = UtcToGff(CreateTestUtc());
-        var criteria = new SearchCriteria { Pattern = "nw_c2_default5" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "ScriptAttacked");
+        Assert.Contains(matches, m => m.Field.Name == expectedFieldName);
     }
 
     [Fact]
@@ -191,30 +106,6 @@ public class UtcSearchProviderTests
 
         Assert.Equal(13, matches.Count);
         Assert.All(matches, m => Assert.Equal(SearchFieldType.Script, m.Field.FieldType));
-    }
-
-    [Fact]
-    public void Search_FindsVarTableName()
-    {
-        var provider = new UtcSearchProvider();
-        var gff = UtcToGff(CreateTestUtc());
-        var criteria = new SearchCriteria { Pattern = "nBossState" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Local Variables");
-    }
-
-    [Fact]
-    public void Search_FindsVarTableStringValue()
-    {
-        var provider = new UtcSearchProvider();
-        var gff = UtcToGff(CreateTestUtc());
-        var criteria = new SearchCriteria { Pattern = "lost amulet" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Local Variables");
     }
 
     [Fact]

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/UtiSearchProviderTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/UtiSearchProviderTests.cs
@@ -61,6 +61,20 @@ public class UtiSearchProviderTests
     }
 
     [Fact]
+    public void Search_Name_ExtractsCorrectMatchedText()
+    {
+        // Field-name coverage lives in the theory above; this guards the localized-name
+        // MatchedText extraction specifically (the only provider without a MatchedText fact otherwise).
+        var provider = new UtiSearchProvider();
+        var gff = UtiToGff(CreateTestUti());
+        var criteria = new SearchCriteria { Pattern = "Louis Romain" };
+
+        var matches = provider.Search(gff, criteria);
+
+        Assert.Contains(matches, m => m.Field.Name == "Name" && m.MatchedText == "Louis Romain");
+    }
+
+    [Fact]
     public void Search_ContentCategoryFilter()
     {
         var provider = new UtiSearchProvider();

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/UtiSearchProviderTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/UtiSearchProviderTests.cs
@@ -40,76 +40,24 @@ public class UtiSearchProviderTests
         return GffReader.Read(bytes);
     }
 
-    [Fact]
-    public void Search_FindsLocalizedName()
+    [Theory]
+    [InlineData("Louis Romain", "Name")]
+    [InlineData("unknown origin", "Description")]
+    [InlineData("Icewind Dale", "Identified Description")]
+    [InlineData("LOUIS_SCYTHE", "Tag")]
+    [InlineData("louis_scythe", "Template ResRef")]
+    [InlineData("Quest reward", "Comment")]
+    [InlineData("nEnchantLevel", "Local Variables")]
+    [InlineData("Dwarven Forge", "Local Variables")]
+    public void Search_FindsFieldByPattern(string pattern, string expectedFieldName)
     {
         var provider = new UtiSearchProvider();
         var gff = UtiToGff(CreateTestUti());
-        var criteria = new SearchCriteria { Pattern = "Louis Romain" };
+        var criteria = new SearchCriteria { Pattern = pattern };
 
         var matches = provider.Search(gff, criteria);
 
-        Assert.Contains(matches, m => m.Field.Name == "Name" && m.MatchedText == "Louis Romain");
-    }
-
-    [Fact]
-    public void Search_FindsDescription()
-    {
-        var provider = new UtiSearchProvider();
-        var gff = UtiToGff(CreateTestUti());
-        var criteria = new SearchCriteria { Pattern = "unknown origin" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Description");
-    }
-
-    [Fact]
-    public void Search_FindsDescIdentified()
-    {
-        var provider = new UtiSearchProvider();
-        var gff = UtiToGff(CreateTestUti());
-        var criteria = new SearchCriteria { Pattern = "Icewind Dale" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Identified Description");
-    }
-
-    [Fact]
-    public void Search_FindsTag()
-    {
-        var provider = new UtiSearchProvider();
-        var gff = UtiToGff(CreateTestUti());
-        var criteria = new SearchCriteria { Pattern = "LOUIS_SCYTHE" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Tag");
-    }
-
-    [Fact]
-    public void Search_FindsTemplateResRef()
-    {
-        var provider = new UtiSearchProvider();
-        var gff = UtiToGff(CreateTestUti());
-        var criteria = new SearchCriteria { Pattern = "louis_scythe" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Template ResRef");
-    }
-
-    [Fact]
-    public void Search_FindsComment()
-    {
-        var provider = new UtiSearchProvider();
-        var gff = UtiToGff(CreateTestUti());
-        var criteria = new SearchCriteria { Pattern = "Quest reward" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Comment");
+        Assert.Contains(matches, m => m.Field.Name == expectedFieldName);
     }
 
     [Fact]
@@ -171,30 +119,6 @@ public class UtiSearchProviderTests
     {
         var provider = new UtiSearchProvider();
         Assert.Contains(".uti", provider.Extensions);
-    }
-
-    [Fact]
-    public void Search_FindsVarTableName()
-    {
-        var provider = new UtiSearchProvider();
-        var gff = UtiToGff(CreateTestUti());
-        var criteria = new SearchCriteria { Pattern = "nEnchantLevel" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Local Variables");
-    }
-
-    [Fact]
-    public void Search_FindsVarTableStringValue()
-    {
-        var provider = new UtiSearchProvider();
-        var gff = UtiToGff(CreateTestUti());
-        var criteria = new SearchCriteria { Pattern = "Dwarven Forge" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Local Variables");
     }
 
     [Fact]

--- a/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/UtmSearchProviderTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Search/Providers/UtmSearchProviderTests.cs
@@ -34,101 +34,24 @@ public class UtmSearchProviderTests
         return GffReader.Read(bytes);
     }
 
-    [Fact]
-    public void Search_FindsLocName()
+    [Theory]
+    [InlineData("Louis Romain", "Name")]
+    [InlineData("LOUIS_STORE", "Tag")]
+    [InlineData("louis_store", "ResRef")]
+    [InlineData("western district", "Comment")]
+    [InlineData("gc_open_store", "OnOpenStore")]
+    [InlineData("gc_close_store", "OnStoreClosed")]
+    [InlineData("nDiscount", "Local Variables")]
+    [InlineData("emporium", "Local Variables")]
+    public void Search_FindsFieldByPattern(string pattern, string expectedFieldName)
     {
         var provider = new UtmSearchProvider();
         var gff = UtmToGff(CreateTestUtm());
-        var criteria = new SearchCriteria { Pattern = "Louis Romain" };
+        var criteria = new SearchCriteria { Pattern = pattern };
 
         var matches = provider.Search(gff, criteria);
 
-        Assert.Contains(matches, m => m.Field.Name == "Name" && m.MatchedText == "Louis Romain");
-    }
-
-    [Fact]
-    public void Search_FindsTag()
-    {
-        var provider = new UtmSearchProvider();
-        var gff = UtmToGff(CreateTestUtm());
-        var criteria = new SearchCriteria { Pattern = "LOUIS_STORE" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Tag");
-    }
-
-    [Fact]
-    public void Search_FindsResRef()
-    {
-        var provider = new UtmSearchProvider();
-        var gff = UtmToGff(CreateTestUtm());
-        var criteria = new SearchCriteria { Pattern = "louis_store" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "ResRef");
-    }
-
-    [Fact]
-    public void Search_FindsComment()
-    {
-        var provider = new UtmSearchProvider();
-        var gff = UtmToGff(CreateTestUtm());
-        var criteria = new SearchCriteria { Pattern = "western district" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Comment");
-    }
-
-    [Fact]
-    public void Search_FindsOnOpenStore()
-    {
-        var provider = new UtmSearchProvider();
-        var gff = UtmToGff(CreateTestUtm());
-        var criteria = new SearchCriteria { Pattern = "gc_open_store" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "OnOpenStore");
-    }
-
-    [Fact]
-    public void Search_FindsOnStoreClosed()
-    {
-        var provider = new UtmSearchProvider();
-        var gff = UtmToGff(CreateTestUtm());
-        var criteria = new SearchCriteria { Pattern = "gc_close_store" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "OnStoreClosed");
-    }
-
-    [Fact]
-    public void Search_FindsVarTableName()
-    {
-        var provider = new UtmSearchProvider();
-        var gff = UtmToGff(CreateTestUtm());
-        var criteria = new SearchCriteria { Pattern = "nDiscount" };
-
-        var matches = provider.Search(gff, criteria);
-
-        Assert.Contains(matches, m => m.Field.Name == "Local Variables");
-    }
-
-    [Fact]
-    public void Search_FindsVarTableStringValue()
-    {
-        var provider = new UtmSearchProvider();
-        var gff = UtmToGff(CreateTestUtm());
-        var criteria = new SearchCriteria { Pattern = "emporium" };
-
-        var matches = provider.Search(gff, criteria);
-
-        // Should find in both LocName and VarTable string value
-        Assert.Contains(matches, m => m.Field.Name == "Local Variables");
+        Assert.Contains(matches, m => m.Field.Name == expectedFieldName);
     }
 
     [Fact]

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlAsciiReader.ListParsing.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlAsciiReader.ListParsing.cs
@@ -266,13 +266,13 @@ public partial class MdlAsciiReader
                 var g = (byte)(ParseFloat(parts[1]) * 255);
                 var b = (byte)(ParseFloat(parts[2]) * 255);
                 var a = parts.Length >= 4 ? (byte)(ParseFloat(parts[3]) * 255) : (byte)255;
-                colors.Add((uint)((a << 24) | (b << 16) | (g << 8) | r));
+                colors.Add((uint)((a << 24) | (b << 16) | (g << 8) | r)); // theme-ok: local var, not Avalonia Colors enum
             }
 
             _currentLine++;
         }
 
-        mesh.VertexColors = colors.ToArray();
+        mesh.VertexColors = colors.ToArray(); // theme-ok: local var, not Avalonia Colors enum
         _currentLine--; // Back up so main loop can advance
     }
 

--- a/Radoub.Formats/Radoub.Formats/Tokens/UserColorConfigLoader.cs
+++ b/Radoub.Formats/Radoub.Formats/Tokens/UserColorConfigLoader.cs
@@ -6,11 +6,11 @@ namespace Radoub.Formats.Tokens;
 
 /// <summary>
 /// Loads and saves user-defined color token configurations.
-/// Configuration file location: ~/Radoub/token-colors.json
+/// Configuration file location: ~/Radoub/token-colors.json   // theme-ok: filename, not Avalonia Colors enum
 /// </summary>
 public static class UserColorConfigLoader
 {
-    private const string ConfigFileName = "token-colors.json";
+    private const string ConfigFileName = "token-colors.json"; // theme-ok: filename, not Avalonia Colors enum
     private const string RadoubFolderName = "Radoub";
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -136,7 +136,7 @@ public static class UserColorConfigLoader
 
         foreach (var kvp in config.Colors)
         {
-            colors.Add(new ColorDefinition
+            colors.Add(new ColorDefinition // theme-ok: local var, not Avalonia Colors enum
             {
                 Name = kvp.Key,
                 Token = kvp.Value,

--- a/Radoub.IntegrationTests/run-tests.ps1
+++ b/Radoub.IntegrationTests/run-tests.ps1
@@ -144,6 +144,14 @@ function Invoke-TechDebtScan {
 }
 
 # Theme compatibility scan - check for hardcoded colors, fonts, brushes
+#
+# Baseline: 0 accepted violations (#2278). As of 2026-06-27 all previously-flagged
+# values were triaged and suppressed with `// theme-ok` (.cs) / `<!-- theme-ok -->`
+# (.axaml), each carrying a reason. They split between false positives (local vars /
+# properties / comment text matching the regex) and legitimate non-chrome colors
+# (NWN palette/token literal colors, missing-resource fallbacks, a 3D-preview scrim).
+# Any NEW unsuppressed hit is real drift — fix it (DynamicResource/BrushManager) or
+# suppress with a documented reason; do not let the count creep above 0.
 function Invoke-ThemeCompatScan {
     Write-Host "`n=== Theme Compatibility Scan ===" -ForegroundColor Magenta
     Write-Host "Checking for hardcoded colors, fonts, and brushes..." -ForegroundColor Yellow

--- a/Radoub.TestUtilities/Radoub.TestUtilities/Bases/ToolSettingsServiceTestBase.cs
+++ b/Radoub.TestUtilities/Radoub.TestUtilities/Bases/ToolSettingsServiceTestBase.cs
@@ -51,6 +51,12 @@ public abstract class ToolSettingsServiceTestBase<TService> : IDisposable
     /// <summary>File extension a recent-file fixture should use (e.g. ".utc").</summary>
     protected virtual string RecentFileExtension => ".dat";
 
+    /// <summary>Minimum window width this tool clamps to (BaseToolSettingsService default is 600).</summary>
+    protected virtual double ExpectedMinWindowWidth => 600;
+
+    /// <summary>Minimum window height this tool clamps to (BaseToolSettingsService default is 400).</summary>
+    protected virtual double ExpectedMinWindowHeight => 400;
+
     protected ToolSettingsServiceTestBase()
     {
         TestSettingsDir = Path.Combine(Path.GetTempPath(), $"{ToolDirPrefix}_Tests_{Guid.NewGuid():N}");
@@ -89,7 +95,7 @@ public abstract class ToolSettingsServiceTestBase<TService> : IDisposable
     {
         var service = GetInstance();
         SetWindowWidth(service, 1);
-        Assert.True(GetWindowWidth(service) >= 600);
+        Assert.True(GetWindowWidth(service) >= ExpectedMinWindowWidth);
     }
 
     [Fact]
@@ -97,7 +103,7 @@ public abstract class ToolSettingsServiceTestBase<TService> : IDisposable
     {
         var service = GetInstance();
         SetWindowHeight(service, 1);
-        Assert.True(GetWindowHeight(service) >= 400);
+        Assert.True(GetWindowHeight(service) >= ExpectedMinWindowHeight);
     }
 
     [Fact]

--- a/Radoub.TestUtilities/Radoub.TestUtilities/Bases/ToolSettingsServiceTestBase.cs
+++ b/Radoub.TestUtilities/Radoub.TestUtilities/Bases/ToolSettingsServiceTestBase.cs
@@ -1,0 +1,156 @@
+using Radoub.TestUtilities.Helpers;
+using Xunit;
+
+namespace Radoub.TestUtilities.Bases;
+
+/// <summary>
+/// Shared test base for tools whose SettingsService derives from
+/// <c>BaseToolSettingsService&lt;TSettings&gt;</c> (Quartermaster, Fence, Manifest,
+/// Trebuchet, Relique, Reliquary). Covers the singleton + window-clamp + recent-files +
+/// log-retention contract that the base class owns and every tool inherited verbatim (#2464).
+///
+/// Parley does NOT use this base (DI-based settings, different isolation) and is excluded.
+///
+/// Each tool's test class derives from this, supplies the env var, dir prefix, and a few
+/// accessors, and keeps ONLY its tool-specific tests (panel widths, validation level, etc.).
+///
+/// The base stays UI-framework-free: the subclass supplies every member accessor as an
+/// abstract method, so Radoub.TestUtilities does not need a reference to Radoub.UI.
+/// </summary>
+/// <typeparam name="TService">The concrete tool SettingsService (exposes a static singleton).</typeparam>
+public abstract class ToolSettingsServiceTestBase<TService> : IDisposable
+    where TService : class
+{
+    protected readonly string TestSettingsDir;
+
+    /// <summary>Environment variable the tool's settings dir override reads (e.g. "FENCE_SETTINGS_DIR").</summary>
+    protected abstract string SettingsEnvironmentVariable { get; }
+
+    /// <summary>Temp-directory name prefix for this tool's isolated settings (e.g. "Fence").</summary>
+    protected abstract string ToolDirPrefix { get; }
+
+    /// <summary>Return the tool's singleton instance (e.g. <c>SettingsService.Instance</c>).</summary>
+    protected abstract TService GetInstance();
+
+    /// <summary>Reset the tool's singleton so the next <see cref="GetInstance"/> reloads from disk.</summary>
+    protected abstract void ResetSingleton();
+
+    // --- Settings surface (public on BaseToolSettingsService; provided by the subclass
+    //     so the base test stays compile-safe and UI-framework-free, no reflection). ---
+    protected abstract double GetWindowWidth(TService service);
+    protected abstract void SetWindowWidth(TService service, double value);
+    protected abstract double GetWindowHeight(TService service);
+    protected abstract void SetWindowHeight(TService service, double value);
+    protected abstract IReadOnlyList<string> GetRecentFiles(TService service);
+    protected abstract void AddRecentFile(TService service, string path);
+    protected abstract int GetMaxRecentFiles(TService service);
+    protected abstract void SetMaxRecentFiles(TService service, int value);
+    protected abstract int GetLogRetentionSessions(TService service);
+    protected abstract void SetLogRetentionSessions(TService service, int value);
+
+    /// <summary>File extension a recent-file fixture should use (e.g. ".utc").</summary>
+    protected virtual string RecentFileExtension => ".dat";
+
+    protected ToolSettingsServiceTestBase()
+    {
+        TestSettingsDir = Path.Combine(Path.GetTempPath(), $"{ToolDirPrefix}_Tests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(TestSettingsDir);
+
+        ResetSingleton();
+        SingletonTestHelper.ConfigureSettingsDirectory(SettingsEnvironmentVariable, TestSettingsDir);
+    }
+
+    public void Dispose()
+    {
+        ResetSingleton();
+        SingletonTestHelper.ConfigureSettingsDirectory(SettingsEnvironmentVariable, null);
+
+        try
+        {
+            if (Directory.Exists(TestSettingsDir))
+                Directory.Delete(TestSettingsDir, recursive: true);
+        }
+        catch
+        {
+            // Ignore cleanup failures
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void Instance_ReturnsSameInstance()
+    {
+        Assert.Same(GetInstance(), GetInstance());
+    }
+
+    [Fact]
+    public void WindowWidth_EnforcesMinimum()
+    {
+        var service = GetInstance();
+        SetWindowWidth(service, 1);
+        Assert.True(GetWindowWidth(service) >= 600);
+    }
+
+    [Fact]
+    public void WindowHeight_EnforcesMinimum()
+    {
+        var service = GetInstance();
+        SetWindowHeight(service, 1);
+        Assert.True(GetWindowHeight(service) >= 400);
+    }
+
+    [Fact]
+    public void MaxRecentFiles_EnforcesRange()
+    {
+        var service = GetInstance();
+
+        SetMaxRecentFiles(service, 0);
+        Assert.True(GetMaxRecentFiles(service) >= 1);
+
+        SetMaxRecentFiles(service, 100);
+        Assert.True(GetMaxRecentFiles(service) <= 20);
+    }
+
+    [Fact]
+    public void LogRetentionSessions_EnforcesRange()
+    {
+        var service = GetInstance();
+
+        SetLogRetentionSessions(service, 0);
+        Assert.True(GetLogRetentionSessions(service) >= 1);
+
+        SetLogRetentionSessions(service, 100);
+        Assert.True(GetLogRetentionSessions(service) <= 10);
+    }
+
+    [Fact]
+    public void RecentFiles_ReturnsListCopy()
+    {
+        var service = GetInstance();
+        Assert.NotSame(GetRecentFiles(service), GetRecentFiles(service));
+    }
+
+    [Fact]
+    public void AddRecentFile_AddsExistingFileToList()
+    {
+        var service = GetInstance();
+        var tempFile = Path.Combine(TestSettingsDir, $"recent{RecentFileExtension}");
+        File.WriteAllText(tempFile, "test");
+
+        AddRecentFile(service, tempFile);
+
+        Assert.Contains(tempFile, GetRecentFiles(service));
+    }
+
+    [Fact]
+    public void WindowWidth_PersistsAcrossReload()
+    {
+        var service = GetInstance();
+        SetWindowWidth(service, 1000);
+
+        ResetSingleton();
+
+        Assert.Equal(1000, GetWindowWidth(GetInstance()));
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/FilterStateTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/FilterStateTests.cs
@@ -42,27 +42,6 @@ public class FilterStateTests
         Assert.Null(state.SelectedBaseItemIndex);
     }
 
-    [Fact]
-    public void CanSetAllProperties()
-    {
-        var state = new FilterState
-        {
-            ShowStandard = false,
-            ShowOverride = true,
-            ShowHak = false,
-            ShowModule = false,
-            SearchText = "sword",
-            SelectedBaseItemIndex = 5
-        };
-
-        Assert.False(state.ShowStandard);
-        Assert.True(state.ShowOverride);
-        Assert.False(state.ShowHak);
-        Assert.False(state.ShowModule);
-        Assert.Equal("sword", state.SearchText);
-        Assert.Equal(5, state.SelectedBaseItemIndex);
-    }
-
     // ---- Legacy migration (old persisted state had a single ShowCustom bool) ----
 
     [Fact]

--- a/Radoub.UI/Radoub.UI.Tests/ItemTypeInfoTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/ItemTypeInfoTests.cs
@@ -6,16 +6,6 @@ namespace Radoub.UI.Tests;
 public class ItemTypeInfoTests
 {
     [Fact]
-    public void Constructor_SetsProperties()
-    {
-        var info = new ItemTypeInfo(5, "Longsword", "longsword");
-
-        Assert.Equal(5, info.BaseItemIndex);
-        Assert.Equal("Longsword", info.Name);
-        Assert.Equal("longsword", info.Label);
-    }
-
-    [Fact]
     public void IsAllTypes_FalseForNormalType()
     {
         var info = new ItemTypeInfo(5, "Longsword", "longsword");
@@ -39,13 +29,5 @@ public class ItemTypeInfoTests
     public void AllTypes_HasCorrectName()
     {
         Assert.Equal("All Types", ItemTypeInfo.AllTypes.Name);
-    }
-
-    [Fact]
-    public void ToString_ReturnsName()
-    {
-        var info = new ItemTypeInfo(5, "Longsword", "longsword");
-
-        Assert.Equal("Longsword", info.ToString());
     }
 }

--- a/Radoub.UI/Radoub.UI.Tests/ItemTypeInfoTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/ItemTypeInfoTests.cs
@@ -30,4 +30,11 @@ public class ItemTypeInfoTests
     {
         Assert.Equal("All Types", ItemTypeInfo.AllTypes.Name);
     }
+
+    [Fact]
+    public void ToString_ReturnsName()
+    {
+        // ToString is a real override that drives the text shown in bound combo/list UI.
+        Assert.Equal("Longsword", new ItemTypeInfo(5, "Longsword", "longsword").ToString());
+    }
 }

--- a/Radoub.UI/Radoub.UI.Tests/SharedPaletteCachePropertiesTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/SharedPaletteCachePropertiesTests.cs
@@ -6,19 +6,6 @@ namespace Radoub.UI.Tests;
 public class SharedPaletteCachePropertiesTests
 {
     [Fact]
-    public void SharedPaletteCacheItem_HasPropertiesDisplay()
-    {
-        var item = new SharedPaletteCacheItem
-        {
-            ResRef = "nw_wswdg001",
-            DisplayName = "Dagger",
-            PropertiesDisplay = "Enhancement +1, Keen"
-        };
-
-        Assert.Equal("Enhancement +1, Keen", item.PropertiesDisplay);
-    }
-
-    [Fact]
     public void SharedPaletteCacheItem_PropertiesDisplay_DefaultsToEmpty()
     {
         var item = new SharedPaletteCacheItem();

--- a/Radoub.UI/Radoub.UI/Services/PaletteColorService.cs
+++ b/Radoub.UI/Radoub.UI/Services/PaletteColorService.cs
@@ -58,7 +58,7 @@ public class PaletteColorService
     {
         var palette = GetPalette(paletteName);
         if (palette == null)
-            return Colors.Gray;
+            return Colors.Gray; // theme-ok: fallback for missing palette TGA — game-data color, not UI chrome
 
         var (r, g, b, a) = TgaReader.GetPixel(palette, 127, colorIndex);
         return Color.FromArgb(a, r, g, b);
@@ -89,8 +89,8 @@ public class PaletteColorService
 
         if (palette == null)
         {
-            stops.Add((0.0, Colors.DarkGray));
-            stops.Add((1.0, Colors.LightGray));
+            stops.Add((0.0, Colors.DarkGray)); // theme-ok: fallback gradient for missing palette TGA — game-data color, not UI chrome
+            stops.Add((1.0, Colors.LightGray)); // theme-ok: fallback gradient for missing palette TGA — game-data color, not UI chrome
             return stops;
         }
 

--- a/Radoub.UI/Radoub.UI/Views/TokenInsertionWindow.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Views/TokenInsertionWindow.axaml.cs
@@ -100,8 +100,8 @@ public partial class TokenInsertionWindow : Window
                     panel.Children.Add(new Border
                     {
                         Width = 16, Height = 16,
-                        Background = SolidColorBrush.Parse(hexColor),
-                        BorderBrush = Brushes.Gray,
+                        Background = SolidColorBrush.Parse(hexColor), // theme-ok: literal user token color, must render as-is regardless of theme
+                        BorderBrush = Brushes.Gray, // theme-ok: 1px hairline border on a color swatch
                         BorderThickness = new Thickness(1),
                         CornerRadius = new CornerRadius(2),
                         VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
@@ -109,7 +109,7 @@ public partial class TokenInsertionWindow : Window
                 }
                 catch
                 {
-                    // Invalid hex color in token-colors.json — skip the swatch
+                    // Invalid hex color in token-colors.json — skip the swatch // theme-ok: filename in comment, not Avalonia Colors enum
                 }
             }
 

--- a/Radoub.UI/Radoub.UI/Views/TokenSelectorWindow.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Views/TokenSelectorWindow.axaml.cs
@@ -64,7 +64,7 @@ namespace Radoub.UI.Views
             foreach (var kvp in _userColorConfig.Colors)
             {
                 var hexColor = _userColorConfig.ColorHexValues.GetValueOrDefault(kvp.Key, "#FFFFFF");
-                colors.Add(new ColorListItem
+                colors.Add(new ColorListItem // theme-ok: local var, not Avalonia Colors enum
                 {
                     Name = kvp.Key,
                     OpenToken = kvp.Value,
@@ -389,7 +389,7 @@ namespace Radoub.UI.Views
         public string Name { get; set; } = "";
         public string OpenToken { get; set; } = "";
         public string CloseToken { get; set; } = "";
-        public IBrush HexColor { get; set; } = Brushes.White;
+        public IBrush HexColor { get; set; } = Brushes.White; // theme-ok: placeholder default, overwritten with the literal user token color
     }
 
     /// <summary>

--- a/Reliquary/Reliquary.Tests/SettingsServiceTests.cs
+++ b/Reliquary/Reliquary.Tests/SettingsServiceTests.cs
@@ -1,22 +1,42 @@
 using System.Reflection;
 using PlaceableEditor.Services;
+using Radoub.TestUtilities.Bases;
+using Radoub.TestUtilities.Helpers;
 
 namespace PlaceableEditor.Tests;
 
-public class SettingsServiceTests
+/// <summary>
+/// Tests for Reliquary's SettingsService. The shared singleton/window/recent-files/log-retention
+/// contract lives in <see cref="ToolSettingsServiceTestBase{TService}"/> (#2464); only
+/// Reliquary-specific behavior (tool identity, browser panel width) is below.
+/// Deriving from the base also gives Reliquary proper per-test isolation it previously lacked.
+/// </summary>
+public class SettingsServiceTests : ToolSettingsServiceTestBase<SettingsService>
 {
-    [Fact]
-    public void Instance_ReturnsSameInstance()
-    {
-        var instance1 = SettingsService.Instance;
-        var instance2 = SettingsService.Instance;
-        Assert.Same(instance1, instance2);
-    }
+    protected override string SettingsEnvironmentVariable => "RELIQUARY_SETTINGS_DIR";
+    protected override string ToolDirPrefix => "Reliquary";
+    protected override string RecentFileExtension => ".utp";
+
+    protected override SettingsService GetInstance() => SettingsService.Instance;
+    protected override void ResetSingleton() => SingletonTestHelper.ResetSingleton<SettingsService>();
+
+    protected override double GetWindowWidth(SettingsService s) => s.WindowWidth;
+    protected override void SetWindowWidth(SettingsService s, double v) => s.WindowWidth = v;
+    protected override double GetWindowHeight(SettingsService s) => s.WindowHeight;
+    protected override void SetWindowHeight(SettingsService s, double v) => s.WindowHeight = v;
+    protected override IReadOnlyList<string> GetRecentFiles(SettingsService s) => s.RecentFiles;
+    protected override void AddRecentFile(SettingsService s, string path) => s.AddRecentFile(path);
+    protected override int GetMaxRecentFiles(SettingsService s) => s.MaxRecentFiles;
+    protected override void SetMaxRecentFiles(SettingsService s, int v) => s.MaxRecentFiles = v;
+    protected override int GetLogRetentionSessions(SettingsService s) => s.LogRetentionSessions;
+    protected override void SetLogRetentionSessions(SettingsService s, int v) => s.LogRetentionSessions = v;
+
+    // ---- Reliquary-specific ----
 
     [Fact]
     public void ToolName_IsReliquary()
     {
-        var settings = SettingsService.Instance;
+        var settings = GetInstance();
         var toolNameProp = settings.GetType()
             .GetProperty("ToolName", BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(toolNameProp);
@@ -26,7 +46,7 @@ public class SettingsServiceTests
     [Fact]
     public void SettingsEnvironmentVariable_IsReliquary()
     {
-        var settings = SettingsService.Instance;
+        var settings = GetInstance();
         var envVarProp = settings.GetType()
             .GetProperty("SettingsEnvironmentVariable", BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(envVarProp);
@@ -36,7 +56,7 @@ public class SettingsServiceTests
     [Fact]
     public void BrowserPanelWidth_ClampsMinimum()
     {
-        var settings = SettingsService.Instance;
+        var settings = GetInstance();
         settings.BrowserPanelWidth = 50;
         Assert.True(settings.BrowserPanelWidth >= 150);
     }
@@ -44,7 +64,7 @@ public class SettingsServiceTests
     [Fact]
     public void BrowserPanelWidth_ClampsMaximum()
     {
-        var settings = SettingsService.Instance;
+        var settings = GetInstance();
         settings.BrowserPanelWidth = 9999;
         Assert.True(settings.BrowserPanelWidth <= 500);
     }

--- a/Relique/Relique.Tests/SettingsServiceTests.cs
+++ b/Relique/Relique.Tests/SettingsServiceTests.cs
@@ -1,22 +1,42 @@
 using System.Reflection;
 using ItemEditor.Services;
+using Radoub.TestUtilities.Bases;
+using Radoub.TestUtilities.Helpers;
 
 namespace ItemEditor.Tests;
 
-public class SettingsServiceTests
+/// <summary>
+/// Tests for Relique's SettingsService. The shared singleton/window/recent-files/log-retention
+/// contract lives in <see cref="ToolSettingsServiceTestBase{TService}"/> (#2464); only
+/// Relique-specific behavior (tool identity, browser panel width, item-editor prefs) is below.
+/// Deriving from the base also gives Relique proper per-test isolation it previously lacked.
+/// </summary>
+public class SettingsServiceTests : ToolSettingsServiceTestBase<SettingsService>
 {
-    [Fact]
-    public void Instance_ReturnsSameInstance()
-    {
-        var instance1 = SettingsService.Instance;
-        var instance2 = SettingsService.Instance;
-        Assert.Same(instance1, instance2);
-    }
+    protected override string SettingsEnvironmentVariable => "RELIQUE_SETTINGS_DIR";
+    protected override string ToolDirPrefix => "Relique";
+    protected override string RecentFileExtension => ".uti";
+
+    protected override SettingsService GetInstance() => SettingsService.Instance;
+    protected override void ResetSingleton() => SingletonTestHelper.ResetSingleton<SettingsService>();
+
+    protected override double GetWindowWidth(SettingsService s) => s.WindowWidth;
+    protected override void SetWindowWidth(SettingsService s, double v) => s.WindowWidth = v;
+    protected override double GetWindowHeight(SettingsService s) => s.WindowHeight;
+    protected override void SetWindowHeight(SettingsService s, double v) => s.WindowHeight = v;
+    protected override IReadOnlyList<string> GetRecentFiles(SettingsService s) => s.RecentFiles;
+    protected override void AddRecentFile(SettingsService s, string path) => s.AddRecentFile(path);
+    protected override int GetMaxRecentFiles(SettingsService s) => s.MaxRecentFiles;
+    protected override void SetMaxRecentFiles(SettingsService s, int v) => s.MaxRecentFiles = v;
+    protected override int GetLogRetentionSessions(SettingsService s) => s.LogRetentionSessions;
+    protected override void SetLogRetentionSessions(SettingsService s, int v) => s.LogRetentionSessions = v;
+
+    // ---- Relique-specific ----
 
     [Fact]
     public void ToolName_IsRelique()
     {
-        var settings = SettingsService.Instance;
+        var settings = GetInstance();
         var toolNameProp = settings.GetType()
             .GetProperty("ToolName", BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(toolNameProp);
@@ -26,7 +46,7 @@ public class SettingsServiceTests
     [Fact]
     public void SettingsEnvironmentVariable_IsRelique()
     {
-        var settings = SettingsService.Instance;
+        var settings = GetInstance();
         var envVarProp = settings.GetType()
             .GetProperty("SettingsEnvironmentVariable", BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(envVarProp);
@@ -36,7 +56,7 @@ public class SettingsServiceTests
     [Fact]
     public void BrowserPanelWidth_ClampsMinimum()
     {
-        var settings = SettingsService.Instance;
+        var settings = GetInstance();
         settings.BrowserPanelWidth = 50;
         Assert.Equal(150, settings.BrowserPanelWidth);
     }
@@ -44,7 +64,7 @@ public class SettingsServiceTests
     [Fact]
     public void BrowserPanelWidth_ClampsMaximum()
     {
-        var settings = SettingsService.Instance;
+        var settings = GetInstance();
         settings.BrowserPanelWidth = 999;
         Assert.Equal(500, settings.BrowserPanelWidth);
     }
@@ -52,7 +72,7 @@ public class SettingsServiceTests
     [Fact]
     public void BrowserPanelWidth_AcceptsValidValue()
     {
-        var settings = SettingsService.Instance;
+        var settings = GetInstance();
         settings.BrowserPanelWidth = 300;
         Assert.Equal(300, settings.BrowserPanelWidth);
     }
@@ -60,24 +80,16 @@ public class SettingsServiceTests
     [Fact]
     public void OpenInEditorAfterCreate_DefaultsToTrue()
     {
-        Assert.True(SettingsService.Instance.OpenInEditorAfterCreate);
+        Assert.True(GetInstance().OpenInEditorAfterCreate);
     }
 
     [Fact]
     public void PreviewGender_RoundTripsValue()
     {
-        var settings = SettingsService.Instance;
-        var original = settings.PreviewGender;
-        try
-        {
-            settings.PreviewGender = 1;
-            Assert.Equal(1, settings.PreviewGender);
-            settings.PreviewGender = 0;
-            Assert.Equal(0, settings.PreviewGender);
-        }
-        finally
-        {
-            settings.PreviewGender = original;
-        }
+        var settings = GetInstance();
+        settings.PreviewGender = 1;
+        Assert.Equal(1, settings.PreviewGender);
+        settings.PreviewGender = 0;
+        Assert.Equal(0, settings.PreviewGender);
     }
 }


### PR DESCRIPTION
## Summary

Tech-debt sprint clearing developer-workflow, cache, and pipeline debt. No app runtime risk — a focused tooling/CI cleanup pass.

## Work Items

- [x] #2278 — Theme-scan triaged to a clean **0 baseline**; every hit suppressed with a reasoned `theme-ok` (9 false positives + 8 legit fallback/literal-color/scrim, no real drift).
- [~] #2464 — Test consolidation, **partial**: shared `ToolSettingsServiceTestBase` (5 tools) + ~45 search-provider facts → theories + trivial-test cleanup. CommandLineService base / Dictionary / Parley fixtures deferred — see the issue comment (blocked by an xunit-v2/v3 split that needs an Avalonia 11→12 upgrade). #2464 stays open.
- [x] #2468 — `/pre-merge` git range syntax replaced with merge-base / `git cherry` equivalents; pattern documented in CLAUDE.md.
- [x] #2471 — Selective auto-merge **evaluated** (recommendation only; blocked on adding required status checks to the branch ruleset first — write-up in NonPublic).
- [x] #2473 — Refresh-GitHubCache tool-label list updated (relique/reliquary/marlinspike); missing-tool-label count 13 → 0.

## Related Issues

- Closes #2559
- Relates to #2464 (partially addressed; remains open for deferred items)

## Checklist

- [x] All work items completed or explicitly deferred with reasons
- [x] Affected scripts/tests verified (QM 1272 · Fence 165 · Manifest 132 · Relique 375 · Reliquary 134 · Radoub.UI 1361 · Radoub.Formats 1493 — all pass)
- [x] CHANGELOG updated with date

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
