### PR TITLE
[Radoub] Sprint: Model Preview Animation Fixes (#2622)

### DIFF
--- a/.claude/scripts/New-PlaceableStateTestUtp.ps1
+++ b/.claude/scripts/New-PlaceableStateTestUtp.ps1
@@ -1,0 +1,54 @@
+# Build throwaway test placeables for Reliquary state-selector verification (#2595).
+# Clones a base UTP and swaps Appearance to models whose open/close/on/off animations live in a
+# SUPERMODEL — the case PlaceableModelLoader now merges. Writing several lets the human confirm the
+# State selector appears and the preview poses each state.
+#
+# Requires PowerShell 7 (net9.0 assembly load); use the full PS7 path, NOT the WindowsApps stub:
+#   & "C:\Program Files\PowerShell\7\pwsh.exe" -NoProfile -ExecutionPolicy Bypass `
+#       -File ".claude/scripts/New-PlaceableStateTestUtp.ps1"
+#
+# Generated UTPs are throwaway (not committed); this generator is reusable and committed.
+
+param(
+    [string] $ModuleDir = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Neverwinter Nights\modules\LNS_DLG'),
+    [string] $BaseUtp = 'chest1.utp'
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+$dll = Join-Path $repoRoot 'Radoub.Formats\Radoub.Formats\bin\Debug\net9.0\Radoub.Formats.dll'
+if (-not (Test-Path $dll)) { throw "Radoub.Formats.dll not found at $dll - build Radoub.Formats first." }
+Add-Type -Path $dll
+
+# Base UTP: try the module first, then the committed test fixture.
+$basePath = Join-Path $ModuleDir $BaseUtp
+if (-not (Test-Path $basePath)) {
+    $basePath = Join-Path $repoRoot 'Reliquary\Reliquary.Tests\Fixtures\chest1.utp'
+}
+if (-not (Test-Path $basePath)) { throw "Base UTP not found (tried module + test fixtures)." }
+
+# file -> @{ Appearance; Label; States } — supermodel-inheriting models confirmed by investigation.
+$cases = @(
+    @{ File = 'rsp_list2';   Appearance = 830;   Label = 'tnp_list02 (open/close/on/off via tnp_list01)' },
+    @{ File = 'rsp_dresser'; Appearance = 8182;  Label = 'zlc_ccp_b93 (open/close via plc_a07)' },
+    @{ File = 'rsp_brazier'; Appearance = 57;    Label = 'plc_i05 brazier (on/off emitter — see #2556)' }
+)
+
+foreach ($c in $cases) {
+    $utp = [Radoub.Formats.Utp.UtpReader]::Read($basePath)
+    $utp.Appearance = [uint32]$c.Appearance
+    $utp.TemplateResRef = $c.File
+    $utp.Tag = $c.File
+    $utp.AnimationState = [byte]0   # start at Default; user switches in the selector
+    $loc = New-Object Radoub.Formats.Gff.CExoLocString
+    $loc.SetString(0, "STATE TEST: $($c.Label)")
+    $utp.LocName = $loc
+
+    $out = Join-Path $ModuleDir ($c.File + '.utp')
+    [Radoub.Formats.Utp.UtpWriter]::Write($utp, $out)
+    "Wrote $out  (appearance $($c.Appearance) — $($c.Label))"
+}
+
+"`nOpen these in Reliquary (--file <name>.utp). Expected: the State selector lists Default plus the"
+"model's states. rsp_list2 -> Default/Open/Closed/Activated/Deactivated; rsp_dresser -> Default/Open/Closed."
+"rsp_brazier's flame on/off is emitter-gated (#2556, out of this sprint) — the selector still appears."

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -13,7 +13,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 - Canine creatures (e.g. blinkdog) now animate in the preview instead of rendering static at bind pose (#2552).
 - Dire tiger mane and other DanglyNode meshes drape over the model rather than sitting flat in their rest pose (#2619).
 - New "Loop all animations" diagnostic in the appearance preview cycles every animation for coverage auditing (#2140).
-- Reliquary now surfaces the animation-state controls a placeable model actually contains (#2595; see Reliquary CHANGELOG).
+- Reliquary now surfaces placeable animation-state controls and gates emitters by state — the brazier flame turns off when Deactivated (#2595, #2556; see Reliquary CHANGELOG).
 
 ---
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.138-alpha] - 2026-06-28
-**Branch**: `radoub/issue-2622` | **PR**: #TBD
+**Branch**: `radoub/issue-2622` | **PR**: #2625
 
 ### Sprint: Model Preview Animation Fixes (#2622)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -11,7 +11,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ### Sprint: Model Preview Animation Fixes (#2622)
 
 - Canine creatures (e.g. blinkdog) now animate in the preview instead of rendering static at bind pose (#2552).
-- Dire tiger mane and other DanglyNode meshes drape over the model rather than sitting flat in their rest pose (#2619).
+- Creatures with animated DanglyNode meshes (e.g. the dire tiger mane) now show their idle pose at rest, and the binary dangly tuning fields (displacement/tightness/constraints) parse correctly. True dangly sag is a runtime physics sim, deferred (#2619).
 - New "Loop all animations" diagnostic in the appearance preview cycles every animation for coverage auditing (#2140).
 - Reliquary now surfaces placeable animation-state controls and gates emitters by state — the brazier flame turns off when Deactivated (#2595, #2556; see Reliquary CHANGELOG).
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.138-alpha] - 2026-06-28
+**Branch**: `radoub/issue-2622` | **PR**: #TBD
+
+### Sprint: Model Preview Animation Fixes (#2622)
+
+- Canine creatures (e.g. blinkdog) now animate in the preview instead of rendering static at bind pose (#2552).
+- Dire tiger mane and other DanglyNode meshes drape over the model rather than sitting flat in their rest pose (#2619).
+- New "Loop all animations" diagnostic in the appearance preview cycles every animation for coverage auditing (#2140).
+- Reliquary now surfaces the animation-state controls a placeable model actually contains (#2595; see Reliquary CHANGELOG).
+
+---
+
 ## [0.2.137-alpha] - 2026-06-28
 **Branch**: `quartermaster/issue-2587` | **PR**: #2621
 

--- a/Quartermaster/Quartermaster.Tests/AnimationLoopControllerTests.cs
+++ b/Quartermaster/Quartermaster.Tests/AnimationLoopControllerTests.cs
@@ -1,0 +1,97 @@
+using Quartermaster.Services;
+using Xunit;
+
+namespace Quartermaster.Tests;
+
+/// <summary>
+/// Tests for the "Loop all animations" diagnostic sequencer (#2140). The controller is a pure
+/// state machine — it owns the index/cycle bookkeeping so the UI partial only has to start a
+/// timer, set the active animation, and show the overlay name. No Avalonia dependency here.
+/// </summary>
+public class AnimationLoopControllerTests
+{
+    [Fact]
+    public void Start_WithAnimations_BeginsAtFirstAnimationCycleOne()
+    {
+        var c = new AnimationLoopController(animationCount: 3, maxCycles: 3);
+
+        Assert.True(c.Start());
+        Assert.True(c.IsRunning);
+        Assert.Equal(0, c.CurrentIndex);
+        Assert.Equal(1, c.CurrentCycle);
+    }
+
+    [Fact]
+    public void Start_WithNoAnimations_DoesNotRun()
+    {
+        var c = new AnimationLoopController(animationCount: 0, maxCycles: 3);
+
+        Assert.False(c.Start());
+        Assert.False(c.IsRunning);
+    }
+
+    [Fact]
+    public void Advance_WalksThroughAnimationsInOrder()
+    {
+        var c = new AnimationLoopController(animationCount: 3, maxCycles: 3);
+        c.Start();
+
+        Assert.Equal(0, c.CurrentIndex);
+        Assert.True(c.Advance());
+        Assert.Equal(1, c.CurrentIndex);
+        Assert.Equal(1, c.CurrentCycle);
+        Assert.True(c.Advance());
+        Assert.Equal(2, c.CurrentIndex);
+        Assert.Equal(1, c.CurrentCycle);
+    }
+
+    [Fact]
+    public void Advance_PastLastAnimation_WrapsToNextCycle()
+    {
+        var c = new AnimationLoopController(animationCount: 2, maxCycles: 3);
+        c.Start();
+
+        Assert.True(c.Advance()); // -> idx 1, cycle 1
+        Assert.True(c.Advance()); // wrap -> idx 0, cycle 2
+        Assert.Equal(0, c.CurrentIndex);
+        Assert.Equal(2, c.CurrentCycle);
+    }
+
+    [Fact]
+    public void Advance_AfterMaxCycles_StopsAndReturnsFalse()
+    {
+        // 1 animation, 3 cycles: plays it once per cycle, stops after the 3rd.
+        var c = new AnimationLoopController(animationCount: 1, maxCycles: 3);
+        c.Start();
+
+        Assert.Equal(1, c.CurrentCycle);
+        Assert.True(c.Advance());  // cycle 2
+        Assert.Equal(2, c.CurrentCycle);
+        Assert.True(c.Advance());  // cycle 3
+        Assert.Equal(3, c.CurrentCycle);
+        Assert.False(c.Advance()); // exhausted -> stop
+        Assert.False(c.IsRunning);
+    }
+
+    [Fact]
+    public void Stop_HaltsAndAdvanceBecomesNoOp()
+    {
+        var c = new AnimationLoopController(animationCount: 3, maxCycles: 3);
+        c.Start();
+        c.Stop();
+
+        Assert.False(c.IsRunning);
+        Assert.False(c.Advance());
+    }
+
+    [Fact]
+    public void Start_ClampsMaxCyclesToAtLeastOne()
+    {
+        var c = new AnimationLoopController(animationCount: 2, maxCycles: 0);
+        c.Start();
+
+        // Even with a bad maxCycles, one full pass must run.
+        Assert.True(c.Advance());  // idx 1
+        Assert.False(c.Advance()); // would wrap to cycle 2, but max is clamped to 1 -> stop
+    }
+}

--- a/Quartermaster/Quartermaster/Services/AnimationLoopController.cs
+++ b/Quartermaster/Quartermaster/Services/AnimationLoopController.cs
@@ -1,0 +1,88 @@
+using System;
+
+namespace Quartermaster.Services;
+
+/// <summary>
+/// Pure state machine driving the "Loop all animations" diagnostic (#2140). It owns only the
+/// index/cycle bookkeeping — selecting the animation, starting the preview timer, and showing
+/// the on-screen overlay name are the UI partial's job. Kept Avalonia-free so it is unit-testable
+/// without FlaUI.
+///
+/// Lifecycle: <see cref="Start"/> to begin at animation 0 / cycle 1, then <see cref="Advance"/>
+/// once each animation finishes its natural length. Advance walks the list in order, wraps to the
+/// next cycle past the last animation, and returns false (auto-stopping) once <c>maxCycles</c>
+/// full passes are done.
+/// </summary>
+public sealed class AnimationLoopController
+{
+    private readonly int _animationCount;
+    private readonly int _maxCycles;
+
+    public AnimationLoopController(int animationCount, int maxCycles)
+    {
+        _animationCount = Math.Max(0, animationCount);
+        // A non-positive maxCycles still runs one full pass — a diagnostic that played nothing
+        // would be a silent no-op, the exact failure mode this tool exists to avoid.
+        _maxCycles = Math.Max(1, maxCycles);
+    }
+
+    /// <summary>Zero-based index of the animation currently playing.</summary>
+    public int CurrentIndex { get; private set; }
+
+    /// <summary>One-based cycle counter (1.._maxCycles).</summary>
+    public int CurrentCycle { get; private set; }
+
+    public bool IsRunning { get; private set; }
+
+    public int AnimationCount => _animationCount;
+    public int MaxCycles => _maxCycles;
+
+    /// <summary>
+    /// Begin the loop. Returns false (and stays stopped) when there are no animations to cycle.
+    /// </summary>
+    public bool Start()
+    {
+        if (_animationCount <= 0)
+        {
+            IsRunning = false;
+            return false;
+        }
+
+        CurrentIndex = 0;
+        CurrentCycle = 1;
+        IsRunning = true;
+        return true;
+    }
+
+    /// <summary>
+    /// Move to the next animation. Wraps to the next cycle past the last animation. Returns false
+    /// — and stops the loop — once the configured number of cycles is exhausted or if not running.
+    /// </summary>
+    public bool Advance()
+    {
+        if (!IsRunning) return false;
+
+        int next = CurrentIndex + 1;
+        if (next < _animationCount)
+        {
+            CurrentIndex = next;
+            return true;
+        }
+
+        // Past the last animation: start the next cycle, unless we have finished the last one.
+        if (CurrentCycle >= _maxCycles)
+        {
+            Stop();
+            return false;
+        }
+
+        CurrentCycle++;
+        CurrentIndex = 0;
+        return true;
+    }
+
+    public void Stop()
+    {
+        IsRunning = false;
+    }
+}

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.EventHandlers.cs
@@ -115,6 +115,8 @@ public partial class AppearancePanel
             _animTimeSlider.PropertyChanged += OnAnimSliderChanged;
         if (_animSpeedSlider != null)
             _animSpeedSlider.PropertyChanged += OnAnimSpeedChanged;
+        if (_loopAllAnimationsCheckBox != null)
+            _loopAllAnimationsCheckBox.IsCheckedChanged += OnLoopAllAnimationsChanged;
 
         // 3D Preview pointer/wheel/key input — wired on the transparent
         // input-surface Border that overlays the GL control (#2124).
@@ -421,6 +423,9 @@ public partial class AppearancePanel
             _animTimeSlider.PropertyChanged -= OnAnimSliderChanged;
         if (_animSpeedSlider != null)
             _animSpeedSlider.PropertyChanged -= OnAnimSpeedChanged;
+        if (_loopAllAnimationsCheckBox != null)
+            _loopAllAnimationsCheckBox.IsCheckedChanged -= OnLoopAllAnimationsChanged;
+        StopLoopAllAnimations();
 
         if (_modelPreviewInputSurface != null)
         {
@@ -862,5 +867,151 @@ public partial class AppearancePanel
         if (e.Property != Slider.ValueProperty) return;
         if (_modelPreviewGL == null || _animSpeedSlider == null) return;
         _modelPreviewGL.AnimationSpeed = (float)_animSpeedSlider.Value;
+    }
+
+    // ----- "Loop all animations" diagnostic (#2140) -----
+    //
+    // Sequencing (which animation, which cycle, when to stop) lives in the pure
+    // AnimationLoopController; this partial only drives the preview and the overlay. A
+    // DispatcherTimer scheduled per-animation for (length + pause) advances the controller — no
+    // completion event on the shared GL control is needed.
+
+    private const int AnimLoopPauseMs = 500;       // pause between animations (#2140 spec)
+    private const float AnimLoopMinSeconds = 0.5f;  // floor for zero-length / single-keyframe anims
+
+    private AnimationLoopController? _animLoop;
+    private Avalonia.Threading.DispatcherTimer? _animLoopTimer;
+
+    private void OnLoopAllAnimationsChanged(object? sender, RoutedEventArgs e)
+    {
+        if (_loopAllAnimationsCheckBox?.IsChecked == true)
+            StartLoopAllAnimations();
+        else
+            StopLoopAllAnimations();
+    }
+
+    private void StartLoopAllAnimations()
+    {
+        var animations = _modelPreviewGL?.Model?.Animations;
+        if (_modelPreviewGL == null || animations == null || animations.Count == 0)
+        {
+            // Nothing to cycle — untick so the UI doesn't claim a running loop.
+            if (_loopAllAnimationsCheckBox != null) _loopAllAnimationsCheckBox.IsChecked = false;
+            return;
+        }
+
+        _animLoop = new AnimationLoopController(animations.Count, maxCycles: 3);
+        if (!_animLoop.Start())
+        {
+            _animLoop = null;
+            if (_loopAllAnimationsCheckBox != null) _loopAllAnimationsCheckBox.IsChecked = false;
+            return;
+        }
+
+        UnifiedLogger.LogApplication(LogLevel.INFO, "AnimationLoop: started (3 cycles)");
+        PlayLoopCurrent();
+    }
+
+    /// <summary>Set the active animation to the controller's current index, play it, log + show
+    /// its name, and schedule the advance for when this animation finishes its natural length.</summary>
+    private void PlayLoopCurrent()
+    {
+        if (_animLoop == null || !_animLoop.IsRunning || _modelPreviewGL?.Model == null) return;
+
+        var animations = _modelPreviewGL.Model.Animations;
+        int idx = _animLoop.CurrentIndex;
+        if (idx < 0 || idx >= animations.Count) { StopLoopAllAnimations(); return; }
+
+        var anim = animations[idx];
+        _modelPreviewGL.SetActiveAnimation(anim);
+        _modelPreviewGL.PlayAnimation();
+        if (_animPlayButton != null) _animPlayButton.Content = "⏸";
+
+        // Keep the combo in sync so the dropdown truthfully reflects what's playing
+        // (offset by 1 past the "(none)" item). Guarded by _isLoading-free direct set.
+        if (_animationComboBox != null) _animationComboBox.SelectedIndex = idx + 1;
+
+        string name = string.IsNullOrEmpty(anim.Name) ? $"#{idx}" : anim.Name;
+        UnifiedLogger.LogApplication(LogLevel.INFO,
+            $"AnimationLoop: playing '{name}' ({idx + 1}/{animations.Count}, cycle {_animLoop.CurrentCycle}/{_animLoop.MaxCycles})");
+        ShowLoopOverlay($"{name}  ({idx + 1}/{animations.Count}, cycle {_animLoop.CurrentCycle}/{_animLoop.MaxCycles})");
+
+        // Schedule advance: animation length (scaled by speed) + pause. Floor short/stub anims so
+        // single-keyframe states still get a visible beat instead of flashing past.
+        float speed = _modelPreviewGL.AnimationSpeed <= 0 ? 1f : _modelPreviewGL.AnimationSpeed;
+        float lengthSec = Math.Max(AnimLoopMinSeconds, anim.Length) / speed;
+        int totalMs = (int)(lengthSec * 1000) + AnimLoopPauseMs;
+        ScheduleLoopAdvance(totalMs);
+    }
+
+    private void ScheduleLoopAdvance(int delayMs)
+    {
+        StopLoopTimer();
+        _animLoopTimer = new Avalonia.Threading.DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(Math.Max(50, delayMs)),
+        };
+        _animLoopTimer.Tick += OnLoopAdvanceTick;
+        _animLoopTimer.Start();
+    }
+
+    private void OnLoopAdvanceTick(object? sender, EventArgs e)
+    {
+        StopLoopTimer(); // one-shot
+        if (_animLoop == null || !_animLoop.IsRunning) { StopLoopAllAnimations(); return; }
+
+        if (_animLoop.Advance())
+            PlayLoopCurrent();
+        else
+            StopLoopAllAnimations(); // finished all cycles
+    }
+
+    private void StopLoopAllAnimations()
+    {
+        StopLoopTimer();
+        bool wasRunning = _animLoop?.IsRunning == true;
+        _animLoop?.Stop();
+        _animLoop = null;
+
+        if (wasRunning)
+            UnifiedLogger.LogApplication(LogLevel.INFO, "AnimationLoop: stopped");
+
+        HideLoopOverlay();
+
+        // Untick without re-entering the handler.
+        if (_loopAllAnimationsCheckBox != null && _loopAllAnimationsCheckBox.IsChecked == true)
+        {
+            _loopAllAnimationsCheckBox.IsCheckedChanged -= OnLoopAllAnimationsChanged;
+            _loopAllAnimationsCheckBox.IsChecked = false;
+            _loopAllAnimationsCheckBox.IsCheckedChanged += OnLoopAllAnimationsChanged;
+        }
+
+        // Return playback to whatever the combo selected (spec: revert on turn-off).
+        if (_modelPreviewGL != null)
+        {
+            _modelPreviewGL.PauseAnimation();
+            if (_animPlayButton != null) _animPlayButton.Content = "▶";
+        }
+    }
+
+    private void StopLoopTimer()
+    {
+        if (_animLoopTimer == null) return;
+        _animLoopTimer.Stop();
+        _animLoopTimer.Tick -= OnLoopAdvanceTick;
+        _animLoopTimer = null;
+    }
+
+    private void ShowLoopOverlay(string text)
+    {
+        if (_previewStateOverlay == null || _previewStateText == null) return;
+        _previewStateText.Text = text;
+        _previewStateText.Foreground = BrushManager.GetWarningBrush(this);
+        _previewStateOverlay.IsVisible = true;
+    }
+
+    private void HideLoopOverlay()
+    {
+        if (_previewStateOverlay != null) _previewStateOverlay.IsVisible = false;
     }
 }

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml
@@ -423,6 +423,11 @@
                                     Minimum="0.1" Maximum="2.0" Value="1.0"
                                     VerticalAlignment="Center"
                                     ToolTip.Tip="Playback speed (0.1x – 2x)"/>
+                            <!-- Diagnostic: auto-cycle every animation for coverage auditing (#2140) -->
+                            <CheckBox x:Name="LoopAllAnimationsCheckBox" Content="Loop all"
+                                      VerticalAlignment="Center" Margin="10,0,0,0"
+                                      AutomationProperties.AutomationId="LoopAllAnimationsCheckBox"
+                                      ToolTip.Tip="Diagnostic: play every animation in order (3 cycles), logging each name"/>
                         </StackPanel>
                     </Border>
                 </Grid>

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
@@ -383,12 +383,16 @@ public partial class AppearancePanel : UserControl
 
         _animationComboBox.ItemsSource = items;
 
-        // Models with animated emitters (e.g. the fairy's flapping wing Dummies) need an idle
-        // animation playing or their emitters render as a static orb instead of sweeping into the
-        // intended shape. Default the dropdown to the creature idle "cpause1" and start playback so
-        // the dropdown truthfully reflects what is animating. Other models default to "(none)". (#2434)
+        // Some models look wrong at bind pose and need an idle animation playing by default:
+        //  - animated emitters (fairy wing Dummies) render as a static orb instead of sweeping (#2434);
+        //  - DanglyNode manes/cloth (dire tiger) sit flat instead of draped (#2619) — the preview has
+        //    no dangly physics, so the idle pose of their parent bones is what drapes them.
+        // In both cases default the dropdown to the creature idle "cpause1" and start playback so the
+        // dropdown truthfully reflects what is animating. Other models default to "(none)".
         int idleItemIndex = -1;
-        if (_modelPreviewGL?.HasAnimatedEmitters() == true)
+        bool wantsIdle = _modelPreviewGL?.HasAnimatedEmitters() == true
+            || Radoub.UI.Services.ModelIdlePoseHeuristic.HasAnimatedDanglyMesh(model);
+        if (wantsIdle)
             idleItemIndex = items.FindIndex(n => string.Equals(n, "cpause1", StringComparison.OrdinalIgnoreCase));
 
         if (idleItemIndex > 0)

--- a/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Panels/AppearancePanel.axaml.cs
@@ -91,6 +91,7 @@ public partial class AppearancePanel : UserControl
     private Button? _animPlayButton;
     private Slider? _animTimeSlider;
     private Slider? _animSpeedSlider;
+    private CheckBox? _loopAllAnimationsCheckBox;
 
     private CreatureDisplayService? _displayService;
     private PaletteColorService? _paletteColorService;
@@ -195,6 +196,7 @@ public partial class AppearancePanel : UserControl
         _animPlayButton = this.FindControl<Button>("AnimPlayButton");
         _animTimeSlider = this.FindControl<Slider>("AnimTimeSlider");
         _animSpeedSlider = this.FindControl<Slider>("AnimSpeedSlider");
+        _loopAllAnimationsCheckBox = this.FindControl<CheckBox>("LoopAllAnimationsCheckBox");
     }
 
     public void SetDisplayService(CreatureDisplayService displayService)

--- a/Radoub.Formats/Radoub.Formats.Tests/Mdl/DanglyNodeParsingTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Mdl/DanglyNodeParsingTests.cs
@@ -1,0 +1,75 @@
+using System.IO;
+using System.Linq;
+using Radoub.Formats.Mdl;
+using Xunit;
+
+namespace Radoub.Formats.Tests.Mdl;
+
+/// <summary>
+/// Danglymesh extension parsing (#2619). The binary reader's dangly fields
+/// (displacement/tightness/period + the per-vertex constraints array) live at
+/// meshHeaderStart+0x200 (nodeOffset+0x270) per nwnexplorer's CNwnMdlDanglyMeshNode. The old code
+/// read from the wrong stream cursor and produced denormal-float garbage with zero constraints —
+/// which is why CEP creatures' dangly manes/hair carried meaningless tuning values.
+/// </summary>
+public class DanglyNodeParsingTests
+{
+    [Fact]
+    public void Binary_DanglyExtension_ReadsDisplacementTightnessPeriod()
+    {
+        var bytes = TrimeshMdlFixture.BuildSingleDangly(
+            displacement: 0.05f, tightness: 3.0f, period: 8.0f,
+            constraints: new[] { 0f, 128f, 240f, 255f });
+
+        var model = new MdlBinaryReader().Parse(bytes);
+        var dangly = Assert.IsType<MdlDanglyNode>(model.GeometryRoot);
+
+        Assert.Equal(0.05f, dangly.Displacement, 4);
+        Assert.Equal(3.0f, dangly.Tightness, 4);
+        Assert.Equal(8.0f, dangly.Period, 4);
+    }
+
+    [Fact]
+    public void Binary_DanglyExtension_ReadsConstraintsArray()
+    {
+        var expected = new[] { 0f, 128f, 240f, 255f };
+        var bytes = TrimeshMdlFixture.BuildSingleDangly(0.05f, 3.0f, 8.0f, expected);
+
+        var model = new MdlBinaryReader().Parse(bytes);
+        var dangly = (MdlDanglyNode)model.GeometryRoot!;
+
+        Assert.Equal(expected, dangly.Constraints);
+    }
+
+    [Fact]
+    public void Binary_DanglyValues_AreNotDenormalGarbage()
+    {
+        // The pre-fix bug yielded denormal floats (~1e-43). Pin that they're plausible tuning values.
+        var bytes = TrimeshMdlFixture.BuildSingleDangly(0.025f, 4.0f, 6.0f, new[] { 10f, 20f });
+        var dangly = (MdlDanglyNode)new MdlBinaryReader().Parse(bytes).GeometryRoot!;
+
+        Assert.True(dangly.Displacement is >= 0f and < 1000f);
+        Assert.True(dangly.Tightness is >= 0f and < 1000f);
+        Assert.True(dangly.Period is >= 0f and < 1000f);
+    }
+
+    // ---- ASCII reader sanity (already handled dangly props; guard against regression) ----
+
+    private static readonly string AsciiAllipPath = Path.Combine(
+        Path.GetDirectoryName(typeof(DanglyNodeParsingTests).Assembly.Location)!,
+        "TestData", "Mdl", "c_allip_d.mdl");
+
+    [Fact]
+    public void Ascii_Allip_DanglyConstraintsMatchVertexCounts()
+    {
+        Assert.True(File.Exists(AsciiAllipPath), $"Fixture missing: {AsciiAllipPath}");
+        var model = new MdlReader().Parse(File.ReadAllBytes(AsciiAllipPath));
+
+        var danglies = model.GetMeshNodes().OfType<MdlDanglyNode>().ToList();
+        Assert.NotEmpty(danglies);
+        Assert.Contains(danglies, d => d.Constraints.Length > 0);
+        foreach (var d in danglies.Where(d => d.Constraints.Length > 0))
+            Assert.True(d.Constraints.Length <= d.Vertices.Length,
+                $"'{d.Name}' has {d.Constraints.Length} constraints but {d.Vertices.Length} vertices");
+    }
+}

--- a/Radoub.Formats/Radoub.Formats.Tests/Mdl/TrimeshMdlFixture.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/Mdl/TrimeshMdlFixture.cs
@@ -85,6 +85,63 @@ public static class TrimeshMdlFixture
         return file;
     }
 
+    private const uint NodeFlagHasDangly = 0x00000100;
+    // Danglymesh node: trimesh flags PLUS the dangly bit. Dangly extension block sits right after
+    // the 0x200 mesh header (meshHeaderStart + 0x200), matching nwnexplorer CNwnMdlDanglyMeshNode.
+    private const uint DanglyMeshFlags = NodeFlagHasMesh | NodeFlagHasDangly;
+    private const int DanglyExtSize = 24; // CNwnArray<float> constraints (12) + displacement/tightness/period (12)
+
+    /// <summary>
+    /// Build a binary MDL whose root is a single danglymesh node carrying the given
+    /// displacement/tightness/period and a constraints float array (#2619 regression). The
+    /// constraints data is appended after the node and referenced by a model-relative pointer.
+    /// </summary>
+    public static byte[] BuildSingleDangly(float displacement, float tightness, float period, float[] constraints)
+    {
+        int danglyNodeSize = NodeHeaderSize + MeshHeaderSize + DanglyExtSize; // 0x288
+        int constraintsBytes = constraints.Length * sizeof(float);
+        // Constraints array placed immediately after the dangly node, inside model data.
+        int constraintsOffset = (int)TrimeshNodeOffset + danglyNodeSize;
+        int modelDataSize = constraintsOffset + constraintsBytes;
+        var modelData = new byte[modelDataSize];
+
+        // ---- Model / geometry header ----
+        WriteUInt32(modelData, 0x00, 0);                  // pointerBase = 0
+        WriteFixedString(modelData, 0x08, "danglytest", 64);
+        WriteUInt32(modelData, 0x48, TrimeshNodeOffset);  // root node pointer
+        WriteUInt32(modelData, 0x4C, 1);                  // node count
+
+        // ---- Dangly node header (0x70) ----
+        int n = (int)TrimeshNodeOffset;
+        WriteFixedString(modelData, n + 32, "mane", 32);  // node name
+        WriteUInt32(modelData, n + 0x6C, DanglyMeshFlags); // node flags -> dangly trimesh
+
+        // ---- Dangly extension at meshHeaderStart + 0x200 ----
+        int ext = n + NodeHeaderSize + MeshHeaderSize;
+        // m_afConstraints CNwnArray { ptr, count, allocated }. Pointer is model-relative (pointerBase=0).
+        WriteUInt32(modelData, ext + 0, (uint)constraintsOffset);
+        WriteUInt32(modelData, ext + 4, (uint)constraints.Length);
+        WriteUInt32(modelData, ext + 8, (uint)constraints.Length);
+        WriteSingle(modelData, ext + 12, displacement);
+        WriteSingle(modelData, ext + 16, tightness);
+        WriteSingle(modelData, ext + 20, period);
+
+        // ---- Constraints float data ----
+        for (int i = 0; i < constraints.Length; i++)
+            WriteSingle(modelData, constraintsOffset + i * sizeof(float), constraints[i]);
+
+        // ---- Prepend file header (12 bytes) ----
+        var file = new byte[FileHeaderSize + modelData.Length];
+        WriteUInt32(file, 0, 0);
+        WriteUInt32(file, 4, (uint)modelData.Length);
+        WriteUInt32(file, 8, 0);
+        Array.Copy(modelData, 0, file, FileHeaderSize, modelData.Length);
+        return file;
+    }
+
+    private static void WriteSingle(byte[] buf, int offset, float value) =>
+        BitConverter.GetBytes(value).CopyTo(buf, offset);
+
     private static void WriteUInt32(byte[] buf, int offset, uint value) =>
         BitConverter.GetBytes(value).CopyTo(buf, offset);
 

--- a/Radoub.Formats/Radoub.Formats.Tests/MdlAsciiAnimationParsingTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/MdlAsciiAnimationParsingTests.cs
@@ -1,0 +1,100 @@
+using System.Linq;
+using Radoub.Formats.Mdl;
+using Xunit;
+
+namespace Radoub.Formats.Tests;
+
+/// <summary>
+/// ASCII MDL animation-node parsing (#2552). Canine creatures (blinkdog) inherit animations from
+/// an ASCII supermodel (canine_a); the ASCII reader previously skipped animation node bodies
+/// (SkipToEndNode), so every animation parsed with GeometryRoot=null and the preview could never
+/// build a pose. These tests pin the keyframe-controller parsing that fixes that.
+/// </summary>
+public class MdlAsciiAnimationParsingTests
+{
+    private const string ModelWithAnimatedNode = @"
+newmodel critter
+setsupermodel critter NULL
+classification character
+beginmodelgeom critter
+node dummy critter
+  parent NULL
+  position 0 0 0
+  node dummy pelvis
+    parent critter
+    position 0 0 1
+  endnode
+endnode
+endmodelgeom critter
+newanim cpause1 critter
+  length 2.0
+  transtime 0.25
+  animroot critter
+  node dummy pelvis
+    parent critter
+    positionkey
+      0.0 0 0 1
+      1.0 0 0 2
+    endlist
+    orientationkey
+      0.0 0 0 1 0.5
+    endlist
+  endnode
+doneanim cpause1 critter
+donemodel critter
+";
+
+    [Fact]
+    public void Parse_AnimationWithKeyframes_PopulatesGeometryRoot()
+    {
+        var model = new MdlAsciiReader().Parse(ModelWithAnimatedNode);
+
+        var anim = Assert.Single(model.Animations);
+        Assert.Equal("cpause1", anim.Name);
+        Assert.NotNull(anim.GeometryRoot);
+    }
+
+    [Fact]
+    public void Parse_AnimationNode_CarriesPositionAndOrientationKeyframes()
+    {
+        var model = new MdlAsciiReader().Parse(ModelWithAnimatedNode);
+        var anim = model.Animations.Single();
+
+        var pelvis = FindNode(anim.GeometryRoot!, "pelvis");
+        Assert.NotNull(pelvis);
+
+        // Two position keys at t=0 and t=1.
+        Assert.Equal(2, pelvis!.PositionTimes.Length);
+        Assert.Equal(0.0f, pelvis.PositionTimes[0]);
+        Assert.Equal(1.0f, pelvis.PositionTimes[1]);
+        Assert.Equal(2, pelvis.PositionValues.Length);
+        Assert.Equal(2f, pelvis.PositionValues[1].Z);
+
+        // One orientation key.
+        Assert.Single(pelvis.OrientationTimes);
+        Assert.Single(pelvis.OrientationValues);
+    }
+
+    [Fact]
+    public void Parse_AnimatedNode_IsDetectedAsAnimated()
+    {
+        // The preview treats a node with >1 position/orientation/scale key as "animated"
+        // (BuildPoseRecursive). The pelvis has 2 position keys, so it must qualify.
+        var model = new MdlAsciiReader().Parse(ModelWithAnimatedNode);
+        var pelvis = FindNode(model.Animations.Single().GeometryRoot!, "pelvis");
+
+        Assert.True(pelvis!.PositionTimes.Length > 1);
+    }
+
+    private static MdlNode? FindNode(MdlNode node, string name)
+    {
+        if (string.Equals(node.Name, name, System.StringComparison.OrdinalIgnoreCase))
+            return node;
+        foreach (var c in node.Children)
+        {
+            var found = FindNode(c, name);
+            if (found != null) return found;
+        }
+        return null;
+    }
+}

--- a/Radoub.Formats/Radoub.Formats.Tests/MdlAsciiSkinWeightTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/MdlAsciiSkinWeightTests.cs
@@ -1,0 +1,136 @@
+using System.Linq;
+using Radoub.Formats.Mdl;
+using Xunit;
+
+namespace Radoub.Formats.Tests;
+
+/// <summary>
+/// ASCII MDL skin-weight parsing (#2552). The ASCII `weights` block references bones by NAME
+/// (e.g. "Wolf_ribcage 0.5 Wolf_pelvis 0.5"), not by index. The reader previously ran ParseInt on
+/// the name → 0, so every vertex weighted to bogus slot 0 and BoneNodeNames stayed empty. With no
+/// slot→bone-name bridge the renderer disabled skinning and ASCII creatures (blinkdog) rendered
+/// frozen. These tests pin name → slot-index resolution.
+/// </summary>
+public class MdlAsciiSkinWeightTests
+{
+    private const string SkinModel = @"
+newmodel critter
+setsupermodel critter NULL
+beginmodelgeom critter
+node dummy critter
+  parent NULL
+  node dummy Wolf_pelvis
+    parent critter
+  endnode
+  node dummy Wolf_ribcage
+    parent Wolf_pelvis
+  endnode
+  node skin body
+    parent critter
+    verts 3
+      0 0 0
+      1 0 0
+      0 1 0
+    weights 3
+      Wolf_ribcage 1.0
+      Wolf_ribcage 0.5 Wolf_pelvis 0.5
+      Wolf_pelvis 1.0
+  endnode
+endnode
+endmodelgeom critter
+donemodel critter
+";
+
+    private static MdlSkinNode LoadSkin()
+    {
+        var model = new MdlAsciiReader().Parse(SkinModel);
+        return model.GetMeshNodes().OfType<MdlSkinNode>().Single();
+    }
+
+    [Fact]
+    public void Parse_WeightsByName_PopulatesBoneNodeNames()
+    {
+        var skin = LoadSkin();
+
+        // Two distinct bones referenced across the block.
+        Assert.Contains("Wolf_ribcage", skin.BoneNodeNames);
+        Assert.Contains("Wolf_pelvis", skin.BoneNodeNames);
+    }
+
+    [Fact]
+    public void Parse_WeightsByName_StoresSlotIndicesNotZero()
+    {
+        var skin = LoadSkin();
+        Assert.Equal(3, skin.BoneWeights.Length);
+
+        // Resolve each vertex's primary bone back to a name via the slot map.
+        string Name(int slot) => slot >= 0 && slot < skin.BoneNodeNames.Length ? skin.BoneNodeNames[slot] : "";
+
+        // Vertex 0: 100% Wolf_ribcage
+        Assert.Equal("Wolf_ribcage", Name(skin.BoneWeights[0].Bone0));
+        Assert.Equal(1.0f, skin.BoneWeights[0].Weight0, 3);
+
+        // Vertex 1: ribcage 0.5 + pelvis 0.5 — two distinct slots, not both 0.
+        var v1 = skin.BoneWeights[1];
+        Assert.NotEqual(v1.Bone0, v1.Bone1);
+        Assert.Equal("Wolf_ribcage", Name(v1.Bone0));
+        Assert.Equal("Wolf_pelvis", Name(v1.Bone1));
+
+        // Vertex 2: 100% Wolf_pelvis
+        Assert.Equal("Wolf_pelvis", Name(skin.BoneWeights[2].Bone0));
+    }
+
+    [Fact]
+    public void Parse_BoneNodeNames_AreUniqueAndStable()
+    {
+        var skin = LoadSkin();
+        // No duplicate slots for the same bone name.
+        Assert.Equal(skin.BoneNodeNames.Distinct().Count(), skin.BoneNodeNames.Length);
+    }
+
+    // A skin whose tverts force a split-vertex unroll: the bone-weight array must be remapped to the
+    // unrolled vertex count, or the renderer's "BoneWeights.Length == Vertices.Length" skinning guard
+    // fails and the creature renders frozen (blinkdog: 199 weights vs 279 unrolled verts). (#2552)
+    private const string SkinNeedingUnroll = @"
+newmodel critter
+beginmodelgeom critter
+node dummy critter
+  parent NULL
+  node dummy Wolf_pelvis
+    parent critter
+  endnode
+  node skin body
+    parent critter
+    verts 3
+      0 0 0
+      1 0 0
+      0 1 0
+    tverts 4
+      0 0
+      1 0
+      0 1
+      0.5 0.5
+    faces 2
+      0 1 2 0 0 1 2 0
+      0 2 1 0 0 3 1 0
+    weights 3
+      Wolf_pelvis 1.0
+      Wolf_pelvis 1.0
+      Wolf_pelvis 1.0
+  endnode
+endnode
+endmodelgeom critter
+donemodel critter
+";
+
+    [Fact]
+    public void Parse_SkinUnroll_RemapsBoneWeightsToVertexCount()
+    {
+        var model = new MdlAsciiReader().Parse(SkinNeedingUnroll);
+        var skin = model.GetMeshNodes().OfType<MdlSkinNode>().Single();
+
+        // Unroll split vertex 0 (used with tvert 0 and tvert 3) into two unified vertices.
+        Assert.True(skin.Vertices.Length > 3, "expected unroll to add vertices");
+        Assert.Equal(skin.Vertices.Length, skin.BoneWeights.Length);
+    }
+}

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlAsciiReader.AnimationParsing.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlAsciiReader.AnimationParsing.cs
@@ -1,6 +1,8 @@
 // MDL ASCII Reader - Animation parsing
 // Partial class for animation data parsing
 
+using System.Collections.Generic;
+
 namespace Radoub.Formats.Mdl;
 
 public partial class MdlAsciiReader
@@ -8,6 +10,14 @@ public partial class MdlAsciiReader
     private MdlAnimation? ParseAnimation(string animName)
     {
         var anim = new MdlAnimation { Name = animName };
+
+        // Animation nodes form a flat list with "parent" properties (same shape as geometry).
+        // Each carries keyframe controllers (positionkey/orientationkey/scalekey). Previously the
+        // ASCII reader skipped these (SkipToEndNode), so every animation parsed with a null
+        // GeometryRoot and the preview could never build a pose — canine_a / blinkdog never
+        // animated (#2552). Reuse the geometry node machinery so the controllers land on the tree.
+        var nodesByName = new Dictionary<string, MdlNode>(System.StringComparer.OrdinalIgnoreCase);
+        var parentNames = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase);
 
         while (_currentLine < _lines.Length)
         {
@@ -29,6 +39,7 @@ public partial class MdlAsciiReader
             {
                 case "doneanim":
                     _currentLine++;
+                    anim.GeometryRoot = LinkNodeHierarchy(nodesByName, parentNames);
                     return anim;
 
                 case "length":
@@ -62,9 +73,20 @@ public partial class MdlAsciiReader
                     break;
 
                 case "node":
-                    // Animation nodes - simplified handling
-                    _currentLine++;
-                    SkipToEndNode();
+                    if (tokens.Length >= 3)
+                    {
+                        var (node, parentName) = ParseNodeWithParent(tokens[1], tokens[2]);
+                        nodesByName[node.Name] = node;
+                        if (!string.IsNullOrEmpty(parentName) &&
+                            !parentName.Equals("NULL", System.StringComparison.OrdinalIgnoreCase))
+                        {
+                            parentNames[node.Name] = parentName;
+                        }
+                    }
+                    else
+                    {
+                        _currentLine++;
+                    }
                     break;
 
                 default:
@@ -73,20 +95,7 @@ public partial class MdlAsciiReader
             }
         }
 
+        anim.GeometryRoot = LinkNodeHierarchy(nodesByName, parentNames);
         return anim;
-    }
-
-    private void SkipToEndNode()
-    {
-        int depth = 1;
-        while (_currentLine < _lines.Length && depth > 0)
-        {
-            var line = CurrentLine().Trim();
-            if (line.StartsWith("node ", StringComparison.OrdinalIgnoreCase))
-                depth++;
-            else if (line.Equals("endnode", StringComparison.OrdinalIgnoreCase))
-                depth--;
-            _currentLine++;
-        }
     }
 }

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlAsciiReader.ListParsing.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlAsciiReader.ListParsing.cs
@@ -197,11 +197,19 @@ public partial class MdlAsciiReader
         if (origUVs == null)
             return;
 
+        // Skin bone weights are parallel to the ORIGINAL vertices; unrolling changes the vertex count,
+        // so the weights must be remapped per source vertex or the renderer's
+        // "BoneWeights.Length == Vertices.Length" skinning guard fails and the creature freezes (#2552).
+        var origWeights = (mesh is MdlSkinNode skin && skin.BoneWeights.Length == origVertices.Length)
+            ? skin.BoneWeights
+            : null;
+
         // Map: (vertexIndex, tvertIndex) -> new unified index
         var indexMap = new Dictionary<(int, int), int>();
         var newVertices = new List<Vector3>();
         var newNormals = new List<Vector3>();
         var newUVs = new List<Vector2>();
+        var newWeights = origWeights != null ? new List<MdlBoneWeight>() : null;
         var newFaces = new MdlFace[mesh.Faces.Length];
 
         int GetOrCreateIndex(int vIdx, int tvIdx)
@@ -217,6 +225,7 @@ public partial class MdlAsciiReader
             if (origNormals.Length > 0)
                 newNormals.Add(vIdx < origNormals.Length ? origNormals[vIdx] : Vector3.UnitZ);
             newUVs.Add(tvIdx >= 0 && tvIdx < origUVs.Length ? origUVs[tvIdx] : Vector2.Zero);
+            newWeights?.Add(vIdx < origWeights!.Length ? origWeights[vIdx] : default);
 
             return newIdx;
         }
@@ -238,6 +247,8 @@ public partial class MdlAsciiReader
         mesh.Normals = newNormals.ToArray();
         mesh.TextureCoords = new[] { newUVs.ToArray() };
         mesh.Faces = newFaces;
+        if (newWeights != null && mesh is MdlSkinNode unrolledSkin)
+            unrolledSkin.BoneWeights = newWeights.ToArray();
 
         Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
             $"[MDL-ASCII] Unrolled mesh '{mesh.Name}': {origVertices.Length} verts + {origUVs.Length} tverts -> {newVertices.Count} unified vertices");
@@ -306,6 +317,25 @@ public partial class MdlAsciiReader
         var count = ParseInt(tokens[1]);
         var weights = new List<MdlBoneWeight>();
 
+        // ASCII MDL weights reference bones by NAME (e.g. "Wolf_ribcage 0.5 Wolf_pelvis 0.5"), not by
+        // index (#2552). Build an ordered, de-duplicated slot table of bone names and store the slot
+        // index per vertex so the renderer's name-keyed skinning (SkinMatrixBuilder) can resolve each
+        // bone in the composed hierarchy. Reading these as ints (the old code) collapsed every bone
+        // to slot 0 and left BoneNodeNames empty, disabling skinning — ASCII creatures stayed frozen.
+        var slotByName = new Dictionary<string, int>(System.StringComparer.OrdinalIgnoreCase);
+        var boneNames = new List<string>();
+
+        int SlotFor(string name)
+        {
+            if (!slotByName.TryGetValue(name, out var slot))
+            {
+                slot = boneNames.Count;
+                slotByName[name] = slot;
+                boneNames.Add(name);
+            }
+            return slot;
+        }
+
         _currentLine++;
         while (weights.Count < count && _currentLine < _lines.Length)
         {
@@ -317,20 +347,22 @@ public partial class MdlAsciiReader
             }
 
             var parts = Tokenize(line);
-            // Format: bone0 weight0 [bone1 weight1] [bone2 weight2] [bone3 weight3]
+            // Format: boneName0 weight0 [boneName1 weight1] [boneName2 weight2] [boneName3 weight3]
             var bw = new MdlBoneWeight { Bone0 = -1, Bone1 = -1, Bone2 = -1, Bone3 = -1 };
 
-            for (int i = 0; i + 1 < parts.Length; i += 2)
+            for (int i = 0; i + 1 < parts.Length && i / 2 < 4; i += 2)
             {
-                var bone = ParseInt(parts[i]);
+                var boneName = parts[i];
+                if (string.IsNullOrEmpty(boneName)) continue;
+                var slot = SlotFor(boneName);
                 var weight = ParseFloat(parts[i + 1]);
 
                 switch (i / 2)
                 {
-                    case 0: bw.Bone0 = bone; bw.Weight0 = weight; break;
-                    case 1: bw.Bone1 = bone; bw.Weight1 = weight; break;
-                    case 2: bw.Bone2 = bone; bw.Weight2 = weight; break;
-                    case 3: bw.Bone3 = bone; bw.Weight3 = weight; break;
+                    case 0: bw.Bone0 = slot; bw.Weight0 = weight; break;
+                    case 1: bw.Bone1 = slot; bw.Weight1 = weight; break;
+                    case 2: bw.Bone2 = slot; bw.Weight2 = weight; break;
+                    case 3: bw.Bone3 = slot; bw.Weight3 = weight; break;
                 }
             }
 
@@ -339,6 +371,7 @@ public partial class MdlAsciiReader
         }
 
         skin.BoneWeights = weights.ToArray();
+        skin.BoneNodeNames = boneNames.ToArray();
         _currentLine--; // Back up so main loop can advance
     }
 }

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlAsciiReader.NodeParsing.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlAsciiReader.NodeParsing.cs
@@ -56,6 +56,14 @@ public partial class MdlAsciiReader
                 parentName = tokens[1];
             }
 
+            // Animation keyframe controllers (#2552): "positionkey/orientationkey/scalekey" introduce
+            // a multi-line list terminated by "endlist". These advance _currentLine themselves.
+            if (prop == "positionkey" || prop == "orientationkey" || prop == "scalekey")
+            {
+                ParseKeyframeList(node, prop);
+                continue;
+            }
+
             ParseNodeProperty(node, prop, tokens);
             _currentLine++;
         }
@@ -65,6 +73,88 @@ public partial class MdlAsciiReader
             UnrollSplitIndexMesh(trimesh);
 
         return (node, parentName);
+    }
+
+    /// <summary>
+    /// Parse a keyframe controller list (positionkey/orientationkey/scalekey) for an animation node
+    /// (#2552). The current line is the controller keyword; rows follow until "endlist". Each row is
+    /// "time value...": position = t x y z, orientation = t x y z angle (axis-angle), scale = t s.
+    /// Leaves _currentLine on the line after "endlist".
+    /// </summary>
+    private void ParseKeyframeList(MdlNode node, string controller)
+    {
+        _currentLine++; // step past the controller keyword line
+
+        var times = new System.Collections.Generic.List<float>();
+        var positions = new System.Collections.Generic.List<Vector3>();
+        var orientations = new System.Collections.Generic.List<Quaternion>();
+        var scales = new System.Collections.Generic.List<float>();
+
+        while (_currentLine < _lines.Length)
+        {
+            var line = CurrentLine();
+            if (string.IsNullOrWhiteSpace(line) || line.StartsWith("#"))
+            {
+                _currentLine++;
+                continue;
+            }
+
+            var tokens = Tokenize(line);
+            if (tokens.Length == 0)
+            {
+                _currentLine++;
+                continue;
+            }
+
+            var first = tokens[0].ToLowerInvariant();
+            if (first == "endlist")
+            {
+                _currentLine++;
+                break;
+            }
+            // A malformed/short list that runs into the next node or endnode: stop without consuming.
+            if (first == "endnode" || first == "node")
+                break;
+
+            switch (controller)
+            {
+                case "positionkey" when tokens.Length >= 4:
+                    times.Add(ParseFloat(tokens[0]));
+                    positions.Add(new Vector3(
+                        ParseFloat(tokens[1]), ParseFloat(tokens[2]), ParseFloat(tokens[3])));
+                    break;
+
+                case "orientationkey" when tokens.Length >= 5:
+                    times.Add(ParseFloat(tokens[0]));
+                    orientations.Add(QuaternionFromAxisAngle(
+                        ParseFloat(tokens[1]), ParseFloat(tokens[2]),
+                        ParseFloat(tokens[3]), ParseFloat(tokens[4])));
+                    break;
+
+                case "scalekey" when tokens.Length >= 2:
+                    times.Add(ParseFloat(tokens[0]));
+                    scales.Add(ParseFloat(tokens[1]));
+                    break;
+            }
+
+            _currentLine++;
+        }
+
+        switch (controller)
+        {
+            case "positionkey":
+                node.PositionTimes = times.ToArray();
+                node.PositionValues = positions.ToArray();
+                break;
+            case "orientationkey":
+                node.OrientationTimes = times.ToArray();
+                node.OrientationValues = orientations.ToArray();
+                break;
+            case "scalekey":
+                node.ScaleTimes = times.ToArray();
+                node.ScaleValues = scales.ToArray();
+                break;
+        }
     }
 
     private void ParseNodeProperty(MdlNode node, string prop, string[] tokens)

--- a/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader.MeshParsing.cs
+++ b/Radoub.Formats/Radoub.Formats/Mdl/MdlBinaryReader.MeshParsing.cs
@@ -211,10 +211,7 @@ public partial class MdlBinaryReader
         // Parse type-specific data
         if ((flags & NodeFlagHasDangly) != 0 && mesh is MdlDanglyNode dangly)
         {
-            reader.BaseStream.Position += 12; // skip constraints array header
-            dangly.Displacement = reader.ReadSingle();
-            dangly.Tightness = reader.ReadSingle();
-            dangly.Period = reader.ReadSingle();
+            ParseDanglyNode(dangly, reader, meshHeaderStart);
         }
 
         if ((flags & NodeFlagHasAABB) != 0 && mesh is MdlAabbNode aabb)
@@ -232,6 +229,58 @@ public partial class MdlBinaryReader
         {
             ParseSkinNode(skin, reader, meshHeaderStart, vertexCount);
         }
+    }
+
+    /// <summary>
+    /// Parse danglymesh extension data (#2619). Per nwnexplorer's CNwnMdlDanglyMeshNode the fields
+    /// live at nodeOffset + 0x270 (= meshHeaderStart + 0x200), NOT immediately after the generic
+    /// mesh header where the stream cursor happens to sit — the old code read from the wrong cursor
+    /// and produced denormal garbage for Displacement/Tightness. Layout:
+    ///   0x270 m_afConstraints  CNwnArray&lt;float&gt; (ptr, count, allocated = 12 bytes)
+    ///   0x27C m_fDisplacement   float
+    ///   0x280 m_fTightness      float
+    ///   0x284 m_fPeriod         float
+    /// Children are parsed by absolute offset, so a wrong cursor here never corrupted siblings — the
+    /// only effect was bad scalar values on the dangly node itself.
+    /// </summary>
+    private void ParseDanglyNode(MdlDanglyNode dangly, BinaryReader reader, long meshHeaderStart)
+    {
+        var danglyExtStart = meshHeaderStart + 0x200;
+        if (danglyExtStart + 24 > reader.BaseStream.Length)
+        {
+            Logging.UnifiedLogger.LogApplication(Logging.LogLevel.WARN,
+                $"[MDL] Dangly '{dangly.Name}': extension at 0x{danglyExtStart:X4} out of range — skipping");
+            return;
+        }
+
+        reader.BaseStream.Position = danglyExtStart;
+
+        // m_afConstraints: CNwnArray<float> { ptr, count, allocated }
+        var constraintsPtr = reader.ReadUInt32();
+        var constraintsCount = reader.ReadUInt32();
+        reader.ReadUInt32(); // allocated
+
+        dangly.Displacement = reader.ReadSingle();
+        dangly.Tightness = reader.ReadSingle();
+        dangly.Period = reader.ReadSingle();
+
+        // Constraints array lives in model data (one float per vertex; 0 = fixed, higher = free).
+        var constraintsOffset = PointerToModelOffset(constraintsPtr);
+        if (constraintsCount > 0 && constraintsCount <= int.MaxValue / sizeof(float) &&
+            constraintsOffset != uint.MaxValue)
+        {
+            var required = constraintsCount * sizeof(float);
+            if (constraintsOffset + required <= _modelData.Length)
+            {
+                var constraints = new float[constraintsCount];
+                Buffer.BlockCopy(_modelData, (int)constraintsOffset, constraints, 0, (int)required);
+                dangly.Constraints = constraints;
+            }
+        }
+
+        Logging.UnifiedLogger.LogApplication(Logging.LogLevel.TRACE,
+            $"[MDL] Dangly '{dangly.Name}': displacement={dangly.Displacement:F4}, tightness={dangly.Tightness:F4}, " +
+            $"period={dangly.Period:F4}, constraints={dangly.Constraints.Length}");
     }
 
     /// <summary>

