### PR TITLE
[Quartermaster] tech-debt: Particle blend-state hygiene + mirror-normal gap survey (#2620)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Model preview: particle blend-state hygiene (#2620)
 
 - The model preview now clears blend state defensively at frame start and restores it in a `finally` around the particle draw, so a mid-render particle failure can no longer leak alpha-blending into the next frame's opaque mesh.
+- Documented two corpus-confirmed limits of the doublesided-cutout detector (cards with absent stored normals or a diagonal mirror plane blend instead of alpha-testing) and added a diagnostic log for the mis-route; a reliable fix needs coincident-face detection and remains open scope.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Radoub.UI 0.2.33-alpha] - 2026-06-30
-**Branch**: `quartermaster/issue-2620` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2620` | **PR**: #2640
 
 ### Model preview: particle blend-state hygiene (#2620)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.UI 0.2.33-alpha] - 2026-06-30
+**Branch**: `quartermaster/issue-2620` | **PR**: #TBD
+
+### Model preview: particle blend-state hygiene (#2620)
+
+- The model preview now clears blend state defensively at frame start and restores it in a `finally` around the particle draw, so a mid-render particle failure can no longer leak alpha-blending into the next frame's opaque mesh.
+
+---
+
 ## [Dependencies] - 2026-06-30
 **Branch**: `radoub/issue-2627` | **PR**: #2639
 

--- a/Radoub.UI/Radoub.UI/Controls/MeshTransparency.cs
+++ b/Radoub.UI/Radoub.UI/Controls/MeshTransparency.cs
@@ -176,6 +176,27 @@ public static class MeshTransparency
     /// <c>hasMirroredNormals</c> (scene_build.js, MIT — behavioral reference). Used to decide that a
     /// Binary-alpha mesh is a true hard cutout (fence/foliage/fur card) rather than ordinary alpha
     /// geometry that should blend. A 40–60% positive/negative split on any well-used axis counts.
+    ///
+    /// <para>KNOWN LIMITATIONS (#2620 — corpus-confirmed, deliberately NOT fixed). A full base+CEP
+    /// scan (139,922 models; see NonPublic/Quartermaster/Research/2620-mirror-normal-corpus-scan.md)
+    /// found two classes of genuine doublesided cutout card this test misses, so they blend and can
+    /// sort-fight in the preview instead of alpha-testing:</para>
+    /// <list type="number">
+    /// <item>Absent stored normals (~4,841 meshes). The 2002 BioWare compiler omitted normals on some
+    /// meshes, so there is nothing to inspect and this returns false (e.g. <c>c_barbazu01/head_g</c>,
+    /// norm=0). The preview recomputes normals for SHADING (smoothgroup path) but that source is not
+    /// wired into this discriminator.</item>
+    /// <item>Diagonal mirror plane (~162 meshes). A card whose mirror plane is diagonal spreads the
+    /// inverted population across X/Y/Z so no single cardinal axis reaches 0.40 (e.g.
+    /// <c>sh_fence500</c>, <c>ptm_weed13c</c>).</item>
+    /// </list>
+    /// <para>Fix attempts that FAILED (verified against real geometry, do not retry blindly): a
+    /// reversed-winding face-pair test does not work — NWN duplicates the back half with SEPARATE
+    /// vertices, so neither indices nor rounded positions reverse-match. A pooled cross-axis normal
+    /// minority fraction cannot separate a doublesided card (~0.39–0.50) from a solid body
+    /// (dire-tiger body ~0.44), so it would regress solids if not for the isSkin gate, and still
+    /// yields nothing for absent-normal meshes. A correct fix needs coincident-face detection with
+    /// opposite facing — non-trivial, tracked as the remaining scope of #2620.</para>
     /// </summary>
     public static bool HasMirroredNormals(Vector3[]? normals)
     {

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.Particles.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.Particles.cs
@@ -246,6 +246,11 @@ void main()
         // particles behind it) but control depth WRITES per blend mode below.
         _gl.Enable(EnableCap.Blend);
 
+        // #2620: restore GL state in a finally so a throw mid-draw (BufferData/DrawArrays) can't
+        // leak blend/depth-write into the mesh pass of THIS frame. The frame-start reset is the
+        // cross-frame net; this try/finally is the intra-frame guarantee.
+        try
+        {
         // TODO(#2395): back-to-front sort for Alpha blend (additive is order-independent).
         foreach (var (node, emitter, system) in _particleSystems)
         {
@@ -299,15 +304,18 @@ void main()
 
             _gl.DrawArrays(PrimitiveType.Triangles, 0, (uint)vertCount);
         }
-
-        // Restore state for the mesh pass: re-enable depth writes, drop blend (mesh is opaque),
-        // unbind everything we touched.
-        _gl.DepthMask(true);
-        _gl.Disable(EnableCap.Blend);
-        _gl.BindTexture(TextureTarget.Texture2D, 0);
-        _gl.BindBuffer(BufferTargetARB.ArrayBuffer, 0);
-        _gl.BindVertexArray(0);
-        _gl.UseProgram(0);
+        }
+        finally
+        {
+            // Restore state for the mesh pass: re-enable depth writes, drop blend (mesh is opaque),
+            // unbind everything we touched. Runs even if a draw above threw (#2620).
+            _gl.DepthMask(true);
+            _gl.Disable(EnableCap.Blend);
+            _gl.BindTexture(TextureTarget.Texture2D, 0);
+            _gl.BindBuffer(BufferTargetARB.ArrayBuffer, 0);
+            _gl.BindVertexArray(0);
+            _gl.UseProgram(0);
+        }
 
         var err = _gl.GetError();
         if (err != GLEnum.NoError)

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
@@ -404,6 +404,11 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
         _gl.Clear((uint)(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit));
         _gl.Enable(EnableCap.DepthTest);
         _gl.DepthFunc(DepthFunction.Less);  // Opaque geometry: strict Less avoids coplanar z-fighting.
+        // Defensive state reset (#2620): if a prior frame threw mid-render (e.g. the particle path
+        // after Enable(Blend)), blend/depth-write could still be set. Start every frame from a known
+        // clean state so a leaked GL state can never bleed into this frame's opaque mesh.
+        _gl.DepthMask(true);
+        _gl.Disable(EnableCap.Blend);
         _gl.Viewport(0, 0, (uint)width, (uint)height);
 
         // Check for any GL errors after basic setup

--- a/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ModelPreviewGLControl.cs
@@ -527,7 +527,7 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
 
         // Resolve a draw call's texture (direct or remapped), whether it has one, and its
         // MaterialMode (#2540). Shared by the routing pass and the actual draw.
-        (string? texture, bool hasTexture, MaterialMode mode) ResolveDrawCall(in MeshDrawCall drawCall)
+        (string? texture, bool hasTexture, MaterialMode mode, AlphaProfile profile) ResolveDrawCall(in MeshDrawCall drawCall)
         {
             var resolvedTexture = drawCall.TextureName;
             if (!string.IsNullOrEmpty(resolvedTexture) && !_textureCache.ContainsKey(resolvedTexture)
@@ -542,19 +542,32 @@ public partial class ModelPreviewGLControl : OpenGlControlBase
             var profile = hasTexture && _textureAlphaProfile.TryGetValue(resolvedTexture!, out var p)
                 ? p : AlphaProfile.Opaque;
             var mode = MeshTransparency.ClassifyMesh(drawCall.MeshAlpha, drawCall.TransparencyHint, profile, drawCall.IsSkin, drawCall.IsMirrored);
-            return (resolvedTexture, hasTexture, mode);
+            return (resolvedTexture, hasTexture, mode, profile);
         }
 
         // Draws one mesh with its texture and transparency uniforms.
         void DrawMesh(in MeshDrawCall drawCall)
         {
-            var (resolvedTexture, hasTexture, mode) = ResolveDrawCall(drawCall);
+            var (resolvedTexture, hasTexture, mode, profile) = ResolveDrawCall(drawCall);
 
             if (_logTransparencyOncePerModel && mode != MaterialMode.Opaque)
             {
                 UnifiedLogger.LogApplication(LogLevel.DEBUG,
                     $"  [Transparency] '{resolvedTexture}' -> {mode} (alpha={drawCall.MeshAlpha:F2}, " +
                     $"hint={drawCall.TransparencyHint})");
+            }
+
+            // #2620 diagnostic: a non-skin Binary-alpha mesh that is NOT flagged mirrored blends
+            // (and may sort-fight) instead of alpha-testing. This is the known mis-route for
+            // doublesided cutout cards the normal-histogram HasMirroredNormals misses (absent stored
+            // normals, or a diagonal mirror plane — see MeshTransparency.HasMirroredNormals KNOWN
+            // LIMITATIONS). Logged so a "this card looks wrong" report is diagnosable in the field.
+            if (_logTransparencyOncePerModel && !drawCall.IsSkin
+                && profile == AlphaProfile.Binary && !drawCall.IsMirrored)
+            {
+                UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                    $"  [MirrorGap #2620] '{resolvedTexture}' Binary but not mirror-detected -> blends " +
+                    $"(a doublesided cutout card here would sort-fight; likely absent normals or diagonal mirror)");
             }
 
             _shaderManager!.SetUniformInt("meshMode", (int)mode);


### PR DESCRIPTION
## Summary

Follow-ups from the #2588 code review of the mirrored-normal cutout discriminator (tech-debt).

- **Item A (done):** particle blend-state hygiene — defensive `Disable(Blend)`/`DepthMask(true)` at frame start plus a `try/finally` restore around the particle draw, so a mid-render particle throw can't leak blend into the next frame's opaque mesh.
- **Item B (done):** full base+CEP MDL corpus scan (139,922 models). Confirmed both heuristic gaps are real: ~4,841 absent-normal + ~162 diagonal doublesided cutout cards mis-route to blend. Research doc: `NonPublic/Quartermaster/Research/2620-mirror-normal-corpus-scan.md`.
- **Item C (done — document + log):** no cheap reliable geometric fix exists (winding-pair detection fails — NWN duplicates back-half vertices so indices/positions don't reverse-match; pooled normals can't separate cards from solid bodies). Documented both gaps as KNOWN LIMITATIONS on `HasMirroredNormals` and added a once-per-model `[MirrorGap #2620]` DEBUG log for the mis-route.

## Related Issues

- Closes #2620

## Test Results

- Unit tests (Windows, canonical runner): 4266 passed, 0 failed (Radoub.Formats 1505, Radoub.UI 1386, Dictionary 75, Quartermaster 1300)
- Privacy scan: pass. Theme scan: pass. Tech-debt: ModelPreviewGLControl.cs 983 lines (800+ warning, under the 1000 issue threshold; pre-existing).
- Code review (medium): clean, no findings.
- Build: 0 errors.

## Manual spot-check (Item A) — PASSED

Forced a `throw` in `RenderParticles` with `GL_BLEND` enabled, every frame, on an emitter creature. Opaque body rendered SOLID across frames (no blend wash); throw caught non-fatal; no lingering GL errors. Temporary throw reverted.

## Checklist

- [x] Item A: frame-start reset + particle try/finally
- [x] Item B: MDL corpus scan + research report
- [x] Item C: document gaps + mis-route diagnostic log
- [x] CHANGELOG updated (Radoub.UI 0.2.33-alpha)
- [x] Manual spot-check (emitter creature; forced-throw recovery) — PASSED
- [x] Unit tests pass, privacy/theme/tech-debt scans pass, code review clean

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)