### PR TITLE
[Trebuchet] Feat: Create new HAK from scratch (#2267)

### DIFF
--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [1.41.0-alpha] - 2026-07-01
-**Branch**: `trebuchet/issue-2267` | **PR**: #TBD
+**Branch**: `trebuchet/issue-2267` | **PR**: #2643
 
 ### Feature: Create new HAK from scratch (#2267)
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.41.0-alpha] - 2026-07-01
+**Branch**: `trebuchet/issue-2267` | **PR**: #TBD
+
+### Feature: Create new HAK from scratch (#2267)
+
+- "New HAK..." produces an empty `.hak` archive, then chains into the add-files picker to populate it.
+
+---
+
 ## [1.40.0-alpha] - 2026-06-27
 **Branch**: `trebuchet/issue-2268` | **PR**: #2607
 

--- a/Trebuchet/CHANGELOG.md
+++ b/Trebuchet/CHANGELOG.md
@@ -11,7 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Feature: Create new HAK from scratch (#2267)
 
-- "New HAK..." produces an empty `.hak` archive, then chains into the add-files picker to populate it.
+- "New HAK..." produces an empty `.hak` archive, then chains into a media/model add-files picker; an optional checkbox registers it in the open module's IFO HAK list.
+- "Add to HAK..." adds media and models (textures, models, sounds, 2DAs) to an existing HAK, defaulting to the game hak folder.
 
 ---
 

--- a/Trebuchet/Trebuchet.Tests/ErfCreationServiceTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ErfCreationServiceTests.cs
@@ -84,4 +84,89 @@ public class ErfCreationServiceTests : IDisposable
 
         Assert.Throws<IOException>(() => _service.CreateErf(path));
     }
+
+    [Fact]
+    public void CreateErf_DefaultsToErfFileType()
+    {
+        var path = Path.Combine(_tempDir, "defaulttype.erf");
+
+        _service.CreateErf(path);
+
+        var erf = ErfReader.Read(path);
+        Assert.Equal("ERF ", erf.FileType);
+    }
+
+    [Fact]
+    public void CreateErf_RejectsInvalidFileType()
+    {
+        var path = Path.Combine(_tempDir, "badtype.erf");
+
+        Assert.Throws<ArgumentException>(() => _service.CreateErf(path, fileType: "XYZ "));
+    }
+
+    [Fact]
+    public void CreateErf_SetsBuildYearAndDay()
+    {
+        var path = Path.Combine(_tempDir, "builddate.erf");
+
+        _service.CreateErf(path);
+
+        var erf = ErfReader.Read(path);
+        Assert.Equal((uint)(DateTime.Now.Year - 1900), erf.BuildYear);
+        Assert.Equal((uint)DateTime.Now.DayOfYear, erf.BuildDay);
+    }
+
+    [Fact]
+    public void CreateHak_ProducesEmptyHakWithCorrectFileType()
+    {
+        var path = Path.Combine(_tempDir, "myhak.hak");
+
+        _service.CreateHak(path);
+
+        var erf = ErfReader.Read(path);
+        Assert.Equal("HAK ", erf.FileType);
+        Assert.Equal("V1.0", erf.FileVersion);
+        Assert.Empty(erf.Resources);
+    }
+
+    [Fact]
+    public void CreateHak_SetsBuildYearAndDay()
+    {
+        var path = Path.Combine(_tempDir, "hakdate.hak");
+
+        _service.CreateHak(path);
+
+        var erf = ErfReader.Read(path);
+        Assert.Equal((uint)(DateTime.Now.Year - 1900), erf.BuildYear);
+        Assert.Equal((uint)DateTime.Now.DayOfYear, erf.BuildDay);
+    }
+
+    [Fact]
+    public void CreateHak_WithDescription_StoresLocalizedString()
+    {
+        var path = Path.Combine(_tempDir, "hakdesc.hak");
+
+        _service.CreateHak(path, description: "My voiceover HAK");
+
+        var erf = ErfReader.Read(path);
+        Assert.Contains(erf.LocalizedStrings, s => s.Text == "My voiceover HAK");
+    }
+
+    [Fact]
+    public void CreateHak_RejectsInvalidAuroraFilename()
+    {
+        var path = Path.Combine(_tempDir, "thisnameistoolong.hak");
+
+        var ex = Assert.Throws<ArgumentException>(() => _service.CreateHak(path));
+        Assert.Contains("16", ex.Message);
+    }
+
+    [Fact]
+    public void CreateHak_DoesNotOverwriteExistingByDefault()
+    {
+        var path = Path.Combine(_tempDir, "exists.hak");
+        File.WriteAllText(path, "preexisting");
+
+        Assert.Throws<IOException>(() => _service.CreateHak(path));
+    }
 }