--- a/Radoub.UI/Radoub.UI.Tests/ModelIdlePoseHeuristicTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/ModelIdlePoseHeuristicTests.cs
@@ -1,0 +1,72 @@
+using Radoub.Formats.Mdl;
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests;
+
+/// <summary>
+/// Idle-pose-at-rest heuristic (#2619). A model with a DanglyNode mane/cloth whose parent chain is
+/// animated should auto-play its idle so the dangly drapes instead of sitting flat at bind pose.
+/// </summary>
+public class ModelIdlePoseHeuristicTests
+{
+    private static MdlNode Bone(string name, params MdlNode[] children)
+    {
+        var n = new MdlNode { Name = name };
+        foreach (var c in children) { c.Parent = n; n.Children.Add(c); }
+        return n;
+    }
+
+    private static MdlDanglyNode Dangly(string name)
+        => new() { Name = name, NodeType = MdlNodeType.Dangly };
+
+    private static MdlAnimation AnimKeyframing(string nodeName)
+    {
+        var animNode = new MdlNode
+        {
+            Name = nodeName,
+            OrientationTimes = new[] { 0f, 0.5f },
+            OrientationValues = new[] { System.Numerics.Quaternion.Identity, System.Numerics.Quaternion.Identity },
+        };
+        return new MdlAnimation { Name = "cpause1", Length = 1f, GeometryRoot = animNode };
+    }
+
+    [Fact]
+    public void NullModel_False()
+        => Assert.False(ModelIdlePoseHeuristic.HasAnimatedDanglyMesh(null));
+
+    [Fact]
+    public void NoDanglyMesh_False()
+    {
+        var model = new MdlModel { GeometryRoot = Bone("root", new MdlTrimeshNode { Name = "body" }) };
+        model.Animations.Add(AnimKeyframing("root"));
+        Assert.False(ModelIdlePoseHeuristic.HasAnimatedDanglyMesh(model));
+    }
+
+    [Fact]
+    public void DanglyMesh_ButNoAnimationTouchesItsChain_False()
+    {
+        // Mane hangs off Cat_head, but the only animation keyframes an unrelated node.
+        var mane = Dangly("Mane");
+        var model = new MdlModel { GeometryRoot = Bone("root", Bone("Cat_head", mane)) };
+        model.Animations.Add(AnimKeyframing("SomeOtherBone"));
+        Assert.False(ModelIdlePoseHeuristic.HasAnimatedDanglyMesh(model));
+    }
+
+    [Fact]
+    public void DanglyMesh_WithAnimatedParentChain_True()
+    {
+        var mane = Dangly("Mane");
+        var model = new MdlModel { GeometryRoot = Bone("root", Bone("Cat_head", mane)) };
+        model.Animations.Add(AnimKeyframing("Cat_head")); // idle poses the mane's parent
+        Assert.True(ModelIdlePoseHeuristic.HasAnimatedDanglyMesh(model));
+    }
+
+    [Fact]
+    public void DanglyMesh_NoAnimations_False()
+    {
+        var mane = Dangly("Mane");
+        var model = new MdlModel { GeometryRoot = Bone("root", Bone("Cat_head", mane)) };
+        Assert.False(ModelIdlePoseHeuristic.HasAnimatedDanglyMesh(model));
+    }
+}

