### PR TITLE
[Trebuchet] Feat: Create new ERF/MOD from scratch (#2268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.x-alpha] - 2026-06-28
+**Branch**: `trebuchet/issue-2268` | **PR**: #2607
+
+### BackupCleanupService: managed Archives bucket
+
+- `BackupCleanupService` now applies flat-file retention to an `Archives/` bucket (alongside `SearchReplace/`), so ERF/HAK archive backups under `~/Radoub/Backups/Archives/` fall under the existing backup retention policy (#2268).
+
+---
+
 ## [Workflow Tooling] - 2026-06-27
 **Branch**: `radoub/issue-2559` | **PR**: #2604
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [Radoub.UI 0.x-alpha] - 2026-06-28
+## [Radoub.UI 0.2.31-alpha] - 2026-06-28
 **Branch**: `trebuchet/issue-2268` | **PR**: #2607
 
 ### BackupCleanupService: managed Archives bucket

--- a/Radoub.UI/Radoub.UI.Tests/Services/BackupCleanupServiceTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/BackupCleanupServiceTests.cs
@@ -38,6 +38,43 @@ public class BackupCleanupServiceTests : IDisposable
         return path;
     }
 
+    private string CreateArchiveBackup(string fileName, DateTime timestamp)
+    {
+        var dir = Path.Combine(_tempRoot, "Archives");
+        Directory.CreateDirectory(dir);
+        var ext = Path.GetExtension(fileName);
+        var name = Path.GetFileNameWithoutExtension(fileName);
+        var path = Path.Combine(dir, $"{name}_{timestamp:yyyyMMdd_HHmmss}{ext}");
+        File.WriteAllText(path, "archive backup data");
+        return path;
+    }
+
+    [Fact]
+    public void CleanupExpiredBackups_DeletesOldArchiveBackups()
+    {
+        var now = DateTime.Now;
+        CreateArchiveBackup("myassets.erf", now.AddDays(-60));
+        CreateArchiveBackup("bigpack.hak", now.AddDays(-5));
+
+        BackupCleanupService.CleanupExpiredBackups(30, _tempRoot);
+
+        var remaining = Directory.GetFiles(Path.Combine(_tempRoot, "Archives"));
+        Assert.Single(remaining);
+        Assert.Contains("bigpack", remaining[0]);
+    }
+
+    [Fact]
+    public void CleanupExpiredBackups_KeepsRecentArchiveBackups()
+    {
+        var now = DateTime.Now;
+        CreateArchiveBackup("a.erf", now.AddDays(-1));
+        CreateArchiveBackup("b.erf", now.AddDays(-29));
+
+        BackupCleanupService.CleanupExpiredBackups(30, _tempRoot);
+
+        Assert.Equal(2, Directory.GetFiles(Path.Combine(_tempRoot, "Archives")).Length);
+    }
+
     [Fact]
     public void CleanupExpiredBackups_DeletesOldBatchBackups()
     {

--- a/Radoub.UI/Radoub.UI/Services/BackupCleanupService.cs
+++ b/Radoub.UI/Radoub.UI/Services/BackupCleanupService.cs
@@ -6,13 +6,28 @@ namespace Radoub.UI.Services;
 /// <summary>
 /// Cleans up old backup files based on a retention policy (days).
 /// Handles both batch replace backups (~/Radoub/Backups/{Module}/{Timestamp}/)
-/// and single-file replace backups (~/Radoub/Backups/SearchReplace/{file}_{timestamp}.ext).
+/// and flat single-file backups (~/Radoub/Backups/{Bucket}/{file}_{timestamp}.ext),
+/// where {Bucket} is a known flat-file bucket such as SearchReplace or Archives.
 /// </summary>
 public static class BackupCleanupService
 {
     private static readonly string DefaultBackupRoot = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
         "Radoub", "Backups");
+
+    /// <summary>
+    /// Subfolder name under the backup root that holds ERF/HAK archive backups (#2268).
+    /// Archives are large, so these are managed flat-file backups under the same retention
+    /// as every other backup bucket.
+    /// </summary>
+    public const string ArchivesBucket = "Archives";
+
+    /// <summary>
+    /// Backup-root subfolders that use the flat single-file layout ({name}_{timestamp}.ext)
+    /// rather than the {Module}/{Timestamp}/ batch layout.
+    /// </summary>
+    private static readonly HashSet<string> FlatFileBuckets =
+        new(StringComparer.OrdinalIgnoreCase) { "SearchReplace", ArchivesBucket };
 
     /// <summary>
     /// Delete backup directories/files older than retentionDays.
@@ -32,9 +47,9 @@ public static class BackupCleanupService
             {
                 var moduleDirName = Path.GetFileName(moduleDir);
 
-                if (moduleDirName == "SearchReplace")
+                if (FlatFileBuckets.Contains(moduleDirName))
                 {
-                    deletedCount += CleanupSearchReplaceBackups(moduleDir, cutoff);
+                    deletedCount += CleanupFlatFileBackups(moduleDir, cutoff);
                 }
                 else
                 {
@@ -152,11 +167,11 @@ public static class BackupCleanupService
         return deleted;
     }
 
-    private static int CleanupSearchReplaceBackups(string searchReplaceDir, DateTime cutoff)
+    private static int CleanupFlatFileBackups(string bucketDir, DateTime cutoff)
     {
         int deleted = 0;
 
-        foreach (var file in Directory.GetFiles(searchReplaceDir))
+        foreach (var file in Directory.GetFiles(bucketDir))
         {
             var fileName = Path.GetFileNameWithoutExtension(file);
             if (TryParseFileTimestamp(fileName, out var timestamp) && timestamp < cutoff)
@@ -165,22 +180,22 @@ public static class BackupCleanupService
                 {
                     File.Delete(file);
                     deleted++;
-                    UnifiedLogger.LogApplication(LogLevel.DEBUG, $"Deleted expired search/replace backup: {file}");
+                    UnifiedLogger.LogApplication(LogLevel.DEBUG, $"Deleted expired backup: {file}");
                 }
                 catch (Exception ex)
                 {
-                    UnifiedLogger.LogApplication(LogLevel.DEBUG, $"Failed to delete search/replace backup: {ex.Message}");
+                    UnifiedLogger.LogApplication(LogLevel.DEBUG, $"Failed to delete backup: {ex.Message}");
                 }
             }
         }
 
-        // Remove empty SearchReplace directory
+        // Remove the bucket directory if it is now empty.
         try
         {
-            if (Directory.Exists(searchReplaceDir) &&
-                Directory.GetFiles(searchReplaceDir).Length == 0)
+            if (Directory.Exists(bucketDir) &&
+                Directory.GetFiles(bucketDir).Length == 0)
             {
-                Directory.Delete(searchReplaceDir);
+                Directory.Delete(bucketDir);
             }
         }
         catch { /* ignore */ }

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Feature: Create new ERF/MOD from scratch (#2268)
 
 - New ERF creation: "New ERF..." produces an empty `.erf` archive ready for resources.
+- Add to ERF: "Add to ERF..." adds files (scripts, blueprints, assets) into an existing archive, zip-style — picker defaults to the current module folder so palette assets are at hand.
 - New module creation service (seeded from a blank-forest template) — backend + tests only, not yet wired into the UI pending area-creation support.
 
 ---

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.40.0-alpha] - 2026-06-27
+**Branch**: `trebuchet/issue-2268` | **PR**: #TBD
+
+### Feature: Create new ERF/MOD from scratch (#2268)
+
+- New ERF creation: "New ERF..." produces an empty `.erf` archive ready for resources.
+- New module creation service (seeded from a blank-forest template) — backend + tests only, not yet wired into the UI pending area-creation support.
+
+---
+
 ## [1.21.0-alpha] - 2026-06-14
 **Branch**: `trebuchet/issue-2477` | **PR**: #2483
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [1.40.0-alpha] - 2026-06-27
-**Branch**: `trebuchet/issue-2268` | **PR**: #TBD
+**Branch**: `trebuchet/issue-2268` | **PR**: #2607
 
 ### Feature: Create new ERF/MOD from scratch (#2268)
 

--- a/Trebuchet/Trebuchet.Tests/ErfAssetServiceTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ErfAssetServiceTests.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Radoub.Formats.Common;
+using Radoub.Formats.Erf;
+using RadoubLauncher.Services;
+using Xunit;
+
+namespace Trebuchet.Tests;
+
+public class ErfAssetServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _erfPath;
+    private readonly ErfAssetService _service;
+
+    public ErfAssetServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "ErfAssetTest_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+        _erfPath = Path.Combine(_tempDir, "archive.erf");
+        _service = new ErfAssetService();
+
+        // Start from an empty ERF (the create-from-scratch output).
+        new ErfCreationService().CreateErf(_erfPath, overwrite: true);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    private string WriteSourceFile(string name, byte[] content)
+    {
+        var path = Path.Combine(_tempDir, name);
+        File.WriteAllBytes(path, content);
+        return path;
+    }
+
+    [Fact]
+    public void AddFiles_AddsResourceToEmptyErf()
+    {
+        var src = WriteSourceFile("door_open.ncs", new byte[] { 0x4E, 0x43, 0x53, 0x20 });
+
+        var result = _service.AddFiles(_erfPath, new[] { src }, overwriteExisting: false);
+
+        Assert.Equal(1, result.AddedCount);
+        var erf = ErfReader.Read(_erfPath);
+        Assert.Contains(erf.Resources,
+            r => r.ResRef.Equals("door_open", StringComparison.OrdinalIgnoreCase) && r.ResourceType == ResourceTypes.Ncs);
+    }
+
+    [Fact]
+    public void AddFiles_PreservesFileContent()
+    {
+        var content = new byte[] { 1, 2, 3, 4, 5 };
+        var src = WriteSourceFile("sword01.uti", content);
+
+        _service.AddFiles(_erfPath, new[] { src }, overwriteExisting: false);
+
+        var erf = ErfReader.Read(_erfPath);
+        var entry = erf.FindResource("sword01", ResourceTypes.Uti);
+        Assert.NotNull(entry);
+        Assert.Equal(content, ErfReader.ExtractResource(_erfPath, entry!));
+    }
+
+    [Fact]
+    public void AddFiles_AddsMultipleFiles()
+    {
+        var a = WriteSourceFile("scr_a.ncs", new byte[] { 1 });
+        var b = WriteSourceFile("item_b.uti", new byte[] { 2 });
+
+        var result = _service.AddFiles(_erfPath, new[] { a, b }, overwriteExisting: false);
+
+        Assert.Equal(2, result.AddedCount);
+        Assert.Equal(2, ErfReader.Read(_erfPath).Resources.Count);
+    }
+
+    [Fact]
+    public void AddFiles_PreservesExistingResources()
+    {
+        var first = WriteSourceFile("existing.ncs", new byte[] { 9 });
+        _service.AddFiles(_erfPath, new[] { first }, overwriteExisting: false);
+
+        var second = WriteSourceFile("added.uti", new byte[] { 8 });
+        _service.AddFiles(_erfPath, new[] { second }, overwriteExisting: false);
+
+        var erf = ErfReader.Read(_erfPath);
+        Assert.Equal(2, erf.Resources.Count);
+        Assert.NotNull(erf.FindResource("existing", ResourceTypes.Ncs));
+        Assert.NotNull(erf.FindResource("added", ResourceTypes.Uti));
+    }
+
+    [Fact]
+    public void AddFiles_SkipsDuplicateByDefault()
+    {
+        var first = WriteSourceFile("dup.ncs", new byte[] { 1 });
+        _service.AddFiles(_erfPath, new[] { first }, overwriteExisting: false);
+
+        var dupAgain = WriteSourceFile("dup.ncs", new byte[] { 2, 2 });
+        var result = _service.AddFiles(_erfPath, new[] { dupAgain }, overwriteExisting: false);
+
+        Assert.Equal(0, result.AddedCount);
+        Assert.Equal(1, result.SkippedCount);
+        // Original content untouched.
+        var erf = ErfReader.Read(_erfPath);
+        Assert.Equal(new byte[] { 1 }, ErfReader.ExtractResource(_erfPath, erf.FindResource("dup", ResourceTypes.Ncs)!));
+    }
+
+    [Fact]
+    public void AddFiles_OverwritesDuplicateWhenRequested()
+    {
+        var first = WriteSourceFile("dup.ncs", new byte[] { 1 });
+        _service.AddFiles(_erfPath, new[] { first }, overwriteExisting: false);
+
+        var dupAgain = WriteSourceFile("dup.ncs", new byte[] { 7, 7, 7 });
+        var result = _service.AddFiles(_erfPath, new[] { dupAgain }, overwriteExisting: true);
+
+        Assert.Equal(1, result.AddedCount);
+        var erf = ErfReader.Read(_erfPath);
+        Assert.Equal(1, erf.Resources.Count);
+        Assert.Equal(new byte[] { 7, 7, 7 }, ErfReader.ExtractResource(_erfPath, erf.FindResource("dup", ResourceTypes.Ncs)!));
+    }
+
+    [Fact]
+    public void AddFiles_RejectsUnknownExtension()
+    {
+        var src = WriteSourceFile("notes.xyz", new byte[] { 1 });
+
+        var result = _service.AddFiles(_erfPath, new[] { src }, overwriteExisting: false);
+
+        Assert.Equal(0, result.AddedCount);
+        Assert.Single(result.Errors);
+        Assert.Empty(ErfReader.Read(_erfPath).Resources);
+    }
+
+    [Fact]
+    public void AddFiles_RejectsTooLongResRef()
+    {
+        // 17-char stem exceeds Aurora's 16-char ResRef limit.
+        var src = WriteSourceFile("thisnameistoolong.ncs", new byte[] { 1 });
+
+        var result = _service.AddFiles(_erfPath, new[] { src }, overwriteExisting: false);
+
+        Assert.Equal(0, result.AddedCount);
+        Assert.Single(result.Errors);
+    }
+
+    [Fact]
+    public void AddFiles_ThrowsWhenErfMissing()
+    {
+        var missing = Path.Combine(_tempDir, "nope.erf");
+        var src = WriteSourceFile("scr.ncs", new byte[] { 1 });
+
+        Assert.Throws<FileNotFoundException>(() => _service.AddFiles(missing, new[] { src }, overwriteExisting: false));
+    }
+
+    [Fact]
+    public void AddFiles_SkipsMissingSourceFile()
+    {
+        var missing = Path.Combine(_tempDir, "ghost.ncs");
+
+        var result = _service.AddFiles(_erfPath, new[] { missing }, overwriteExisting: false);
+
+        Assert.Equal(0, result.AddedCount);
+        Assert.Single(result.Errors);
+    }
+}

--- a/Trebuchet/Trebuchet.Tests/ErfAssetServiceTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ErfAssetServiceTests.cs
@@ -12,6 +12,7 @@ namespace Trebuchet.Tests;
 public class ErfAssetServiceTests : IDisposable
 {
     private readonly string _tempDir;
+    private readonly string _backupRoot;
     private readonly string _erfPath;
     private readonly ErfAssetService _service;
 
@@ -19,8 +20,10 @@ public class ErfAssetServiceTests : IDisposable
     {
         _tempDir = Path.Combine(Path.GetTempPath(), "ErfAssetTest_" + Guid.NewGuid().ToString("N")[..8]);
         Directory.CreateDirectory(_tempDir);
+        _backupRoot = Path.Combine(_tempDir, "Backups");
         _erfPath = Path.Combine(_tempDir, "archive.erf");
-        _service = new ErfAssetService();
+        // Isolate backups to the temp dir so the suite never touches the real ~/Radoub/Backups.
+        _service = new ErfAssetService(_backupRoot);
 
         // Start from an empty ERF (the create-from-scratch output).
         new ErfCreationService().CreateErf(_erfPath, overwrite: true);
@@ -166,5 +169,45 @@ public class ErfAssetServiceTests : IDisposable
 
         Assert.Equal(0, result.AddedCount);
         Assert.Single(result.Errors);
+    }
+
+    [Fact]
+    public void AddFiles_WritesBackupToArchivesBucket()
+    {
+        var src = WriteSourceFile("scr.ncs", new byte[] { 1 });
+
+        _service.AddFiles(_erfPath, new[] { src }, overwriteExisting: false);
+
+        var archivesDir = Path.Combine(_backupRoot, "Archives");
+        Assert.True(Directory.Exists(archivesDir));
+        var backups = Directory.GetFiles(archivesDir, "archive_*.erf");
+        Assert.Single(backups);
+        // Backup is not left next to the working archive.
+        Assert.Empty(Directory.GetFiles(_tempDir, "archive_backup_*.erf"));
+    }
+
+    [Fact]
+    public void AddFiles_NoBackupWhenDisabled()
+    {
+        var src = WriteSourceFile("scr.ncs", new byte[] { 1 });
+
+        _service.AddFiles(_erfPath, new[] { src }, overwriteExisting: false, createBackup: false);
+
+        var archivesDir = Path.Combine(_backupRoot, "Archives");
+        Assert.False(Directory.Exists(archivesDir));
+    }
+
+    [Fact]
+    public void AddFiles_RapidAddsProduceDistinctBackups()
+    {
+        var a = WriteSourceFile("a.ncs", new byte[] { 1 });
+        var b = WriteSourceFile("b.ncs", new byte[] { 2 });
+
+        // Two adds in the same second must not collide on the backup filename.
+        _service.AddFiles(_erfPath, new[] { a }, overwriteExisting: false);
+        _service.AddFiles(_erfPath, new[] { b }, overwriteExisting: false);
+
+        var backups = Directory.GetFiles(Path.Combine(_backupRoot, "Archives"), "archive_*.erf");
+        Assert.Equal(2, backups.Length);
     }
 }

--- a/Trebuchet/Trebuchet.Tests/ErfCreationServiceTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ErfCreationServiceTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using Radoub.Formats.Erf;
+using RadoubLauncher.Services;
+using Xunit;
+
+namespace Trebuchet.Tests;
+
+public class ErfCreationServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly ErfCreationService _service;
+
+    public ErfCreationServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "ErfCreateTest_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+        _service = new ErfCreationService();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public void CreateErf_WritesFileToDisk()
+    {
+        var path = Path.Combine(_tempDir, "myarchive.erf");
+
+        _service.CreateErf(path);
+
+        Assert.True(File.Exists(path));
+    }
+
+    [Fact]
+    public void CreateErf_ProducesEmptyErfWithCorrectFileType()
+    {
+        var path = Path.Combine(_tempDir, "myarchive.erf");
+
+        _service.CreateErf(path);
+
+        var erf = ErfReader.Read(path);
+        Assert.Equal("ERF ", erf.FileType);
+        Assert.Equal("V1.0", erf.FileVersion);
+        Assert.Empty(erf.Resources);
+    }
+
+    [Fact]
+    public void CreateErf_WithDescription_StoresLocalizedString()
+    {
+        var path = Path.Combine(_tempDir, "myarchive.erf");
+
+        _service.CreateErf(path, description: "My test archive");
+
+        var erf = ErfReader.Read(path);
+        Assert.Contains(erf.LocalizedStrings, s => s.Text == "My test archive");
+    }
+
+    [Fact]
+    public void CreateErf_RejectsInvalidAuroraFilename()
+    {
+        // 17-char stem exceeds Aurora's 16-char limit
+        var path = Path.Combine(_tempDir, "thisnameistoolong.erf");
+
+        var ex = Assert.Throws<ArgumentException>(() => _service.CreateErf(path));
+        Assert.Contains("16", ex.Message);
+    }
+
+    [Fact]
+    public void CreateErf_RejectsIllegalCharacters()
+    {
+        var path = Path.Combine(_tempDir, "bad-name!.erf");
+
+        Assert.Throws<ArgumentException>(() => _service.CreateErf(path));
+    }
+
+    [Fact]
+    public void CreateErf_DoesNotOverwriteExistingByDefault()
+    {
+        var path = Path.Combine(_tempDir, "exists.erf");
+        File.WriteAllText(path, "preexisting");
+
+        Assert.Throws<IOException>(() => _service.CreateErf(path));
+    }
+}

--- a/Trebuchet/Trebuchet.Tests/ModuleCreationServiceTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ModuleCreationServiceTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Radoub.Formats.Common;
+using Radoub.Formats.Erf;
+using RadoubLauncher.Services;
+using Xunit;
+
+namespace Trebuchet.Tests;
+
+public class ModuleCreationServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _templatePath;
+    private readonly ModuleCreationService _service;
+
+    public ModuleCreationServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "ModCreateTest_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+        _templatePath = Path.Combine(_tempDir, "blank.mod");
+        _service = new ModuleCreationService();
+
+        CreateTemplateMod();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    /// <summary>
+    /// Build a minimal blank-forest template .mod mirroring the real blank.mod:
+    /// one area (.are/.git/.gic), module.ifo, Repute.fac, and palette .itp stubs.
+    /// </summary>
+    private void CreateTemplateMod()
+    {
+        var erf = new ErfFile { FileType = "MOD ", FileVersion = "V1.0" };
+        var data = new Dictionary<(string ResRef, ushort Type), byte[]>();
+
+        Add(erf, data, "area001", ResourceTypes.Are, GffStub());
+        Add(erf, data, "area001", ResourceTypes.Git, GffStub());
+        Add(erf, data, "area001", ResourceTypes.Gic, GffStub());
+        Add(erf, data, "module", ResourceTypes.Ifo, GffStub());
+        Add(erf, data, "Repute", ResourceTypes.Fac, GffStub());
+        Add(erf, data, "creaturepalcus", ResourceTypes.Itp, GffStub());
+
+        ErfWriter.Write(erf, _templatePath, data);
+    }
+
+    private static byte[] GffStub() => new byte[] { 0x47, 0x46, 0x46, 0x20, 0x56, 0x33, 0x2E, 0x32 }; // "GFF V3.2"
+
+    private static void Add(ErfFile erf, Dictionary<(string, ushort), byte[]> data,
+        string resRef, ushort type, byte[] content)
+    {
+        erf.Resources.Add(new ErfResourceEntry { ResRef = resRef, ResourceType = type, ResId = (uint)erf.Resources.Count });
+        data[(resRef.ToLowerInvariant(), type)] = content;
+    }
+
+    [Fact]
+    public void CreateModule_WritesFileToDisk()
+    {
+        var outPath = Path.Combine(_tempDir, "mymodule.mod");
+
+        _service.CreateModule(outPath, _templatePath);
+
+        Assert.True(File.Exists(outPath));
+    }
+
+    [Fact]
+    public void CreateModule_ProducesModFileType()
+    {
+        var outPath = Path.Combine(_tempDir, "mymodule.mod");
+
+        _service.CreateModule(outPath, _templatePath);
+
+        var mod = ErfReader.Read(outPath);
+        Assert.Equal("MOD ", mod.FileType);
+        Assert.Equal("V1.0", mod.FileVersion);
+    }
+
+    [Fact]
+    public void CreateModule_SeedsModuleIfo()
+    {
+        var outPath = Path.Combine(_tempDir, "mymodule.mod");
+
+        _service.CreateModule(outPath, _templatePath);
+
+        var mod = ErfReader.Read(outPath);
+        Assert.Contains(mod.Resources,
+            r => r.ResRef.Equals("module", StringComparison.OrdinalIgnoreCase) && r.ResourceType == ResourceTypes.Ifo);
+    }
+
+    [Fact]
+    public void CreateModule_SeedsBlankForestArea()
+    {
+        var outPath = Path.Combine(_tempDir, "mymodule.mod");
+
+        _service.CreateModule(outPath, _templatePath);
+
+        var mod = ErfReader.Read(outPath);
+        Assert.Contains(mod.Resources,
+            r => r.ResRef.Equals("area001", StringComparison.OrdinalIgnoreCase) && r.ResourceType == ResourceTypes.Are);
+    }
+
+    [Fact]
+    public void CreateModule_PreservesAllTemplateResources()
+    {
+        var outPath = Path.Combine(_tempDir, "mymodule.mod");
+        var template = ErfReader.Read(_templatePath);
+
+        _service.CreateModule(outPath, _templatePath);
+
+        var mod = ErfReader.Read(outPath);
+        Assert.Equal(template.Resources.Count, mod.Resources.Count);
+    }
+
+    [Fact]
+    public void CreateModule_PreservesResourceContent()
+    {
+        var outPath = Path.Combine(_tempDir, "mymodule.mod");
+
+        _service.CreateModule(outPath, _templatePath);
+
+        // module.ifo content survives the copy intact
+        var mod = ErfReader.Read(outPath);
+        var ifo = mod.FindResource("module", ResourceTypes.Ifo);
+        Assert.NotNull(ifo);
+        var bytes = ErfReader.ExtractResource(outPath, ifo!);
+        Assert.Equal(GffStub(), bytes);
+    }
+
+    [Fact]
+    public void CreateModule_RejectsInvalidAuroraFilename()
+    {
+        var outPath = Path.Combine(_tempDir, "thisnameistoolong.mod");
+
+        var ex = Assert.Throws<ArgumentException>(() => _service.CreateModule(outPath, _templatePath));
+        Assert.Contains("16", ex.Message);
+    }
+
+    [Fact]
+    public void CreateModule_ThrowsWhenTemplateMissing()
+    {
+        var outPath = Path.Combine(_tempDir, "mymodule.mod");
+        var missing = Path.Combine(_tempDir, "nope.mod");
+
+        Assert.Throws<FileNotFoundException>(() => _service.CreateModule(outPath, missing));
+    }
+
+    [Fact]
+    public void CreateModule_DoesNotOverwriteExistingByDefault()
+    {
+        var outPath = Path.Combine(_tempDir, "exists.mod");
+        File.WriteAllText(outPath, "preexisting");
+
+        Assert.Throws<IOException>(() => _service.CreateModule(outPath, _templatePath));
+    }
+}

