### PR TITLE
[Quartermaster] Enhancement: Appearance list omits some CEP creatures (#2587)

### DIFF
--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.137-alpha] - 2026-06-28
+**Branch**: `quartermaster/issue-2587` | **PR**: #TBD
+
+### Enhancement: Appearance list omits some CEP creatures (#2587)
+
+- Investigate and fix why some valid CEP creature appearances are dropped from the Quartermaster appearance list (UI filter/cap/validity gate, not the resource resolver).
+
+---
+
 ## [0.2.136-alpha] - 2026-06-28
 **Branch**: `quartermaster/issue-2588` | **PR**: #2618
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.137-alpha] - 2026-06-28
-**Branch**: `quartermaster/issue-2587` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2587` | **PR**: #2621
 
 ### Enhancement: Appearance list omits some CEP creatures (#2587)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -8,9 +8,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ## [0.2.137-alpha] - 2026-06-28
 **Branch**: `quartermaster/issue-2587` | **PR**: #2621
 
-### Enhancement: Appearance list omits some CEP creatures (#2587)
+### Enhancement: Appearance list discoverability (#2587, #2027, #2028)
 
-- Investigate and fix why some valid CEP creature appearances are dropped from the Quartermaster appearance list (UI filter/cap/validity gate, not the resource resolver).
+- The appearance list is now a sortable Row# / Name / Maker / Model grid; the search box also matches a creature's 2DA row number, and the CEP author is parsed into its own Maker column. (Investigation confirmed no rows were being dropped — the gap was finding them in a 5,000+ row flat list.)
 
 ---
 

--- a/Quartermaster/Quartermaster.Tests/AppearanceFilterTests.cs
+++ b/Quartermaster/Quartermaster.Tests/AppearanceFilterTests.cs
@@ -95,6 +95,57 @@ public class AppearanceFilterTests
 
     #endregion
 
+    #region Row-Number Search (#2027)
+
+    [Fact]
+    public void FilterAppearances_NumericSearch_MatchesExactRowNumber()
+    {
+        // Typing "100" should surface the row whose AppearanceId is 100.
+        var result = AppearanceFilterHelper.Filter(_testAppearances, "100", true, true, true);
+        Assert.Contains(result, a => a.AppearanceId == 100);
+    }
+
+    [Fact]
+    public void FilterAppearances_NumericSearch_AlsoMatchesNameContainingDigits()
+    {
+        // Forgiving: "10" matches exact row 10 (none here) OR any name/label/race containing "10".
+        // "Invisible_Dragon_10" (id 569) and "Invisible_Dwarf_Female_010" (id 589) contain "10".
+        var result = AppearanceFilterHelper.Filter(_testAppearances, "10", true, true, true);
+        Assert.Contains(result, a => a.AppearanceId == 569);
+        Assert.Contains(result, a => a.AppearanceId == 589);
+    }
+
+    [Fact]
+    public void FilterAppearances_NumericSearch_ExactRowWithNoTextMatch_StillFound()
+    {
+        // Row 200 ("Custom Dragon") has no "200" anywhere in its text — only the exact-id branch finds it.
+        var result = AppearanceFilterHelper.Filter(_testAppearances, "200", true, true, true);
+        Assert.Contains(result, a => a.AppearanceId == 200);
+    }
+
+    [Fact]
+    public void FilterAppearances_NonNumericSearch_UnaffectedByRowNumberLogic()
+    {
+        var result = AppearanceFilterHelper.Filter(_testAppearances, "badger", true, true, true);
+        Assert.Single(result);
+        Assert.Equal("Badger", result[0].Name);
+    }
+
+    #endregion
+
+    #region Regression: no silent drop (#2587 core)
+
+    [Fact]
+    public void FilterAppearances_DefaultSettings_ReturnsEveryLabeledRow()
+    {
+        // The #2587 investigation proved nothing is dropped at default settings (all sources on,
+        // no text, no exclude). Lock that in so a future filter change can't silently hide rows.
+        var result = AppearanceFilterHelper.Filter(_testAppearances, null, true, true, true, null);
+        Assert.Equal(_testAppearances.Count, result.Count);
+    }
+
+    #endregion
+
     #region Source Filters
 
     [Fact]

--- a/Quartermaster/Quartermaster.Tests/AppearanceServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/AppearanceServiceTests.cs
@@ -339,6 +339,25 @@ public class AppearanceServiceTests
 
     #endregion
 
+    #region AppearanceRow tooltip (#2587 review)
+
+    [Fact]
+    public void AppearanceRow_Tooltip_IncludesTypeAndLabel()
+    {
+        var staticRow = new Quartermaster.Views.Panels.AppearanceRow
+        {
+            AppearanceId = 175, Model = "wlfdr01", IsPartBased = false, Label = "Dog_Wolf_Dire"
+        };
+        Assert.Contains("Type: Static", staticRow.Tooltip);
+        Assert.Contains("Dog_Wolf_Dire", staticRow.Tooltip);
+        Assert.Contains("175", staticRow.Tooltip);
+
+        var dynamicRow = new Quartermaster.Views.Panels.AppearanceRow { IsPartBased = true };
+        Assert.Contains("Type: Part-Based", dynamicRow.Tooltip);
+    }
+
+    #endregion
+
     #region Phenotype
 
     [Fact]

--- a/Quartermaster/Quartermaster.Tests/AppearanceServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/AppearanceServiceTests.cs
@@ -280,6 +280,63 @@ public class AppearanceServiceTests
         Assert.False(badger.IsPartBased);
     }
 
+    [Fact]
+    public void GetAllAppearances_PopulatesMakerFromLabelParentheses()
+    {
+        // CEP-style label with a trailing maker parenthetical.
+        _mockGameData.Set2DAValue("appearance", 40, "LABEL", "Bear: Black (Shemsu-Heru)");
+        _mockGameData.Set2DAValue("appearance", 40, "STRING_REF", "****");
+        _mockGameData.Set2DAValue("appearance", 40, "MODELTYPE", "F");
+        _mockGameData.Set2DAValue("appearance", 40, "RACE", "c_bearblck");
+
+        var appearances = _service.GetAllAppearances();
+        var bear = appearances.First(a => a.AppearanceId == 40);
+        Assert.Equal("Shemsu-Heru", bear.Maker);
+    }
+
+    [Fact]
+    public void GetAllAppearances_NoParentheses_MakerIsEmpty()
+    {
+        var appearances = _service.GetAllAppearances();
+        var badger = appearances.First(a => a.AppearanceId == 0); // "A_Badger" — no parens
+        Assert.Equal("", badger.Maker);
+    }
+
+    #endregion
+
+    #region ParseMaker (#2028)
+
+    [Theory]
+    // Simple trailing maker.
+    [InlineData("Bear: Black (Shemsu-Heru)", "c_bearblck", "Shemsu-Heru")]
+    // Last paren is the model resref → drop it, use the previous group (the Abishai case).
+    [InlineData("Devil: Abishai: Blue 1* (Darklight) (c_abishaibl)", "c_abishaibl", "Darklight")]
+    // Double paren where the first is a model hint and the last is the maker (Dragonrider case).
+    [InlineData("Dragonrider: Female: Green (cep2_drgrid_*)* (TheOneBlackRider)", "flygreen_fr_hood2", "TheOneBlackRider")]
+    // No parentheses at all.
+    [InlineData("Dog: Wolf, Dire", "wlfdr01", "")]
+    // The synthetic UI "(Dynamic)" prefix must not be treated as a maker.
+    [InlineData("(Dynamic) Human", "h", "")]
+    // Trailing whitespace after the maker group.
+    [InlineData("Cat: Leopard (Shemsu-Heru) ", "c_cat_lep", "Shemsu-Heru")]
+    public void ParseMaker_VariousLabels(string label, string modelRef, string expected)
+    {
+        Assert.Equal(expected, AppearanceFilterHelper.ParseMaker(label, modelRef));
+    }
+
+    [Fact]
+    public void ParseMaker_OnlyParenIsModel_ReturnsEmpty()
+    {
+        Assert.Equal("", AppearanceFilterHelper.ParseMaker("Creature (c_thing)", "c_thing"));
+    }
+
+    [Fact]
+    public void ParseMaker_NullOrEmptyLabel_ReturnsEmpty()
+    {
+        Assert.Equal("", AppearanceFilterHelper.ParseMaker(null!, "x"));
+        Assert.Equal("", AppearanceFilterHelper.ParseMaker("", "x"));
+    }
+
     #endregion
 
     #region Phenotype

--- a/Quartermaster/Quartermaster/Services/AppearanceFilterHelper.cs
+++ b/Quartermaster/Quartermaster/Services/AppearanceFilterHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Quartermaster.Services;
 
@@ -74,8 +75,9 @@ public static class AppearanceFilterHelper
         // Row-number search (#2027): an all-digit query also matches the exact AppearanceId,
         // so typing "175" surfaces row 175 even when "175" appears nowhere in its text. The
         // substring match still runs, so digit queries also catch names containing the digits.
+        // All-digits check (not just int.TryParse, which would accept "+5"/" 5"/"-5" as a row).
         var trimmed = searchText.Trim();
-        if (trimmed.Length > 0 && IsAllDigits(trimmed)
+        if (trimmed.Length > 0 && trimmed.All(char.IsDigit)
             && int.TryParse(trimmed, out int rowNumber)
             && app.AppearanceId == rowNumber)
         {
@@ -85,16 +87,6 @@ public static class AppearanceFilterHelper
         return app.Name.Contains(searchText, StringComparison.OrdinalIgnoreCase)
             || app.Label.Contains(searchText, StringComparison.OrdinalIgnoreCase)
             || app.Race.Contains(searchText, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static bool IsAllDigits(string s)
-    {
-        foreach (var c in s)
-        {
-            if (c < '0' || c > '9')
-                return false;
-        }
-        return true;
     }
 
     /// <summary>

--- a/Quartermaster/Quartermaster/Services/AppearanceFilterHelper.cs
+++ b/Quartermaster/Quartermaster/Services/AppearanceFilterHelper.cs
@@ -71,9 +71,68 @@ public static class AppearanceFilterHelper
 
     private static bool MatchesTextSearch(AppearanceInfo app, string searchText)
     {
+        // Row-number search (#2027): an all-digit query also matches the exact AppearanceId,
+        // so typing "175" surfaces row 175 even when "175" appears nowhere in its text. The
+        // substring match still runs, so digit queries also catch names containing the digits.
+        var trimmed = searchText.Trim();
+        if (trimmed.Length > 0 && IsAllDigits(trimmed)
+            && int.TryParse(trimmed, out int rowNumber)
+            && app.AppearanceId == rowNumber)
+        {
+            return true;
+        }
+
         return app.Name.Contains(searchText, StringComparison.OrdinalIgnoreCase)
             || app.Label.Contains(searchText, StringComparison.OrdinalIgnoreCase)
             || app.Race.Contains(searchText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsAllDigits(string s)
+    {
+        foreach (var c in s)
+        {
+            if (c < '0' || c > '9')
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Parse the maker/author of a CEP appearance from its label's parentheses (#2028).
+    /// CEP labels append the author in a trailing group, e.g. "Bear: Black (Shemsu-Heru)".
+    /// Some labels also carry a model-resref group (e.g. "...(Darklight) (c_abishaibl)"); the
+    /// group equal to <paramref name="modelRef"/> is skipped so the real author is returned.
+    /// The synthetic "(Dynamic)" UI prefix is treated as not-a-maker.
+    /// Returns the empty string when no maker group is present.
+    /// </summary>
+    /// <param name="label">Raw appearance.2da LABEL (not the UI-decorated display name).</param>
+    /// <param name="modelRef">Known model resref to exclude from maker candidates.</param>
+    public static string ParseMaker(string label, string modelRef)
+    {
+        if (string.IsNullOrEmpty(label))
+            return "";
+
+        var matches = System.Text.RegularExpressions.Regex.Matches(label, @"\(([^()]*)\)");
+        if (matches.Count == 0)
+            return "";
+
+        var model = modelRef?.Trim() ?? "";
+
+        // Walk from the last parenthetical backward; skip groups that are the model resref or
+        // the synthetic "Dynamic" prefix. Return the first real author group found.
+        for (int i = matches.Count - 1; i >= 0; i--)
+        {
+            var group = matches[i].Groups[1].Value.Trim();
+            if (group.Length == 0)
+                continue;
+            if (model.Length > 0 && group.Equals(model, StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (group.Equals("Dynamic", StringComparison.OrdinalIgnoreCase))
+                continue;
+            return group;
+        }
+
+        return "";
     }
 
     /// <summary>

--- a/Quartermaster/Quartermaster/Services/AppearanceService.cs
+++ b/Quartermaster/Quartermaster/Services/AppearanceService.cs
@@ -145,6 +145,12 @@ public class AppearanceService
                     $"name='{name}'");
             }
 
+            // Maker (#2028): parse the CEP author from the label's trailing parenthetical,
+            // skipping any group that is actually the model resref. Use the raw 2DA label so
+            // the synthetic "(Dynamic)" UI prefix (added later) is never present here.
+            var makerModelRef = !string.IsNullOrEmpty(race) ? race! : label;
+            var maker = AppearanceFilterHelper.ParseMaker(label, makerModelRef);
+
             appearances.Add(new AppearanceInfo
             {
                 AppearanceId = (ushort)i,
@@ -152,7 +158,8 @@ public class AppearanceService
                 Label = label,
                 IsPartBased = isPartBased,
                 Race = race ?? "",
-                ModelResRef = modelResRef ?? ""
+                ModelResRef = modelResRef ?? "",
+                Maker = maker
             });
         }
 
@@ -739,6 +746,7 @@ public class AppearanceInfo : SkillDisplayHelper.INamedItem
     public bool IsPartBased { get; set; }
     public string Race { get; set; } = "";
     public string ModelResRef { get; set; } = "";
+    public string Maker { get; set; } = "";
     public AppearanceSource Source { get; set; } = AppearanceSource.Unknown;
 }
 

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.DataLoading.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.DataLoading.cs
@@ -44,35 +44,29 @@ public partial class AppearancePanel
         var filtered = AppearanceFilterHelper.Filter(_appearances, searchText, showBif, showHak, showOverride, excludePatterns);
 
         // Remember current selection
-        ushort? selectedId = null;
-        if (_appearanceListBox.SelectedItem is ListBoxItem selectedItem && selectedItem.Tag is ushort id)
-            selectedId = id;
+        ushort? selectedId = (_appearanceListBox.SelectedItem as AppearanceRow)?.AppearanceId;
 
-        _appearanceListBox.Items.Clear();
+        _appearanceRows.Clear();
         foreach (var app in filtered)
         {
-            var baseName = app.IsPartBased && !app.Name.Contains("(Dynamic)")
-                ? $"(Dynamic) {app.Name}"
-                : app.Name;
             var modelRef = !string.IsNullOrEmpty(app.Race) ? app.Race : app.Label;
-            var displayText = $"[{app.AppearanceId}] {baseName} ({modelRef})";
-            var item = new ListBoxItem
+            _appearanceRows.Add(new AppearanceRow
             {
-                Content = displayText,
-                Tag = app.AppearanceId
-            };
-            // Context menu is attached once to the parent ListBox (see WireEvents),
-            // not per-item — #2058.
-            Avalonia.Controls.ToolTip.SetTip(item, $"ID: {app.AppearanceId} | Model: {modelRef} | Type: {(app.IsPartBased ? "Part-Based" : "Static")} | Label: {app.Label}");
-            _appearanceListBox.Items.Add(item);
+                AppearanceId = app.AppearanceId,
+                Name = app.IsPartBased ? $"(Dynamic) {app.Name}" : app.Name,
+                Maker = app.Maker,
+                Model = modelRef,
+                IsPartBased = app.IsPartBased,
+                Label = app.Label
+            });
         }
 
         // Restore selection if still present
         if (selectedId.HasValue)
         {
-            for (int i = 0; i < _appearanceListBox.Items.Count; i++)
+            for (int i = 0; i < _appearanceRows.Count; i++)
             {
-                if (_appearanceListBox.Items[i] is ListBoxItem item && item.Tag is ushort itemId && itemId == selectedId.Value)
+                if (_appearanceRows[i].AppearanceId == selectedId.Value)
                 {
                     _appearanceListBox.SelectedIndex = i;
                     break;
@@ -295,41 +289,46 @@ public partial class AppearancePanel
     {
         if (_appearanceListBox == null || _appearances == null) return;
 
-        for (int i = 0; i < _appearanceListBox.Items.Count; i++)
-        {
-            if (_appearanceListBox.Items[i] is ListBoxItem item &&
-                item.Tag is ushort id && id == appearanceId)
-            {
-                _appearanceListBox.SelectedIndex = i;
-                return;
-            }
-        }
+        if (TrySelectAppearanceRow(appearanceId))
+            return;
 
         // If not found in filtered list, clear search and try again
         if (_appearanceSearchBox != null && !string.IsNullOrEmpty(_appearanceSearchBox.Text))
         {
             _appearanceSearchBox.Text = "";
             RefreshFilteredAppearanceList();
-            for (int i = 0; i < _appearanceListBox.Items.Count; i++)
-            {
-                if (_appearanceListBox.Items[i] is ListBoxItem item &&
-                    item.Tag is ushort id && id == appearanceId)
-                {
-                    _appearanceListBox.SelectedIndex = i;
-                    return;
-                }
-            }
+            if (TrySelectAppearanceRow(appearanceId))
+                return;
         }
 
-        // Still not found, add it with consistent format. Shared ContextMenu
-        // on the parent ListBox handles the copy actions for all rows (#2058).
-        var fallbackItem = new ListBoxItem
+        // Still not found (e.g. excluded by a source/exclude filter, or an unknown id on a
+        // loaded creature). Add a synthetic row so the current value is visible and selectable.
+        // The shared ContextMenu on the DataGrid handles copy actions for all rows (#2058).
+        _appearanceRows.Add(new AppearanceRow
         {
-            Content = $"[{appearanceId}] Appearance {appearanceId}",
-            Tag = appearanceId
-        };
-        _appearanceListBox.Items.Add(fallbackItem);
-        _appearanceListBox.SelectedIndex = _appearanceListBox.Items.Count - 1;
+            AppearanceId = appearanceId,
+            Name = $"Appearance {appearanceId}",
+            Maker = "",
+            Model = "",
+            IsPartBased = false,
+            Label = $"Appearance {appearanceId}"
+        });
+        _appearanceListBox.SelectedIndex = _appearanceRows.Count - 1;
+    }
+
+    private bool TrySelectAppearanceRow(ushort appearanceId)
+    {
+        if (_appearanceListBox == null) return false;
+
+        for (int i = 0; i < _appearanceRows.Count; i++)
+        {
+            if (_appearanceRows[i].AppearanceId == appearanceId)
+            {
+                _appearanceListBox.SelectedIndex = i;
+                return true;
+            }
+        }
+        return false;
     }
 
     private void SelectGender(byte genderId)
@@ -378,4 +377,17 @@ public partial class AppearancePanel
         });
         _phenotypeComboBox.SelectedIndex = _phenotypeComboBox.Items.Count - 1;
     }
+}
+
+/// <summary>
+/// Row model bound to the appearance DataGrid (#2587): Row# / Name / Maker / Model columns.
+/// </summary>
+public class AppearanceRow
+{
+    public ushort AppearanceId { get; set; }
+    public string Name { get; set; } = "";
+    public string Maker { get; set; } = "";
+    public string Model { get; set; } = "";
+    public bool IsPartBased { get; set; }
+    public string Label { get; set; } = "";
 }

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.DataLoading.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.DataLoading.cs
@@ -61,14 +61,16 @@ public partial class AppearancePanel
             });
         }
 
-        // Restore selection if still present
+        // Restore selection if still present. Select by item reference, not SelectedIndex:
+        // the DataGrid is sortable, so the view order can differ from the backing collection
+        // order — an index would select the wrong row and silently change AppearanceType (#2587).
         if (selectedId.HasValue)
         {
-            for (int i = 0; i < _appearanceRows.Count; i++)
+            foreach (var row in _appearanceRows)
             {
-                if (_appearanceRows[i].AppearanceId == selectedId.Value)
+                if (row.AppearanceId == selectedId.Value)
                 {
-                    _appearanceListBox.SelectedIndex = i;
+                    _appearanceListBox.SelectedItem = row;
                     break;
                 }
             }
@@ -304,7 +306,7 @@ public partial class AppearancePanel
         // Still not found (e.g. excluded by a source/exclude filter, or an unknown id on a
         // loaded creature). Add a synthetic row so the current value is visible and selectable.
         // The shared ContextMenu on the DataGrid handles copy actions for all rows (#2058).
-        _appearanceRows.Add(new AppearanceRow
+        var synthetic = new AppearanceRow
         {
             AppearanceId = appearanceId,
             Name = $"Appearance {appearanceId}",
@@ -312,19 +314,22 @@ public partial class AppearancePanel
             Model = "",
             IsPartBased = false,
             Label = $"Appearance {appearanceId}"
-        });
-        _appearanceListBox.SelectedIndex = _appearanceRows.Count - 1;
+        };
+        _appearanceRows.Add(synthetic);
+        // Select by item reference (sort-agnostic), not by index — see RefreshFilteredAppearanceList.
+        _appearanceListBox.SelectedItem = synthetic;
     }
 
     private bool TrySelectAppearanceRow(ushort appearanceId)
     {
         if (_appearanceListBox == null) return false;
 
-        for (int i = 0; i < _appearanceRows.Count; i++)
+        foreach (var row in _appearanceRows)
         {
-            if (_appearanceRows[i].AppearanceId == appearanceId)
+            if (row.AppearanceId == appearanceId)
             {
-                _appearanceListBox.SelectedIndex = i;
+                // Select by item reference (sort-agnostic), not by index.
+                _appearanceListBox.SelectedItem = row;
                 return true;
             }
         }
@@ -390,4 +395,11 @@ public class AppearanceRow
     public string Model { get; set; } = "";
     public bool IsPartBased { get; set; }
     public string Label { get; set; } = "";
+
+    /// <summary>
+    /// Per-row hover tooltip preserving the Type (Part-Based/Static) and raw 2DA Label that the
+    /// pre-DataGrid ListBox surfaced (#2587 review).
+    /// </summary>
+    public string Tooltip =>
+        $"ID: {AppearanceId} | Model: {Model} | Type: {(IsPartBased ? "Part-Based" : "Static")} | Label: {Label}";
 }

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
@@ -21,9 +21,10 @@ public partial class AppearancePanel
     {
         if (_appearanceListBox != null)
         {
+            _appearanceListBox.ItemsSource = _appearanceRows;
             _appearanceListBox.SelectionChanged += OnAppearanceSelectionChanged;
-            // Attach the Copy context menu once to the ListBox rather than per-item.
-            // Per-item ContextMenu allocation was a hot path during load and filter
+            // Attach the Copy context menu once to the DataGrid rather than per-row.
+            // Per-row ContextMenu allocation was a hot path during load and filter
             // refresh with ~1000 rows (#2058).
             _appearanceListBox.ContextMenu = BuildSharedAppearanceCopyMenu();
         }
@@ -224,25 +225,23 @@ public partial class AppearancePanel
 
     private void OnAppearanceSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
-        if (_isLoading || _appearanceListBox?.SelectedItem is not ListBoxItem item) return;
+        if (_isLoading || _appearanceListBox?.SelectedItem is not AppearanceRow row) return;
 
         try
         {
-            if (item.Tag is ushort appearanceId)
+            var appearanceId = row.AppearanceId;
+            UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                $"AppearancePanel: Appearance changed to {appearanceId}, name='{row.Name}'");
+            var isPartBased = _displayService?.IsPartBasedAppearance(appearanceId) ?? false;
+            UpdateBodyPartsEnabledState(isPartBased);
+
+            if (_currentCreature != null)
             {
-                UnifiedLogger.LogApplication(LogLevel.DEBUG,
-                    $"AppearancePanel: Appearance changed to {appearanceId}, displayText='{item.Content}'");
-                var isPartBased = _displayService?.IsPartBasedAppearance(appearanceId) ?? false;
-                UpdateBodyPartsEnabledState(isPartBased);
-
-                if (_currentCreature != null)
-                {
-                    _currentCreature.AppearanceType = appearanceId;
-                    UpdateModelPreview();
-                }
-
-                AppearanceChanged?.Invoke(this, EventArgs.Empty);
+                _currentCreature.AppearanceType = appearanceId;
+                UpdateModelPreview();
             }
+
+            AppearanceChanged?.Invoke(this, EventArgs.Empty);
         }
         catch (Exception ex)
         {
@@ -736,27 +735,11 @@ public partial class AppearancePanel
         name = string.Empty;
         resref = string.Empty;
 
-        if (_appearanceListBox?.SelectedItem is not ListBoxItem selected) return false;
-        if (selected.Tag is not ushort selectedId) return false;
+        if (_appearanceListBox?.SelectedItem is not AppearanceRow selected) return false;
 
-        id = selectedId;
-
-        if (_appearances != null)
-        {
-            foreach (var app in _appearances)
-            {
-                if (app.AppearanceId != selectedId) continue;
-
-                name = app.IsPartBased && !app.Name.Contains("(Dynamic)")
-                    ? $"(Dynamic) {app.Name}"
-                    : app.Name;
-                resref = !string.IsNullOrEmpty(app.Race) ? app.Race : app.Label;
-                return true;
-            }
-        }
-
-        // Fallback: synthesize from ListBoxItem content (matches the "Appearance N" row format)
-        name = selected.Content?.ToString() ?? $"Appearance {selectedId}";
+        id = selected.AppearanceId;
+        name = selected.Name;
+        resref = selected.Model;
         return true;
     }
 

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
@@ -8,7 +8,8 @@
 
     <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
         <!-- Main split: Left (body parts) / Right (3D preview) -->
-        <Grid ColumnDefinitions="350,*">
+        <!-- Left column widened (350→430) to fit the Row#/Name/Maker/Model appearance grid (#2587). -->
+        <Grid ColumnDefinitions="430,*">
 
             <!-- LEFT PANEL: Body Parts Configuration -->
             <ScrollViewer Grid.Column="0" VerticalScrollBarVisibility="Auto">
@@ -59,11 +60,26 @@
                                      AutomationProperties.AutomationId="ExcludePatternBox"
                                      ToolTip.Tip="Hide entries matching these patterns (e.g. Invisible;object). Matches Name and Label, case-insensitive."/>
 
-                            <!-- Appearance List (replaces ComboBox for searchability) -->
-                            <ListBox x:Name="AppearanceListBox"
-                                     MaxHeight="150"
-                                     FontSize="{DynamicResource FontSizeSmall}"
-                                     AutomationProperties.AutomationId="AppearanceListBox"/>
+                            <!-- Appearance list: Row#/Name/Maker/Model columns, sortable (#2587, #2027, #2028).
+                                 Kept compact; search (incl. row-number) does the heavy lifting, not scrolling. -->
+                            <DataGrid x:Name="AppearanceListBox"
+                                      MaxHeight="190"
+                                      FontSize="{DynamicResource FontSizeSmall}"
+                                      IsReadOnly="True"
+                                      SelectionMode="Single"
+                                      CanUserSortColumns="True"
+                                      CanUserResizeColumns="True"
+                                      CanUserReorderColumns="False"
+                                      GridLinesVisibility="Horizontal"
+                                      HeadersVisibility="Column"
+                                      AutomationProperties.AutomationId="AppearanceListBox">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Header="Row#" Binding="{Binding AppearanceId}" Width="Auto"/>
+                                    <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
+                                    <DataGridTextColumn Header="Maker" Binding="{Binding Maker}" Width="Auto"/>
+                                    <DataGridTextColumn Header="Model" Binding="{Binding Model}" Width="Auto"/>
+                                </DataGrid.Columns>
+                            </DataGrid>
 
                             <Grid ColumnDefinitions="70,*" RowDefinitions="Auto,Auto" RowSpacing="6" ColumnSpacing="10">
                                 <!-- Gender -->

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
@@ -79,6 +79,12 @@
                                       GridLinesVisibility="Horizontal"
                                       HeadersVisibility="Column"
                                       AutomationProperties.AutomationId="AppearanceListBox">
+                                <DataGrid.Styles>
+                                    <!-- Per-row tooltip: Type (Part-Based/Static) + raw 2DA Label (#2587 review) -->
+                                    <Style Selector="DataGridRow">
+                                        <Setter Property="ToolTip.Tip" Value="{Binding Tooltip}"/>
+                                    </Style>
+                                </DataGrid.Styles>
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Header="Row#" Binding="{Binding AppearanceId}" Width="Auto"/>
                                     <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
@@ -7,9 +7,15 @@
              x:Class="Quartermaster.Views.Panels.AppearancePanel">
 
     <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
-        <!-- Main split: Left (body parts) / Right (3D preview) -->
-        <!-- Left column widened (350→430) to fit the Row#/Name/Maker/Model appearance grid (#2587). -->
-        <Grid ColumnDefinitions="430,*">
+        <!-- Main split: Left (body parts) | splitter | Right (3D preview). Proportional (star)
+             widths with MinWidth floors + a draggable GridSplitter so the panel resizes with the
+             window instead of pinning a fixed left width (#2587). -->
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*" MinWidth="360"/>
+                <ColumnDefinition Width="5"/>
+                <ColumnDefinition Width="3*" MinWidth="280"/>
+            </Grid.ColumnDefinitions>
 
             <!-- LEFT PANEL: Body Parts Configuration -->
             <ScrollViewer Grid.Column="0" VerticalScrollBarVisibility="Auto">
@@ -63,7 +69,7 @@
                             <!-- Appearance list: Row#/Name/Maker/Model columns, sortable (#2587, #2027, #2028).
                                  Kept compact; search (incl. row-number) does the heavy lifting, not scrolling. -->
                             <DataGrid x:Name="AppearanceListBox"
-                                      MaxHeight="190"
+                                      MinHeight="150" MaxHeight="340"
                                       FontSize="{DynamicResource FontSizeSmall}"
                                       IsReadOnly="True"
                                       SelectionMode="Single"
@@ -306,8 +312,13 @@
                 </StackPanel>
             </ScrollViewer>
 
+            <!-- Draggable divider between the editor column and the 3D preview -->
+            <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch"
+                          Background="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                          ResizeDirection="Columns"/>
+
             <!-- RIGHT PANEL: 3D Model Preview -->
-            <Border Grid.Column="1"
+            <Border Grid.Column="2"
                     BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
                     BorderThickness="1,0,0,0"
                     Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
@@ -66,7 +66,7 @@
                                      AutomationProperties.AutomationId="ExcludePatternBox"
                                      ToolTip.Tip="Hide entries matching these patterns (e.g. Invisible;object). Matches Name and Label, case-insensitive."/>
 
-                            <!-- Appearance list: Row#/Name/Maker/Model columns, sortable (#2587, #2027, #2028).
+                            <!-- Appearance list: Row#/Name/Model/Maker columns, sortable (#2587, #2027, #2028).
                                  Kept compact; search (incl. row-number) does the heavy lifting, not scrolling. -->
                             <DataGrid x:Name="AppearanceListBox"
                                       MinHeight="150" MaxHeight="340"
@@ -82,8 +82,8 @@
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Header="Row#" Binding="{Binding AppearanceId}" Width="Auto"/>
                                     <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
-                                    <DataGridTextColumn Header="Maker" Binding="{Binding Maker}" Width="Auto"/>
                                     <DataGridTextColumn Header="Model" Binding="{Binding Model}" Width="Auto"/>
+                                    <DataGridTextColumn Header="Maker" Binding="{Binding Maker}" Width="Auto"/>
                                 </DataGrid.Columns>
                             </DataGrid>
 

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
@@ -20,12 +20,15 @@ public partial class AppearancePanel : UserControl
 {
     // Appearance section
     private TextBox? _appearanceSearchBox;
-    private ListBox? _appearanceListBox;
+    private DataGrid? _appearanceListBox;
     private CheckBox? _showBifCheckBox;
     private CheckBox? _showHakCheckBox;
     private CheckBox? _showOverrideCheckBox;
     private TextBlock? _appearanceCountText;
     private TextBox? _excludePatternBox;
+
+    // Backing collection for the appearance DataGrid (#2587).
+    private readonly System.Collections.ObjectModel.ObservableCollection<AppearanceRow> _appearanceRows = new();
     private ComboBox? _genderComboBox;
     private ComboBox? _phenotypeComboBox;
 
@@ -125,7 +128,7 @@ public partial class AppearancePanel : UserControl
     {
         // Appearance section
         _appearanceSearchBox = this.FindControl<TextBox>("AppearanceSearchBox");
-        _appearanceListBox = this.FindControl<ListBox>("AppearanceListBox");
+        _appearanceListBox = this.FindControl<DataGrid>("AppearanceListBox");
         _showBifCheckBox = this.FindControl<CheckBox>("ShowBifCheckBox");
         _showHakCheckBox = this.FindControl<CheckBox>("ShowHakCheckBox");
         _showOverrideCheckBox = this.FindControl<CheckBox>("ShowOverrideCheckBox");


### PR DESCRIPTION
## Summary

Investigation found the reported "filter drops CEP creatures" does **not** reproduce — all 5,135 labeled appearances already show at default settings (full stage-by-stage evidence in `NonPublic/Quartermaster/Research/`). The real gap was discoverability in a 5,000+ row flat list, so this PR delivers the search/columns work tracked by #2027 and #2028:

- **Sortable DataGrid** — the appearance list is now Row# / Name / Model / Maker columns (sortable, resizable) instead of a single-line ListBox (#2028).
- **Row-number search** — a numeric query also matches the exact 2DA row number (#2027).
- **Maker column** — the CEP author is parsed from the label parentheses, skipping the model resref and the synthetic `(Dynamic)` prefix (validated 99.3% on real CEP data).
- **Resizable panel** — fixed widths replaced with proportional star columns + a draggable `GridSplitter`.
- **Regression test** — locks in "default filter returns every labeled row" (the #2587 no-silent-drop guarantee).

## Related Issues

- Closes #2587
- Closes #2027
- Closes #2028

## Verification

- ✅ 1,293 Quartermaster unit tests pass (added ParseMaker, row-number search, regression, tooltip tests)
- ✅ Quartermaster FlaUI smoke passes; clean app launch against the live CEP fixture (LNS_DLG) — no binding errors
- ✅ Code review applied: fixed sort-safe selection (select by item reference, not index — a sortable grid + index could silently change AppearanceType), restored the per-row tooltip, simplified the digit check

## Checklist

- [x] Implementation complete
- [x] Tests added/updated
- [x] CHANGELOG updated with date
- [ ] Manual spot-check (3D preview — FlaUI can't see the GL surface): columns render, header sort works, row-number search jumps, selecting a row updates the preview, splitter resizes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
