### PR TITLE
[Relique] Fix: Burnt rags shins misaligned + arms suppressed on mannequin (#2596)

### DIFF
--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [0.10.32-alpha] - 2026-06-28
-**Branch**: `relique/issue-2596` | **PR**: #TBD
+**Branch**: `relique/issue-2596` | **PR**: #2617
 
 ### Fix: Burnt rags — shins misaligned + arms suppressed but hands shown on mannequin (#2596)
 

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -9,9 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [0.10.32-alpha] - 2026-06-28
 **Branch**: `relique/issue-2596` | **PR**: #2617
 
-### Fix: Burnt rags — shins misaligned + arms suppressed but hands shown on mannequin (#2596)
+### Fix: Robe armor — hands/shins swung away from the coat on the mannequin (#2596)
 
-- Robe armor on the Relique mannequin renders arms consistently with hands and seats shins correctly. Shared suppression/resolver fix (`RobePartSuppression` / `ItemModelResolver`) — propagates to Quartermaster.
+- The relaxed preview stance is now skipped when a robe is equipped. A robe coat is a rigid mesh that can't follow the per-bone pose, so relaxing the stance had swung the bone-attached hands/shins/feet out from under the frozen robe (looked like "arms gone, shins misaligned"). Relique-only; robe suppression/composition were correct.
 
 ---
 

--- a/Relique/CHANGELOG.md
+++ b/Relique/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.10.32-alpha] - 2026-06-28
+**Branch**: `relique/issue-2596` | **PR**: #TBD
+
+### Fix: Burnt rags — shins misaligned + arms suppressed but hands shown on mannequin (#2596)
+
+- Robe armor on the Relique mannequin renders arms consistently with hands and seats shins correctly. Shared suppression/resolver fix (`RobePartSuppression` / `ItemModelResolver`) — propagates to Quartermaster.
+
+---
+
 ## [0.10.31-alpha] - 2026-06-22
 **Branch**: `quartermaster/issue-2582` | **PR**: #2583
 

--- a/Relique/Relique.Tests/Services/MannequinPoseAdjusterTests.cs
+++ b/Relique/Relique.Tests/Services/MannequinPoseAdjusterTests.cs
@@ -118,6 +118,39 @@ public class MannequinPoseAdjusterTests
     }
 
     [Fact]