--- a/Trebuchet/Trebuchet.Tests/ModulePathHelperTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ModulePathHelperTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using RadoubLauncher.Services;
+using Xunit;
+
+namespace Trebuchet.Tests;
+
+public class ModulePathHelperTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public ModulePathHelperTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "ModPathTest_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public void IsCurrentModuleArchive_TrueWhenTargetIsOpenModuleMod()
+    {
+        var modPath = Path.Combine(_tempDir, "mymodule.mod");
+        File.WriteAllText(modPath, "x");
+
+        Assert.True(ModulePathHelper.IsCurrentModuleArchive(modPath, modPath));
+    }
+
+    [Fact]
+    public void IsCurrentModuleArchive_TrueWhenCurrentIsWorkingDir()
+    {
+        // CurrentModulePath can be the unpacked working dir; the target is the sibling .mod.
+        var workingDir = Path.Combine(_tempDir, "mymodule");
+        Directory.CreateDirectory(workingDir);
+        var modPath = Path.Combine(_tempDir, "mymodule.mod");
+        File.WriteAllText(modPath, "x");
+
+        Assert.True(ModulePathHelper.IsCurrentModuleArchive(modPath, workingDir));
+    }
+
+    [Fact]
+    public void IsCurrentModuleArchive_FalseForDifferentArchive()
+    {
+        var modPath = Path.Combine(_tempDir, "mymodule.mod");
+        File.WriteAllText(modPath, "x");
+        var otherErf = Path.Combine(_tempDir, "other.erf");
+        File.WriteAllText(otherErf, "x");
+
+        Assert.False(ModulePathHelper.IsCurrentModuleArchive(otherErf, modPath));
+    }
+
+    [Fact]
+    public void IsCurrentModuleArchive_CaseInsensitive()
+    {
+        var modPath = Path.Combine(_tempDir, "mymodule.mod");
+        File.WriteAllText(modPath, "x");
+        var upper = Path.Combine(_tempDir, "MYMODULE.MOD");
+
+        Assert.True(ModulePathHelper.IsCurrentModuleArchive(upper, modPath));
+    }
+
+    [Fact]
+    public void IsCurrentModuleArchive_FalseWhenNoModuleOpen()
+    {
+        var modPath = Path.Combine(_tempDir, "mymodule.mod");
+        File.WriteAllText(modPath, "x");
+
+        Assert.False(ModulePathHelper.IsCurrentModuleArchive(modPath, null));
+        Assert.False(ModulePathHelper.IsCurrentModuleArchive(modPath, ""));
+    }
+}

