### PR TITLE
[Parley] Sprint: Conversation Simulator Fixes (#2524, #2523)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -364,6 +364,17 @@ When all sprint items are done (before `/pre-merge`), generate a **manual spot-c
 - User-facing behavior (new shortcuts, menu items, dialog behavior)
 - Event/notification wiring (events that should trigger visible UI updates)
 - File format changes (round-trip with real files)
+- **Platform-dependent behavior — flag with a `(Linux)` tag** when a change touches code
+  whose behavior or backend differs between Windows and Linux/macOS. Development happens on
+  Windows, so anything with a Linux-specific dependency needs a human to verify it on a Linux
+  box. Common triggers:
+  - **Filesystem**: path handling, case sensitivity, separators, symlinks, permissions, temp-dir
+    resolution (`Path.GetTempPath()`, `SpecialFolder`), file locking/delete-while-open semantics
+  - **Audio / TTS**: different backends per platform (e.g. Windows `System.Speech` vs Linux
+    Piper/`espeak-ng`, macOS `say`), sound playback (`aplay`/`afplay`), stop/cancel semantics
+    that differ (see #2523 — `Stop()` fires completion sync on Windows, silent on Piper)
+  - **Process launch**: external editors, spawned CLIs, argument quoting, PATH lookup
+  - **Native/interop**: SkiaSharp/OpenGL rendering, platform packages, `[SupportedOSPlatform]` code
 
 **Skip spot-checks when:**
 - Changes are purely internal (refactoring, test-only, documentation)
@@ -377,15 +388,20 @@ Verify in the running app before `/pre-merge`:
 
 - [ ] [Specific thing to check] — [where/how to verify]
 - [ ] [Another thing] — [steps to reproduce]
+- [ ] (Linux) [Platform-specific thing] — verify on a Linux box, not just Windows
 ```
 
 **Rules:**
 - Be specific — "check the UI" is not useful
 - Include how to trigger the behavior
 - Only list things automated tests can't verify
+- **Tag Linux-specific items with `(Linux)`** and say what Linux dependency makes it differ
+  (filesystem, TTS/audio backend, process launch, native interop). If unsure whether behavior
+  is platform-identical, err toward flagging it — a Windows-only check can silently pass while
+  the Linux path is broken.
 - Keep it short (3-8 items typical)
 
-**Example** (for a sprint with a new FlowView icon + theme fixes):
+**Example** (for a sprint with a new FlowView icon + theme fixes + a TTS stop fix):
 ```markdown
 ### Manual Spot-Checks
 
@@ -394,6 +410,9 @@ Verify in the running app before `/pre-merge`:
 - [ ] 📋 icon appears when quest selected via Browse dialog
 - [ ] Browser window text readable on dark theme (no white-on-white)
 - [ ] Browser window text readable on light theme (no invisible text)
+- [ ] (Linux) TTS Stop halts in-progress speech — Piper/espeak backend differs from Windows;
+      verify audio actually stops and does not auto-advance
+- [ ] (Linux) File open/save round-trips with a module on a case-sensitive filesystem
 ```
 
 ---

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Parley. One-line highlights per version; full details in 
 ---
 
 ## [0.1.177-alpha] - 2026-07-07
-**Branch**: `parley/sprint/2524-simulator-fixes` | **PR**: #TBD
+**Branch**: `parley/sprint/2524-simulator-fixes` | **PR**: #2652
 
 ### Sprint: Conversation Simulator Fixes
 

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Parley. One-line highlights per version; full details in 
 
 ---
 
+## [0.1.177-alpha] - 2026-07-07
+**Branch**: `parley/sprint/2524-simulator-fixes` | **PR**: #TBD
+
+### Sprint: Conversation Simulator Fixes
+
+- Add a Back/Previous button to step to the prior entry in a playthrough (#2524)
+- Fix: Stop button now halts in-progress TTS playback (#2523)
+
+---
+
 ## [0.1.176-alpha] - 2026-06-19
 **Branch**: `parley/sprint/2445-ui-ux` | **PR**: #2519
 

--- a/Parley/CHANGELOG.md
+++ b/Parley/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Parley. One-line highlights per version; full details in 
 
 ---
 
-## [0.1.177-alpha] - 2026-07-07
+## [0.1.177-alpha] - 2026-07-08
 **Branch**: `parley/sprint/2524-simulator-fixes` | **PR**: #2652
 
 ### Sprint: Conversation Simulator Fixes

--- a/Parley/Parley.Tests/ConversationSimulatorAutoAdvanceTests.cs
+++ b/Parley/Parley.Tests/ConversationSimulatorAutoAdvanceTests.cs
@@ -1,0 +1,114 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using DialogEditor;
+using DialogEditor.Models;
+using DialogEditor.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+using Parley.Tests.Mocks;
+using Xunit;
+
+namespace Parley.Tests
+{
+    /// <summary>
+    /// Regression guard: single-reply auto-advance (AutoAdvance on, AutoSpeak off) must still
+    /// chain forward after the #2524 Back-button snapshot push and _suppressAutoSpeak guard.
+    /// </summary>
+    public class ConversationSimulatorAutoAdvanceTests
+    {
+        private static void SetToggles(bool autoAdvance, bool autoSpeak, bool ttsEnabled)
+        {
+            var s = Program.Services.GetRequiredService<DialogEditor.Services.ISettingsService>();
+            s.SimulatorAutoAdvance = autoAdvance;
+            s.SimulatorAutoSpeak = autoSpeak;
+            s.SimulatorTtsEnabled = ttsEnabled;
+        }
+
+        /// <summary>
+        /// START -> Entry("A") -> Reply("only-1") -> Entry("B") -> Reply("only-2") -> Entry("C") (leaf reply -> ends)
+        /// Every NPC entry has exactly one reply, so AutoAdvance should walk to the end from the first pick.
+        /// </summary>
+        private static Dialog BuildSingleReplyChain()
+        {
+            var dialog = new Dialog();
+
+            var a = dialog.CreateNode(DialogNodeType.Entry)!; a.Text.Add(0, "A"); dialog.AddNodeInternal(a, a.Type);
+            var r1 = dialog.CreateNode(DialogNodeType.Reply)!; r1.Text.Add(0, "only-1"); dialog.AddNodeInternal(r1, r1.Type);
+            var b = dialog.CreateNode(DialogNodeType.Entry)!; b.Text.Add(0, "B"); dialog.AddNodeInternal(b, b.Type);
+            var r2 = dialog.CreateNode(DialogNodeType.Reply)!; r2.Text.Add(0, "only-2"); dialog.AddNodeInternal(r2, r2.Type);
+            var c = dialog.CreateNode(DialogNodeType.Entry)!; c.Text.Add(0, "C"); dialog.AddNodeInternal(c, c.Type);
+            var r3 = dialog.CreateNode(DialogNodeType.Reply)!; r3.Text.Add(0, "only-3"); dialog.AddNodeInternal(r3, r3.Type);
+
+            AddPtr(dialog, a, r1, DialogNodeType.Reply);
+            AddPtr(dialog, r1, b, DialogNodeType.Entry);
+            AddPtr(dialog, b, r2, DialogNodeType.Reply);
+            AddPtr(dialog, r2, c, DialogNodeType.Entry);
+            AddPtr(dialog, c, r3, DialogNodeType.Reply);
+            // r3 has no pointers -> ends
+
+            var start = dialog.CreatePtr()!;
+            start.Type = DialogNodeType.Entry;
+            start.Node = a;
+            dialog.Starts.Add(start);
+            return dialog;
+        }
+
+        private static void AddPtr(Dialog dialog, DialogNode from, DialogNode to, DialogNodeType type)
+        {
+            var ptr = dialog.CreatePtr()!;
+            ptr.Type = type;
+            ptr.Node = to;
+            from.Pointers.Add(ptr);
+        }
+
+        [AvaloniaFact]
+        public void SingleReply_AutoAdvanceOn_AutoSpeakOff_WalksToEnd()
+        {
+            SetToggles(autoAdvance: true, autoSpeak: false, ttsEnabled: false);
+            var vm = new ConversationSimulatorViewModel(BuildSingleReplyChain(), "test-aa.dlg", new MockTtsService());
+
+            vm.StartConversation();
+            vm.SelectReply(0);   // pick the root entry "A"; AutoAdvance should chain A -> B -> C -> end
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(vm.HasEnded, "AutoAdvance with single replies should have walked to the conversation end.");
+        }
+
+        [AvaloniaFact]
+        public void SingleReply_AutoAdvanceOn_AutoSpeakOn_WalksToEndAsSpeechCompletes()
+        {
+            SetToggles(autoAdvance: true, autoSpeak: true, ttsEnabled: true);
+            var tts = new MockTtsService();
+            var vm = new ConversationSimulatorViewModel(BuildSingleReplyChain(), "test-aa3.dlg", tts);
+
+            vm.StartConversation();
+            vm.SelectReply(0);   // pick root "A"; auto-speaks "A"
+            Dispatcher.UIThread.RunJobs();
+
+            // Drive speech completions; each completion drives the next auto-advance/auto-speak step.
+            // Bound the loop so a regression (advance stops firing) fails via the assertion, not a hang.
+            for (int i = 0; i < 20 && !vm.HasEnded; i++)
+            {
+                tts.CompleteSpeech();
+                Dispatcher.UIThread.RunJobs();
+            }
+
+            Assert.True(vm.HasEnded,
+                "AutoAdvance+AutoSpeak with single replies should walk to the end as each speech completes.");
+        }
+
+        [AvaloniaFact]
+        public void SingleReply_AutoAdvanceOff_StopsAtFirstEntry()
+        {
+            SetToggles(autoAdvance: false, autoSpeak: false, ttsEnabled: false);
+            var vm = new ConversationSimulatorViewModel(BuildSingleReplyChain(), "test-aa2.dlg", new MockTtsService());
+
+            vm.StartConversation();
+            vm.SelectReply(0);   // pick root "A"; without AutoAdvance it should stop showing "A" + its 1 reply
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.False(vm.HasEnded);
+            Assert.Equal("A", vm.NpcText);
+            Assert.Single(vm.Replies);
+        }
+    }
+}

--- a/Parley/Parley.Tests/ConversationSimulatorBackNavigationTests.cs
+++ b/Parley/Parley.Tests/ConversationSimulatorBackNavigationTests.cs
@@ -1,0 +1,176 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using DialogEditor;
+using DialogEditor.Models;
+using DialogEditor.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+using Parley.Tests.Mocks;
+using Xunit;
+
+namespace Parley.Tests
+{
+    /// <summary>
+    /// #2524: The Conversation Simulator needs a Back button that steps to the prior entry
+    /// in the current playthrough. Back restores the previous NPC text + replies, clears the
+    /// ended/loop state when returning from a leaf, and preserves already-recorded coverage.
+    /// </summary>
+    public class ConversationSimulatorBackNavigationTests
+    {
+        private static void DisableTts()
+        {
+            var settings = Program.Services.GetRequiredService<DialogEditor.Services.ISettingsService>();
+            settings.SimulatorTtsEnabled = false;
+            settings.SimulatorAutoSpeak = false;
+            settings.SimulatorAutoAdvance = false;
+        }
+
+        /// <summary>
+        /// START -> Entry("NPC greets") -> [Reply("Ask name"), Reply("Leave")]
+        /// Reply("Ask name") -> Entry("I am Bob") -> Reply("Bye") -> (leaf, ends)
+        /// Reply("Leave") -> (leaf, ends)
+        /// </summary>
+        private static Dialog BuildBranchingDialog()
+        {
+            var dialog = new Dialog();
+
+            var greet = dialog.CreateNode(DialogNodeType.Entry)!;
+            greet.Text.Add(0, "NPC greets");
+            dialog.AddNodeInternal(greet, greet.Type);
+
+            var askName = dialog.CreateNode(DialogNodeType.Reply)!;
+            askName.Text.Add(0, "Ask name");
+            dialog.AddNodeInternal(askName, askName.Type);
+
+            var leave = dialog.CreateNode(DialogNodeType.Reply)!;
+            leave.Text.Add(0, "Leave");
+            dialog.AddNodeInternal(leave, leave.Type);
+
+            var iAmBob = dialog.CreateNode(DialogNodeType.Entry)!;
+            iAmBob.Text.Add(0, "I am Bob");
+            dialog.AddNodeInternal(iAmBob, iAmBob.Type);
+
+            var bye = dialog.CreateNode(DialogNodeType.Reply)!;
+            bye.Text.Add(0, "Bye");
+            dialog.AddNodeInternal(bye, bye.Type);
+
+            AddPtr(dialog, greet, askName, DialogNodeType.Reply);
+            AddPtr(dialog, greet, leave, DialogNodeType.Reply);
+            AddPtr(dialog, askName, iAmBob, DialogNodeType.Entry);
+            AddPtr(dialog, iAmBob, bye, DialogNodeType.Reply);
+            // bye has no pointers -> conversation ends
+
+            var start = dialog.CreatePtr()!;
+            start.Type = DialogNodeType.Entry;
+            start.Node = greet;
+            dialog.Starts.Add(start);
+
+            return dialog;
+        }
+
+        private static void AddPtr(Dialog dialog, DialogNode from, DialogNode to, DialogNodeType type)
+        {
+            var ptr = dialog.CreatePtr()!;
+            ptr.Type = type;
+            ptr.Node = to;
+            from.Pointers.Add(ptr);
+        }
+
+        private static ConversationSimulatorViewModel NewVm(Dialog dialog)
+        {
+            DisableTts();
+            return new ConversationSimulatorViewModel(dialog, "test-back.dlg", new MockTtsService());
+        }
+
+        [AvaloniaFact]
+        public void CanGoBack_IsFalse_AtRootSelectionAndFirstEntry()
+        {
+            var vm = NewVm(BuildBranchingDialog());
+            vm.StartConversation();
+            Assert.False(vm.CanGoBack); // at root-entry selection
+
+            vm.SelectReply(0); // choose the root entry -> first NPC entry
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(vm.CanGoBack); // can now step back to root selection
+        }
+
+        [AvaloniaFact]
+        public void GoBack_FromFirstEntry_ReturnsToRootSelection()
+        {
+            var vm = NewVm(BuildBranchingDialog());
+            vm.StartConversation();
+            vm.SelectReply(0); // -> "NPC greets" with 2 replies
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal("NPC greets", vm.NpcText);
+
+            vm.GoBack();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.False(vm.CanGoBack);
+            Assert.False(vm.HasEnded);
+            // Back at the root-entry selection menu (single start -> 1 root option)
+            Assert.Single(vm.Replies);
+            Assert.Contains(vm.Replies, r => r.Text.Contains("NPC greets"));
+        }
+
+        [AvaloniaFact]
+        public void GoBack_RestoresPriorNpcTextAndReplies()
+        {
+            var vm = NewVm(BuildBranchingDialog());
+            vm.StartConversation();
+            vm.SelectReply(0);            // -> "NPC greets" (replies: Ask name, Leave)
+            Dispatcher.UIThread.RunJobs();
+            vm.SelectReply(0);            // pick "Ask name" -> "I am Bob" (reply: Bye)
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal("I am Bob", vm.NpcText);
+
+            vm.GoBack();                  // back to "NPC greets"
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal("NPC greets", vm.NpcText);
+            Assert.Equal(2, vm.Replies.Count);
+            Assert.Contains(vm.Replies, r => r.Text.Contains("Ask name"));
+            Assert.Contains(vm.Replies, r => r.Text.Contains("Leave"));
+        }
+
+        [AvaloniaFact]
+        public void GoBack_FromEndedConversation_ClearsEndedAndRestoresLastEntry()
+        {
+            var vm = NewVm(BuildBranchingDialog());
+            vm.StartConversation();
+            vm.SelectReply(0);            // "NPC greets"
+            Dispatcher.UIThread.RunJobs();
+            vm.SelectReply(0);            // "Ask name" -> "I am Bob"
+            Dispatcher.UIThread.RunJobs();
+            vm.SelectReply(0);            // "Bye" -> leaf -> conversation ends
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(vm.HasEnded);
+
+            vm.GoBack();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.False(vm.HasEnded);
+            Assert.Equal("I am Bob", vm.NpcText);
+            Assert.Contains(vm.Replies, r => r.Text.Contains("Bye"));
+        }
+
+        [AvaloniaFact]
+        public void GoBack_PreservesRecordedCoverage()
+        {
+            var dialog = BuildBranchingDialog();
+            var vm = NewVm(dialog);
+            vm.StartConversation();
+            vm.SelectReply(0);            // "NPC greets"
+            Dispatcher.UIThread.RunJobs();
+            vm.SelectReply(0);            // "Ask name" -> "I am Bob"
+            Dispatcher.UIThread.RunJobs();
+
+            var coverageBefore = vm.Coverage.VisitedReplies;
+
+            vm.GoBack();                  // step back to "NPC greets"
+            Dispatcher.UIThread.RunJobs();
+
+            // Coverage is not reverted by Back; the "Ask name" reply stays recorded.
+            Assert.Equal(coverageBefore, vm.Coverage.VisitedReplies);
+        }
+    }
+}

--- a/Parley/Parley.Tests/ConversationSimulatorBackNavigationTests.cs
+++ b/Parley/Parley.Tests/ConversationSimulatorBackNavigationTests.cs
@@ -93,6 +93,64 @@ namespace Parley.Tests
             Assert.True(vm.CanGoBack); // can now step back to root selection
         }
 
+        /// <summary>
+        /// #2524 race guard: GoBack calls _ttsService.Stop(), and on Windows/espeak/say that
+        /// fires SpeakCompleted synchronously → OnTtsSpeakCompleted. With AutoAdvance+AutoSpeak on
+        /// and the pre-Back display showing a single reply, the NPC-auto-advance gate could fire a
+        /// spurious forward SelectReply, undoing the Back. GoBack must not advance forward.
+        /// </summary>
+        [AvaloniaFact]
+        public void GoBack_WithAutoAdvanceAndSingleReply_DoesNotSpuriouslyAdvanceForward()
+        {
+            var settings = Program.Services.GetRequiredService<DialogEditor.Services.ISettingsService>();
+            settings.SimulatorTtsEnabled = true;
+            settings.SimulatorAutoSpeak = true;
+            settings.SimulatorAutoAdvance = true;
+
+            var tts = new MockTtsService(); // StopFiresCompleted = true (Windows-style)
+            // Single-reply chain: A -> B -> C, each NPC entry has exactly one reply.
+            var dialog = BuildSingleReplyChainForBack();
+            var vm = new ConversationSimulatorViewModel(dialog, "test-back-race.dlg", tts);
+
+            vm.StartConversation();
+            vm.SelectReply(0);              // pick root "A"; auto-speaks
+            Dispatcher.UIThread.RunJobs();
+            tts.CompleteSpeech();           // NPC "A" done -> auto-advance to speak PC reply
+            Dispatcher.UIThread.RunJobs();
+            tts.CompleteSpeech();           // PC reply done -> advance to "B"
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal("B", vm.NpcText);  // now at B with its single reply displayed
+
+            int spokenBeforeBack = tts.SpokenTexts.Count;
+
+            vm.GoBack();                    // GoBack -> Stop() fires completion; must NOT advance forward
+            Dispatcher.UIThread.RunJobs();
+
+            // We stepped back to "A" and must stay there, not get bounced forward to "B"/"C".
+            Assert.Equal("A", vm.NpcText);
+            // GoBack must not trigger any new speech (a spurious SelectReply would re-speak a reply).
+            Assert.Equal(spokenBeforeBack, tts.SpokenTexts.Count);
+        }
+
+        /// <summary>A -> only-1 -> B -> only-2 -> C -> only-3 (leaf ends). Every entry: 1 reply.</summary>
+        private static Dialog BuildSingleReplyChainForBack()
+        {
+            var dialog = new Dialog();
+            var a = dialog.CreateNode(DialogNodeType.Entry)!; a.Text.Add(0, "A"); dialog.AddNodeInternal(a, a.Type);
+            var r1 = dialog.CreateNode(DialogNodeType.Reply)!; r1.Text.Add(0, "only-1"); dialog.AddNodeInternal(r1, r1.Type);
+            var b = dialog.CreateNode(DialogNodeType.Entry)!; b.Text.Add(0, "B"); dialog.AddNodeInternal(b, b.Type);
+            var r2 = dialog.CreateNode(DialogNodeType.Reply)!; r2.Text.Add(0, "only-2"); dialog.AddNodeInternal(r2, r2.Type);
+            var c = dialog.CreateNode(DialogNodeType.Entry)!; c.Text.Add(0, "C"); dialog.AddNodeInternal(c, c.Type);
+            var r3 = dialog.CreateNode(DialogNodeType.Reply)!; r3.Text.Add(0, "only-3"); dialog.AddNodeInternal(r3, r3.Type);
+            AddPtr(dialog, a, r1, DialogNodeType.Reply);
+            AddPtr(dialog, r1, b, DialogNodeType.Entry);
+            AddPtr(dialog, b, r2, DialogNodeType.Reply);
+            AddPtr(dialog, r2, c, DialogNodeType.Entry);
+            AddPtr(dialog, c, r3, DialogNodeType.Reply);
+            var start = dialog.CreatePtr()!; start.Type = DialogNodeType.Entry; start.Node = a; dialog.Starts.Add(start);
+            return dialog;
+        }
+
         [AvaloniaFact]
         public void GoBack_FromFirstEntry_ReturnsToRootSelection()
         {

--- a/Parley/Parley.Tests/ConversationSimulatorTtsStopTests.cs
+++ b/Parley/Parley.Tests/ConversationSimulatorTtsStopTests.cs
@@ -1,0 +1,113 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using DialogEditor;
+using DialogEditor.Models;
+using DialogEditor.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+using Parley.Tests.Mocks;
+using Xunit;
+
+namespace Parley.Tests
+{
+    /// <summary>
+    /// #2523: The Stop button must halt in-progress TTS and must NOT let the
+    /// completion event fired by cancellation advance the conversation or restart speech.
+    /// The Windows synthesizer's SpeakAsyncCancelAll() raises SpeakCompleted (Cancelled=true),
+    /// which is exactly what MockTtsService.Stop() simulates. The auto-advance runs via
+    /// Dispatcher.UIThread.Post, so these use [AvaloniaFact] + RunJobs() to pump those jobs.
+    /// </summary>
+    public class ConversationSimulatorTtsStopTests
+    {
+        private static void EnableTts()
+        {
+            var settings = Program.Services.GetRequiredService<DialogEditor.Services.ISettingsService>();
+            settings.SimulatorTtsEnabled = true;
+            settings.SimulatorAutoSpeak = true;
+            settings.SimulatorAutoAdvance = true;
+        }
+
+        /// <summary>
+        /// Builds: START -> Entry("NPC greets") -> Reply("Hi") -> Entry("NPC replies").
+        /// </summary>
+        private static Dialog BuildTwoStepDialog()
+        {
+            var dialog = new Dialog();
+
+            var entry1 = dialog.CreateNode(DialogNodeType.Entry)!;
+            entry1.Text.Add(0, "NPC greets");
+            dialog.AddNodeInternal(entry1, entry1.Type);
+
+            var reply = dialog.CreateNode(DialogNodeType.Reply)!;
+            reply.Text.Add(0, "Hi");
+            dialog.AddNodeInternal(reply, reply.Type);
+
+            var entry2 = dialog.CreateNode(DialogNodeType.Entry)!;
+            entry2.Text.Add(0, "NPC replies");
+            dialog.AddNodeInternal(entry2, entry2.Type);
+
+            var e1ToReply = dialog.CreatePtr()!;
+            e1ToReply.Type = DialogNodeType.Reply;
+            e1ToReply.Node = reply;
+            entry1.Pointers.Add(e1ToReply);
+
+            var replyToE2 = dialog.CreatePtr()!;
+            replyToE2.Type = DialogNodeType.Entry;
+            replyToE2.Node = entry2;
+            reply.Pointers.Add(replyToE2);
+
+            var start = dialog.CreatePtr()!;
+            start.Type = DialogNodeType.Entry;
+            start.Node = entry1;
+            dialog.Starts.Add(start);
+
+            return dialog;
+        }
+
+        [AvaloniaFact]
+        public void StopSpeaking_WhileSpeakingPcReply_DoesNotAdvanceOrRestartSpeech()
+        {
+            EnableTts();
+            var tts = new MockTtsService();
+            var vm = new ConversationSimulatorViewModel(BuildTwoStepDialog(), "test-stop-1.dlg", tts);
+
+            vm.StartConversation();      // shows root entry
+            vm.SelectReply(0);           // choose the root entry -> NPC entry1 + its reply (auto-speaks NPC1)
+            Dispatcher.UIThread.RunJobs();
+            vm.SelectReply(0);           // choose the PC reply -> speaks PC reply, pends advance
+            Dispatcher.UIThread.RunJobs();
+
+            int spokenBeforeStop = tts.SpokenTexts.Count;
+
+            vm.StopSpeaking();           // user presses Stop; mock fires SpeakCompleted (cancellation)
+            Dispatcher.UIThread.RunJobs();
+
+            // Bug: the cancellation-fired completion advances to entry2 and auto-speaks it.
+            Assert.Equal(spokenBeforeStop, tts.SpokenTexts.Count);
+            Assert.DoesNotContain("NPC replies", tts.SpokenTexts);
+        }
+
+        [AvaloniaFact]
+        public void StopSpeaking_ClearsPendingAutoAdvanceState()
+        {
+            EnableTts();
+            var tts = new MockTtsService();
+            var vm = new ConversationSimulatorViewModel(BuildTwoStepDialog(), "test-stop-2.dlg", tts);
+
+            vm.StartConversation();
+            vm.SelectReply(0);
+            Dispatcher.UIThread.RunJobs();
+            vm.SelectReply(0);           // now mid-speaking PC reply with a pending advance
+            Dispatcher.UIThread.RunJobs();
+
+            vm.StopSpeaking();
+            Dispatcher.UIThread.RunJobs();
+
+            // The pending PC-reply advance must be discarded: a subsequent stray completion
+            // must never advance to the next NPC entry ("NPC replies") that the cancelled
+            // PC reply pointed to.
+            tts.CompleteSpeech();
+            Dispatcher.UIThread.RunJobs();
+            Assert.DoesNotContain("NPC replies", tts.SpokenTexts);
+        }
+    }
+}

--- a/Parley/Parley.Tests/ConversationSimulatorTtsStopTests.cs
+++ b/Parley/Parley.Tests/ConversationSimulatorTtsStopTests.cs
@@ -109,5 +109,38 @@ namespace Parley.Tests
             Dispatcher.UIThread.RunJobs();
             Assert.DoesNotContain("NPC replies", tts.SpokenTexts);
         }
+
+        /// <summary>
+        /// #2523 cross-platform: PiperTtsService.Stop() kills its process WITHOUT raising
+        /// SpeakCompleted. The user-stop flag must therefore be cleared when the next speech
+        /// begins, so a stale flag doesn't wrongly suppress a later natural completion.
+        /// </summary>
+        [AvaloniaFact]
+        public void SilentStop_DoesNotSuppressLaterNaturalCompletion()
+        {
+            EnableTts();
+            var tts = new MockTtsService { StopFiresCompleted = false }; // Piper-style silent Stop
+            var vm = new ConversationSimulatorViewModel(BuildTwoStepDialog(), "test-stop-3.dlg", tts);
+
+            vm.StartConversation();
+            vm.SelectReply(0);           // NPC entry1 auto-speaks
+            Dispatcher.UIThread.RunJobs();
+
+            vm.StopSpeaking();           // Piper-style: no SpeakCompleted, flag left armed
+            Dispatcher.UIThread.RunJobs();
+
+            // User re-speaks the current NPC entry; the fresh speak must clear the stale flag.
+            vm.Speak();
+            Dispatcher.UIThread.RunJobs();
+
+            // Natural completion of that speech must now drive auto-advance normally (single reply),
+            // i.e. it is NOT suppressed by a lingering user-stop flag.
+            int before = tts.SpokenTexts.Count;
+            tts.CompleteSpeech();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(tts.SpokenTexts.Count > before,
+                "Auto-advance should proceed after a fresh speak; the stale stop flag was not cleared.");
+        }
     }
 }

--- a/Parley/Parley.Tests/Mocks/MockTtsService.cs
+++ b/Parley/Parley.Tests/Mocks/MockTtsService.cs
@@ -16,6 +16,13 @@ namespace Parley.Tests.Mocks
         public string UnavailableReason { get; set; } = "TTS not available in test environment";
         public string InstallInstructions { get; set; } = "No installation needed for tests";
 
+        /// <summary>
+        /// When true (default), Stop() raises SpeakCompleted like the Windows synthesizer's
+        /// SpeakAsyncCancelAll() and espeak/say's async process-exit. When false, Stop() is
+        /// silent like PiperTtsService, which kills its process without firing the event (#2523).
+        /// </summary>
+        public bool StopFiresCompleted { get; set; } = true;
+
         public event EventHandler? SpeakCompleted;
 
         public IReadOnlyList<string> GetVoiceNames() => _voiceNames.AsReadOnly();
@@ -29,7 +36,8 @@ namespace Parley.Tests.Mocks
         public void Stop()
         {
             IsSpeaking = false;
-            SpeakCompleted?.Invoke(this, EventArgs.Empty);
+            if (StopFiresCompleted)
+                SpeakCompleted?.Invoke(this, EventArgs.Empty);
         }
 
         /// <summary>

--- a/Parley/Parley/ViewModels/ConversationSimulatorViewModel.ConversationFlow.cs
+++ b/Parley/Parley/ViewModels/ConversationSimulatorViewModel.ConversationFlow.cs
@@ -24,6 +24,7 @@ namespace DialogEditor.ViewModels
             LoopDetected = false;
             ShowLoopWarning = false;
             _isSelectingRootEntry = true;
+            ResetNavigationHistory(); // #2524: a fresh playthrough has no back-history
             OnPropertyChanged(nameof(IsShowingPcChoices));
 
             if (_dialog.Starts.Count == 0)
@@ -117,6 +118,9 @@ namespace DialogEditor.ViewModels
                 return;
 
             SelectedReplyIndex = replyIndex;
+
+            // #2524: capture the state we're leaving so Back can return to it.
+            PushNavigationSnapshot();
 
             // Handle root entry selection
             if (_isSelectingRootEntry)

--- a/Parley/Parley/ViewModels/ConversationSimulatorViewModel.ConversationFlow.cs
+++ b/Parley/Parley/ViewModels/ConversationSimulatorViewModel.ConversationFlow.cs
@@ -146,6 +146,7 @@ namespace DialogEditor.ViewModels
                         // Advancement will happen when PC speech completes
                         _isSpeakingPcReply = true;
                         _pendingReplyToAdvance = reply;
+                        _userStoppedSpeaking = false; // #2523: fresh speak clears stale stop flag
                         var pcVoice = GetVoiceForSpeaker("(PC)");
                         _ttsService.Speak(_ttsTextParser.GetSpeechText(pcText), pcVoice, TtsRate);
                         return; // Don't advance yet - wait for speech to complete

--- a/Parley/Parley/ViewModels/ConversationSimulatorViewModel.Navigation.cs
+++ b/Parley/Parley/ViewModels/ConversationSimulatorViewModel.Navigation.cs
@@ -70,6 +70,12 @@ namespace DialogEditor.ViewModels
             // A pending PC-reply advance would fire after we've already stepped back; cancel it.
             _isSpeakingPcReply = false;
             _pendingReplyToAdvance = null;
+            // #2524: Stop() fires SpeakCompleted synchronously on Windows/espeak/say. Arm the
+            // user-stop flag first (as StopSpeaking does) so that completion is treated as an
+            // intentional stop and does NOT drive a spurious auto-advance off the pre-restore
+            // reply list. Armed unconditionally: the restore below suppresses auto-speak, and the
+            // next real speak clears the flag (matching the Piper silent-Stop path in #2523).
+            _userStoppedSpeaking = true;
             _ttsService.Stop();
 
             var snapshot = _navigationHistory.Pop();

--- a/Parley/Parley/ViewModels/ConversationSimulatorViewModel.Navigation.cs
+++ b/Parley/Parley/ViewModels/ConversationSimulatorViewModel.Navigation.cs
@@ -1,0 +1,110 @@
+using System.Collections.Generic;
+using System.Linq;
+using DialogEditor.Models;
+
+namespace DialogEditor.ViewModels
+{
+    /// <summary>
+    /// #2524: Back/Previous navigation for the Conversation Simulator.
+    /// Maintains a history stack of navigation snapshots so the user can step back one entry
+    /// per press without restarting. Coverage already recorded is preserved (Back only restores
+    /// navigation position, it does not un-record visited nodes).
+    /// </summary>
+    public partial class ConversationSimulatorViewModel
+    {
+        /// <summary>
+        /// Immutable snapshot of the restorable navigation state for a single step.
+        /// </summary>
+        private sealed class NavigationSnapshot
+        {
+            public bool IsSelectingRootEntry { get; init; }
+            public DialogNode? CurrentEntry { get; init; }
+            public IReadOnlyList<DialogNode> CurrentReplies { get; init; } = new List<DialogNode>();
+            public int PathDepth { get; init; }
+            public int SelectedReplyIndex { get; init; }
+            public bool HasEnded { get; init; }
+        }
+
+        /// <summary>
+        /// True when there is a prior step to return to. Bound to the Back button's IsEnabled.
+        /// </summary>
+        public bool CanGoBack => _navigationHistory.Count > 0;
+
+        /// <summary>
+        /// Captures the CURRENT navigation state onto the history stack before a forward
+        /// transition. Call this immediately before advancing/selecting.
+        /// </summary>
+        private void PushNavigationSnapshot()
+        {
+            _navigationHistory.Push(new NavigationSnapshot
+            {
+                IsSelectingRootEntry = _isSelectingRootEntry,
+                CurrentEntry = _currentEntry,
+                CurrentReplies = _currentReplies.ToList(),
+                PathDepth = _pathDepth,
+                SelectedReplyIndex = _selectedReplyIndex,
+                HasEnded = _hasEnded
+            });
+            OnPropertyChanged(nameof(CanGoBack));
+        }
+
+        /// <summary>
+        /// Clears the navigation history (called when the conversation restarts).
+        /// </summary>
+        private void ResetNavigationHistory()
+        {
+            _navigationHistory.Clear();
+            OnPropertyChanged(nameof(CanGoBack));
+        }
+
+        /// <summary>
+        /// Step back to the previous entry in the current playthrough. Restores the prior NPC
+        /// text and reply list, clears any ended/loop state, and does not re-speak (TTS suppressed).
+        /// Coverage recorded so far is left intact.
+        /// </summary>
+        public void GoBack()
+        {
+            if (_navigationHistory.Count == 0)
+                return;
+
+            // A pending PC-reply advance would fire after we've already stepped back; cancel it.
+            _isSpeakingPcReply = false;
+            _pendingReplyToAdvance = null;
+            _ttsService.Stop();
+
+            var snapshot = _navigationHistory.Pop();
+
+            _isSelectingRootEntry = snapshot.IsSelectingRootEntry;
+            _currentEntry = snapshot.CurrentEntry;
+            _currentReplies = snapshot.CurrentReplies.ToList();
+            _pathDepth = snapshot.PathDepth;
+            HasEnded = snapshot.HasEnded;
+
+            // Returning from a leaf clears the ended/loop flags so the user can choose again.
+            LoopDetected = false;
+            ShowLoopWarning = false;
+
+            _suppressAutoSpeak = true;
+            try
+            {
+                if (_isSelectingRootEntry)
+                {
+                    ShowRootEntrySelection();
+                }
+                else
+                {
+                    UpdateDisplay();
+                }
+            }
+            finally
+            {
+                _suppressAutoSpeak = false;
+            }
+
+            SelectedReplyIndex = snapshot.SelectedReplyIndex;
+            OnPropertyChanged(nameof(IsShowingPcChoices));
+            OnPropertyChanged(nameof(CanGoBack));
+            StatusMessage = "Stepped back to the previous entry.";
+        }
+    }
+}

--- a/Parley/Parley/ViewModels/ConversationSimulatorViewModel.cs
+++ b/Parley/Parley/ViewModels/ConversationSimulatorViewModel.cs
@@ -73,6 +73,12 @@ namespace DialogEditor.ViewModels
         // SpeakAsyncCancelAll() suppresses auto-advance instead of progressing the conversation.
         private bool _userStoppedSpeaking = false;
 
+        // #2524: navigation history for the Back button. Each snapshot captures the restorable
+        // state of one step; GoBack pops and restores it. _suppressAutoSpeak stops a restored
+        // display from re-triggering TTS.
+        private readonly Stack<NavigationSnapshot> _navigationHistory = new();
+        private bool _suppressAutoSpeak = false;
+
         public event PropertyChangedEventHandler? PropertyChanged;
         public event EventHandler? ConversationEnded;
         public event EventHandler? RequestClose;
@@ -489,14 +495,14 @@ namespace DialogEditor.ViewModels
             OnPropertyChanged(nameof(CoverageComplete));
 
             // Auto-speak NPC text if enabled
-            if (AutoSpeak && TtsAvailable && TtsEnabled && !string.IsNullOrWhiteSpace(NpcText))
+            if (!_suppressAutoSpeak && AutoSpeak && TtsAvailable && TtsEnabled && !string.IsNullOrWhiteSpace(NpcText))
             {
                 var npcVoice = GetVoiceForSpeaker(NpcSpeaker);
                 _userStoppedSpeaking = false; // #2523: fresh speak clears stale stop flag
                 _ttsService.Speak(_ttsTextParser.GetSpeechText(NpcText), npcVoice, TtsRate);
                 // Auto-advance will be triggered by OnTtsSpeakCompleted when speech finishes
             }
-            else if (AutoAdvance && Replies.Count == 1 && !_isSelectingRootEntry)
+            else if (!_suppressAutoSpeak && AutoAdvance && Replies.Count == 1 && !_isSelectingRootEntry)
             {
                 // Auto-advance immediately when not auto-speaking
                 SelectReply(0);

--- a/Parley/Parley/ViewModels/ConversationSimulatorViewModel.cs
+++ b/Parley/Parley/ViewModels/ConversationSimulatorViewModel.cs
@@ -356,6 +356,9 @@ namespace DialogEditor.ViewModels
 
             // Get the voice for the current speaker
             var voiceName = GetVoiceForSpeaker(NpcSpeaker);
+            // #2523: a fresh speak clears any stale user-stop flag (Piper's Stop() never fires
+            // SpeakCompleted, so the flag would otherwise linger and suppress the next completion).
+            _userStoppedSpeaking = false;
             _ttsService.Speak(_ttsTextParser.GetSpeechText(NpcText), voiceName, TtsRate);
             OnPropertyChanged(nameof(TtsSpeaking));
         }
@@ -489,6 +492,7 @@ namespace DialogEditor.ViewModels
             if (AutoSpeak && TtsAvailable && TtsEnabled && !string.IsNullOrWhiteSpace(NpcText))
             {
                 var npcVoice = GetVoiceForSpeaker(NpcSpeaker);
+                _userStoppedSpeaking = false; // #2523: fresh speak clears stale stop flag
                 _ttsService.Speak(_ttsTextParser.GetSpeechText(NpcText), npcVoice, TtsRate);
                 // Auto-advance will be triggered by OnTtsSpeakCompleted when speech finishes
             }

--- a/Parley/Parley/ViewModels/ConversationSimulatorViewModel.cs
+++ b/Parley/Parley/ViewModels/ConversationSimulatorViewModel.cs
@@ -69,19 +69,24 @@ namespace DialogEditor.ViewModels
         private string _defaultNpcVoice = "";
         private bool _isSpeakingPcReply = false;
         private DialogNode? _pendingReplyToAdvance = null;
+        // #2523: set true when the user presses Stop so the completion event fired by
+        // SpeakAsyncCancelAll() suppresses auto-advance instead of progressing the conversation.
+        private bool _userStoppedSpeaking = false;
 
         public event PropertyChangedEventHandler? PropertyChanged;
         public event EventHandler? ConversationEnded;
         public event EventHandler? RequestClose;
 
-        public ConversationSimulatorViewModel(Dialog dialog, string filePath)
+        // #2523: ttsService is injectable for unit testing the stop/auto-advance flow;
+        // production passes null and resolves the platform service from DI.
+        public ConversationSimulatorViewModel(Dialog dialog, string filePath, ITtsService? ttsService = null)
         {
             _settings = Program.Services.GetRequiredService<ISettingsService>();
             _dialog = dialog ?? throw new ArgumentNullException(nameof(dialog));
             _filePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
             _conversationManager = new ConversationManager(dialog, new AlwaysTrueScriptEngine());
             _coverageTracker = Program.Services.GetRequiredService<CoverageTracker>();
-            _ttsService = Program.Services.GetRequiredService<ITtsService>();
+            _ttsService = ttsService ?? Program.Services.GetRequiredService<ITtsService>();
 
             Replies = new ObservableCollection<ReplyOption>();
             VoiceNames = new ObservableCollection<string>();
@@ -360,6 +365,13 @@ namespace DialogEditor.ViewModels
         /// </summary>
         public void StopSpeaking()
         {
+            // #2523: Stop() cancels playback but the platform synthesizer fires SpeakCompleted
+            // (Cancelled) synchronously; flag it so OnTtsSpeakCompleted suppresses auto-advance
+            // and clears any pending PC-reply advance instead of restarting speech. Only arm the
+            // flag when speech (or a pending PC-reply advance) is actually active, otherwise a
+            // Stop with nothing queued could leave it set and wrongly suppress the next completion.
+            if (_ttsService.IsSpeaking || _isSpeakingPcReply)
+                _userStoppedSpeaking = true;
             _ttsService.Stop();
             OnPropertyChanged(nameof(TtsSpeaking));
         }
@@ -370,6 +382,16 @@ namespace DialogEditor.ViewModels
         private void OnTtsSpeakCompleted(object? sender, EventArgs e)
         {
             OnPropertyChanged(nameof(TtsSpeaking));
+
+            // #2523: This completion was triggered by the user pressing Stop. Do not advance
+            // or restart speech; clear any pending PC-reply advance so it can't resurrect later.
+            if (_userStoppedSpeaking)
+            {
+                _userStoppedSpeaking = false;
+                _isSpeakingPcReply = false;
+                _pendingReplyToAdvance = null;
+                return;
+            }
 
             // If we were speaking a PC reply, now advance to NPC response
             if (_isSpeakingPcReply && _pendingReplyToAdvance != null)

--- a/Parley/Parley/ViewModels/ConversationSimulatorViewModel.cs
+++ b/Parley/Parley/ViewModels/ConversationSimulatorViewModel.cs
@@ -409,13 +409,30 @@ namespace DialogEditor.ViewModels
                 _isSpeakingPcReply = false;
                 _pendingReplyToAdvance = null;
 
+                UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                    "[AutoAdvance] PC-reply speech complete, advancing to next NPC entry");
                 // Use dispatcher to ensure UI thread safety
                 Avalonia.Threading.Dispatcher.UIThread.Post(() => AdvanceToNextEntry(reply));
                 return;
             }
+            // #2524: PC-reply flag set but pending reply missing (or vice-versa) would drop an
+            // advance — log the inconsistency so a one-off no-advance can be traced.
+            if (_isSpeakingPcReply || _pendingReplyToAdvance != null)
+            {
+                UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                    $"[AutoAdvance] inconsistent PC-reply state on completion " +
+                    $"(isSpeakingPcReply={_isSpeakingPcReply}, pending={_pendingReplyToAdvance != null})");
+            }
 
             // NPC speech completed - auto-advance if enabled and single reply available
-            if (AutoAdvance && AutoSpeak && Replies.Count == 1 && !_isSelectingRootEntry && !HasEnded)
+            bool npcAutoAdvance = AutoAdvance && AutoSpeak && Replies.Count == 1 && !_isSelectingRootEntry && !HasEnded;
+            // #2524: DEBUG trace of the gating state — a one-off "failed to advance" that later
+            // works is a timing/race symptom; this shows which condition was false when it missed.
+            UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                $"[AutoAdvance] NPC-complete gate={npcAutoAdvance} " +
+                $"(AutoAdvance={AutoAdvance}, AutoSpeak={AutoSpeak}, Replies={Replies.Count}, " +
+                $"selectingRoot={_isSelectingRootEntry}, ended={HasEnded})");
+            if (npcAutoAdvance)
             {
                 // Use dispatcher to ensure UI thread safety
                 Avalonia.Threading.Dispatcher.UIThread.Post(() => SelectReply(0));
@@ -505,7 +522,18 @@ namespace DialogEditor.ViewModels
             else if (!_suppressAutoSpeak && AutoAdvance && Replies.Count == 1 && !_isSelectingRootEntry)
             {
                 // Auto-advance immediately when not auto-speaking
+                UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                    "[AutoAdvance] immediate (no auto-speak): single reply, advancing");
                 SelectReply(0);
+            }
+            else if (AutoAdvance && Replies.Count == 1 && !_isSelectingRootEntry)
+            {
+                // #2524: AutoAdvance wanted but skipped — record why (suppress during Back restore,
+                // or auto-speak deferring to speech-completion). Helps diagnose a one-off no-advance.
+                UnifiedLogger.LogApplication(LogLevel.DEBUG,
+                    $"[AutoAdvance] deferred/suppressed at UpdateDisplay " +
+                    $"(suppressAutoSpeak={_suppressAutoSpeak}, AutoSpeak={AutoSpeak}, " +
+                    $"TtsEnabled={TtsEnabled}, TtsAvailable={TtsAvailable})");
             }
         }
 

--- a/Parley/Parley/Views/ConversationSimulatorWindow.axaml
+++ b/Parley/Parley/Views/ConversationSimulatorWindow.axaml
@@ -227,6 +227,12 @@
                     Click="OnStopClick"
                     IsEnabled="{Binding TtsSpeaking}"
                     ToolTip.Tip="Stop speaking"/>
+            <Button x:Name="BackButton"
+                    Content="Back"
+                    Width="80"
+                    Click="OnBackClick"
+                    IsEnabled="{Binding CanGoBack}"
+                    ToolTip.Tip="Step back to the previous entry"/>
             <Button x:Name="SkipButton"
                     Content="Skip"
                     Width="80"

--- a/Parley/Parley/Views/ConversationSimulatorWindow.axaml.cs
+++ b/Parley/Parley/Views/ConversationSimulatorWindow.axaml.cs
@@ -157,6 +157,11 @@ namespace DialogEditor.Views
             }
         }
 
+        private void OnBackClick(object? sender, RoutedEventArgs e)
+        {
+            _viewModel?.GoBack();
+        }
+
         private void OnSkipClick(object? sender, RoutedEventArgs e)
         {
             _viewModel?.Skip();


### PR DESCRIPTION
## Summary

Two Conversation Simulator fixes (reported during #2445 manual testing) plus supporting chores.

- **#2524 — Back/Previous button**: steps to the prior entry in a playthrough without restarting. Restores prior NPC text + replies via a navigation history stack, clears the ended/loop state when returning from a leaf, and preserves recorded coverage. Auto-speak suppressed on restore.
- **#2523 — Stop halts TTS**: Stop now actually cancels in-progress speech and no longer lets the cancellation-fired completion drive a spurious auto-advance. Fix is cross-platform (Windows `System.Speech`, Piper, espeak/`say`).

## Related Issues

- Closes #2524
- Closes #2523

## Tests

- 908 → 909 Parley unit tests pass (11 new: TTS-stop, Back-navigation incl. a code-review race regression, auto-advance guards).
- Privacy scan ✅ · Tech-debt scan ✅ (no files >800 lines) · Theme scan ✅.
- Code review (fast local) surfaced one real bug — GoBack triggering a spurious auto-advance — fixed on this branch with a regression test.
- FlaUI intentionally skipped: no integration tests cover the Conversation Simulator window, and FlaUI cannot verify TTS audio. Manual spot-checks below.

## Chores

- Root `CLAUDE.md`: manual spot-check spec now requires a `(Linux)` tag for platform-dependent behavior (filesystem, TTS/audio backend, process launch, native interop).
- DEBUG logging at the simulator auto-advance decision gates (diagnoses a one-off no-advance race if it recurs).

## Manual Spot-Checks (before merge)

- [ ] Back button appears (before Skip), disabled at the start-entry menu and first NPC entry; enabled after advancing.
- [ ] Advance several steps, press Back repeatedly — NPC text + replies restore each step; ✓ coverage marks persist.
- [ ] Reach a conversation end, press Back — returns to the last NPC entry with replies (ended state cleared).
- [ ] AutoAdvance checked + single-reply NPC entry auto-advances (both AutoSpeak on and off).
- [ ] (Linux) TTS Stop halts in-progress speech — Piper/espeak backend differs from Windows; verify audio stops and does not auto-advance.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