--- a/Trebuchet/Trebuchet.Tests/ModuleEditorHakListTests.cs
+++ b/Trebuchet/Trebuchet.Tests/ModuleEditorHakListTests.cs
@@ -1,0 +1,59 @@
+using RadoubLauncher.ViewModels;
+using Xunit;
+
+namespace Trebuchet.Tests;
+
+// Covers ModuleEditorViewModel.AddHakByName — the shared HAK-list append used by both the
+// HAK-list "Add" field and the "New HAK → register in module IFO" flow (#2267).
+public class ModuleEditorHakListTests
+{
+    [Fact]
+    public void AddHakByName_AddsBareName()
+    {
+        var vm = new ModuleEditorViewModel();
+
+        var added = vm.AddHakByName("myhak");
+
+        Assert.True(added);
+        Assert.Contains("myhak", vm.HakList);
+        Assert.True(vm.HasUnsavedChanges);
+    }
+
+    [Fact]
+    public void AddHakByName_StripsHakExtension()
+    {
+        var vm = new ModuleEditorViewModel();
+
+        vm.AddHakByName("myhak.hak");
+
+        Assert.Contains("myhak", vm.HakList);
+        Assert.DoesNotContain("myhak.hak", vm.HakList);
+    }
+
+    [Fact]
+    public void AddHakByName_IsCaseInsensitiveDuplicate()
+    {
+        var vm = new ModuleEditorViewModel();
+        vm.AddHakByName("myhak");
+
+        var addedAgain = vm.AddHakByName("MyHak.HAK");
+
+        Assert.False(addedAgain);
+        Assert.Single(vm.HakList);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(".hak")]
+    public void AddHakByName_RejectsBlankOrExtensionOnly(string? name)
+    {
+        var vm = new ModuleEditorViewModel();
+
+        var added = vm.AddHakByName(name);
+
+        Assert.False(added);
+        Assert.Empty(vm.HakList);
+    }
+}

--- a/Trebuchet/Trebuchet/Services/ErfCreationService.cs
+++ b/Trebuchet/Trebuchet/Services/ErfCreationService.cs
@@ -8,25 +8,38 @@ using Radoub.UI.Services;
 namespace RadoubLauncher.Services;
 
 /// <summary>
-/// Creates new, empty ERF archives from scratch.
+/// Creates new, empty ERF-family archives (ERF/HAK/MOD/…) from scratch.
 /// Wraps <see cref="ErfWriter"/> (which already supports write-from-scratch with an
-/// empty resource list) and enforces Aurora filename constraints up front (#2268).
+/// empty resource list) and enforces Aurora filename constraints up front (#2268, #2267).
 /// </summary>
 public class ErfCreationService
 {
     /// <summary>
-    /// Create a new empty ERF archive at the given path.
+    /// ERF-family FileType values accepted by the writer/reader (matches
+    /// <c>ErfReader.ValidFileTypes</c>). The trailing space is part of the 4-char header field.
+    /// </summary>
+    private static readonly string[] ValidFileTypes = { "ERF ", "HAK ", "MOD ", "SAV ", "NWM " };
+
+    /// <summary>
+    /// Create a new empty ERF-family archive at the given path.
     /// </summary>
     /// <param name="filePath">Output path. The filename stem (without extension) must satisfy
     /// Aurora's 16-char, lowercase, alphanumeric/underscore constraints.</param>
     /// <param name="description">Optional localized description (English, neutral gender).</param>
     /// <param name="overwrite">When false (default), throws if the file already exists.</param>
-    /// <exception cref="ArgumentException">The filename violates Aurora naming rules.</exception>
+    /// <param name="fileType">4-char ERF-family header type (default <c>"ERF "</c>).</param>
+    /// <exception cref="ArgumentException">The filename violates Aurora naming rules, or
+    /// <paramref name="fileType"/> is not an ERF-family type.</exception>
     /// <exception cref="IOException">The file exists and <paramref name="overwrite"/> is false.</exception>
-    public void CreateErf(string filePath, string? description = null, bool overwrite = false)
+    public void CreateErf(string filePath, string? description = null, bool overwrite = false, string fileType = "ERF ")
     {
         if (string.IsNullOrWhiteSpace(filePath))
             throw new ArgumentException("File path cannot be empty.", nameof(filePath));
+
+        if (!Array.Exists(ValidFileTypes, t => t == fileType))
+            throw new ArgumentException(
+                $"Invalid ERF file type: '{fileType}', expected one of: {string.Join(", ", ValidFileTypes)}",
+                nameof(fileType));
 
         var stem = Path.GetFileNameWithoutExtension(filePath);
         var validation = AuroraFilenameValidator.Validate(stem);
@@ -38,8 +51,11 @@ public class ErfCreationService
 
         var erf = new ErfFile
         {
-            FileType = "ERF ",
+            FileType = fileType,
             FileVersion = "V1.0",
+            // BuildYear = years since 1900; BuildDay = day-of-year (1-366).
+            BuildYear = (uint)(DateTime.Now.Year - 1900),
+            BuildDay = (uint)DateTime.Now.DayOfYear,
         };
 
         if (!string.IsNullOrEmpty(description))
@@ -52,6 +68,16 @@ public class ErfCreationService
         var resourceData = new Dictionary<(string ResRef, ushort Type), byte[]>();
         ErfWriter.Write(erf, filePath, resourceData);
 
-        UnifiedLogger.LogApplication(LogLevel.INFO, $"Created new empty ERF: {PrivacyHelper.SanitizePath(filePath)}");
+        UnifiedLogger.LogApplication(LogLevel.INFO, $"Created new empty {fileType.Trim()}: {PrivacyHelper.SanitizePath(filePath)}");
     }
+
+    /// <summary>
+    /// Create a new empty HAK archive at the given path. Thin convenience over
+    /// <see cref="CreateErf"/> with <c>fileType = "HAK "</c> (#2267).
+    /// </summary>
+    /// <param name="filePath">Output path (stem must satisfy Aurora naming rules).</param>
+    /// <param name="description">Optional localized description.</param>
+    /// <param name="overwrite">When false (default), throws if the file already exists.</param>
+    public void CreateHak(string filePath, string? description = null, bool overwrite = false)
+        => CreateErf(filePath, description, overwrite, "HAK ");
 }