--- a/Trebuchet/Trebuchet/Services/ErfAssetService.cs
+++ b/Trebuchet/Trebuchet/Services/ErfAssetService.cs
@@ -47,13 +47,16 @@ public class ErfAssetService
 
         var result = new ErfAddResult();
 
-        var erf = ErfReader.Read(erfPath);
+        // Read the archive once into a buffer; extract existing resources from that buffer rather
+        // than re-opening the file per resource (a large archive has many resources).
+        var erfBuffer = File.ReadAllBytes(erfPath);
+        var erf = ErfReader.Read(erfBuffer);
 
         // Materialize the existing archive contents so the rewrite preserves them.
         var resourceData = new Dictionary<(string ResRef, ushort Type), byte[]>();
         foreach (var entry in erf.Resources)
             resourceData[(entry.ResRef.ToLowerInvariant(), entry.ResourceType)] =
-                ErfReader.ExtractResource(erfPath, entry);
+                ErfReader.ExtractResource(erfBuffer, entry);
 
         bool changed = false;
 

--- a/Trebuchet/Trebuchet/Services/ErfAssetService.cs
+++ b/Trebuchet/Trebuchet/Services/ErfAssetService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using Radoub.Formats.Common;
 using Radoub.Formats.Erf;
 using Radoub.Formats.Logging;
