### PR TITLE
[Quartermaster] Fix: Shared body+mane texture carves black patches on body SkinNode (#2588)

### DIFF
--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.136-alpha] - 2026-06-28
+**Branch**: `quartermaster/issue-2588` | **PR**: #TBD
+
+### Fix: Shared body+mane texture carves black patches on body SkinNode (#2588)
+
+- A deformable body SkinNode that shares its DDS texture with a cutout fur/mane mesh (e.g. CEP dire tiger) no longer alpha-tests its solid body region into black patches. Cutout stays for the trimesh/dangly fur accessories. Shared-library change (Radoub.UI).
+
+---
+
 ## [0.2.135-alpha] - 2026-06-28
 **Branch**: `quartermaster/issue-2615` | **PR**: #2616
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -8,9 +8,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ## [0.2.136-alpha] - 2026-06-28
 **Branch**: `quartermaster/issue-2588` | **PR**: #2618
 
-### Fix: Shared body+mane texture carves black patches on body SkinNode (#2588)
+### Fix: Shared body+mane texture transparency on the dire tiger (#2588)
 
-- A deformable body SkinNode that shares its DDS texture with a cutout fur/mane mesh (e.g. CEP dire tiger) no longer alpha-tests its solid body region into black patches. Cutout stays for the trimesh/dangly fur accessories. Shared-library change (Radoub.UI).
+- A deformable body SkinNode that shares its DDS texture with a cutout fur/mane mesh (e.g. CEP dire tiger) no longer alpha-tests its solid body region into black patches. Cutout is now a true hard cutout (no blend, opaque queue) gated on mirrored-normal geometry, and zero-length stored normals no longer render fragments black (NaN-normal guard). Shared-library change (Radoub.UI).
 
 ---
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.136-alpha] - 2026-06-28
-**Branch**: `quartermaster/issue-2588` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2588` | **PR**: #2618
 
 ### Fix: Shared body+mane texture carves black patches on body SkinNode (#2588)
 

--- a/Radoub.UI/Radoub.UI.Tests/MeshTransparencyTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/MeshTransparencyTests.cs
@@ -9,6 +9,7 @@
 // Transparent — opaque _d PBR bodies overload the alpha channel as a spec value, so their
 // alpha is never consulted.
 
+using System.Numerics;
 using Radoub.UI.Controls;
 
 namespace Radoub.UI.Tests;
@@ -119,25 +120,34 @@ public class MeshTransparencyTests
     }
 
     [Fact]
-    public void HintZero_BinaryProfile_IsCutout()
+    public void HintZero_BinaryProfile_Mirrored_IsCutout()
     {
-        // #2540: a hint-less mesh with a hard 0/1 alpha mask (fur/mane cards — e.g. the dire-tiger
-        // texture shared by the mane AND the body skin, #2507) is alpha-TESTED with depth write,
-        // not order-dependent blended. The engine's default for alpha-bearing meshes is alpha-test
-        // (xoreos keeps GL_ALPHA_TEST on; behavioral ref only, GPLv3, not copied). Routing the many
-        // overlapping mane/body layers through the depth-mask-off blend pass made them sort-fight
-        // into black triangular shards; Cutout is order-independent and renders clean.
+        // #2588 (systemic, xoreos + nwn_mdl_webviewer): a hard 0/1 alpha mask is a TRUE hard cutout
+        // ONLY when the mesh is handbuilt-doublesided (mirrored normals — fences, foliage, fur/mane
+        // cards with duplicated inverted-face quads). Such a mesh can't be depth-sorted as a unit in
+        // a blend pass, so it stays in the opaque queue and alpha-tests (punch-through). The
+        // discriminator is the geometry (mirrored normals), NOT the texture histogram alone.
         Assert.Equal(MaterialMode.Cutout,
-            MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Binary));
+            MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Binary, isSkin: false, isMirrored: true));
+    }
+
+    [Fact]
+    public void HintZero_BinaryProfile_NotMirrored_IsTransparent()
+    {
+        // A hard-mask alpha mesh that is NOT handbuilt-doublesided blends like any other alpha mesh
+        // (xoreos: NWN has only Opaque + Transparent; isTransparent = hasAlpha). No cutout mode for
+        // ordinary single-sided alpha geometry — it would otherwise hard-edge wisps into black.
+        Assert.Equal(MaterialMode.Transparent,
+            MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Binary, isSkin: false, isMirrored: false));
     }
 
     [Fact]
     public void HintZero_GradedProfile_IsTransparent()
     {
-        // Genuinely graded alpha with no hint (the zodiac/celestial creatures, #2435 — a real soft
-        // see-through body) blends. Distinct from the binary fur mask above.
+        // Genuinely graded alpha (the zodiac/celestial creatures, #2435 — a real soft see-through
+        // body) blends regardless of mirrored normals — a gradient is never a hard cutout.
         Assert.Equal(MaterialMode.Transparent,
-            MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Graded));
+            MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Graded, isSkin: false, isMirrored: true));
     }
 
     [Fact]
@@ -151,10 +161,18 @@ public class MeshTransparencyTests
     }
 
     [Fact]
-    public void HintSet_BinaryProfile_IsCutout()
+    public void HintSet_BinaryProfile_Mirrored_IsCutout()
     {
         Assert.Equal(MaterialMode.Cutout,
-            MeshTransparency.ClassifyMesh(1.0f, 1, AlphaProfile.Binary));
+            MeshTransparency.ClassifyMesh(1.0f, 1, AlphaProfile.Binary, isSkin: false, isMirrored: true));
+    }
+
+    [Fact]
+    public void HintSet_BinaryProfile_NotMirrored_IsTransparent()
+    {
+        // Even with a hint, a non-doublesided Binary mesh blends rather than hard-cutout.
+        Assert.Equal(MaterialMode.Transparent,
+            MeshTransparency.ClassifyMesh(1.0f, 1, AlphaProfile.Binary, isSkin: false, isMirrored: false));
     }
 
     // ---- SkinNode never carves (#2588) ----
@@ -201,12 +219,47 @@ public class MeshTransparencyTests
     }
 
     [Fact]
-    public void TrimeshDangly_BinaryProfile_StillCutout_NotSkin()
+    public void TrimeshDangly_BinaryProfile_Mirrored_StillCutout_NotSkin()
     {
-        // The mane/fur accessory (Dangly/Trimesh, NOT a SkinNode) keeps Cutout — the body-skin
-        // carve-out must not disarm cutout on the fur cards that genuinely need it (#2507).
+        // The mane/fur accessory (Dangly/Trimesh, NOT a SkinNode) with mirrored normals keeps Cutout
+        // — the body-skin carve-out must not disarm cutout on the handbuilt-doublesided fur cards
+        // that genuinely need it (#2507 / #2588). The dire-tiger Mane/Object01/fangs_up are all
+        // mirrored-normal, so they take this path.
         Assert.Equal(MaterialMode.Cutout,
-            MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Binary, isSkin: false));
+            MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Binary, isSkin: false, isMirrored: true));
+    }
+
+    // ---- HasMirroredNormals (#2588) ----
+
+    [Fact]
+    public void HasMirroredNormals_HalfInverted_IsTrue()
+    {
+        // Handbuilt-doublesided: half the normals point +Z, half -Z (duplicated inverted faces).
+        var n = new[]
+        {
+            new Vector3(0, 0,  1), new Vector3(0, 0,  1), new Vector3(0, 0,  1),
+            new Vector3(0, 0, -1), new Vector3(0, 0, -1), new Vector3(0, 0, -1),
+        };
+        Assert.True(MeshTransparency.HasMirroredNormals(n));
+    }
+
+    [Fact]
+    public void HasMirroredNormals_AllSameDirection_IsFalse()
+    {
+        // An ordinary single-sided mesh: normals fan one way, no ~50/50 inversion on any axis.
+        var n = new[]
+        {
+            new Vector3(0, 0, 1), new Vector3(0.1f, 0, 1), new Vector3(-0.1f, 0, 1),
+            new Vector3(0, 0.1f, 1), new Vector3(0, -0.1f, 1),
+        };
+        Assert.False(MeshTransparency.HasMirroredNormals(n));
+    }
+
+    [Fact]
+    public void HasMirroredNormals_EmptyOrNull_IsFalse()
+    {
+        Assert.False(MeshTransparency.HasMirroredNormals(System.Array.Empty<Vector3>()));
+        Assert.False(MeshTransparency.HasMirroredNormals(null!));
     }
 
     [Fact]

--- a/Radoub.UI/Radoub.UI.Tests/MeshTransparencyTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/MeshTransparencyTests.cs
@@ -157,6 +157,58 @@ public class MeshTransparencyTests
             MeshTransparency.ClassifyMesh(1.0f, 1, AlphaProfile.Binary));
     }
 
+    // ---- SkinNode never carves (#2588) ----
+
+    [Fact]
+    public void SkinNode_BinaryProfile_HintZero_IsOpaque_NotCutout()
+    {
+        // #2588: a deformable body SkinNode that SHARES its DDS atlas with a cutout fur/mane mesh
+        // (CEP dire tiger: dire_tiger SkinNode + Mane DanglyNode both use N_Tiger_LaoHu02_D) reads
+        // the shared texture as Binary. A single per-texture profile can't be right for both: the
+        // mane region is a cutout silhouette, the body region is solid skin. Alpha-testing the body
+        // discards fragments where its UVs land on the mane's low-alpha region -> black patches on
+        // body/crown. A SkinNode body is never a cutout card: classify Opaque, keep depth writes,
+        // no discard. The separate mane/dangly trimeshes still classify Cutout and carve correctly.
+        Assert.Equal(MaterialMode.Opaque,
+            MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Binary, isSkin: true));
+    }
+
+    [Fact]
+    public void SkinNode_BinaryProfile_HintSet_IsOpaque_NotCutout()
+    {
+        // Even with an explicit TransparencyHint, a body SkinNode must not alpha-test itself into
+        // holes — the never-cutout rule for skins holds regardless of the hint.
+        Assert.Equal(MaterialMode.Opaque,
+            MeshTransparency.ClassifyMesh(1.0f, 1, AlphaProfile.Binary, isSkin: true));
+    }
+
+    [Fact]
+    public void SkinNode_GradedProfile_IsTransparent()
+    {
+        // A genuinely soft-gradient skinned body (none observed in the #2588 test set — zodiac
+        // creatures are Trimesh — but kept correct) still blends. The never-cutout rule only
+        // diverts the Binary case; Graded skins keep their real translucency.
+        Assert.Equal(MaterialMode.Transparent,
+            MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Graded, isSkin: true));
+    }
+
+    [Fact]
+    public void SkinNode_MeshAlphaBelowOne_IsTransparent()
+    {
+        // Controller-driven fade still wins for skins — a body told to be semi-transparent blends.
+        Assert.Equal(MaterialMode.Transparent,
+            MeshTransparency.ClassifyMesh(0.5f, 0, AlphaProfile.Binary, isSkin: true));
+    }
+
+    [Fact]
+    public void TrimeshDangly_BinaryProfile_StillCutout_NotSkin()
+    {
+        // The mane/fur accessory (Dangly/Trimesh, NOT a SkinNode) keeps Cutout — the body-skin
+        // carve-out must not disarm cutout on the fur cards that genuinely need it (#2507).
+        Assert.Equal(MaterialMode.Cutout,
+            MeshTransparency.ClassifyMesh(1.0f, 0, AlphaProfile.Binary, isSkin: false));
+    }
+
     [Fact]
     public void HintSet_GradedProfile_IsTransparent()
     {

--- a/Radoub.UI/Radoub.UI/Controls/MeshTransparency.cs
+++ b/Radoub.UI/Radoub.UI/Controls/MeshTransparency.cs
@@ -115,11 +115,32 @@ public static class MeshTransparency
     /// <param name="alpha">Mesh Alpha controller value (1.0 = fully opaque).</param>
     /// <param name="transparencyHint">MDL TransparencyHint (0 = no transparency interpretation).</param>
     /// <param name="profile">Alpha profile of the mesh's diffuse texture.</param>
-    public static MaterialMode ClassifyMesh(float alpha, int transparencyHint, AlphaProfile profile)
+    /// <param name="isSkin">
+    /// True when the mesh is a deformable body <c>SkinNode</c> (#2588). A SkinNode is never a cutout
+    /// card: it is the solid creature body. When it shares its DDS atlas with a cutout fur/mane mesh
+    /// (CEP dire tiger — body skin + mane both use <c>N_Tiger_LaoHu02_D</c>), the texture reads
+    /// Binary, but the body's UVs map to the SOLID skin region, not the mane's cutout silhouette.
+    /// Alpha-testing the body then discards fragments where its UVs land on the mane's low-alpha
+    /// region, carving black patches on the body/crown. So a Binary-profile skin classifies Opaque
+    /// (depth writes on, no discard) instead of Cutout; the separate mane/dangly trimeshes still
+    /// classify Cutout and carve correctly. A genuinely graded skin (none in the test set) still
+    /// blends. The never-cutout rule holds regardless of TransparencyHint.
+    /// </param>
+    public static MaterialMode ClassifyMesh(float alpha, int transparencyHint, AlphaProfile profile, bool isSkin = false)
     {
         // Controller-driven fade wins outright — a mesh told to be semi-transparent always blends.
         if (alpha < OpaqueAlphaCutoff)
             return MaterialMode.Transparent;
+
+        // #2588: a deformable body SkinNode is never a cutout card. Its Binary profile means the
+        // SHARED atlas carries a cutout mask in the mane region, but the body's own UVs map to solid
+        // skin — alpha-testing it would punch holes in the body. Route Binary->Opaque (keep depth
+        // writes, no discard); leave a genuinely graded skin to blend. Cutout stays for the separate
+        // fur/mane trimesh/dangly meshes (isSkin == false), which genuinely need it (#2507).
+        if (isSkin)
+            return profile == AlphaProfile.Graded
+                ? MaterialMode.Transparent
+                : MaterialMode.Opaque;
 
         // No MDL hint: follow the real Aurora engine (xoreos modelnode.cpp:505 — behavioral
         // reference only, GPLv3, not copied), which blends a hint-less mesh iff its texture has an

--- a/Radoub.UI/Radoub.UI/Controls/MeshTransparency.cs
+++ b/Radoub.UI/Radoub.UI/Controls/MeshTransparency.cs
@@ -1,3 +1,5 @@
+using System.Numerics;
+
 namespace Radoub.UI.Controls;
 
 /// <summary>
@@ -126,7 +128,8 @@ public static class MeshTransparency
     /// classify Cutout and carve correctly. A genuinely graded skin (none in the test set) still
     /// blends. The never-cutout rule holds regardless of TransparencyHint.
     /// </param>
-    public static MaterialMode ClassifyMesh(float alpha, int transparencyHint, AlphaProfile profile, bool isSkin = false)
+    public static MaterialMode ClassifyMesh(float alpha, int transparencyHint, AlphaProfile profile,
+        bool isSkin = false, bool isMirrored = false)
     {
         // Controller-driven fade wins outright — a mesh told to be semi-transparent always blends.
         if (alpha < OpaqueAlphaCutoff)
@@ -135,43 +138,67 @@ public static class MeshTransparency
         // #2588: a deformable body SkinNode is never a cutout card. Its Binary profile means the
         // SHARED atlas carries a cutout mask in the mane region, but the body's own UVs map to solid
         // skin — alpha-testing it would punch holes in the body. Route Binary->Opaque (keep depth
-        // writes, no discard); leave a genuinely graded skin to blend. Cutout stays for the separate
-        // fur/mane trimesh/dangly meshes (isSkin == false), which genuinely need it (#2507).
+        // writes, no discard); leave a genuinely graded skin to blend.
         if (isSkin)
             return profile == AlphaProfile.Graded
                 ? MaterialMode.Transparent
                 : MaterialMode.Opaque;
 
-        // No MDL hint: follow the real Aurora engine (xoreos modelnode.cpp:505 — behavioral
-        // reference only, GPLv3, not copied), which blends a hint-less mesh iff its texture has an
-        // alpha channel: isTransparent = hasAlpha. Our production decoder (TextureService) yields a
-        // non-Opaque profile exactly when the texture FORMAT carries alpha (DXT5 / 32-bit TGA);
-        // a DXT1/24-bit body decodes fully opaque -> Opaque profile. So "profile != Opaque" is our
-        // hasAlpha. This blends the dire-tiger mane (#2507) and the zodiac/celestial creatures
-        // (#2435), matching Aurora, while DXT1 bodies (incl. the #2507 _d-spec trap) stay opaque.
-        // Blend (not discard): a near-opaque body (alpha~1) blends to ~itself, so the ~145 DXT5
-        // animal bodies that classify non-Opaque render visually opaque with no holes.
-        if (transparencyHint <= 0)
-            return profile switch
-            {
-                // Binary 0/1 mask (fur/mane cards like the dire tiger's shared body+mane texture):
-                // alpha-TEST with depth write, NOT order-dependent blend. The engine's default for
-                // alpha-bearing meshes is alpha-test (xoreos keeps GL_ALPHA_TEST on); routing these
-                // through the depth-mask-off blend pass makes the many overlapping mane/body layers
-                // sort-fight into black triangular shards. Cutout is order-independent -> clean.
-                AlphaProfile.Binary => MaterialMode.Cutout,
-                // Genuinely graded alpha (the zodiac/celestial creatures, #2435): a real soft blend.
-                AlphaProfile.Graded => MaterialMode.Transparent,
-                _ => MaterialMode.Opaque,
-            };
+        // No alpha channel -> opaque, regardless of hint. A DXT1/24-bit body decodes Opaque (incl.
+        // the #2507 _d-spec trap), so it never blends or carves.
+        if (profile == AlphaProfile.Opaque)
+            return MaterialMode.Opaque;
 
-        // Hint set: the alpha channel is real; its profile decides cutout vs blend.
-        return profile switch
+        // Alpha-bearing mesh. The authoritative Aurora engine (xoreos modelnode.cpp:505/779-810 —
+        // behavioral reference only, GPLv3, not copied) has only TWO modes for NWN: Opaque and
+        // Transparent (blend). isTransparent = hasAlpha; renderGeometryNormal just alpha-blends,
+        // with no alpha-test for ordinary meshes. So the DEFAULT for any alpha mesh is Transparent.
+        //
+        // The one exception (#2588, from nwn_mdl_webviewer scene_build.js — MIT): handbuilt
+        // double-sided meshes (fences, foliage, fur/mane cards) duplicate every face with inverted
+        // normals to fake two-sidedness, so ~half their normals point the opposite way on some axis
+        // (HasMirroredNormals). Such a mesh cannot be depth-sorted as a unit in a blend pass — the
+        // back-face quads sort over the front-face quads and show the clear colour through. The
+        // viewer's fix: keep these in the OPAQUE queue and alpha-TEST (hard cutout, depth write on,
+        // order-independent) instead of blending. The discriminator is the GEOMETRY (mirrored
+        // normals) plus a hard 0/1 mask (Binary) — NOT the texture histogram alone. A genuinely
+        // graded alpha (zodiac/celestial #2435) is never a hard cutout: it always blends.
+        if (profile == AlphaProfile.Binary && isMirrored)
+            return MaterialMode.Cutout;
+
+        return MaterialMode.Transparent;
+    }
+
+    /// <summary>
+    /// True when a mesh is "handbuilt double-sided" (#2588): NWN modellers duplicate every face
+    /// with inverted normals/winding to fake two-sidedness, so roughly half the vertex normals
+    /// point the opposite way along at least one axis. Mirrors nwn_mdl_webviewer's
+    /// <c>hasMirroredNormals</c> (scene_build.js, MIT — behavioral reference). Used to decide that a
+    /// Binary-alpha mesh is a true hard cutout (fence/foliage/fur card) rather than ordinary alpha
+    /// geometry that should blend. A 40–60% positive/negative split on any well-used axis counts.
+    /// </summary>
+    public static bool HasMirroredNormals(Vector3[]? normals)
+    {
+        if (normals == null || normals.Length < 4)
+            return false;
+
+        int posX = 0, negX = 0, posY = 0, negY = 0, posZ = 0, negZ = 0;
+        foreach (var n in normals)
         {
-            AlphaProfile.Binary => MaterialMode.Cutout,
-            AlphaProfile.Graded => MaterialMode.Transparent,
-            _ => MaterialMode.Opaque,
-        };
+            if (n.X > 0.01f) posX++; else if (n.X < -0.01f) negX++;
+            if (n.Y > 0.01f) posY++; else if (n.Y < -0.01f) negY++;
+            if (n.Z > 0.01f) posZ++; else if (n.Z < -0.01f) negZ++;
+        }
+
+        int total = normals.Length;
+        bool Mirrored(int p, int q)
+        {
+            int used = p + q;
+            if (used < total * 0.5) return false;          // axis barely used -> skip
+            return (double)Math.Min(p, q) / used >= 0.40;  // 40-60% split -> mirrored
+        }
+
+        return Mirrored(posX, negX) || Mirrored(posY, negY) || Mirrored(posZ, negZ);
     }
 
     /// <summary>

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
@@ -85,6 +85,10 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
         // AlphaProfile — which ClassifyMesh needs — isn't known at population time.
         public float MeshAlpha;
         public int TransparencyHint;
+        // True for deformable body SkinNodes (#2588). A SkinNode is never classified Cutout —
+        // see MeshTransparency.ClassifyMesh — so a body sharing a cutout fur/mane atlas (dire tiger)
+        // does not alpha-test itself into black patches.
+        public bool IsSkin;
         // Geometric centroid in the same centered space as the GPU vertex buffer (#2540).
         // Used to depth-sort Transparent meshes back-to-front.
         public Vector3 Centroid;
@@ -527,7 +531,7 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
 
             var profile = hasTexture && _textureAlphaProfile.TryGetValue(resolvedTexture!, out var p)
                 ? p : AlphaProfile.Opaque;
-            var mode = MeshTransparency.ClassifyMesh(drawCall.MeshAlpha, drawCall.TransparencyHint, profile);
+            var mode = MeshTransparency.ClassifyMesh(drawCall.MeshAlpha, drawCall.TransparencyHint, profile, drawCall.IsSkin);
             return (resolvedTexture, hasTexture, mode);
         }
 
@@ -773,7 +777,8 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
                 IndexOffset = indices.Count * sizeof(uint),
                 TextureName = rawBitmap,
                 MeshAlpha = mesh.Alpha,
-                TransparencyHint = mesh.TransparencyHint
+                TransparencyHint = mesh.TransparencyHint,
+                IsSkin = isSkinMesh
             };
 
             // #2026/#1584: Pick normal source by whether the mesh carries a usable stored normal

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
@@ -89,17 +89,22 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
         // see MeshTransparency.ClassifyMesh — so a body sharing a cutout fur/mane atlas (dire tiger)
         // does not alpha-test itself into black patches.
         public bool IsSkin;
+        // True for handbuilt-doublesided meshes (#2588): duplicated inverted-normal faces (fences,
+        // foliage, fur/mane cards). Only these become a true hard Cutout; ordinary alpha meshes
+        // blend. See MeshTransparency.HasMirroredNormals / ClassifyMesh.
+        public bool IsMirrored;
         // Geometric centroid in the same centered space as the GPU vertex buffer (#2540).
         // Used to depth-sort Transparent meshes back-to-front.
         public Vector3 Centroid;
     }
 
     // Discard cutoff for Cutout meshes (#2540). The real engine alpha-tests at GL_GREATER 0.1
-    // (xoreos modelnode.cpp:440, behavioral ref only — GPLv3, not copied), keeping the soft fur
-    // tips of a mane/fur card instead of carving them away. 0.5 (rollnw's hard-silhouette default)
-    // discarded the wispy upper-mane fragments and left black triangular voids behind them; 0.1
-    // keeps the wisps, matching the in-game dire-tiger mane.
-    private const float CutoutAlphaThreshold = 0.1f;
+    // Cutout is now a TRUE hard cutout (#2588): no blend, opaque queue, depth write on. The
+    // discard threshold is 0.5 — nwn_mdl_webviewer's useAlphaTest value (scene_build.js, MIT,
+    // behavioral ref). The earlier 0.1 was a workaround for the blended-cutout hybrid that left
+    // black triangles; with blend removed, a discarded fragment shows the opaque geometry behind
+    // it (the body), not the background, so the high threshold no longer carves black voids.
+    private const float CutoutAlphaThreshold = 0.5f;
 
     // Alpha-test floor applied to Transparent meshes during the blend pass (#2540). The engine
     // keeps GL_ALPHA_TEST on at GL_GREATER 0.1 while blending (xoreos modelnode.cpp:440/770,
@@ -531,7 +536,7 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
 
             var profile = hasTexture && _textureAlphaProfile.TryGetValue(resolvedTexture!, out var p)
                 ? p : AlphaProfile.Opaque;
-            var mode = MeshTransparency.ClassifyMesh(drawCall.MeshAlpha, drawCall.TransparencyHint, profile, drawCall.IsSkin);
+            var mode = MeshTransparency.ClassifyMesh(drawCall.MeshAlpha, drawCall.TransparencyHint, profile, drawCall.IsSkin, drawCall.IsMirrored);
             return (resolvedTexture, hasTexture, mode);
         }
 
@@ -587,20 +592,19 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
             DrawMesh(drawCall);
         }
 
-        // Pass 1b: cutout meshes (#2540), depth write ON + blend + depth func LEQUAL. LEQUAL is
-        // scoped to ONLY these fur/mane cards: it lets equal-depth fragments of overlapping cards
-        // both draw so the layered mane fills without dark gaps, while the kept soft tips composite
-        // by alpha (no black opaque texels). Depth write on keeps it order-independent (no shards).
-        // Restored to Less after so it cannot leak into the transparent pass or the next frame.
+        // Pass 1b: cutout meshes (#2588) — TRUE hard cutout, NO blend. These are only the
+        // handbuilt-doublesided fur/mane/fence cards (mirrored normals + hard 0/1 mask). Following
+        // nwn_mdl_webviewer's useAlphaTest path (scene_build.js, MIT — behavioral ref): they stay in
+        // the OPAQUE queue (transparent=false, depthWrite on, alpha-test at 0.5) so the duplicated
+        // front/back quads don't sort-fight. The shader discards texels below the threshold and
+        // writes FULL-opaque colour for the rest — no SrcAlpha blend. The previous blended-cutout
+        // hybrid (blend ON + alphaTest 0.1 + LEQUAL) composited kept low-alpha edge fragments over
+        // the background, painting the dark/black triangles reported on the dire tiger. Plain opaque
+        // draw (depth func stays Less) removes that compositing entirely.
         if (cutoutCalls.Count > 0)
         {
-            _gl.DepthFunc(DepthFunction.Lequal);
-            _gl.Enable(EnableCap.Blend);
-            _gl.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
             foreach (var drawCall in cutoutCalls)
                 DrawMesh(drawCall);
-            _gl.Disable(EnableCap.Blend);
-            _gl.DepthFunc(DepthFunction.Less);
         }
 
         // Pass 2: transparent meshes, sorted back-to-front, alpha-blended, depth writes off so
@@ -778,7 +782,8 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
                 TextureName = rawBitmap,
                 MeshAlpha = mesh.Alpha,
                 TransparencyHint = mesh.TransparencyHint,
-                IsSkin = isSkinMesh
+                IsSkin = isSkinMesh,
+                IsMirrored = MeshTransparency.HasMirroredNormals(mesh.Normals)
             };
 
             // #2026/#1584: Pick normal source by whether the mesh carries a usable stored normal

--- a/Radoub.UI/Radoub.UI/Controls/OpenGLShaderManager.cs
+++ b/Radoub.UI/Radoub.UI/Controls/OpenGLShaderManager.cs
@@ -82,7 +82,14 @@ uniform int debugMode;
 
 void main()
 {
-    vec3 norm = normalize(Normal);
+    // #2588: guard against degenerate (zero-length) stored normals. Some NWN meshes ship vertices
+    // with a zero normal (e.g. the dire-tiger Mane has 11/166) — the 2002 BioWare compiler left
+    // them unset. normalize(vec3(0)) is NaN in GLSL; abs(dot(NaN, lightDir)) propagates NaN through
+    // the lighting math and the fragment renders pure black. This was masked while the mane drew as
+    // a low-alpha blended cutout but became visible black triangles once it became a true opaque
+    // hard cutout. Fall back to a fixed up-normal so the fragment lights normally instead of NaN.
+    float normLen = length(Normal);
+    vec3 norm = normLen > 0.0001 ? Normal / normLen : vec3(0.0, 0.0, 1.0);
 
     if (debugMode == 1) {
         // Visualise the post-transform normal as colour. If the normal is
@@ -166,13 +173,12 @@ void main()
     // PBR _d diffuse maps); 1/1.1 keeps only a slight lift without bleaching (#1762).
     result = pow(result, vec3(1.0 / 1.1));
 
-    // Output alpha (#2540): Opaque (mode 0) writes 1.0. Cutout (mode 1) and Transparent (mode 2)
-    // both write the texel alpha (× mesh Alpha controller). The cutout pass blends with depth-write
-    // ON: discarding below the floor removes the void, while letting the kept soft fur tips
-    // composite by their real alpha stops them rendering as opaque dark texels (the black mane
-    // spots). Depth-write on keeps it order-independent so overlapping mane cards do not sort-fight
-    // into shards — this is the engine's alpha-test + alpha-blend combination.
-    float outAlpha = (meshMode == 0) ? 1.0 : (texAlpha * meshAlpha);
+    // Output alpha (#2588): Opaque (mode 0) and Cutout (mode 1) both write 1.0 — Cutout is a TRUE
+    // hard cutout in the opaque queue (no blend): a texel either passes the 0.5 alpha-test and draws
+    // fully opaque, or is discarded. Writing texAlpha here (the old blended-cutout hybrid) let kept
+    // low-alpha edge fragments composite over the background as dark/black triangles. Only the
+    // Transparent pass (mode 2) writes texel alpha (× mesh Alpha controller) for real blending.
+    float outAlpha = (meshMode == 2) ? (texAlpha * meshAlpha) : 1.0;
     FragColor = vec4(result, outAlpha);
 }
 ";


### PR DESCRIPTION
## Summary

Follow-up to the #2540 transparency epic. When a creature's deformable body SkinNode shares its DDS texture with a cutout fur/mane mesh (e.g. CEP dire tiger), the body skin classifies `Binary -> Cutout` and is alpha-tested across its whole surface, leaving black patches where the body's UVs map to low-alpha regions of the shared atlas.

Candidate fix (deferred from #2540, needs validation): treat a SkinNode (deformable body) as never-Cutout — classify Opaque or Transparent, never alpha-test/discard. Cutout stays for the trimesh/dangly fur accessories.

## Related Issues

- Closes #2588
- Relates to #2540 (transparency pipeline epic)
- Relates to #2507 (dire-tiger mane — closed), #2482 (MTR consumer gap)

## Checklist

- [ ] Implementation complete
- [ ] Tests added/updated
- [ ] CHANGELOG updated with date
- [ ] Validated against a1 (tiger), lion, zodiac creatures

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