+    public void ContainsRobePart_TrueWhenAnyResRefIsRobe()
+    {
+        // #2596: a robe coat is grafted as a rigid 0-bone skin; it can't follow the relaxed
+        // pose's per-bone rotation, so the controller must NOT relax the pose when a robe is
+        // present (else the bone-attached hands/shins swing away from the frozen robe).
+        var withRobe = new[] { "pmh0_handl001", "pmh0_shinl008", "pmh0_robe247" };
+        Assert.True(MannequinPoseAdjuster.ContainsRobePart(withRobe));
+    }
+
+    [Fact]
+    public void ContainsRobePart_FalseForPlainArmorParts()
+    {
+        var noRobe = new[] { "pmh0_chest008", "pmh0_bicepl001", "pmh0_handl001" };
+        Assert.False(MannequinPoseAdjuster.ContainsRobePart(noRobe));
+    }
+
+    [Fact]
+    public void ContainsRobePart_FalseForNullOrEmpty()
+    {
+        Assert.False(MannequinPoseAdjuster.ContainsRobePart(null));
+        Assert.False(MannequinPoseAdjuster.ContainsRobePart(System.Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void ContainsRobePart_DoesNotFalseMatchSubstring()
+    {
+        // A non-robe resref that merely contains the letters "robe" must not match.
+        // Detection keys on the part-type token (pmh0_robeNNN), not substring containment.
+        var tricky = new[] { "pmh0_wardrobe001", "pmh0_chest008" };
+        Assert.False(MannequinPoseAdjuster.ContainsRobePart(tricky));
+    }
+
+    [Fact]
     public void ApplyRelaxedPose_NullModel_DoesNotThrow()
     {
         MannequinPoseAdjuster.ApplyRelaxedPose(null);

--- a/Relique/Relique/Services/ItemPreviewController.cs
+++ b/Relique/Relique/Services/ItemPreviewController.cs
@@ -189,7 +189,14 @@ public sealed class ItemPreviewController
             // Relax the armor mannequin's stance so limb parts (hands, forearms, boots) are
             // visible from the default camera (#2232). Armor only — the skeleton composition
             // path is the mannequin; flat composites (weapons) have no skeleton.
-            if (resolution.HasArmorParts)
+            //
+            // EXCEPT when a robe is present (#2596): the robe coat is a rigid, non-bone-bound skin
+            // grafted under the composite root, so it cannot follow the per-bone rotations. Relaxing
+            // the stance would swing the bone-attached kept parts (hands, shins, feet) away from the
+            // frozen robe — the "arms gone / shins misaligned" defect. A robe already drapes the
+            // limbs, so the relaxed pose's purpose (exposing limb armor) is moot here.
+            if (resolution.HasArmorParts
+                && !MannequinPoseAdjuster.ContainsRobePart(resolution.MdlResRefs))
                 MannequinPoseAdjuster.ApplyRelaxedPose(composed);
 
             ApplyTrophyRotationIfHeldWeapon(uti, composed);

--- a/Relique/Relique/Services/MannequinPoseAdjuster.cs
+++ b/Relique/Relique/Services/MannequinPoseAdjuster.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using Radoub.Formats.Mdl;
@@ -64,6 +65,40 @@ public static class MannequinPoseAdjuster
         ("lshin_g", FlexionAxis, -KneeFlexionDegrees),
         ("rshin_g", FlexionAxis, -KneeFlexionDegrees),
     };
+
+    /// <summary>
+    /// Whether any resolved part resref is the robe part (#2596). A robe composes as a rigid,
+    /// non-bone-bound coat skin grafted under the composite root, so it cannot follow the
+    /// per-bone rotations of the relaxed pose. Relaxing the stance would swing the bone-attached
+    /// kept parts (hands, shins, feet) away from the frozen robe — the "arms gone / shins
+    /// misaligned" defect. The caller skips <see cref="ApplyRelaxedPose"/> when this is true.
+    ///
+    /// Detection keys on the part-type token of each resref (<c>{prefix}_robe{NNN}</c>), matching
+    /// <c>ItemModelResolver</c>'s "robe" suffix — NOT a substring match, so "pmh0_wardrobe001"
+    /// does not false-match.
+    /// </summary>
+    public static bool ContainsRobePart(IEnumerable<string>? resRefs)
+    {
+        if (resRefs == null)
+            return false;
+
+        foreach (var resRef in resRefs)
+        {
+            if (string.IsNullOrEmpty(resRef))
+                continue;
+
+            // Strip the body prefix ("pmh0_") then the trailing part number; compare the stem.
+            var underscore = resRef.IndexOf('_');
+            var stem = underscore >= 0 && underscore + 1 < resRef.Length
+                ? resRef.Substring(underscore + 1)
+                : resRef;
+            stem = stem.TrimEnd('0', '1', '2', '3', '4', '5', '6', '7', '8', '9');
+            if (stem.Equals("robe", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// Apply the relaxed stance in place. No-op if the model has no skeleton root. Bones that


### PR DESCRIPTION
## Summary

Burnt rags (robe-style armor) on Relique's armor mannequin renders with shins misaligned and arms suppressed while hands still show — a recent regression in the shared robe part-suppression / part-composition layer.

The suspect code (`RobePartSuppression`, `ItemModelResolver`) is shared between Quartermaster and Relique. The fix should be systemic — arm parts suppressed consistently with hands, and shin part bone best-match corrected (exact-stem vs substring per #2541) — so it propagates to QM rather than patching Relique alone.

## Related Issues

- Closes #2596
- Regression window: #2583 (robe suppression → `parts_robe.2da`), #2569 (part composition data-driven + robe arms)
- Sibling QM behavior: #2398, #2601

## Checklist

- [ ] Repro in LNS_DLG with burnt-rags UTI; capture resolved part list + suppressed meshes
- [ ] Arm vs hand parts handled consistently in `RobePartSuppression` / `ItemModelResolver`
- [ ] Shin bone best-match verified (exact-stem)
- [ ] Fix confirmed systemic (QM + Relique), not Relique-only
- [ ] Tests added/updated
- [ ] CHANGELOG updated with date

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