+using Radoub.UI.Services;
 
 namespace RadoubLauncher.Services;
 
@@ -17,6 +18,17 @@ namespace RadoubLauncher.Services;
 /// </summary>
 public class ErfAssetService
 {
+    private readonly string _backupRoot;
+
+    /// <param name="backupRoot">Root backup directory (defaults to ~/Radoub/Backups). Archive
+    /// backups land in its <see cref="BackupCleanupService.ArchivesBucket"/> subfolder.</param>
+    public ErfAssetService(string? backupRoot = null)
+    {
+        _backupRoot = backupRoot ?? Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            "Radoub", "Backups");
+    }
+
     /// <summary>
     /// Add the given files to <paramref name="erfPath"/>.
     /// </summary>
@@ -121,24 +133,14 @@ public class ErfAssetService
     }
 
     // Backup + atomic replace, mirroring ErfWriter.UpdateResource so a failure mid-swap never
-    // leaves the archive missing.
-    private static void WriteWithBackup(ErfFile erf, string erfPath,
+    // leaves the archive missing. The backup goes to the managed Archives bucket under
+    // ~/Radoub/Backups/ so it falls under the backup retention policy — ERFs/HAKs are large and
+    // should not pile up next to the working file (#2268).
+    private void WriteWithBackup(ErfFile erf, string erfPath,
         Dictionary<(string ResRef, ushort Type), byte[]> resourceData, bool createBackup)
     {
-        string? backupPath = null;
         if (createBackup)
-        {
-            var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
-            var directory = Path.GetDirectoryName(erfPath) ?? ".";
-            var fileName = Path.GetFileNameWithoutExtension(erfPath);
-            var extension = Path.GetExtension(erfPath);
-            backupPath = Path.Combine(directory, $"{fileName}_backup_{timestamp}{extension}");
-            // The HHmmss timestamp collides when two adds land in the same second; disambiguate
-            // so a rapid second add doesn't fail on File.Copy (overwrite: false).
-            for (int n = 2; File.Exists(backupPath); n++)
-                backupPath = Path.Combine(directory, $"{fileName}_backup_{timestamp}_{n}{extension}");
-            File.Copy(erfPath, backupPath, overwrite: false);
-        }
+            BackupToArchivesBucket(erfPath);
 
         var tempPath = erfPath + ".tmp";
         try
@@ -151,6 +153,32 @@ public class ErfAssetService
             if (File.Exists(tempPath))
                 File.Delete(tempPath);
         }
+    }
+
+    // Copy the archive to ~/Radoub/Backups/Archives/{name}_{yyyyMMdd_HHmmss}{ext}. The name keeps
+    // the timestamp as the trailing two underscore-segments so BackupCleanupService's flat-file
+    // retention parser recognizes it.
+    private void BackupToArchivesBucket(string erfPath)
+    {
+        var backupRoot = Path.Combine(_backupRoot, BackupCleanupService.ArchivesBucket);
+        Directory.CreateDirectory(backupRoot);
+
+        var name = Path.GetFileNameWithoutExtension(erfPath);
+        var ext = Path.GetExtension(erfPath);
+        var now = DateTime.Now;
+
+        var backupPath = Path.Combine(backupRoot, $"{name}_{now:yyyyMMdd_HHmmss}{ext}");
+
+        // Two adds in the same second collide; bump the seconds forward until the name is free so
+        // the timestamp stays the trailing segment (parser-compatible) and File.Copy won't clobber.
+        var candidate = now;
+        while (File.Exists(backupPath))
+        {
+            candidate = candidate.AddSeconds(1);
+            backupPath = Path.Combine(backupRoot, $"{name}_{candidate:yyyyMMdd_HHmmss}{ext}");
+        }
+
+        File.Copy(erfPath, backupPath, overwrite: false);
     }
 }
 

