### PR TITLE
[Radoub] Sprint: Dependabot consolidation + labeling fix (#2627)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,126 +1,29 @@
 # Dependabot configuration for Radoub toolset
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
 #
-# Central package management (Directory.Packages.props) is in use, but Dependabot
-# still walks each project directory to discover PackageReference items. One
-# update block per project keeps PRs scoped + labeled per tool.
+# Central package management: all NuGet versions live in the root
+# Directory.Packages.props. A per-tool block scheme mislabels PRs — Dependabot
+# opens the PR under whichever project directory it discovered the shared package
+# first, so identical bumps landed as random tool labels (e.g. an Avalonia bump
+# tagged "parley" vs "radoub"). Since every version change is repo-wide, use a
+# SINGLE nuget block rooted at the repo (where Directory.Packages.props lives),
+# labeled "radoub".
 
 version: 2
 updates:
-  # ---- Tools ----
+  # ---- NuGet (central package management: root Directory.Packages.props) ----
 
   - package-ecosystem: "nuget"
-    directory: "/Parley"
+    directory: "/"
     schedule:
       interval: "weekly"
     labels:
       - "dependencies"
-      - "parley"
+      - "radoub"
     ignore:
       # Avalonia 12.x has too many breaking changes for now — stay on 11.x.
       - dependency-name: "Avalonia*"
         update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "nuget"
-    directory: "/Manifest"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-      - "manifest"
-    ignore:
-      - dependency-name: "Avalonia*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "nuget"
-    directory: "/Quartermaster"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-      - "quartermaster"
-    ignore:
-      - dependency-name: "Avalonia*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "nuget"
-    directory: "/Fence"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-      - "fence"
-    ignore:
-      - dependency-name: "Avalonia*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "nuget"
-    directory: "/Relique"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-      - "relique"
-    ignore:
-      - dependency-name: "Avalonia*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "nuget"
-    directory: "/Trebuchet"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-      - "trebuchet"
-    ignore:
-      - dependency-name: "Avalonia*"
-        update-types: ["version-update:semver-major"]
-
-  # ---- Shared libraries ----
-
-  - package-ecosystem: "nuget"
-    directory: "/Radoub.Formats"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-      - "radoub"
-
-  - package-ecosystem: "nuget"
-    directory: "/Radoub.UI"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-      - "radoub"
-    ignore:
-      - dependency-name: "Avalonia*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "nuget"
-    directory: "/Radoub.Dictionary"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-      - "radoub"
-
-  - package-ecosystem: "nuget"
-    directory: "/Radoub.TestUtilities"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-      - "radoub"
-
-  - package-ecosystem: "nuget"
-    directory: "/Radoub.IntegrationTests"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-      - "radoub"
-      - "tests"
 
   # ---- CI ----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Dependencies] - 2026-06-30
-**Branch**: `radoub/issue-2627` | **PR**: #TBD
+**Branch**: `radoub/issue-2627` | **PR**: #2639
 
 ### Dependabot consolidation + labeling fix (#2627)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Dependencies] - 2026-06-30
+**Branch**: `radoub/issue-2627` | **PR**: #TBD
+
+### Dependabot consolidation + labeling fix (#2627)
+
+- Bumped Avalonia 11.3.17 → 11.3.18 (all packages) and Microsoft.NET.Test.Sdk 18.6.0 → 18.7.0. SkiaSharp 3.x → 4.x major deferred to its own PR.
+- Reworked `dependabot.yml` to a single root-level NuGet block labeled `radoub`, matching central package management — fixes bumps being mislabeled with arbitrary tool names.
+
+---
+
 ## [Radoub.UI 0.2.32-alpha] - 2026-06-28
 **Branch**: `quartermaster/issue-2615` | **PR**: #2616
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,13 +5,13 @@
 
   <ItemGroup>
     <!-- Avalonia UI Framework -->
-    <PackageVersion Include="Avalonia" Version="11.3.17" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.17" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.17" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.17" />
+    <PackageVersion Include="Avalonia" Version="11.3.18" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.3.18" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.18" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.18" />
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.3.13" />
-    <PackageVersion Include="Avalonia.Skia" Version="11.3.17" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.17" />
+    <PackageVersion Include="Avalonia.Skia" Version="11.3.18" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.18" />
 
     <!-- SkiaSharp -->
     <PackageVersion Include="SkiaSharp" Version="3.119.4" />
@@ -47,8 +47,8 @@
     <PackageVersion Include="AvaloniaGraphControl" Version="0.7.0" />
 
     <!-- Testing -->
-    <PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.17" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.18" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
## Summary

Consolidates the low-risk open Dependabot PRs and fixes the root cause of arbitrary per-tool labeling on dependency PRs.

**Version bumps (in `Directory.Packages.props`):**
- Avalonia `11.3.17` → `11.3.18` (Avalonia, Desktop, Themes.Fluent, Fonts.Inter, Skia, Diagnostics, Headless.XUnit)
- Microsoft.NET.Test.Sdk `18.6.0` → `18.7.0`

**Deferred:** SkiaSharp `3.119.4` → `4.148.0` (#2635 / #2636) — a major graphics-backend bump, held for its own PR with a rendering spot-check.

**Config fix (`dependabot.yml`):** replaced the ~10 per-tool NuGet blocks with a single root-level block labeled `radoub`. With central package management, every bump edits the one root `Directory.Packages.props`, so per-tool labels were assigned arbitrarily (e.g. an Avalonia bump tagged `parley` in #2634 vs `radoub` in #2635). All NuGet bumps are repo-wide → `radoub`.

## Consolidates / supersedes

#2634, #2633, #2631, #2630, #2629, #2627

## Test Results

- Build: 0 errors, 18 warnings (all pre-existing)
- Unit tests: 6293 passed, 0 failed, 1 skipped

## Risk Assessment

| Package | Change | Risk |
|---------|--------|------|
| Avalonia (family) | 11.3.17 → 11.3.18 | Low (patch) |
| Microsoft.NET.Test.Sdk | 18.6.0 → 18.7.0 | Low |
| SkiaSharp | 3.x → 4.x | High — **deferred** |

## Checklist

- [x] Build passes
- [x] Unit tests pass
- [x] CHANGELOG updated
- [x] dependabot.yml labeling fixed
- [ ] Close superseded dependabot PRs after merge

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)