### PR TITLE
[Quartermaster] Fix: Equipped-armor shoulder/belt parts missing in 3D preview (#2601)

### DIFF
--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.134-alpha] - 2026-06-28
+**Branch**: `quartermaster/issue-2601` | **PR**: #TBD
+
+### Fix: Equipped-armor shoulder/belt parts missing in 3D preview (#2601)
+
+- Shoulder (shol/shor) and belt parts driven by an equipped armor item's appearance now render in the preview, matching the Aurora toolset. Previously QM resolved these parts only from the creature's `BodyPart_*` fields and skipped them when armor supplied them.
+
+---
+
 ## [0.2.133-alpha] - 2026-06-25
 **Branch**: `quartermaster/issue-1584` | **PR**: #2602
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.134-alpha] - 2026-06-28
-**Branch**: `quartermaster/issue-2601` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2601` | **PR**: #2614
 
 ### Fix: Equipped-armor shoulder/belt parts missing in 3D preview (#2601)
 

--- a/Quartermaster/Quartermaster.Tests/ModelNameConstructionTests.cs
+++ b/Quartermaster/Quartermaster.Tests/ModelNameConstructionTests.cs
@@ -103,4 +103,46 @@ public class ModelNameConstructionTests
         Assert.False(ModelService.HasConnectorNode(
             new Radoub.Formats.Mdl.MdlModel { GeometryRoot = null }, "tail"));
     }
+
+    // #2601: Part-number resolution must match the Aurora engine rule
+    // (xoreos creature.cpp:533): finalId = armorId > 0 ? armorId : creatureId.
+    // The armor part wins whenever it is present and > 0, REGARDLESS of the creature's
+    // own BodyPart_* value (which is commonly 0 for shoulders/belt). The earlier QM code
+    // short-circuited on creatureValue == 0 and dropped armor-driven shoulder/belt parts.
+
+    [Fact]
+    public void ResolvePartNumber_ArmorWins_WhenCreatureIsZero()
+    {
+        // Bucky case: BodyPart_LShoul=0, armor nw_maarcl071 supplies LShoul=15 → renders 15.
+        Assert.Equal((byte)15, ModelService.ResolvePartNumber(creatureValue: 0, armorValue: 15));
+    }
+
+    [Fact]
+    public void ResolvePartNumber_ArmorWins_OverNonZeroCreatureValue()
+    {
+        // Armor override beats a creature part value too (e.g. torso).
+        Assert.Equal((byte)7, ModelService.ResolvePartNumber(creatureValue: 3, armorValue: 7));
+    }
+
+    [Fact]
+    public void ResolvePartNumber_CreatureUsed_WhenArmorAbsent()
+    {
+        // No armor entry for this part → fall back to the creature's own value.
+        Assert.Equal((byte)4, ModelService.ResolvePartNumber(creatureValue: 4, armorValue: null));
+    }
+
+    [Fact]
+    public void ResolvePartNumber_CreatureUsed_WhenArmorIsZero()
+    {
+        // Armor present but 0 (kFieldIDInvalid-equivalent / explicit none) → creature value wins.
+        Assert.Equal((byte)4, ModelService.ResolvePartNumber(creatureValue: 4, armorValue: 0));
+    }
+
+    [Fact]
+    public void ResolvePartNumber_Zero_WhenBothZeroOrAbsent()
+    {
+        // Naked creature, no armor part → 0 (part skipped downstream).
+        Assert.Equal((byte)0, ModelService.ResolvePartNumber(creatureValue: 0, armorValue: null));
+        Assert.Equal((byte)0, ModelService.ResolvePartNumber(creatureValue: 0, armorValue: 0));
+    }
 }

--- a/Quartermaster/Quartermaster/Services/ModelService.cs
+++ b/Quartermaster/Quartermaster/Services/ModelService.cs
@@ -58,6 +58,25 @@ public class ModelService
     }
 
     /// <summary>
+    /// Resolve the final body-part number, matching the Aurora engine (xoreos
+    /// <c>creature.cpp:533</c>): <c>idArmor &gt; 0 ? idArmor : id</c>. The equipped armor's
+    /// <c>ArmorPart_*</c> value wins whenever it is present and greater than 0 — even when the
+    /// creature's own <c>BodyPart_*</c> field is 0 (the common case for shoulders/belt, #2601).
+    /// The creature value is used only when armor does not supply this part (null) or supplies 0.
+    /// A final value of 0 means "no part" and is skipped downstream by <see cref="AppendPart"/>.
+    /// </summary>
+    /// <param name="creatureValue">The creature's own <c>BodyPart_*</c> value (0 = none).</param>
+    /// <param name="armorValue">The equipped armor's <c>ArmorPart_*</c> value, or null if the
+    /// armor does not define this part.</param>
+    internal static byte ResolvePartNumber(byte creatureValue, byte? armorValue)
+    {
+        if (armorValue is > 0)
+            return armorValue.Value;
+
+        return creatureValue;
+    }
+
+    /// <summary>
     /// Load the model for a creature based on its appearance settings.
     /// For part-based models, loads and combines body part models.
     /// Equipped armor can override certain body parts.
@@ -193,17 +212,12 @@ public class ModelService
         var basePrefix = BuildModelPrefix(creature.Gender, race, creature.Phenotype);
         UnifiedLogger.LogApplication(LogLevel.INFO, $"LoadPartBasedCreatureModel: basePrefix={basePrefix}");
 
-        // Helper: armor override beats creature value, but creature value of 0 (none/invisible)
-        // always wins regardless of armor.
+        // Resolve the final part number for an armor key, applying the engine rule (#2601).
         byte GetPartNumber(string armorKey, byte creatureValue)
         {
-            if (creatureValue == 0)
-                return 0;
-
-            if (armorOverrides != null && armorOverrides.TryGetValue(armorKey, out var armorValue) && armorValue > 0)
-                return armorValue;
-
-            return creatureValue;
+            byte? armorValue = (armorOverrides != null && armorOverrides.TryGetValue(armorKey, out var v))
+                ? v : (byte?)null;
+            return ResolvePartNumber(creatureValue, armorValue);
         }
 
         var parts = new List<(string PartType, string ResRef)>();


### PR DESCRIPTION
## Summary

Equipped-armor shoulder pauldrons (shol/shor) and belt parts were missing in QM's 3D preview for part-based creatures, even though the Aurora toolset renders them. QM's `GetPartNumber` short-circuited on a creature `BodyPart_*` value of 0, dropping the armor-supplied part. The Aurora engine (xoreos `creature.cpp:533`) uses `idArmor > 0 ? idArmor : id` — armor wins whenever present and > 0, regardless of the creature value. Extracted the rule into the unit-testable `ModelService.ResolvePartNumber` and removed the inverted short-circuit.

## Root cause (engine + fixture confirmed)

- xoreos `creature.cpp:533`: `finalId = idArmor > 0 ? idArmor : creatureId`.
- Fixture `Bucky.utc`: `BodyPart_LShoul/RShoul/Belt = 0`; chest armor `nw_maarcl071` supplies `LShoul=15` etc.
- Human body MDL `pmh0` declares `Lshoulder_g/Rshoulder_g/belt_g` connectors, so the parts attach and render.

## Tests

- 5 new `ResolvePartNumber` cases (written test-first, RED→GREEN).
- 1277/1277 Quartermaster unit tests pass. Privacy/tech-debt/theme scans clean.

## Verification

- Human spot-check confirmed: pauldrons + belt now render on Bucky, matching Aurora. (3D GL surface — not FlaUI-observable.)

## Related Issues

- Closes #2601
- Relates to #2584 (distinct refresh-event bug)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