--- a/Trebuchet/Trebuchet/Services/ErfAssetService.cs
+++ b/Trebuchet/Trebuchet/Services/ErfAssetService.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Radoub.Formats.Common;
+using Radoub.Formats.Erf;
+using Radoub.Formats.Logging;
+
+namespace RadoubLauncher.Services;
+
+/// <summary>
+/// Adds asset files to an existing ERF/MOD archive, zip-style (#2268): each source file
+/// becomes a resource whose ResRef is the filename stem and whose type is derived from the
+/// extension. Files keep their identity, exactly like entries in a zip.
+///
+/// Wraps <see cref="ErfReader"/>/<see cref="ErfWriter"/> with the same backup + atomic-replace
+/// robustness as <see cref="ErfWriter.UpdateResource"/>, but batches many files in one rewrite.
+/// </summary>
+public class ErfAssetService
+{
+    /// <summary>
+    /// Add the given files to <paramref name="erfPath"/>.
+    /// </summary>
+    /// <param name="erfPath">Existing ERF/MOD to add into.</param>
+    /// <param name="filePaths">Source files on disk to add.</param>
+    /// <param name="overwriteExisting">When true, a file whose ResRef+type already exists in the
+    /// archive replaces it; when false, such files are skipped.</param>
+    /// <param name="createBackup">When true (default), a timestamped backup is written before modifying.</param>
+    /// <returns>A summary of what was added, skipped, and rejected.</returns>
+    /// <exception cref="FileNotFoundException">The ERF does not exist.</exception>
+    public ErfAddResult AddFiles(string erfPath, IEnumerable<string> filePaths,
+        bool overwriteExisting, bool createBackup = true)
+    {
+        if (!File.Exists(erfPath))
+            throw new FileNotFoundException($"ERF archive not found: {erfPath}", erfPath);
+
+        var result = new ErfAddResult();
+
+        var erf = ErfReader.Read(erfPath);
+
+        // Materialize the existing archive contents so the rewrite preserves them.
+        var resourceData = new Dictionary<(string ResRef, ushort Type), byte[]>();
+        foreach (var entry in erf.Resources)
+            resourceData[(entry.ResRef.ToLowerInvariant(), entry.ResourceType)] =
+                ErfReader.ExtractResource(erfPath, entry);
+
+        bool changed = false;
+
+        foreach (var filePath in filePaths)
+        {
+            if (!File.Exists(filePath))
+            {
+                result.Errors.Add((Path.GetFileName(filePath), "Source file not found"));
+                continue;
+            }
+
+            var stem = Path.GetFileNameWithoutExtension(filePath);
+            var ext = Path.GetExtension(filePath);
+            var type = ResourceTypes.FromExtension(ext);
+
+            if (type == ResourceTypes.Invalid)
+            {
+                result.Errors.Add((stem, $"Unknown resource type for extension '{ext}'"));
+                continue;
+            }
+
+            if (!IsResRefValid(stem))
+            {
+                result.Errors.Add((stem, "Invalid ResRef: must be 1-16 chars, alphanumeric/underscore, lowercase"));
+                continue;
+            }
+
+            var key = (stem.ToLowerInvariant(), type);
+            bool exists = resourceData.ContainsKey(key);
+            if (exists && !overwriteExisting)
+            {
+                result.SkippedCount++;
+                continue;
+            }
+
+            var bytes = File.ReadAllBytes(filePath);
+            resourceData[key] = bytes;
+
+            if (!exists)
+            {
+                erf.Resources.Add(new ErfResourceEntry
+                {
+                    ResRef = stem.ToLowerInvariant(),
+                    ResourceType = type,
+                    ResId = (uint)erf.Resources.Count,
+                });
+            }
+
+            result.AddedCount++;
+            changed = true;
+        }
+
+        if (changed)
+            WriteWithBackup(erf, erfPath, resourceData, createBackup);
+
+        UnifiedLogger.LogApplication(LogLevel.INFO,
+            $"ERF add: {result.AddedCount} added, {result.SkippedCount} skipped, {result.Errors.Count} rejected " +
+            $"-> {PrivacyHelper.SanitizePath(erfPath)}");
+
+        return result;
+    }
+
+    // Aurora ResRef: 1-16 chars, alphanumeric + underscore, lowercase. Mirrors the
+    // AuroraFilenameValidator rules but operates on the already-extracted stem.
+    private static bool IsResRefValid(string resRef)
+    {
+        if (string.IsNullOrEmpty(resRef) || resRef.Length > 16)
+            return false;
+        foreach (var c in resRef)
+        {
+            if (!(char.IsLetterOrDigit(c) && c <= 127) && c != '_')
+                return false;
+            if (char.IsUpper(c))
+                return false;
+        }
+        return true;
+    }
+
+    // Backup + atomic replace, mirroring ErfWriter.UpdateResource so a failure mid-swap never
+    // leaves the archive missing.
+    private static void WriteWithBackup(ErfFile erf, string erfPath,
+        Dictionary<(string ResRef, ushort Type), byte[]> resourceData, bool createBackup)
+    {
+        string? backupPath = null;
+        if (createBackup)
+        {
+            var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+            var directory = Path.GetDirectoryName(erfPath) ?? ".";
+            var fileName = Path.GetFileNameWithoutExtension(erfPath);
+            var extension = Path.GetExtension(erfPath);
+            backupPath = Path.Combine(directory, $"{fileName}_backup_{timestamp}{extension}");
+            // The HHmmss timestamp collides when two adds land in the same second; disambiguate
+            // so a rapid second add doesn't fail on File.Copy (overwrite: false).
+            for (int n = 2; File.Exists(backupPath); n++)
+                backupPath = Path.Combine(directory, $"{fileName}_backup_{timestamp}_{n}{extension}");
+            File.Copy(erfPath, backupPath, overwrite: false);
+        }
+
+        var tempPath = erfPath + ".tmp";
+        try
+        {
+            ErfWriter.Write(erf, tempPath, resourceData);
+            AtomicFile.Replace(tempPath, erfPath, backupPath: null);
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
+        }
+    }
+}
+
+/// <summary>Summary of an <see cref="ErfAssetService.AddFiles"/> operation.</summary>
+public class ErfAddResult
+{
+    /// <summary>Number of resources added or overwritten.</summary>
+    public int AddedCount { get; set; }
+
+    /// <summary>Number of files skipped because their ResRef+type already existed.</summary>
+    public int SkippedCount { get; set; }
+
+    /// <summary>Files rejected before adding: (name, reason).</summary>
+    public List<(string Name, string Reason)> Errors { get; } = new();
+}