--- a/Trebuchet/Trebuchet/ViewModels/ModuleEditorViewModel.Collections.cs
+++ b/Trebuchet/Trebuchet/ViewModels/ModuleEditorViewModel.Collections.cs
@@ -14,20 +14,31 @@ public partial class ModuleEditorViewModel
     [RelayCommand]
     private void AddHak()
     {
-        if (string.IsNullOrWhiteSpace(NewHakName)) return;
+        AddHakByName(NewHakName);
+        NewHakName = string.Empty;
+    }
 
-        var hakName = NewHakName.Trim();
+    /// <summary>
+    /// Append a HAK to the list by name (extension optional), deduplicating case-insensitively
+    /// and marking the module dirty when it actually changes. Shared by the HAK-list "Add" field
+    /// and the "New HAK → register in module IFO" flow (#2267).
+    /// </summary>
+    /// <returns>True if the HAK was added; false when blank or already present.</returns>
+    public bool AddHakByName(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return false;
+
+        var hakName = name.Trim();
         // Remove .hak extension if present
         if (hakName.EndsWith(".hak", StringComparison.OrdinalIgnoreCase))
             hakName = hakName[..^4];
 
-        if (!HakList.Contains(hakName, StringComparer.OrdinalIgnoreCase))
-        {
-            HakList.Add(hakName);
-            HasUnsavedChanges = true;
-        }
+        if (string.IsNullOrEmpty(hakName)) return false;
+        if (HakList.Contains(hakName, StringComparer.OrdinalIgnoreCase)) return false;
 
-        NewHakName = string.Empty;
+        HakList.Add(hakName);
+        HasUnsavedChanges = true;
+        return true;
     }
 
     [RelayCommand]

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml
@@ -108,6 +108,10 @@
                             Click="OnNewHakClick"
                             Padding="8,4"
                             ToolTip.Tip="Create a new empty HAK archive"/>
+                    <Button Content="Add to HAK..."
+                            Click="OnAddToHakClick"
+                            Padding="8,4"
+                            ToolTip.Tip="Add media and models (textures, models, sounds, 2DAs) to an existing HAK archive"/>
                     <Button Content="Import ERF..."
                             Click="OnImportErfClick"
                             IsVisible="{Binding IsModuleUnpacked}"

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml
@@ -103,7 +103,11 @@
                     <Button Content="Add to ERF..."
                             Click="OnAddToErfClick"
                             Padding="8,4"
-                            ToolTip.Tip="Add files (scripts, blueprints, assets) to an existing ERF archive"/>
+                            ToolTip.Tip="Add files (scripts, blueprints, assets) to an existing ERF/HAK/MOD archive"/>
+                    <Button Content="New HAK..."
+                            Click="OnNewHakClick"
+                            Padding="8,4"
+                            ToolTip.Tip="Create a new empty HAK archive"/>
                     <Button Content="Import ERF..."
                             Click="OnImportErfClick"
                             IsVisible="{Binding IsModuleUnpacked}"

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
@@ -591,6 +591,7 @@ public partial class MainWindow : Window
         // HAK content (models, textures, sounds, 2DAs) lives outside the module (#2267).
         Avalonia.Platform.Storage.IStorageFolder? startFolder;
         Avalonia.Platform.Storage.FilePickerFileType[] fileTypes;