--- a/Radoub.UI/Radoub.UI.Tests/Particles/EmitterAnimationGateTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Particles/EmitterAnimationGateTests.cs
@@ -84,4 +84,57 @@ public class EmitterAnimationGateTests
 
         Assert.True(EmitterAnimationGate.ShouldRenderAtRest(model, "fairyDust"));
     }
+
+    // ---- State-aware gating for placeable preview states (#2556) ----
+
+    // Brazier-like model: header flame 20, default 20, on 20, off 0 (the real plc_i05 shape).
+    private static MdlModel BrazierModel()
+    {
+        var model = new MdlModel { Name = "plc_i05" };
+        var root = new MdlNode { Name = "root" };
+        root.Children.Add(Emitter("fire!06", 20f));
+        model.GeometryRoot = root;
+
+        void AddStateAnim(string name, float flameBr)
+        {
+            var r = new MdlNode { Name = "root" };
+            r.Children.Add(Emitter("fire!06", flameBr));
+            model.Animations.Add(new MdlAnimation { Name = name, Length = 0.033f, GeometryRoot = r });
+        }
+        AddStateAnim("default", 20f);
+        AddStateAnim("on", 20f);
+        AddStateAnim("off", 0f);
+        return model;
+    }
+
+    [Fact]
+    public void DeactivatedState_TurnsFlameOff()
+    {
+        // Selecting Deactivated (off animation) keys fire!06 birthrate to 0 → silent.
+        Assert.False(EmitterAnimationGate.ShouldRenderForState(BrazierModel(), "fire!06", "off"));
+    }
+
+    [Fact]
+    public void ActivatedState_KeepsFlameOn()
+    {
+        Assert.True(EmitterAnimationGate.ShouldRenderForState(BrazierModel(), "fire!06", "on"));
+    }
+
+    [Fact]
+    public void DefaultState_FallsBackToDefaultAnim()
+    {
+        // Null/"default" state behaves exactly like ShouldRenderAtRest.
+        Assert.True(EmitterAnimationGate.ShouldRenderForState(BrazierModel(), "fire!06", null));
+        Assert.True(EmitterAnimationGate.ShouldRenderForState(BrazierModel(), "fire!06", "default"));
+    }
+
+    [Fact]
+    public void StateAnimMissingEmitter_FallsBackToDefault()
+    {
+        // A state whose animation doesn't carry this emitter falls through to the default-anim rule.
+        var model = BrazierModel();
+        // "open" has no emitter copy → fall back to default (20) → render.
+        model.Animations.Add(new MdlAnimation { Name = "open", Length = 0.033f, GeometryRoot = new MdlNode { Name = "root" } });
+        Assert.True(EmitterAnimationGate.ShouldRenderForState(model, "fire!06", "open"));
+    }
 }

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.Emitters.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.Emitters.cs
@@ -96,6 +96,43 @@ public partial class ModelPreviewGLControl
         }
     }
 