--- a/Trebuchet/Trebuchet/Services/ErfCreationService.cs
+++ b/Trebuchet/Trebuchet/Services/ErfCreationService.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Radoub.Formats.Erf;
+using Radoub.Formats.Logging;
+using Radoub.UI.Services;
+
+namespace RadoubLauncher.Services;
+
+/// <summary>
+/// Creates new, empty ERF archives from scratch.
+/// Wraps <see cref="ErfWriter"/> (which already supports write-from-scratch with an
+/// empty resource list) and enforces Aurora filename constraints up front (#2268).
+/// </summary>
+public class ErfCreationService
+{
+    /// <summary>
+    /// Create a new empty ERF archive at the given path.
+    /// </summary>
+    /// <param name="filePath">Output path. The filename stem (without extension) must satisfy
+    /// Aurora's 16-char, lowercase, alphanumeric/underscore constraints.</param>
+    /// <param name="description">Optional localized description (English, neutral gender).</param>
+    /// <param name="overwrite">When false (default), throws if the file already exists.</param>
+    /// <exception cref="ArgumentException">The filename violates Aurora naming rules.</exception>
+    /// <exception cref="IOException">The file exists and <paramref name="overwrite"/> is false.</exception>
+    public void CreateErf(string filePath, string? description = null, bool overwrite = false)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+            throw new ArgumentException("File path cannot be empty.", nameof(filePath));
+
+        var stem = Path.GetFileNameWithoutExtension(filePath);
+        var validation = AuroraFilenameValidator.Validate(stem);
+        if (!validation.IsValid)
+            throw new ArgumentException(validation.GetErrorMessage(), nameof(filePath));
+
+        if (!overwrite && File.Exists(filePath))
+            throw new IOException($"File already exists: {filePath}");
+
+        var erf = new ErfFile
+        {
+            FileType = "ERF ",
+            FileVersion = "V1.0",
+        };
+
+        if (!string.IsNullOrEmpty(description))
+        {
+            // LanguageId 0 = English, neutral/masculine gender (LanguageID * 2 + Gender).
+            erf.LocalizedStrings.Add(new ErfLocalizedString { LanguageId = 0, Text = description });
+        }
+
+        // Empty archive: no resources, so an empty data dictionary.
+        var resourceData = new Dictionary<(string ResRef, ushort Type), byte[]>();
+        ErfWriter.Write(erf, filePath, resourceData);
+
+        UnifiedLogger.LogApplication(LogLevel.INFO, $"Created new empty ERF: {PrivacyHelper.SanitizePath(filePath)}");
+    }
+}

--- a/Trebuchet/Trebuchet/Services/ModuleCreationService.cs
+++ b/Trebuchet/Trebuchet/Services/ModuleCreationService.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Radoub.Formats.Erf;
+using Radoub.Formats.Logging;
+using Radoub.UI.Services;
+
+namespace RadoubLauncher.Services;
+
+/// <summary>
+/// Creates a new module (.mod) from scratch by cloning a blank-forest template (#2268).
+///
+/// The template is a complete, NWN:EE-loadable blank module — one area (.are/.git/.gic),
+/// module.ifo, Repute.fac, and the standard palette .itp files. Cloning the template
+/// (rather than synthesizing each format) guarantees the result loads in-game without
+/// reimplementing ARE/GIT/IFO generation.
+///
+/// NOTE: This service is intentionally NOT wired into the Trebuchet UI yet. There is
+/// little value in a "New Module" command until area creation exists; this lays the
+/// tested foundation to wire in later.
+/// </summary>
+public class ModuleCreationService
+{
+    /// <summary>
+    /// Create a new module at <paramref name="filePath"/> by cloning <paramref name="templatePath"/>.
+    /// </summary>
+    /// <param name="filePath">Output .mod path. The filename stem must satisfy Aurora's
+    /// 16-char, lowercase, alphanumeric/underscore constraints.</param>
+    /// <param name="templatePath">Path to a blank-forest template .mod to clone.</param>
+    /// <param name="overwrite">When false (default), throws if the output already exists.</param>
+    /// <exception cref="ArgumentException">The filename violates Aurora naming rules.</exception>
+    /// <exception cref="FileNotFoundException">The template does not exist.</exception>
+    /// <exception cref="IOException">The output exists and <paramref name="overwrite"/> is false.</exception>
+    public void CreateModule(string filePath, string templatePath, bool overwrite = false)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+            throw new ArgumentException("File path cannot be empty.", nameof(filePath));
+
+        var stem = Path.GetFileNameWithoutExtension(filePath);
+        var validation = AuroraFilenameValidator.Validate(stem);
+        if (!validation.IsValid)
+            throw new ArgumentException(validation.GetErrorMessage(), nameof(filePath));
+
+        if (!File.Exists(templatePath))
+            throw new FileNotFoundException($"Module template not found: {templatePath}", templatePath);
+
+        if (!overwrite && File.Exists(filePath))
+            throw new IOException($"File already exists: {filePath}");
+
+        // Read the template and re-extract every resource so the new module is a clean,
+        // self-contained copy rather than a reference to the template on disk.
+        var template = ErfReader.Read(templatePath);
+        var resourceData = new Dictionary<(string ResRef, ushort Type), byte[]>();
+        foreach (var entry in template.Resources)
+        {
+            resourceData[(entry.ResRef.ToLowerInvariant(), entry.ResourceType)] =
+                ErfReader.ExtractResource(templatePath, entry);
+        }
+
+        var mod = new ErfFile
+        {
+            FileType = "MOD ",
+            FileVersion = "V1.0",
+            // Stamp the new module's build date (days since 1900-01-01).
+            BuildYear = (uint)(DateTime.Now.Year - 1900),
+            BuildDay = (uint)DateTime.Now.DayOfYear,
+            Resources = template.Resources,
+            LocalizedStrings = template.LocalizedStrings,
+            DescriptionStrRef = template.DescriptionStrRef,
+        };
+
+        ErfWriter.Write(mod, filePath, resourceData);
+
+        UnifiedLogger.LogApplication(LogLevel.INFO,
+            $"Created new module from template: {PrivacyHelper.SanitizePath(filePath)} " +
+            $"({mod.Resources.Count} resources)");
+    }
+}

--- a/Trebuchet/Trebuchet/Services/ModulePathHelper.cs
+++ b/Trebuchet/Trebuchet/Services/ModulePathHelper.cs
@@ -89,4 +89,25 @@ public static class ModulePathHelper
     /// </summary>
     public static string? FindWorkingDirectoryWithFallbacks(string? modulePath)
         => PathHelper.FindWorkingDirectoryWithFallbacks(modulePath);