+        var archiveLabel = contentKind == ArchiveContentKind.HakMedia ? "HAK" : "ERF";
         if (contentKind == ArchiveContentKind.HakMedia)
         {
             startFolder = await TryGetHakFolderAsync(storage);
@@ -660,12 +661,12 @@ public partial class MainWindow : Window
                 foreach (var (name, reason) in result.Errors)
                     message += $"\n  • {name}: {reason}";
             }
-            new AlertDialog("Add to ERF", message).Show(this);
+            new AlertDialog($"Add to {archiveLabel}", message).Show(this);
         }
         catch (Exception ex)
         {
-            UnifiedLogger.LogApplication(LogLevel.WARN, $"Add to ERF failed: {ex.Message}");
-            new AlertDialog("Add to ERF Failed", ex.Message).Show(this);
+            UnifiedLogger.LogApplication(LogLevel.WARN, $"Add to {archiveLabel} failed: {ex.Message}");
+            new AlertDialog($"Add to {archiveLabel} Failed", ex.Message).Show(this);
         }
     }
 

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
@@ -428,6 +428,51 @@ public partial class MainWindow : Window
 
     #endregion
 
+    #region New HAK
+
+    private void OnNewHakClick(object? sender, RoutedEventArgs e)
+    {
+        var dialog = new NewHakDialog();
+        dialog.Confirmed += OnNewHakConfirmed;
+        dialog.Show(this);
+    }
+
+    private async void OnNewHakConfirmed(object? sender, EventArgs e)
+    {
+        if (sender is not NewHakDialog dialog) return;
+
+        var path = System.IO.Path.Combine(dialog.OutputFolder, dialog.HakName + ".hak");
+
+        // Overwrite is the one destructive branch — a modal confirm is the sanctioned exception
+        // to the non-modal rule.
+        if (System.IO.File.Exists(path))
+        {
+            var confirm = new ConfirmDialog(
+                "Overwrite HAK?",
+                $"{System.IO.Path.GetFileName(path)} already exists in that folder.\n\nOverwrite it?");
+            await confirm.ShowDialog(this);
+            if (!confirm.Confirmed) return;
+        }
+
+        try
+        {
+            new ErfCreationService().CreateHak(path,
+                string.IsNullOrEmpty(dialog.Description) ? null : dialog.Description,
+                overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN, $"New HAK failed: {ex.Message}");
+            new AlertDialog("HAK Creation Failed", ex.Message).Show(this);
+            return;
+        }
+
+        // Chain straight into populating the fresh HAK (#2267).
+        await AddFilesToArchiveAsync(path);
+    }
+
+    #endregion
+
     #region Add to ERF
 
     private async void OnAddToErfClick(object? sender, RoutedEventArgs e)
@@ -442,11 +487,12 @@ public partial class MainWindow : Window
             AllowMultiple = false,
             FileTypeFilter = new[]
             {
-                // ERF only. Adding to a .mod is the module workflow (unpack -> edit -> Save Module),
-                // and .hak has its own "Add to HAK" flow (#2267); neither belongs here.
-                new Avalonia.Platform.Storage.FilePickerFileType("ERF Archives")
+                // ERF-family archives you build/populate directly (#2267). The open module's own
+                // archive is guarded below — packing working files back into it is the Save Module
+                // workflow, not this one.
+                new Avalonia.Platform.Storage.FilePickerFileType("ERF-family Archives")
                 {
-                    Patterns = new[] { "*.erf" }
+                    Patterns = new[] { "*.erf", "*.hak", "*.mod" }
                 }
             }
         });
@@ -463,12 +509,25 @@ public partial class MainWindow : Window
             return;
         }
 