+    // Emitter names suppressed by the current preview state (#2556). A brazier's flame keys its
+    // birthrate to 0 in the "off" (Deactivated) animation; when a placeable state gates an emitter
+    // off we stop updating + drawing it and clear its live particles so the effect disappears.
+    private readonly HashSet<string> _stateSuppressedEmitters =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private bool IsEmitterStateSuppressed(string? name)
+        => !string.IsNullOrEmpty(name) && _stateSuppressedEmitters.Contains(name!);
+
+    /// <summary>
+    /// Re-evaluate every particle system against a placeable preview state's animation and gate each
+    /// emitter on/off accordingly (#2556). <paramref name="stateAnimName"/> is the state's MDL
+    /// animation (e.g. "off" for Deactivated, "on" for Activated; null/"default" = resting). The
+    /// brazier flame (fire!06) keys to birthrate 0 in "off", so Deactivated turns it off; switching
+    /// back re-enables it. Systems are kept (not rebuilt) — suppressed ones are cleared and skipped.
+    /// </summary>
+    public void ApplyEmitterStateGate(string? stateAnimName)
+    {
+        if (_model == null) return;
+
+        _stateSuppressedEmitters.Clear();
+        foreach (var (node, _, system) in _particleSystems)
+        {
+            bool render = Radoub.UI.Particles.EmitterAnimationGate.ShouldRenderForState(
+                _model, node.Name, stateAnimName);
+            if (!render)
+            {
+                _stateSuppressedEmitters.Add(node.Name);
+                system.Clear(); // drop live particles so the effect disappears immediately
+            }
+        }
+
+        UnifiedLogger.LogApplication(LogLevel.INFO,
+            $"[Particle] state '{stateAnimName ?? "default"}' suppresses {_stateSuppressedEmitters.Count} emitter(s)");
+        RequestNextFrameRendering();
+    }
+
     /// <summary>
     /// True if the active model has any emitter node that is animated by some animation (i.e. an
     /// ancestor or the emitter itself has position/orientation keyframes). Tools use this to decide
