### PR TITLE
[Quartermaster] Fix: Static creature head renders see-through (no depth occlusion) (#2615)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.32-alpha] - 2026-06-28
+**Branch**: `quartermaster/issue-2615` | **PR**: #2616
+
+### Model preview: spec-in-alpha meshes no longer render see-through (#2615)
+
+- The mesh transparency classifier now requires actual near-transparent texels before treating a hint-less mesh as transparent. Textures that pack a specular/gloss map in the alpha channel (NWN:EE `_d` skins) are kept opaque, so static creature heads/bodies write depth and occlude correctly instead of showing through. Genuinely transparent creatures are unaffected.
+
+---
+
 ## [Radoub.UI 0.2.31-alpha] - 2026-06-28
 **Branch**: `trebuchet/issue-2268` | **PR**: #2607
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -10,6 +10,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ### Fix: Static creature head renders see-through (no depth occlusion) (#2615)
 
+- Solid creature meshes whose texture packs a specular/gloss map in the alpha channel (NWN:EE `_d` skins, e.g. Child: Male 01) are no longer mistaken for transparent — they keep depth writes and occlude correctly. Genuinely transparent creatures (zodiac/celestial) are unaffected. Shared-library change (Radoub.UI).
+
 ---
 
 ## [0.2.134-alpha] - 2026-06-28

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.135-alpha] - 2026-06-28
-**Branch**: `quartermaster/issue-2615` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2615` | **PR**: #2616
 
 ### Fix: Static creature head renders see-through (no depth occlusion) (#2615)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.135-alpha] - 2026-06-28
+**Branch**: `quartermaster/issue-2615` | **PR**: #TBD
+
+### Fix: Static creature head renders see-through (no depth occlusion) (#2615)
+
+---
+
 ## [0.2.134-alpha] - 2026-06-28
 **Branch**: `quartermaster/issue-2601` | **PR**: #2614
 

--- a/Radoub.UI/Radoub.UI.Tests/MeshTransparencyTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/MeshTransparencyTests.cs
@@ -47,20 +47,23 @@ public class MeshTransparencyTests
     }
 
     [Fact]
-    public void MostlyOpaqueWithRareSoftPixel_IsBinary()
+    public void MostlyOpaqueWithRareSoftEdge_IsBinary()
     {
-        // 1 soft pixel out of 100 = 1% < 5% threshold -> binary, not graded.
+        // A hard cutout that reaches 0 with a thin anti-aliased edge: 1 soft pixel out of 100
+        // = 1% < 5% threshold -> binary mask, not graded. (#2615: requires near-zero texels to
+        // be transparency at all; here index 1 is a true-0 cutout texel.)
         var alphas = new byte[100];
-        for (int i = 0; i < 100; i++) alphas[i] = (byte)(i == 0 ? 128 : 255);
+        for (int i = 0; i < 100; i++) alphas[i] = (byte)(i == 0 ? 128 : (i == 1 ? 0 : 255));
         Assert.Equal(AlphaProfile.Binary, MeshTransparency.AnalyzeAlphaProfile(Rgba(alphas), 10, 10));
     }
 
     [Fact]
-    public void ManySoftPixels_IsGraded()
+    public void ManySoftPixelsReachingZero_IsGraded()
     {
-        // 50% of pixels in the soft band -> a real gradient (ghost, glass).
+        // 50% of pixels in the soft band AND the channel reaches 0 -> a real gradient (ghost,
+        // glass). (#2615: a soft gradient is only transparency if it actually goes transparent.)
         var alphas = new byte[100];
-        for (int i = 0; i < 100; i++) alphas[i] = (byte)(i < 50 ? 128 : 255);
+        for (int i = 0; i < 100; i++) alphas[i] = (byte)(i < 50 ? (i % 10 == 0 ? 0 : 128) : 255);
         Assert.Equal(AlphaProfile.Graded, MeshTransparency.AnalyzeAlphaProfile(Rgba(alphas), 10, 10));
     }
 
@@ -69,6 +72,40 @@ public class MeshTransparencyTests
     {
         Assert.Equal(AlphaProfile.Opaque, MeshTransparency.AnalyzeAlphaProfile(System.Array.Empty<byte>(), 0, 0));
         Assert.Equal(AlphaProfile.Opaque, MeshTransparency.AnalyzeAlphaProfile(null!, 0, 0));
+    }
+
+    [Fact]
+    public void HighGradientNeverNearZero_IsOpaque_SpecPackedInAlpha()
+    {
+        // #2615: NWN:EE _d skin textures pack a SPECULAR/gloss map in the alpha channel — a
+        // high-valued gradient that never approaches 0 (no actual transparency). c_ykid_m's
+        // 'boy_head' is exactly this: minA=42, ZERO texels at alpha 0, ~25% in the soft band.
+        // The old "any texel < 255 => transparent" gate mis-read this as Graded -> Transparent
+        // -> the head drew with depth-write off -> see-through face. A channel with no near-zero
+        // texels is a packed data channel, not transparency: classify Opaque (mirrors xoreos's
+        // alphaMean~=1 => not transparent gate, modelnode.cpp:473).
+        var alphas = new byte[100];
+        for (int i = 0; i < 100; i++) alphas[i] = (byte)(i < 25 ? 128 : 255); // 25% soft, min 128, none near 0
+        Assert.Equal(AlphaProfile.Opaque, MeshTransparency.AnalyzeAlphaProfile(Rgba(alphas), 10, 10));
+    }
+
+    [Fact]
+    public void GradientReachingZero_IsGraded_RealTransparency()
+    {
+        // #2615 must-not-regress: a genuinely transparent body (zodiac rat c_zod_rat, #2435) has
+        // texels at/near alpha 0 (real punch-through/blend). It must still classify non-Opaque.
+        var alphas = new byte[100];
+        for (int i = 0; i < 100; i++) alphas[i] = (byte)(i < 50 ? (i % 25 == 0 ? 0 : 128) : 255); // soft band + true-zero texels
+        Assert.Equal(AlphaProfile.Graded, MeshTransparency.AnalyzeAlphaProfile(Rgba(alphas), 10, 10));
+    }
+
+    [Fact]
+    public void HardCutoutReachingZero_IsBinary_FurMask()
+    {
+        // #2615 must-not-regress: a 0/255 fur/mane cutout card (dire-tiger mane, #2507) reaches 0
+        // and stays a hard mask -> Binary (alpha-test cutout), not Opaque.
+        var rgba = Rgba(0, 255, 0, 255, 255, 0, 255, 0);
+        Assert.Equal(AlphaProfile.Binary, MeshTransparency.AnalyzeAlphaProfile(rgba, 4, 2));
     }
 
     // ---- ClassifyMesh ----

--- a/Radoub.UI/Radoub.UI/Controls/MeshTransparency.cs
+++ b/Radoub.UI/Radoub.UI/Controls/MeshTransparency.cs
@@ -36,12 +36,14 @@ public enum MaterialMode
 /// <c>Alpha</c> controller, the MDL <c>TransparencyHint</c>, and the texture's <see cref="AlphaProfile"/>.
 ///
 /// <para>Hint-less meshes (#2540): the real Aurora engine blends a mesh with no TransparencyHint
-/// iff its texture has an alpha channel (xoreos <c>modelnode.cpp:505</c>, behavioral reference only
-/// — GPLv3, not copied). Our production decoder yields a non-Opaque <see cref="AlphaProfile"/>
-/// exactly when the texture FORMAT carries alpha (DXT5 / 32-bit TGA); DXT1 / 24-bit bodies decode
-/// fully opaque. So a hint-less non-Opaque mesh blends (mane #2507, zodiac creatures #2435) and a
-/// DXT1 body (incl. the #2507 overloaded-<c>_d</c> trap, which decodes Opaque) stays opaque. This
-/// is blend, not discard: a near-opaque body blends to ~itself, so no holes are punched.</para>
+/// iff its texture has a meaningful alpha channel (xoreos <c>modelnode.cpp:505</c>, gated by the
+/// <c>alphaMean != 1.0</c> check at <c>:473</c> — behavioral reference only, GPLv3, not copied).
+/// A texture FORMAT carrying alpha (DXT5 / 32-bit TGA) is necessary but not sufficient: NWN:EE
+/// <c>_d</c> skins pack a specular/gloss map in alpha that never goes transparent (#2615). So
+/// <see cref="AnalyzeAlphaProfile"/> requires actual near-zero texels before reporting a non-Opaque
+/// profile — a high gradient with no transparent texels (<c>boy_head</c>) stays Opaque and keeps
+/// depth writes, while genuinely transparent skins (zodiac creatures #2435, reaching alpha 0) and
+/// hard fur masks (mane #2507) classify Graded / Binary. DXT1 / 24-bit bodies decode fully opaque.</para>
 /// </summary>
 public static class MeshTransparency
 {
@@ -58,6 +60,20 @@ public static class MeshTransparency
     /// </summary>
     private const double GradedSoftFraction = 0.05;
 
+    /// <summary>Alpha at/below this counts as effectively transparent (a true see-through texel).</summary>
+    private const byte NearZeroAlpha = 16;
+
+    /// <summary>
+    /// Minimum fraction of near-zero texels required for the alpha channel to be transparency
+    /// at all (#2615). NWN:EE <c>_d</c> skin textures pack a specular/gloss map in alpha — a
+    /// high-valued gradient that never approaches 0 (e.g. <c>boy_head</c>: minAlpha=42, zero
+    /// near-zero texels). Such a channel is a packed data channel, not transparency; without
+    /// this gate it mis-read as Graded and the head drew with depth-write off (see-through).
+    /// One texel is enough to count as real transparency (a genuine cutout/blend always has a
+    /// transparent region); the threshold only filters channels with literally none.
+    /// </summary>
+    private const double MinTransparentFraction = 0.0;
+
     /// <summary>
     /// Classify a texture's alpha channel from its RGBA bytes. <paramref name="rgba"/> is tightly
     /// packed (4 bytes/pixel, alpha last). Returns <see cref="AlphaProfile.Opaque"/> for empty/null
@@ -70,18 +86,24 @@ public static class MeshTransparency
 
         int pixels = rgba.Length / 4;
         int softCount = 0;
-        bool anyTransparent = false;
+        int nearZeroCount = 0;
 
         for (int i = 0; i < pixels; i++)
         {
             byte a = rgba[i * 4 + 3];
-            if (a < 255) anyTransparent = true;
+            if (a <= NearZeroAlpha) nearZeroCount++;
             if (a > SoftMin && a < SoftMax) softCount++;
         }
 
-        if (!anyTransparent)
+        // #2615: transparency requires texels that actually go (near) transparent. A channel with
+        // no near-zero texels is a packed spec/gloss map (NWN:EE _d skins), not a transparency
+        // mask — treat it as Opaque so the mesh keeps depth writes and occludes correctly. This
+        // mirrors xoreos's "alphaMean ~= 1.0 => not transparent" gate (modelnode.cpp:473), using
+        // the decoded pixels our production decoder yields.
+        if ((double)nearZeroCount / pixels <= MinTransparentFraction)
             return AlphaProfile.Opaque;
 
+        // Has real transparent texels: soft-band fraction decides hard mask (Binary) vs gradient.
         return (double)softCount / pixels >= GradedSoftFraction
             ? AlphaProfile.Graded
             : AlphaProfile.Binary;

--- a/Radoub.UI/Radoub.UI/Controls/MeshTransparency.cs
+++ b/Radoub.UI/Radoub.UI/Controls/MeshTransparency.cs
@@ -64,15 +64,15 @@ public static class MeshTransparency
     private const byte NearZeroAlpha = 16;
 
     /// <summary>
-    /// Minimum fraction of near-zero texels required for the alpha channel to be transparency
-    /// at all (#2615). NWN:EE <c>_d</c> skin textures pack a specular/gloss map in alpha — a
-    /// high-valued gradient that never approaches 0 (e.g. <c>boy_head</c>: minAlpha=42, zero
-    /// near-zero texels). Such a channel is a packed data channel, not transparency; without
-    /// this gate it mis-read as Graded and the head drew with depth-write off (see-through).
-    /// One texel is enough to count as real transparency (a genuine cutout/blend always has a
-    /// transparent region); the threshold only filters channels with literally none.
+    /// Minimum count of near-zero texels for the alpha channel to be transparency at all (#2615).
+    /// NWN:EE <c>_d</c> skin textures pack a specular/gloss map in alpha — a high-valued gradient
+    /// that never approaches 0 (e.g. <c>boy_head</c>: minAlpha=42, zero near-zero texels). Such a
+    /// channel is a packed data channel, not transparency; without this gate it mis-read as Graded
+    /// and the head drew with depth-write off (see-through). A single transparent texel is enough
+    /// (a genuine cutout/blend always has a transparent region), so this is a count, not a fraction:
+    /// a fraction would wrongly gate out a small-but-real cutout hole in a large texture.
     /// </summary>
-    private const double MinTransparentFraction = 0.0;
+    private const int MinTransparentTexels = 1;
 
     /// <summary>
     /// Classify a texture's alpha channel from its RGBA bytes. <paramref name="rgba"/> is tightly
@@ -100,7 +100,7 @@ public static class MeshTransparency
         // mask — treat it as Opaque so the mesh keeps depth writes and occludes correctly. This
         // mirrors xoreos's "alphaMean ~= 1.0 => not transparent" gate (modelnode.cpp:473), using
         // the decoded pixels our production decoder yields.
-        if ((double)nearZeroCount / pixels <= MinTransparentFraction)
+        if (nearZeroCount < MinTransparentTexels)
             return AlphaProfile.Opaque;
 
         // Has real transparent texels: soft-band fraction decides hard mask (Binary) vs gradient.


### PR DESCRIPTION
## Summary

Fixes the see-through depth-occlusion failure on static (full-body) creature heads — Child: Male 01 (`c_ykid_m`). The `head_g` mesh uses texture `boy_head`, an NWN:EE `_d` skin that packs a specular/gloss map in its alpha channel (a gradient bottoming out at alpha 42, **zero** fully-transparent texels). The #2540 transparency classifier read *any* alpha < 255 as transparency, so it classified the head `Graded → Transparent` and drew it with depth writes off → see-through face.

Root cause confirmed against the real MDL (authored `TransparencyHint=0, Alpha=1.0` = opaque) and the authoritative xoreos engine, which gates transparency on `alphaMean != 1.0` (`modelnode.cpp:473`). Systemic fix: `AnalyzeAlphaProfile` now requires actual near-zero texels before reporting a non-Opaque profile. A channel with none is a packed data channel → Opaque (keeps depth writes).

Shared `Radoub.UI` change, so it corrects every static creature with spec-in-alpha skins, not just this one.

## Verification

- `c_ykid_m`: all 17 meshes now Opaque (was head→Transparent + 5 body parts→Cutout). See-through head fixed.
- Zodiac rat `c_zod_rat` (#2435, alpha reaches 0): still Transparent — genuine see-through preserved, no regression.
- Tests: MeshTransparency 19/19, Radoub.UI 1367, Quartermaster 1277 (full runner: 4213 passed, 0 failed).
- Code review: applied one cleanup (explicit texel-count threshold instead of a fraction constant).

## Related Issues

- Closes #2615
- Relates to #2540 (transparency pipeline — regression source)

## Manual spot-check (FlaUI can't see the GL surface)

- [ ] Open Child: Male 01 (appearance 241) — face occludes hair/mouth from front; eye not visible from rear; holds through full rotation.
- [ ] A genuinely-transparent creature (zodiac/celestial) still renders see-through.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