-        // 2. Pick files to add. Default the picker to the current module's working folder so
-        //    palette assets (loose blueprints, compiled scripts) are right there to select.
+        await AddFilesToArchiveAsync(erfPath);
+    }
+
+    /// <summary>
+    /// Pick files and add them to an existing ERF-family archive (.erf/.hak/.mod), reporting the
+    /// result. Shared by "Add to ERF" and the post-create step of "New HAK" (#2267).
+    /// </summary>
+    private async System.Threading.Tasks.Task AddFilesToArchiveAsync(string archivePath)
+    {
+        var storage = GetTopLevel(this)?.StorageProvider;
+        if (storage is null) return;
+
+        // Pick files to add. Default the picker to the current module's working folder so
+        // palette assets (loose blueprints, compiled scripts) are right there to select.
         var startFolder = await TryGetModuleFolderAsync(storage);
+        var archiveName = System.IO.Path.GetFileName(archivePath);
         var files = await storage.OpenFilePickerAsync(new Avalonia.Platform.Storage.FilePickerOpenOptions
         {
-            Title = "Add to ERF — choose files",
+            Title = $"Add to {archiveName} — choose files",
             AllowMultiple = true,
             SuggestedStartLocation = startFolder,
             FileTypeFilter = new[]
@@ -491,8 +550,7 @@ public partial class MainWindow : Window
 
         try
         {
-            var result = new ErfAssetService().AddFiles(erfPath, paths, overwriteExisting: false);
-            var archiveName = System.IO.Path.GetFileName(erfPath);
+            var result = new ErfAssetService().AddFiles(archivePath, paths, overwriteExisting: false);
 
             string message;
             if (result.AddedCount == 0 && result.SkippedCount > 0 && result.Errors.Count == 0)

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
@@ -432,7 +432,10 @@ public partial class MainWindow : Window
 
     private void OnNewHakClick(object? sender, RoutedEventArgs e)
     {
-        var dialog = new NewHakDialog();
+        // The IFO checkbox only applies when a module is open (Trebuchet auto-unpacks on open,
+        // so "module open" already implies "unpacked").
+        var moduleName = _moduleEditorVm?.IsModuleLoaded == true ? _moduleEditorVm.ModuleName : null;
+        var dialog = new NewHakDialog(moduleName);
         dialog.Confirmed += OnNewHakConfirmed;
         dialog.Show(this);
     }
@@ -467,8 +470,56 @@ public partial class MainWindow : Window
             return;
         }
 
+        // Optionally register the new HAK in the open module's IFO HAK list. Staged into the
+        // module editor; persisted on the next Save Module, matching the existing HAK-list flow (#2267).
+        if (dialog.AddToModuleIfo)
+            StageHakInModuleIfo(dialog.HakName);
+
         // Chain straight into populating the fresh HAK (#2267).
-        await AddFilesToArchiveAsync(path);
+        await AddFilesToArchiveAsync(path, ArchiveContentKind.HakMedia);
+    }
+
+    /// <summary>
+    /// Append a HAK (by bare name, no extension) to the open module editor's HAK list so the
+    /// next Save Module writes it to the module IFO. Deduplicates case-insensitively (#2267).
+    /// </summary>
+    private void StageHakInModuleIfo(string hakName)
+    {
+        if (_moduleEditorVm?.IsModuleLoaded != true) return;
+
+        if (_moduleEditorVm.AddHakByName(hakName))
+        {
+            new AlertDialog("Added to Module",
+                $"'{hakName}' was added to the module's HAK list.\n\nUse Save Module to write it to the .ifo.").Show(this);
+        }
+    }
+
+    #endregion
+
+    #region Add to HAK
+
+    private async void OnAddToHakClick(object? sender, RoutedEventArgs e)
+    {
+        var storage = GetTopLevel(this)?.StorageProvider;
+        if (storage is null) return;
+
+        var startFolder = await TryGetHakFolderAsync(storage);
+        var targets = await storage.OpenFilePickerAsync(new Avalonia.Platform.Storage.FilePickerOpenOptions
+        {
+            Title = "Add to HAK Archive — choose target",
+            AllowMultiple = false,
+            SuggestedStartLocation = startFolder,
+            FileTypeFilter = new[]
+            {
+                new Avalonia.Platform.Storage.FilePickerFileType("HAK Archives")
+                {
+                    Patterns = new[] { "*.hak" }
+                }
+            }
+        });
+        if (targets.Count == 0) return;
+
+        await AddFilesToArchiveAsync(targets[0].Path.LocalPath, ArchiveContentKind.HakMedia);
     }
 
     #endregion
@@ -509,28 +560,55 @@ public partial class MainWindow : Window
             return;
         }
 
-        await AddFilesToArchiveAsync(erfPath);
+        await AddFilesToArchiveAsync(erfPath, ArchiveContentKind.ModuleContent);
+    }
+
+    /// <summary>
+    /// Picker-default profile for <see cref="AddFilesToArchiveAsync"/>. ERF archives hold
+    /// module user-generated content (blueprints, scripts) authored inside the module; HAK
+    /// archives hold media/models the module references but that live outside it (#2267).
+    /// </summary>
+    private enum ArchiveContentKind
+    {
+        ModuleContent,
+        HakMedia,
     }
 
     /// <summary>
     /// Pick files and add them to an existing ERF-family archive (.erf/.hak/.mod), reporting the
-    /// result. Shared by "Add to ERF" and the post-create step of "New HAK" (#2267).
+    /// result. Shared by "Add to ERF", "Add to HAK", and the post-create step of "New HAK" (#2267).
+    /// The picker's filter and default folder follow <paramref name="contentKind"/>.
     /// </summary>
