### PR TITLE
[Quartermaster] Fix: Dynamic Armor Stand (CEP) preview broken (#2598)

### DIFF
--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.134-alpha] - 2026-06-28
-**Branch**: `quartermaster/issue-2598` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2598` | **PR**: #2613
 
 ### Fix: Dynamic Armor Stand (CEP) preview broken (#2598)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.134-alpha] - 2026-06-28
+**Branch**: `quartermaster/issue-2598` | **PR**: #TBD
+
+### Fix: Dynamic Armor Stand (CEP) preview broken (#2598)
+
+---
+
 ## [0.2.133-alpha] - 2026-06-25
 **Branch**: `quartermaster/issue-1584` | **PR**: #2602
 


### PR DESCRIPTION
## Summary

The CEP **Dynamic Armor Stand** appearance renders broken in Quartermaster's appearance preview. Pre-existing bug surfaced during #2557 UAT (the #2557 control split is verified behavior-neutral). Suspected regression window: the mesh-transparency work (#2540/#2586) — a shared cutout texture may be carving the stand geometry (cf. #2588).

## Related Issues

- Closes #2598

## Checklist

- [ ] Identify CEP appearance index + model resref
- [ ] Repro in QM with CEP; capture GL-error log + mesh/texture resolution
- [ ] Implementation complete
- [ ] Tests added/updated
- [ ] CHANGELOG updated with date

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)