+
+    /// <summary>
+    /// Returns true when <paramref name="archivePath"/> is the currently-open module's own .mod
+    /// (#2268). Adding a module's contents back to itself via Add-to-ERF is a confusing no-op —
+    /// "Save Module" is what repacks the working files. <paramref name="currentModulePath"/> may
+    /// be either the .mod or its unpacked working directory.
+    /// </summary>
+    public static bool IsCurrentModuleArchive(string? archivePath, string? currentModulePath)
+    {
+        if (string.IsNullOrEmpty(archivePath) || string.IsNullOrEmpty(currentModulePath))
+            return false;
+
+        var currentMod = GetModFilePath(currentModulePath);
+        if (string.IsNullOrEmpty(currentMod))
+            return false;
+
+        return string.Equals(
+            Path.GetFullPath(archivePath),
+            Path.GetFullPath(currentMod),
+            StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml
@@ -96,6 +96,10 @@
                             IsEnabled="{Binding CanBuildModule}"
                             Padding="8,4"
                             ToolTip.Tip="Save IFO changes and pack working directory into .mod file"/>
+                    <Button Content="New ERF..."
+                            Click="OnNewErfClick"
+                            Padding="8,4"
+                            ToolTip.Tip="Create a new empty ERF archive"/>
                     <Button Content="Import ERF..."
                             Click="OnImportErfClick"
                             IsVisible="{Binding IsModuleUnpacked}"

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml
@@ -100,6 +100,10 @@
                             Click="OnNewErfClick"
                             Padding="8,4"
                             ToolTip.Tip="Create a new empty ERF archive"/>
+                    <Button Content="Add to ERF..."
+                            Click="OnAddToErfClick"
+                            Padding="8,4"
+                            ToolTip.Tip="Add files (scripts, blueprints, assets) to an existing ERF archive"/>
                     <Button Content="Import ERF..."
                             Click="OnImportErfClick"
                             IsVisible="{Binding IsModuleUnpacked}"

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
@@ -425,4 +425,83 @@ public partial class MainWindow : Window
     }
 
     #endregion
+
+    #region Add to ERF
+
+    private async void OnAddToErfClick(object? sender, RoutedEventArgs e)
+    {
+        var storage = GetTopLevel(this)?.StorageProvider;
+        if (storage is null) return;
+
+        // 1. Pick the target ERF (must already exist).
+        var targets = await storage.OpenFilePickerAsync(new Avalonia.Platform.Storage.FilePickerOpenOptions
+        {
+            Title = "Add to ERF Archive — choose target",
+            AllowMultiple = false,
+            FileTypeFilter = new[]
+            {
+                new Avalonia.Platform.Storage.FilePickerFileType("ERF/MOD/HAK Archives")
+                {
+                    Patterns = new[] { "*.erf", "*.mod", "*.hak" }
+                }
+            }
+        });
+        if (targets.Count == 0) return;
+        var erfPath = targets[0].Path.LocalPath;
+
+        // 2. Pick files to add. Default the picker to the current module's working folder so
+        //    palette assets (loose blueprints, compiled scripts) are right there to select.
+        var startFolder = await TryGetModuleFolderAsync(storage);
+        var files = await storage.OpenFilePickerAsync(new Avalonia.Platform.Storage.FilePickerOpenOptions
+        {
+            Title = "Add to ERF — choose files",
+            AllowMultiple = true,
+            SuggestedStartLocation = startFolder,
+            FileTypeFilter = new[]
+            {
+                new Avalonia.Platform.Storage.FilePickerFileType("Aurora resources")
+                {
+                    Patterns = new[] { "*.ncs", "*.nss", "*.uti", "*.utc", "*.utp", "*.utd", "*.utm",
+                                       "*.utt", "*.uts", "*.ute", "*.utw", "*.dlg", "*.are", "*.git",
+                                       "*.gic", "*.2da", "*.fac", "*.jrl", "*.itp" }
+                },
+                new Avalonia.Platform.Storage.FilePickerFileType("All Files") { Patterns = new[] { "*" } }
+            }
+        });
+        if (files.Count == 0) return;
+
+        var paths = new System.Collections.Generic.List<string>();
+        foreach (var f in files)
+            paths.Add(f.Path.LocalPath);
+
+        try
+        {
+            var result = new ErfAssetService().AddFiles(erfPath, paths, overwriteExisting: false);
+            var message =
+                $"Added {result.AddedCount} resource(s) to {System.IO.Path.GetFileName(erfPath)}.\n" +
+                $"Skipped {result.SkippedCount} (already present).";
+            if (result.Errors.Count > 0)
+            {
+                message += $"\n\nRejected {result.Errors.Count}:";
+                foreach (var (name, reason) in result.Errors)
+                    message += $"\n  • {name}: {reason}";
+            }
+            new AlertDialog("Add to ERF", message).Show(this);
+        }
+        catch (Exception ex)
+        {
+            new AlertDialog("Add to ERF Failed", ex.Message).Show(this);
+        }
+    }
+
+    private static async System.Threading.Tasks.Task<Avalonia.Platform.Storage.IStorageFolder?>
+        TryGetModuleFolderAsync(Avalonia.Platform.Storage.IStorageProvider storage)
+    {
+        var folder = ModulePathHelper.GetWorkingDirectory(RadoubSettings.Instance.CurrentModulePath);
+        if (string.IsNullOrEmpty(folder) || !System.IO.Directory.Exists(folder))
+            return null;
+        return await storage.TryGetFolderFromPathAsync(new Uri(folder));
+    }
+
+    #endregion
 }

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
@@ -440,22 +440,24 @@ public partial class MainWindow : Window
             AllowMultiple = false,
             FileTypeFilter = new[]
             {
-                new Avalonia.Platform.Storage.FilePickerFileType("ERF/MOD/HAK Archives")
+                // ERF only. Adding to a .mod is the module workflow (unpack -> edit -> Save Module),
+                // and .hak has its own "Add to HAK" flow (#2267); neither belongs here.
+                new Avalonia.Platform.Storage.FilePickerFileType("ERF Archives")
                 {
-                    Patterns = new[] { "*.erf", "*.mod", "*.hak" }
+                    Patterns = new[] { "*.erf" }
                 }
             }
         });
         if (targets.Count == 0) return;
         var erfPath = targets[0].Path.LocalPath;
 
-        // Block the currently-open module's own .mod: adding its working files back to itself is a
-        // confusing no-op (everything reports "skipped"). "Save Module" is what repacks it (#2268).
+        // Defense-in-depth: the picker only offers .erf, but guard against the open module's own
+        // archive anyway — adding its working files back to itself is a confusing no-op (#2268).
         if (ModulePathHelper.IsCurrentModuleArchive(erfPath, RadoubSettings.Instance.CurrentModulePath))
         {
             new AlertDialog("Add to ERF",
                 "That is the currently open module. To pack its working files into the module, " +
-                "use Save Module.\n\nAdd to ERF is for building a separate ERF or HAK archive.").Show(this);
+                "use Save Module.\n\nAdd to ERF builds a separate ERF archive.").Show(this);
             return;
         }
 