-    private async System.Threading.Tasks.Task AddFilesToArchiveAsync(string archivePath)
+    private async System.Threading.Tasks.Task AddFilesToArchiveAsync(string archivePath, ArchiveContentKind contentKind)
     {
         var storage = GetTopLevel(this)?.StorageProvider;
         if (storage is null) return;
 
-        // Pick files to add. Default the picker to the current module's working folder so
-        // palette assets (loose blueprints, compiled scripts) are right there to select.
-        var startFolder = await TryGetModuleFolderAsync(storage);
         var archiveName = System.IO.Path.GetFileName(archivePath);
-        var files = await storage.OpenFilePickerAsync(new Avalonia.Platform.Storage.FilePickerOpenOptions
+
+        // Default location + type filter depend on what the archive is for. ERF: module working
+        // folder + blueprint/script filter. HAK: the game hak folder + media/model filter, since
+        // HAK content (models, textures, sounds, 2DAs) lives outside the module (#2267).
+        Avalonia.Platform.Storage.IStorageFolder? startFolder;
+        Avalonia.Platform.Storage.FilePickerFileType[] fileTypes;
+        if (contentKind == ArchiveContentKind.HakMedia)
         {
-            Title = $"Add to {archiveName} — choose files",
-            AllowMultiple = true,
-            SuggestedStartLocation = startFolder,
-            FileTypeFilter = new[]
+            startFolder = await TryGetHakFolderAsync(storage);
+            fileTypes = new[]
+            {
+                new Avalonia.Platform.Storage.FilePickerFileType("HAK media & models")
+                {
+                    Patterns = new[] { "*.mdl", "*.dds", "*.tga", "*.plt", "*.txi", "*.mtr",
+                                       "*.wav", "*.bmu", "*.mp3", "*.ogg", "*.2da", "*.tlk",
+                                       "*.ssf", "*.gui", "*.set", "*.itp" }
+                },
+                new Avalonia.Platform.Storage.FilePickerFileType("All Files") { Patterns = new[] { "*" } }
+            };
+        }
+        else
+        {
+            startFolder = await TryGetModuleFolderAsync(storage);
+            fileTypes = new[]
             {
                 // Module user-generated content: blueprints, scripts, and dialog — the assets
                 // a user authors and would package into an ERF.
@@ -540,7 +618,15 @@ public partial class MainWindow : Window
                                        "*.ute", "*.utw", "*.utm", "*.nss", "*.ncs", "*.dlg" }
                 },
                 new Avalonia.Platform.Storage.FilePickerFileType("All Files") { Patterns = new[] { "*" } }
-            }
+            };
+        }
+
+        var files = await storage.OpenFilePickerAsync(new Avalonia.Platform.Storage.FilePickerOpenOptions
+        {
+            Title = $"Add to {archiveName} — choose files",
+            AllowMultiple = true,
+            SuggestedStartLocation = startFolder,
+            FileTypeFilter = fileTypes
         });
         if (files.Count == 0) return;
 
@@ -593,6 +679,21 @@ public partial class MainWindow : Window
             return null;
 
         return await storage.TryGetFolderFromPathAsync(new Uri(folder));