@@ -154,6 +191,7 @@ public partial class ModelPreviewGLControl
         var pose = GetCurrentPose();
         foreach (var (node, _, system) in _particleSystems)
         {
+            if (IsEmitterStateSuppressed(node.Name)) continue; // gated off by preview state (#2556)
             var worldPos = GetEmitterWorldPosition(node, pose);
             var worldRot = GetEmitterWorldRotation(node, pose);
             system.Update(pdt, worldPos, worldRot);

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.Emitters.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.Emitters.cs
@@ -26,6 +26,11 @@ public partial class ModelPreviewGLControl
     private void RebuildParticleSystems(MdlModel? model)
     {
         _particleSystems.Clear();
+        // Reset per-state emitter suppression when the model changes, otherwise a stale suppression
+        // from the previous model's Deactivated state could hide a same-named emitter in the new
+        // model until a state is re-selected (#2556). Reliquary re-applies the gate on load, but
+        // clearing here keeps the control self-consistent for any host/order.
+        _stateSuppressedEmitters.Clear();
 
         if (model == null || !model.HasEmitterNodes())
             return;

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.Particles.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.Particles.cs
@@ -249,6 +249,7 @@ void main()
         // TODO(#2395): back-to-front sort for Alpha blend (additive is order-independent).
         foreach (var (node, emitter, system) in _particleSystems)
         {
+            if (IsEmitterStateSuppressed(node.Name)) continue; // gated off by preview state (#2556)
             int count = system.LiveCount;
             if (count == 0) continue;
 

--- a/Radoub.UI/Radoub.UI/Particles/EmitterAnimationGate.cs
+++ b/Radoub.UI/Radoub.UI/Particles/EmitterAnimationGate.cs
@@ -23,7 +23,29 @@ public static class EmitterAnimationGate
     /// the emitter, falls back to the static-header birthrate (render unless that is ~0).
     /// </summary>
     public static bool ShouldRenderAtRest(MdlModel model, string emitterName)
+        => ShouldRenderForState(model, emitterName, stateAnimName: null);
+
+    /// <summary>
+    /// True if the named emitter should render while the preview is posed at a placeable state
+    /// (#2556). <paramref name="stateAnimName"/> is the state's MDL animation (e.g. "off" for
+    /// Deactivated, "on" for Activated; null/"default" = the resting state). If that animation
+    /// carries a copy of the emitter, its keyed birthrate is authoritative — the brazier flame
+    /// (fire!06) keys to 0 in "off", so Deactivated turns it off. Falls back to the "default"
+    /// animation and then the static header, exactly like <see cref="ShouldRenderAtRest"/>.
+    /// </summary>
+    public static bool ShouldRenderForState(MdlModel model, string emitterName, string? stateAnimName)
     {
+        // State animation first: its keyed birthrate is the authoritative emission for that state.
+        if (!string.IsNullOrEmpty(stateAnimName) &&
+            !string.Equals(stateAnimName, "default", System.StringComparison.OrdinalIgnoreCase))
+        {
+            var stateAnim = FindAnimation(model, stateAnimName!);
+            var stateEmitter = stateAnim?.GeometryRoot != null
+                ? FindEmitter(stateAnim.GeometryRoot, emitterName) : null;
+            if (stateEmitter != null)
+                return stateEmitter.BirthRate > 0f;
+        }
+
         // The at-rest pose is the "default" animation. If it carries a copy of this emitter, its
         // keyed birthrate is the authoritative at-rest emission — 0 means "off until destroyed".
         var defaultAnim = FindAnimation(model, "default");

--- a/Radoub.UI/Radoub.UI/Particles/ParticleSystem.cs
+++ b/Radoub.UI/Radoub.UI/Particles/ParticleSystem.cs
@@ -57,6 +57,9 @@ public sealed class ParticleSystem
 
     public IReadOnlyList<Particle> Particles => _particles;
 
+    /// <summary>Remove all live particles (e.g. when a preview state gates this emitter off). (#2556)</summary>
+    public void Clear() => _particles.Clear();
+
     /// <summary>First live particle (test/inspection convenience).</summary>
     /// <remarks>Intended for tests/inspection only; check <see cref="LiveCount"/> first.</remarks>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when no particles are live.</exception>

--- a/Radoub.UI/Radoub.UI/Services/ModelIdlePoseHeuristic.cs
+++ b/Radoub.UI/Radoub.UI/Services/ModelIdlePoseHeuristic.cs
@@ -10,6 +10,10 @@ namespace Radoub.UI.Services;
 /// draped because an idle animation poses their parent bones. We mirror that by auto-playing the
 /// idle when a dangly mesh's ancestor chain is actually keyframed by an animation. Pure (model-only)
 /// so it is unit-testable without the GL control. Companion to the emitter heuristic (#2434).
+///
+/// NOTE: this only poses the dangly mesh's parent bones; it does not simulate the dangly spring sag
+/// itself. True constraint-driven drape (a mane hanging over a back) needs a physics solver —
+/// deferred to #2626.
 /// </summary>
 public static class ModelIdlePoseHeuristic
 {

--- a/Radoub.UI/Radoub.UI/Services/ModelIdlePoseHeuristic.cs
+++ b/Radoub.UI/Radoub.UI/Services/ModelIdlePoseHeuristic.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using Radoub.Formats.Mdl;
+
+namespace Radoub.UI.Services;
+
+/// <summary>
+/// Decides whether a model should default to a playing idle animation in the preview so its
+/// pose-dependent geometry looks right at rest (#2619). DanglyNode meshes (manes, cloth, hair)
+/// have no physics in the preview, so at bind pose they sit flat; the engine/toolset shows them
+/// draped because an idle animation poses their parent bones. We mirror that by auto-playing the
+/// idle when a dangly mesh's ancestor chain is actually keyframed by an animation. Pure (model-only)
+/// so it is unit-testable without the GL control. Companion to the emitter heuristic (#2434).
+/// </summary>
+public static class ModelIdlePoseHeuristic
+{
+    /// <summary>
+    /// True if the model has a DanglyNode mesh whose geometry-tree ancestor chain is keyframed by
+    /// some animation — i.e. an idle pose would visibly drape it. False for static dangly meshes
+    /// (no animation touches their chain), so we don't needlessly auto-play unrelated models.
+    /// </summary>
+    public static bool HasAnimatedDanglyMesh(MdlModel? model)
+    {
+        if (model == null || model.Animations.Count == 0 || model.GeometryRoot == null)
+            return false;
+
+        // Ancestor names of every dangly mesh.
+        var danglyChainNames = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
+        bool anyDangly = false;
+        CollectDanglyChains(model.GeometryRoot, danglyChainNames, ref anyDangly);
+        if (!anyDangly) return false;
+
+        foreach (var anim in model.Animations)
+        {
+            if (anim.GeometryRoot == null) continue;
+            if (AnimTreeKeyframesAny(anim.GeometryRoot, danglyChainNames))
+                return true;
+        }
+        return false;
+    }
+
+    private static void CollectDanglyChains(MdlNode node, HashSet<string> names, ref bool anyDangly)
+    {
+        if (node is MdlDanglyNode)
+        {
+            anyDangly = true;
+            for (var cur = (MdlNode?)node; cur != null; cur = cur.Parent)
+                if (!string.IsNullOrEmpty(cur.Name)) names.Add(cur.Name);
+        }
+        foreach (var child in node.Children)
+            CollectDanglyChains(child, names, ref anyDangly);
+    }
+
+    private static bool AnimTreeKeyframesAny(MdlNode animNode, HashSet<string> names)
+    {
+        bool keyed = animNode.PositionTimes.Length > 1 || animNode.OrientationTimes.Length > 1
+            || animNode.ScaleTimes.Length > 1;
+        if (keyed && !string.IsNullOrEmpty(animNode.Name) && names.Contains(animNode.Name))
+            return true;
+        foreach (var child in animNode.Children)
+            if (AnimTreeKeyframesAny(child, names))
+                return true;
+        return false;
+    }
+}

--- a/Reliquary/CHANGELOG.md
+++ b/Reliquary/CHANGELOG.md
@@ -9,9 +9,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/); versioning via 
 ## [0.10.3-alpha] - 2026-06-28
 **Branch**: `radoub/issue-2622` | **PR**: #2625
 
-### Fix: Preview animation-state controls (#2595)
+### Fix: Preview animation-state controls + emitter gating (#2595, #2556)
 
-- The 3D preview now surfaces the animation-state controls a placeable model actually contains, matching QM/Relique. Part of the cross-tool animation sprint (canonical entry in Quartermaster CHANGELOG, #2622).
+- The 3D preview surfaces the animation-state controls a placeable model actually contains (including states inherited from a supermodel), and emitters now respond to the selected state — the brazier flame turns off when Deactivated. Part of the cross-tool animation sprint (canonical entry in Quartermaster CHANGELOG, #2622).
 
 ---
 

--- a/Reliquary/CHANGELOG.md
+++ b/Reliquary/CHANGELOG.md
@@ -7,7 +7,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/); versioning via 
 ---
 
 ## [0.10.3-alpha] - 2026-06-28
-**Branch**: `radoub/issue-2622` | **PR**: #TBD
+**Branch**: `radoub/issue-2622` | **PR**: #2625
 
 ### Fix: Preview animation-state controls (#2595)
 

--- a/Reliquary/CHANGELOG.md
+++ b/Reliquary/CHANGELOG.md
@@ -6,6 +6,15 @@ Format based on [Keep a Changelog](https://keepachangelog.com/); versioning via 
 
 ---
 
+## [0.10.3-alpha] - 2026-06-28
+**Branch**: `radoub/issue-2622` | **PR**: #TBD
+
+### Fix: Preview animation-state controls (#2595)
+
+- The 3D preview now surfaces the animation-state controls a placeable model actually contains, matching QM/Relique. Part of the cross-tool animation sprint (canonical entry in Quartermaster CHANGELOG, #2622).
+
+---
+
 ## [0.10.2-alpha] - 2026-06-20
 **Branch**: `quartermaster/issue-2440` | **PR**: #2525
 

--- a/Reliquary/Reliquary.Tests/Services/SuperModelAnimationMergeTests.cs
+++ b/Reliquary/Reliquary.Tests/Services/SuperModelAnimationMergeTests.cs
@@ -1,0 +1,97 @@
+using System.Linq;
+using PlaceableEditor.Services;
+using Radoub.Formats.Mdl;
+using Xunit;
+
+namespace PlaceableEditor.Tests.Services;
+
+/// <summary>
+/// Placeable supermodel animation merge (#2595). Some placeables (e.g. tnp_list02 → tnp_list01,
+/// zlc_ccp_b93 → plc_a07) declare their open/close/on/off state animations only in a SUPERMODEL.
+/// PlaceableModelLoader previously skipped supermodel merging ("placeables are static"), so the
+/// state selector found no animations and was hidden — the reported missing-controls symptom.
+/// SuperModelAnimationMerger walks the chain and appends inherited animations by name.
+/// </summary>
+public class SuperModelAnimationMergeTests
+{
+    private static MdlModel ModelWith(string superModel, params string[] animationNames)
+    {
+        var model = new MdlModel { SuperModel = superModel };
+        foreach (var name in animationNames)
+            model.Animations.Add(new MdlAnimation { Name = name, Length = 1f });
+        return model;
+    }
+
+    [Fact]
+    public void Merge_PullsStateAnimationsFromSupermodel()
+    {
+        var leaf = ModelWith("parent"); // no own animations
+        var parent = ModelWith("NULL", "open", "close");
+
+        SuperModelAnimationMerger.Merge(leaf, name =>
+            string.Equals(name, "parent", System.StringComparison.OrdinalIgnoreCase) ? parent : null);
+
+        var names = leaf.Animations.Select(a => a.Name).OrderBy(n => n).ToArray();
+        Assert.Equal(new[] { "close", "open" }, names);
+    }
+
+    [Fact]
+    public void Merge_DoesNotOverrideOwnAnimations()
+    {
+        var leaf = ModelWith("parent", "open");
+        var parent = ModelWith("NULL", "open", "close");
+
+        SuperModelAnimationMerger.Merge(leaf, name => name == "parent" ? parent : null);
+
+        // "open" stays the leaf's own; "close" is inherited. No duplicate "open".
+        Assert.Equal(2, leaf.Animations.Count);
+        Assert.Single(leaf.Animations, a => a.Name == "open");
+        Assert.Single(leaf.Animations, a => a.Name == "close");
+    }
+
+    [Fact]
+    public void Merge_WalksMultiLevelChain()
+    {
+        var leaf = ModelWith("mid");
+        var mid = ModelWith("root", "on");
+        var root = ModelWith("NULL", "off");
+
+        SuperModelAnimationMerger.Merge(leaf, name => name switch
+        {
+            "mid" => mid,
+            "root" => root,
+            _ => null,
+        });
+
+        var names = leaf.Animations.Select(a => a.Name).OrderBy(n => n).ToArray();
+        Assert.Equal(new[] { "off", "on" }, names);
+    }
+
+    [Fact]
+    public void Merge_NoSupermodel_IsNoOp()
+    {
+        var leaf = ModelWith("NULL", "open");
+        SuperModelAnimationMerger.Merge(leaf, _ => null);
+        Assert.Single(leaf.Animations);
+    }
+
+    [Fact]
+    public void Merge_CycleDoesNotInfiniteLoop()
+    {
+        var a = ModelWith("b", "open");
+        var b = ModelWith("a", "close");
+
+        SuperModelAnimationMerger.Merge(a, name => name switch { "a" => a, "b" => b, _ => null });
+
+        // open (own) + close (from b); the a→b→a cycle terminates.
+        Assert.Equal(2, a.Animations.Count);
+    }
+
+    [Fact]
+    public void Merge_MissingSupermodel_IsNoOp()
+    {
+        var leaf = ModelWith("ghost", "on");
+        SuperModelAnimationMerger.Merge(leaf, _ => null); // parent never resolves
+        Assert.Single(leaf.Animations);
+    }
+}

--- a/Reliquary/Reliquary/Services/PlaceableModelLoader.cs
+++ b/Reliquary/Reliquary/Services/PlaceableModelLoader.cs
@@ -8,8 +8,11 @@ namespace PlaceableEditor.Services;
 /// <summary>
 /// Loads a placeable's 3D model for preview: appearance id → model name (placeables.2da) →
 /// raw MDL bytes (BIF/HAK/Override) → parsed <see cref="MdlModel"/>. This is the lightweight
-/// raw-MDL path the Sprint 1 spike confirmed (no ModelService creature-composition needed);
-/// placeables are static, so super-model animation merging is skipped.
+/// raw-MDL path the Sprint 1 spike confirmed (no ModelService creature-composition needed).
+///
+/// Supermodel animations ARE merged (#2595): ~29 placeables (e.g. tnp_list02 → tnp_list01,
+/// zlc_ccp_b93 → plc_a07) declare their open/close/on/off state animations only in a supermodel.
+/// Without the merge the placeable state selector found no animations and stayed hidden.
 /// </summary>
 public sealed class PlaceableModelLoader
 {
@@ -28,6 +31,20 @@ public sealed class PlaceableModelLoader
         var modelName = _appearances.GetModelName(appearanceId);
         if (string.IsNullOrEmpty(modelName)) return null;
 
+        var model = ParseModel(modelName);
+        if (model == null) return null;
+
+        // Pull in open/close/on/off animations that live only in a supermodel so the state
+        // selector surfaces them (#2595).
+        SuperModelAnimationMerger.Merge(model, ParseModel);
+        return model;
+    }
+
+    /// <summary>Resolve + parse a single MDL by resref (no supermodel merge), or null.</summary>
+    private MdlModel? ParseModel(string modelName)
+    {
+        if (string.IsNullOrEmpty(modelName)) return null;
+
         var bytes = _gameData.FindResource(modelName, ResourceTypes.Mdl);
         if (bytes is null || bytes.Length == 0) return null;
 
@@ -38,7 +55,7 @@ public sealed class PlaceableModelLoader
         catch (System.Exception ex)
         {
             UnifiedLogger.LogApplication(LogLevel.WARN,
-                $"Reliquary: failed to parse model '{modelName}' (appearance {appearanceId}): {ex.Message}");
+                $"Reliquary: failed to parse model '{modelName}': {ex.Message}");
             return null;
         }
     }

--- a/Reliquary/Reliquary/Services/SuperModelAnimationMerger.cs
+++ b/Reliquary/Reliquary/Services/SuperModelAnimationMerger.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using Radoub.Formats.Mdl;
+
+namespace PlaceableEditor.Services;
+
+/// <summary>
+/// Merges supermodel-inherited animations into a placeable model (#2595). Some placeables declare
+/// their open/close/on/off state animations only in a supermodel (e.g. tnp_list02 → tnp_list01),
+/// so without this the placeable state selector finds no animations and stays hidden. Walks the
+/// <see cref="MdlModel.SuperModel"/> chain, appending each parent animation whose name the leaf
+/// doesn't already define. Mirrors Quartermaster's CreatureModelResolver merge for creatures.
+/// </summary>
+public static class SuperModelAnimationMerger
+{
+    /// <summary>
+    /// Append supermodel animations to <paramref name="model"/> by name. <paramref name="loadModel"/>
+    /// resolves a supermodel name to a parsed model (or null if unavailable). Safe against cycles and
+    /// missing parents — both terminate the walk.
+    /// </summary>
+    public static void Merge(MdlModel? model, Func<string, MdlModel?> loadModel)
+    {
+        if (model == null) return;
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        MergeChain(model, model, loadModel, visited);
+    }
+
+    private static void MergeChain(MdlModel leaf, MdlModel current,
+        Func<string, MdlModel?> loadModel, HashSet<string> visited)
+    {
+        var parentName = current.SuperModel;
+        if (string.IsNullOrWhiteSpace(parentName) ||
+            parentName.Equals("NULL", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+        if (!visited.Add(parentName))
+            return; // cycle guard
+
+        var parent = loadModel(parentName);
+        if (parent == null) return;
+
+        var existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var a in leaf.Animations)
+            existing.Add(a.Name);
+
+        foreach (var anim in parent.Animations)
+        {
+            if (existing.Add(anim.Name))
+                leaf.Animations.Add(anim);
+        }
+
+        // Continue up the chain (the parent may itself inherit further).
+        MergeChain(leaf, parent, loadModel, visited);
+    }
+}

--- a/Reliquary/Reliquary/Views/MainWindow.Services.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.Services.cs
@@ -176,6 +176,10 @@ public partial class MainWindow
         gl.SetActiveAnimation(anim);
         if (anim != null)
             gl.AnimationTime = anim.Length; // hold the end pose = the state's resting look
+
+        // Gate emitters by the selected state (#2556): a brazier's flame keys its birthrate to 0 in
+        // the "off" (Deactivated) animation, so it must stop streaming when Deactivated is selected.
+        gl.ApplyEmitterStateGate(PlaceableStateResolver.AnimationNameForState(state));
     }
 
     private void OnAppearanceChanged(object? sender, uint appearanceId)


### PR DESCRIPTION
## Summary

Cross-tool sprint fixing model-preview animation gaps in Quartermaster and Reliquary. Two root causes: models that don't animate **at all** (bone/pose pipeline, or animation-state controls never surfaced) and models **missing some** animation (dangly-mesh deformation not applied). All sit on the shared `ModelPreviewGLControl` / pose pipeline in `Radoub.UI`.

## Work Items

- [ ] #2552 — [Quartermaster] Canine creatures (blinkdog) don't animate — pose-dict node-name mismatch vs `canine_a` supermodel
- [ ] #2595 — [Reliquary] Preview missing animation-state controls for certain placeables — `PlaceableStateResolver` gap
- [ ] #2619 — [Quartermaster] Dire tiger mane (DanglyNode) renders flat — dangly-mesh deformation not applied
- [ ] #2140 — [Quartermaster] "Loop all animations" diagnostic checkbox — coverage auditing enabler

## Related Issues

- Closes #2622
- Closes #2552
- Closes #2595
- Closes #2619
- Closes #2140

## Checklist

- [ ] Implementation complete
- [ ] Tests added/updated
- [ ] CHANGELOGs updated with date (Quartermaster + Reliquary)
- [ ] Manual spot-checks (LNS_DLG fixtures — GL preview not FlaUI-visible)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