@@ -470,7 +472,7 @@ public partial class MainWindow : Window
             FileTypeFilter = new[]
             {
                 // Module user-generated content: blueprints, scripts, and dialog — the assets
-                // a user authors and would package into an ERF/MOD/HAK.
+                // a user authors and would package into an ERF.
                 new Avalonia.Platform.Storage.FilePickerFileType("Module content (blueprints, scripts)")
                 {
                     Patterns = new[] { "*.utc", "*.uti", "*.utp", "*.utd", "*.utt", "*.uts",

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
@@ -380,4 +380,49 @@ public partial class MainWindow : Window
     }
 
     #endregion
+
+    #region New ERF
+
+    private async void OnNewErfClick(object? sender, RoutedEventArgs e)
+    {
+        var storage = GetTopLevel(this)?.StorageProvider;
+        if (storage is null) return;
+
+        var file = await storage.SaveFilePickerAsync(new Avalonia.Platform.Storage.FilePickerSaveOptions
+        {
+            Title = "New ERF Archive",
+            DefaultExtension = "erf",
+            SuggestedFileName = "newarchive.erf",
+            FileTypeChoices = new[]
+            {
+                new Avalonia.Platform.Storage.FilePickerFileType("ERF Archives") { Patterns = new[] { "*.erf" } }
+            }
+        });
+
+        if (file is null) return;
+
+        var path = file.Path.LocalPath;
+
+        // Validate the chosen filename against Aurora constraints before writing,
+        // so the user gets a clear message instead of an unusable in-game file (#2268).
+        var stem = System.IO.Path.GetFileNameWithoutExtension(path);
+        var validation = AuroraFilenameValidator.Validate(stem);
+        if (!validation.IsValid)
+        {
+            new AlertDialog("Invalid ERF Name", validation.GetErrorMessage()).Show(this);
+            return;
+        }
+
+        try
+        {
+            new ErfCreationService().CreateErf(path, overwrite: true);
+            new AlertDialog("ERF Created", $"Created empty ERF archive:\n{System.IO.Path.GetFileName(path)}").Show(this);
+        }
+        catch (Exception ex)
+        {
+            new AlertDialog("ERF Creation Failed", ex.Message).Show(this);
+        }
+    }
+
+    #endregion
 }

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
@@ -459,11 +459,12 @@ public partial class MainWindow : Window
             SuggestedStartLocation = startFolder,
             FileTypeFilter = new[]
             {
-                new Avalonia.Platform.Storage.FilePickerFileType("Aurora resources")
+                // Module user-generated content: blueprints, scripts, and dialog — the assets
+                // a user authors and would package into an ERF/MOD/HAK.
+                new Avalonia.Platform.Storage.FilePickerFileType("Module content (blueprints, scripts)")
                 {
-                    Patterns = new[] { "*.ncs", "*.nss", "*.uti", "*.utc", "*.utp", "*.utd", "*.utm",
-                                       "*.utt", "*.uts", "*.ute", "*.utw", "*.dlg", "*.are", "*.git",
-                                       "*.gic", "*.2da", "*.fac", "*.jrl", "*.itp" }
+                    Patterns = new[] { "*.utc", "*.uti", "*.utp", "*.utd", "*.utt", "*.uts",
+                                       "*.ute", "*.utw", "*.utm", "*.nss", "*.ncs", "*.dlg" }
                 },
                 new Avalonia.Platform.Storage.FilePickerFileType("All Files") { Patterns = new[] { "*" } }
             }
@@ -497,9 +498,12 @@ public partial class MainWindow : Window
     private static async System.Threading.Tasks.Task<Avalonia.Platform.Storage.IStorageFolder?>
         TryGetModuleFolderAsync(Avalonia.Platform.Storage.IStorageProvider storage)
     {
+        // Trebuchet unpacks a module when you open it, so the working directory (where loose
+        // UGC files live) is the opened module's directory.
         var folder = ModulePathHelper.GetWorkingDirectory(RadoubSettings.Instance.CurrentModulePath);
         if (string.IsNullOrEmpty(folder) || !System.IO.Directory.Exists(folder))
             return null;
+
         return await storage.TryGetFolderFromPathAsync(new Uri(folder));
     }
 

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
@@ -449,6 +449,16 @@ public partial class MainWindow : Window
         if (targets.Count == 0) return;
         var erfPath = targets[0].Path.LocalPath;
 
+        // Block the currently-open module's own .mod: adding its working files back to itself is a
+        // confusing no-op (everything reports "skipped"). "Save Module" is what repacks it (#2268).
+        if (ModulePathHelper.IsCurrentModuleArchive(erfPath, RadoubSettings.Instance.CurrentModulePath))
+        {
+            new AlertDialog("Add to ERF",
+                "That is the currently open module. To pack its working files into the module, " +
+                "use Save Module.\n\nAdd to ERF is for building a separate ERF or HAK archive.").Show(this);
+            return;
+        }
+
         // 2. Pick files to add. Default the picker to the current module's working folder so
         //    palette assets (loose blueprints, compiled scripts) are right there to select.
         var startFolder = await TryGetModuleFolderAsync(storage);
@@ -478,9 +488,24 @@ public partial class MainWindow : Window
         try
         {
             var result = new ErfAssetService().AddFiles(erfPath, paths, overwriteExisting: false);
-            var message =
-                $"Added {result.AddedCount} resource(s) to {System.IO.Path.GetFileName(erfPath)}.\n" +
-                $"Skipped {result.SkippedCount} (already present).";
+            var archiveName = System.IO.Path.GetFileName(erfPath);
+
+            string message;
+            if (result.AddedCount == 0 && result.SkippedCount > 0 && result.Errors.Count == 0)
+            {
+                // Everything the user picked was already in the archive — say so plainly rather
+                // than the confusing "Added 0, Skipped N" (#2268).
+                message = result.SkippedCount == 1
+                    ? $"Nothing added — that resource is already in {archiveName}."
+                    : $"Nothing added — all {result.SkippedCount} resources are already in {archiveName}.";
+            }
+            else
+            {
+                message =
+                    $"Added {result.AddedCount} resource(s) to {archiveName}.\n" +
+                    $"Skipped {result.SkippedCount} (already present).";
+            }
+
             if (result.Errors.Count > 0)
             {
                 message += $"\n\nRejected {result.Errors.Count}:";

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Radoub.Formats.Logging;
 using Radoub.Formats.Settings;
 using Radoub.UI.Services;
 using RadoubLauncher.Services;
@@ -420,6 +421,7 @@ public partial class MainWindow : Window
         }
         catch (Exception ex)
         {
+            UnifiedLogger.LogApplication(LogLevel.WARN, $"New ERF failed: {ex.Message}");
             new AlertDialog("ERF Creation Failed", ex.Message).Show(this);
         }
     }
@@ -518,6 +520,7 @@ public partial class MainWindow : Window
         }
         catch (Exception ex)
         {
+            UnifiedLogger.LogApplication(LogLevel.WARN, $"Add to ERF failed: {ex.Message}");
             new AlertDialog("Add to ERF Failed", ex.Message).Show(this);
         }
     }


### PR DESCRIPTION
## Summary

Create new ERF/MOD from scratch — and make ERFs useful by adding assets to them, zip-style (#2268).

- **New ERF** — "New ERF..." writes an empty `.erf` (Aurora-name validated).
- **Add to ERF** — "Add to ERF..." adds module content (blueprints `.utc/.uti/.utp/...`, scripts `.nss/.ncs`, `.dlg`) into an existing `.erf`, zip-style: ResRef from filename, type from extension, dedup, atomic write. The file picker opens in the current (auto-unpacked) module's working folder. Target is **ERF only** (adding to `.mod` is the Save-Module workflow; `.hak` gets its own flow #2267). The open module's own archive is blocked as a target.
- **Backups** — archive backups go to the managed `~/Radoub/Backups/Archives/` bucket under the existing retention policy (ERFs/HAKs are large). `BackupCleanupService` generalized to handle the new bucket.
- **New Module (.mod)** — `ModuleCreationService` clones a blank-forest template `.mod`. Backend + tests only; **not UI-wired** until area creation exists.

## Related Issues

- Closes #2268
- Relates to #2444 (Archive Creation sprint), #2267 (HAK creation)
- Follow-ups filed: #2608 (palette-aware picker), #2609 (Tag/Name picker, incl. HAK), #2610 (ERF/HAK backup toggles — ERF default on, HAK off), #2611 (configurable backup location), #2612 (service-duplication tech-debt from review)

## Tests

- Local (Windows): privacy ✅, tech-debt ✅, theme ✅, **3274 unit tests pass** (Formats 1494, UI 1364, Dictionary 75, Trebuchet 341 incl. 27 new for this work).
- E2E verified: clone of real `blank.mod` (14 resources, `module.ifo` byte-identical) and a live create+add round-trip.
- Code review (high effort): 2 findings fixed on-branch (missing exception logging; redundant per-resource archive reads); reuse/altitude items deferred to #2612.

## Manual Spot-Checks

- [ ] "New ERF..." / "Add to ERF..." buttons visible in toolbar.
- [ ] New ERF → empty `.erf` on disk; bad name (>16 char / illegal) → validation alert, no file.
- [ ] Add to ERF target picker offers `.erf` only; second picker opens in the module folder, lists module content types.
- [ ] Add files → "Added N, skipped M"; re-add same → "Nothing added — already present"; backup appears under `~/Radoub/Backups/Archives/`, not beside the archive.
- [ ] Picking the open module's own `.mod`-derived archive as target → "use Save Module" message (n/a now target is .erf-only; defense-in-depth).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