+    }
+
+    /// <summary>
+    /// Default folder for HAK content pickers: the first existing configured HAK search folder
+    /// (the game hak/ folder first). HAK media/models live outside the module (#2267).
+    /// </summary>
+    private static async System.Threading.Tasks.Task<Avalonia.Platform.Storage.IStorageFolder?>
+        TryGetHakFolderAsync(Avalonia.Platform.Storage.IStorageProvider storage)
+    {
+        foreach (var folder in RadoubSettings.Instance.GetAllHakSearchPaths())
+        {
+            if (!string.IsNullOrEmpty(folder) && System.IO.Directory.Exists(folder))
+                return await storage.TryGetFolderFromPathAsync(new Uri(folder));
+        }
+        return null;
     }
 
     #endregion

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
@@ -443,6 +443,9 @@ public partial class MainWindow : Window
     private async void OnNewHakConfirmed(object? sender, EventArgs e)
     {
         if (sender is not NewHakDialog dialog) return;
+        // One-shot: the dialog raises Confirmed at most once, but unsubscribe so the handler
+        // doesn't outlive the dialog instance.
+        dialog.Confirmed -= OnNewHakConfirmed;
 
         var path = System.IO.Path.Combine(dialog.OutputFolder, dialog.HakName + ".hak");
 
@@ -550,8 +553,9 @@ public partial class MainWindow : Window
         if (targets.Count == 0) return;
         var erfPath = targets[0].Path.LocalPath;
 
-        // Defense-in-depth: the picker only offers .erf, but guard against the open module's own
-        // archive anyway — adding its working files back to itself is a confusing no-op (#2268).
+        // Defense-in-depth: the picker now offers .erf/.hak/.mod (#2267), so guard against the
+        // open module's own .mod — adding its working files back to itself is a confusing no-op,
+        // and packing another module's .mod this way would corrupt it. Use Save Module instead (#2268).
         if (ModulePathHelper.IsCurrentModuleArchive(erfPath, RadoubSettings.Instance.CurrentModulePath))
         {
             new AlertDialog("Add to ERF",

--- a/Trebuchet/Trebuchet/Views/NewHakDialog.axaml
+++ b/Trebuchet/Trebuchet/Views/NewHakDialog.axaml
@@ -1,0 +1,70 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="RadoubLauncher.Views.NewHakDialog"
+        Title="New HAK"
+        Width="440" Height="360"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        ShowInTaskbar="False">
+
+    <Border Padding="16">
+        <StackPanel Spacing="12">
+            <TextBlock Text="Create New HAK Archive"
+                       FontSize="{DynamicResource FontSizeMedium}"
+                       FontWeight="SemiBold"/>
+
+            <!-- Name -->
+            <StackPanel Spacing="4">
+                <TextBlock Text="HAK Name"/>
+                <TextBox x:Name="NameTextBox"
+                         Watermark="e.g. myvoiceover"
+                         ToolTip.Tip="Max 16 characters, lowercase letters, digits, and underscore."/>
+                <TextBlock x:Name="NameError"
+                           Foreground="{DynamicResource ThemeError}"
+                           TextWrapping="Wrap"
+                           IsVisible="False"/>
+            </StackPanel>
+
+            <!-- Description -->
+            <StackPanel Spacing="4">
+                <TextBlock Text="Description (optional)"/>
+                <TextBox x:Name="DescriptionTextBox"
+                         AcceptsReturn="True"
+                         Height="70"
+                         TextWrapping="Wrap"
+                         Watermark="Describe what this HAK contains..."/>
+            </StackPanel>
+
+            <!-- Folder -->
+            <StackPanel Spacing="4">
+                <TextBlock Text="Output Folder"/>
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBox x:Name="FolderTextBox"
+                             IsReadOnly="True"
+                             Watermark="Choose a folder..."/>
+                    <Button Grid.Column="1"
+                            Content="Browse..."
+                            Click="OnBrowseClick"
+                            Margin="8,0,0,0"
+                            Padding="12,4"/>
+                </Grid>
+            </StackPanel>
+
+            <!-- Buttons -->
+            <StackPanel Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        Spacing="8"
+                        Margin="0,8,0,0">
+                <Button Content="Create"
+                        x:Name="CreateButton"
+                        Click="OnCreateClick"
+                        IsDefault="True"
+                        Padding="24,6"/>
+                <Button Content="Cancel"
+                        Click="OnCancelClick"
+                        IsCancel="True"
+                        Padding="24,6"/>
+            </StackPanel>
+        </StackPanel>
+    </Border>
+</Window>

--- a/Trebuchet/Trebuchet/Views/NewHakDialog.axaml
+++ b/Trebuchet/Trebuchet/Views/NewHakDialog.axaml
@@ -2,7 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="RadoubLauncher.Views.NewHakDialog"
         Title="New HAK"
-        Width="440" Height="360"
+        Width="440" Height="400"
         WindowStartupLocation="CenterOwner"
         CanResize="False"
         ShowInTaskbar="False">
@@ -49,6 +49,11 @@
                             Padding="12,4"/>
                 </Grid>
             </StackPanel>
+
+            <!-- Register in module IFO -->
+            <CheckBox x:Name="AddToIfoCheckBox"
+                      Content="Add to open module (IFO HAK list)"
+                      ToolTip.Tip="Append this HAK to the currently open module's HAK list. Writes on the next Save Module."/>
 
             <!-- Buttons -->
             <StackPanel Orientation="Horizontal"

--- a/Trebuchet/Trebuchet/Views/NewHakDialog.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/NewHakDialog.axaml.cs
@@ -20,9 +20,28 @@ public partial class NewHakDialog : Window
     public string Description { get; private set; } = string.Empty;
     public string OutputFolder { get; private set; } = string.Empty;
 
+    /// <summary>True when the user opted to register the HAK in the open module's IFO HAK list.</summary>
+    public bool AddToModuleIfo { get; private set; }
+
     public NewHakDialog()
     {
         InitializeComponent();
+    }
+
+    /// <param name="moduleName">Open module's name, or null when no module is loaded. Drives the
+    /// "add to module IFO" checkbox — disabled with an explanatory tooltip when null (#2267).</param>
+    public NewHakDialog(string? moduleName) : this()
+    {
+        if (string.IsNullOrEmpty(moduleName))
+        {
+            AddToIfoCheckBox.IsEnabled = false;
+            AddToIfoCheckBox.Content = "Add to open module (IFO HAK list)";
+            ToolTip.SetTip(AddToIfoCheckBox, "Open a module first to register this HAK in its IFO.");
+        }
+        else
+        {
+            AddToIfoCheckBox.Content = $"Add to '{moduleName}' module (IFO HAK list)";
+        }
     }
 
     private async void OnBrowseClick(object? sender, RoutedEventArgs e)
@@ -61,6 +80,7 @@ public partial class NewHakDialog : Window
         HakName = name;
         Description = DescriptionTextBox.Text?.Trim() ?? string.Empty;
         OutputFolder = folder;
+        AddToModuleIfo = AddToIfoCheckBox.IsEnabled && AddToIfoCheckBox.IsChecked == true;
 
         Confirmed?.Invoke(this, EventArgs.Empty);
         Close();

--- a/Trebuchet/Trebuchet/Views/NewHakDialog.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/NewHakDialog.axaml.cs
@@ -1,0 +1,79 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
+using Radoub.UI.Services;
+
+namespace RadoubLauncher.Views;
+
+/// <summary>
+/// Non-modal dialog to gather the inputs for a new HAK archive: name (Aurora-validated),
+/// optional description, and output folder (#2267). Raises <see cref="Confirmed"/> when the
+/// user commits valid input; the caller performs the actual file creation.
+/// </summary>
+public partial class NewHakDialog : Window
+{
+    /// <summary>Raised once, when the user confirms with a valid name and chosen folder.</summary>
+    public event EventHandler? Confirmed;
+
+    public string HakName { get; private set; } = string.Empty;
+    public string Description { get; private set; } = string.Empty;
+    public string OutputFolder { get; private set; } = string.Empty;
+
+    public NewHakDialog()
+    {
+        InitializeComponent();
+    }
+
+    private async void OnBrowseClick(object? sender, RoutedEventArgs e)
+    {
+        var storage = GetTopLevel(this)?.StorageProvider;
+        if (storage is null) return;
+
+        var folders = await storage.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = "Choose output folder for the new HAK",
+            AllowMultiple = false,
+        });
+
+        if (folders.Count > 0)
+            FolderTextBox.Text = folders[0].Path.LocalPath;
+    }
+
+    private void OnCreateClick(object? sender, RoutedEventArgs e)
+    {
+        var name = NameTextBox.Text?.Trim() ?? string.Empty;
+        var folder = FolderTextBox.Text?.Trim() ?? string.Empty;
+
+        var validation = AuroraFilenameValidator.Validate(name);
+        if (!validation.IsValid)
+        {
+            ShowNameError(validation.GetErrorMessage());
+            return;
+        }
+
+        if (string.IsNullOrEmpty(folder))
+        {
+            ShowNameError("Choose an output folder.");
+            return;
+        }
+
+        HakName = name;
+        Description = DescriptionTextBox.Text?.Trim() ?? string.Empty;
+        OutputFolder = folder;
+
+        Confirmed?.Invoke(this, EventArgs.Empty);
+        Close();
+    }
+
+    private void ShowNameError(string message)
+    {
+        NameError.Text = message;
+        NameError.IsVisible = true;
+    }
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+}


### PR DESCRIPTION
## Summary

Add HAK archive creation and population to Trebuchet (last remaining item of sprint #2444).

- **New HAK...** creates an empty `.hak` (ERF V1.0, FileType `HAK `) from name + description + folder, then chains into a media/model add-files picker.
- **Add to HAK...** adds files to an existing HAK. Both default the picker to the game hak folder and filter for HAK-appropriate content (models, textures, sounds, 2DAs) — HAK content lives outside the module.
- Optional **"Add to open module (IFO HAK list)"** checkbox registers the new HAK in the open module's IFO (staged in the module editor, written on the next Save Module).
- Generalizes `ErfCreationService` with a `fileType` param (+ `CreateHak` wrapper, `BuildYear`/`BuildDay`) rather than a parallel `HakCreationService`. Shared `AddHakByName` on `ModuleEditorViewModel` powers both the HAK-list field and IFO registration.

## Related Issues

- Closes #2267
- Part of sprint #2444 (pairs with #2268, already shipped)
- Prerequisite for the voice-acting epic #44 (record VO → bundle into a HAK)

## Pre-Merge

- **Unit tests**: 356 pass (Trebuchet), incl. 14 `ErfCreationService` + 7 `AddHakByName` tests. Privacy/tech-debt/theme scans clean.
- **Code review** (8-angle): 2 low-risk items fixed (stale guard comment, dialog handler unsubscribe); reuse/altitude nitpicks noted, none blocking.
- **CHANGELOG**: `1.41.0-alpha`, PR filled.

## Checklist

- [x] Implementation complete
- [x] Tests added/updated
- [x] CHANGELOG updated with date
- [ ] Manual spot-check (New/Add HAK dialogs, IFO checkbox — pickers can't be FlaUI-driven)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
