### PR TITLE
[Radoub] docs: CLAUDE.md + slash-command housekeeping; PowerShell-tool rule

### DIFF
--- a/.claude/commands/backlog.md
+++ b/.claude/commands/backlog.md
@@ -1,68 +1,52 @@
 # Backlog Review & Sprint Planning
 
-Review open issues and plan next sprint. Combines light hygiene check with sprint option generation.
+Review open issues and plan the next sprint. Light hygiene check plus sprint options.
 
 ## Usage
 
 ```
-/backlog [options]
+/backlog [--tool <name>] [--full] [--refresh] [#N]
 ```
 
-**Options:**
-- No args: Review all open issues, generate sprint options
-- `--tool parley|radoub|manifest|quartermaster|fence`: Filter by tool
-- `--full`: Include detailed grooming (label fixes, title standardization)
-- `--refresh`: Force cache refresh before review
-- `#N`: Focus on specific epic's issues
+| Option | Effect |
+|--------|--------|
+| (none) | Review all open issues, generate sprint options |
+| `--tool <name>` | Filter to one tool |
+| `--full` | Add detailed grooming — label fixes, title standardization |
+| `--refresh` | Force a cache refresh first |
+| `#N` | Focus on one epic's issues |
 
-**Examples:**
-- `/backlog` - Quick review + sprint options
-- `/backlog --tool quartermaster` - Quartermaster issues only
-- `/backlog #544` - Focus on epic #544
-- `/backlog --full` - Include detailed grooming pass
-- `/backlog --refresh` - Force fresh data from GitHub
+Ask both up front, in one interaction: create the sprint issue on GitHub afterward
+(`y/n/ask-after`), and if so, add it to the project board.
 
-## Upfront Questions
+## Phase 1 — Load
 
-Collect in ONE interaction:
-
-1. **Create Issues**: "After planning, create sprint issue on GitHub? [y/n/ask-after]"
-2. **Project Board**: "Add created sprint to project board? [y/n]" (only if creating issues)
-
-## Workflow
-
-### Step 0: Ensure Cache is Fresh
+### 1.1 Refresh the cache
 
 ```bash
-# Auto-refresh if cache is stale (>1 hour) or missing
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Refresh-GitHubCache.ps1"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Refresh-GitHubCache.ps1" [-Force]
 ```
 
-If `--refresh` flag is passed, force refresh:
-```bash
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Refresh-GitHubCache.ps1" -Force
-```
+Auto-refreshes when stale (over an hour). `--refresh` forces it.
 
-### Step 1: Load Issues from Cache
+### 1.2 Read issues
 
-- Don't over label.  3 to Five is usually sufficient.
-
-Use the helper script to get a compact view (~25KB instead of 220KB):
+The `backlog` view is sorted **oldest-first**, which is what the anti-recency rules below
+need. Output is `#NNNN  <age>d  <title>` plus labels.
 
 ```bash
-# Get list view (no bodies) - filtered by tool if specified
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View list [-Tool parley]
-
-# Or just summary stats
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View summary
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View backlog [-Tool parley] [-Label "tech-debt|refactor"] [-Query "<title-regex>"]
 ```
 
-The list view includes: number, title, updatedAt, author, labels (comma-separated).
-Bodies are omitted to reduce context size - fetch individually if needed.
+Other views: `-View list` for a compact dump (~25KB versus 220KB — number, title, updatedAt,
+author, labels, no bodies), `-View summary` for counts alone, `-View search -Query` for
+title-and-body regex. Fetch bodies individually only when needed.
 
-### Step 2: Quick Hygiene Summary
+## Phase 2 — Assess
 
-Count issues with problems (don't detail each one unless `--full`):
+### 2.1 Hygiene summary
+
+Counts only, unless `--full`:
 
 ```markdown
 ## Hygiene Summary
@@ -75,14 +59,11 @@ Count issues with problems (don't detail each one unless `--full`):
 [Run `/backlog --full` for detailed fixes]
 ```
 
-If `--full` flag: Include per-issue recommendations (label fixes, title standardization).
+Keep labels sparse — three to five per issue is plenty.
 
-### Step 3: Categorize by Epic/Area
+### 2.2 Group by epic and area
 
-Group issues by:
-- Epic label (if present)
-- Tool label
-- Type (bug, enhancement, tech-debt)
+Group by epic label, then tool, then type (bug, enhancement, tech-debt):
 
 ```markdown
 ## By Epic
@@ -98,20 +79,19 @@ Group issues by:
 | #123 | Fix button alignment | 3 | bug |
 ```
 
-### Step 3.5: Languishing Issues Report
+### 2.3 Languishing issues (MANDATORY)
 
-**MANDATORY** — before generating sprint options, identify issues that are being neglected.
+Never skip this. Age alone is a signal.
 
-An issue is **languishing** if:
-- Open 30+ days with no activity (no comments, no PR, no label changes)
-- Open 60+ days regardless of activity (**call out explicitly**)
-- Tagged `bug` and open 14+ days
-- Tagged `security` or `tech-debt` and open 21+ days
+| Condition | Threshold |
+|-----------|-----------|
+| No activity — no comments, PR, or label changes | 30+ days |
+| Any state, called out explicitly | 60+ days |
+| Tagged `bug` | 14+ days |
+| Tagged `security` or `tech-debt` | 21+ days |
 
 ```markdown
 ## ⚠️ Languishing Issues
-
-These issues need attention — age alone is a signal.
 
 ### Critical (60+ days)
 | # | Title | Age | Type | Last Activity |
@@ -125,31 +105,35 @@ These issues need attention — age alone is a signal.
 ### Overdue Bugs (14+ days)
 | # | Title | Age | Assigned? |
 |---|-------|-----|-----------|
-
-**Action Required**: At least ONE languishing issue must be included in a sprint option below, or the user must explicitly acknowledge and defer it.
 ```
 
-If no issues are languishing, output: "No languishing issues. 👍"
+At least one languishing issue must appear in a sprint option below, or the user must
+explicitly defer it. When none qualify, say "No languishing issues. 👍".
 
-### Step 4: Generate Sprint Options
+## Phase 3 — Plan
 
-**CRITICAL RULES:**
+### 3.1 Generate three sprint options
 
-1. **No overlapping issues** — each issue appears in AT MOST ONE sprint option. If an issue fits multiple themes, pick the best fit. Never duplicate.
+Always exactly three, one per category:
 
-2. **Mandatory sprint categories** — always generate exactly 3 sprint options from these categories:
+| Category | Covers | Skip only when |
+|----------|--------|----------------|
+| Feature | New functionality, enhancements | No feature or enhancement issues exist |
+| Bug Fix | Bugs, corrections | No bug issues exist |
+| Health | Tech debt, security, testing, refactoring | Never — health work always exists |
 
-| Category | Description | When to Skip |
-|----------|-------------|--------------|
-| **Feature Sprint** | New functionality, enhancements | Only if zero feature/enhancement issues exist |
-| **Bug/Fix Sprint** | Bug fixes, corrections | Only if zero bug issues exist |
-| **Health Sprint** | Tech debt, security, testing, refactoring | NEVER skip — there is always health work to do |
+Four rules govern selection:
 
-3. **Anti-recency bias** — for each sprint option, at least ONE issue must be the **oldest qualifying issue** in that category. Do not exclusively pick recent issues. Sort candidates by age (oldest first) when selecting.
+1. **No overlap.** An issue appears in at most one option. If it fits two themes, pick the
+   better fit.
+2. **Oldest-first.** Each option must include the oldest qualifying issue in its category.
+   Sort candidates by age before selecting.
+3. **Breadth over momentum.** If the last three sprints hit Quartermaster, favor another tool.
+   If the last was a feature, lean bug or health.
+4. **Show age everywhere.** Every issue listing carries `(NN days old)`.
 
-4. **Breadth over momentum** — resist grouping issues that were just worked on. If the last 3 sprints touched Quartermaster, prioritize other tools. If the last sprint was a feature, lean toward bug/health.
-
-Present 3 sprint options (one per category):
+Within a category, prioritize blockers, then languishing issues, then user-facing bugs over
+internal cleanup, then natural groupings (same code path), then tool balance.
 
 ```markdown
 ## Sprint Options
@@ -161,51 +145,39 @@ Present 3 sprint options (one per category):
 - #Y - [title] (NN days old)
 
 **Oldest issue included**: #X (NN days)
-**Rationale**: [why these fit together - shared code path, etc.]
+**Rationale**: [why these fit — shared code path, etc.]
 **Complexity**: Small/Medium/Large
-
----
 
 ### Option B: Bug Fix — [Theme]
-
-**Issues:**
-- #X - [title] (NN days old)
-
-**Oldest issue included**: #X (NN days)
-**Rationale**: [why these fit together]
-**Complexity**: Small/Medium/Large
-
----
+...
 
 ### Option C: Health — [Theme]
-
-**Issues:**
-- #X - [title] (NN days old)
-- #Y - [title] (NN days old)
-
-**Oldest issue included**: #X (NN days)
-**Rationale**: [tech debt / security / testing justification]
-**Complexity**: Small/Medium/Large
-
----
+...
 
 ## Recommendation
 
-**Option [X]** recommended because:
-1. [reason — include age/urgency justification]
+**Option [X]** because:
+1. [reason, including age or urgency]
 2. [reason]
 
 **Recent sprint history** (last 3):
 - [tool] [type] — [date]
-- [tool] [type] — [date]
-- [tool] [type] — [date]
-
-If the last 3 sprints were the same tool/type, explicitly recommend a different tool/type for balance.
 ```
 
-### Step 5: Create Sprint Issue (if requested)
+When the last three sprints share a tool or type, recommend a different one and say why.
 
-If user said yes to creating issues:
+Sizing: Small is 1–2 focused items (~1 day), Medium is 2–4 related items (~2–3 days), Large
+is 4+ or a complex feature (~a week). Good pairings include a feature with its related tech
+debt, a bug with its cleanup, several small issues on one code path, or a blocked issue
+alongside its blocker.
+
+Avoid: the same issue in two options, always recommending the most recently active tool,
+ignoring anything over 30 days, feature-only slates, grouping by momentum rather than code
+area, and never surfacing security or tech-debt work.
+
+## Phase 4 — Create (if requested)
+
+### 4.1 Sprint issue
 
 ```bash
 gh issue create \
@@ -224,7 +196,7 @@ gh issue create \
 
 ## Sprint Goals
 
-[Brief description of what this sprint accomplishes]
+[What this sprint accomplishes]
 
 ## Acceptance Criteria
 
@@ -239,123 +211,28 @@ EOF
 )"
 ```
 
-### Step 6: Add to Project Board (if requested)
-
-Only for created sprint issues:
+### 4.2 Project board
 
 ```bash
-# Add to project
-gh project item-add [PROJECT_NUMBER] --owner LordOfMyatar --url https://github.com/LordOfMyatar/Radoub/issues/[number] --format json
+gh project item-add 3 --owner LordOfMyatar --url https://github.com/LordOfMyatar/Radoub/issues/[number] --format json
 
-# Set status to "In Progress" (see project IDs below)
+gh project item-edit --id "[item-id]" \
+  --project-id PVT_kwHOAotjYs4BHbMq \
+  --field-id PVTSSF_lAHOAotjYs4BHbMqzg4Lxyk \
+  --single-select-option-id 47fc9ee4
 ```
 
-**Project:** All tools use Radoub project (#3)
+All tools use Radoub project #3.
 
-**Project IDs for status update:**
-- Radoub: `--project-id PVT_kwHOAotjYs4BHbMq --field-id PVTSSF_lAHOAotjYs4BHbMqzg4Lxyk --single-select-option-id 47fc9ee4`
+## Output
 
-## Output Format
+Write the full review to `NonPublic/backlog.md`, clobbering each run. Structure: header with
+date, tool filter, and recent sprint history; then Hygiene Summary, Languishing Issues, By
+Epic, Sprint Options, Recommendation, and Next Steps.
+
+Next steps read:
 
 ```markdown
-# Backlog Review
-
-**Date**: YYYY-MM-DD
-**Tool Filter**: [all/specific tool]
-**Recent Sprint History**: [last 3 sprints: tool + type + date]
-
-## Hygiene Summary
-
-- **Missing tool label**: N issues
-- **Missing type label**: N issues
-- **Stale (15+ days)**: N issues
-- **Well-formed**: N issues
-
-[Run `/backlog --full` for detailed fixes]
-
----
-
-## ⚠️ Languishing Issues
-
-[Languishing report — see Step 3.5]
-
----
-
-## By Epic
-
-### Epic #N: [Name] (X issues)
-| # | Title | Days | Priority |
-|---|-------|------|----------|
-
-### Uncategorized (X issues)
-| # | Title | Days | Type |
-|---|-------|------|------|
-
----
-
-## Sprint Options
-
-### Option A: Feature — [Theme]
-...
-
-### Option B: Bug Fix — [Theme]
-...
-
-### Option C: Health — [Theme]
-...
-
----
-
-## Recommendation
-
-**Option [X]** recommended because:
-...
-
----
-
-## Next Steps
-
-- To start selected sprint: `/init-item #[sprint-issue-number]`
+- To start the selected sprint: `/init-item #[sprint-issue-number]`
 - For detailed grooming: `/backlog --full`
 ```
-
-## Save to File
-
-Save output to `NonPublic/backlog.md` (clobber each run).
-
-## Grouping Guidelines
-
-**Good sprint combinations:**
-- Feature + related tech debt in same area
-- Bug fix + related cleanup
-- Multiple small issues touching same code path
-- Blocked issue + its blocker (clear the blocker first)
-
-**Sprint sizing:**
-- Small: 1-2 focused items, ~1 day
-- Medium: 2-4 related items, ~2-3 days
-- Large: 4+ items or complex feature, ~week
-
-**HARD RULES (non-negotiable):**
-
-1. **No issue overlap between sprint options** — an issue can appear in exactly ONE option
-2. **3 categories always** — Feature, Bug Fix, Health (tech debt/security/testing)
-3. **Oldest-first selection** — within each category, start candidate selection from the oldest issues
-4. **Languishing report is mandatory** — never skip Step 3.5
-5. **Include age in all issue listings** — always show "(NN days old)" next to each issue
-6. **Recent sprint awareness** — check last 3 merged PRs for tool/type distribution; if skewed, recommend the underrepresented category
-
-**Prioritization (within each sprint category):**
-1. Blockers first (issues blocking other work)
-2. Languishing issues (30+ days, called out in Step 3.5)
-3. User-facing bugs over internal cleanup
-4. Natural groupings over isolated tasks (same code path = same sprint)
-5. Balance across tools (don't always sprint on the same tool)
-
-**Anti-Patterns to AVOID:**
-- Putting the same issue in multiple sprint options
-- Always recommending the most recently active tool
-- Ignoring issues older than 30 days
-- Creating only feature sprints (health work always exists)
-- Grouping by "momentum" instead of logical code area
-- Never surfacing security or tech-debt issues

--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -1,6 +1,7 @@
 # Create Issue
 
-Create a well-structured GitHub issue with consistent formatting, correct labels, and proper tool prefixes.
+Create a well-structured GitHub issue with consistent formatting, correct labels, and the
+right tool prefix.
 
 ## Usage
 
@@ -8,42 +9,41 @@ Create a well-structured GitHub issue with consistent formatting, correct labels
 /create-issue [description]
 ```
 
-**Examples:**
-- `/create-issue Fence crashes when opening UTM with empty inventory`
-- `/create-issue Add portrait preview to Quartermaster`
-- `/create-issue` (interactive — will prompt for details)
+With no description, prompts for details.
 
-## Workflow
+## Phase 1 — Gather
 
-### Step 1: Gather Information
+Extract what you can from the description, then ask for the rest: tool, type, title, and
+optional body.
 
-If the user provided a description, extract what you can. Otherwise, ask for:
+| Description contains | Type | Title prefix | Labels |
+|----------------------|------|--------------|--------|
+| crash, broken, error, fails, wrong | bug | `fix:` | `bug`, `[tool]` |
+| add, new, improve, support | enhancement | `feat:` | `enhancement`, `[tool]` |
+| refactor, cleanup, split, rename, dead code | tech-debt | `refactor:` | `tech-debt`, `[tool]` |
 
-1. **Tool**: Which tool? (Parley, Manifest, Quartermaster, Fence, Relique, Trebuchet, Radoub)
-2. **Type**: What kind of issue?
-   - `bug` — Something is broken
-   - `enhancement` — New feature or improvement
-   - `tech-debt` — Code quality, refactoring, cleanup
-3. **Title**: Brief description of the issue
-4. **Body**: Details (optional — can be minimal for simple issues)
+A tool name in the description sets the tool. Ask when ambiguous.
 
-**Auto-detection from description**:
-- Words like "crash", "broken", "error", "fails", "wrong" → `bug`
-- Words like "add", "new", "improve", "support" → `enhancement`
-- Words like "refactor", "cleanup", "split", "rename", "dead code" → `tech-debt`
-- Tool name in description → that tool
-- If ambiguous, ask
+Tool labels are lowercase: `parley`, `manifest`, `quartermaster`, `fence`, `relique`,
+`reliquary`, `trebuchet`, `radoub`.
 
-### Step 2: Check for Duplicates
+## Phase 2 — Check for duplicates
 
-Search the cache for similar issues before creating:
+Always search before creating.
 
 ```bash
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Refresh-GitHubCache.ps1"
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View search -Query "[key terms from title]"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View search -Query "[key terms]"
 ```
 
-If similar issues found, report them:
+The cache holds only OPEN issues, so a closed duplicate will not appear. When the search hints
+at related work, verify live state:
+
+```bash
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Test-IssueState.ps1" -Numbers "N,N"
+```
+
+Report matches and ask whether to continue:
 
 ```markdown
 ### Potentially Related Issues
@@ -55,48 +55,31 @@ If similar issues found, report them:
 Create anyway? [y/n]
 ```
 
-If no matches, proceed silently.
+No matches: proceed silently.
 
-### Step 3: Format and Create
+## Phase 3 — Create
 
-**Title format**: `[Tool] type: Description`
+Title format: `[Tool] type: Description`, under 80 characters.
 
-Examples:
 - `[Fence] fix: Crash when opening UTM with empty inventory`
 - `[Quartermaster] feat: Add portrait preview panel`
 - `[Radoub] refactor: Split oversized MainWindowViewModel`
 
-**Type prefixes** (in title):
-| Issue Type | Title Prefix |
-|------------|-------------|
-| bug | `fix:` |
-| enhancement | `feat:` |
-| tech-debt | `refactor:` |
-
-**Labels**:
-| Issue Type | Labels |
-|------------|--------|
-| bug | `bug`, `[tool]` |
-| enhancement | `enhancement`, `[tool]` |
-| tech-debt | `tech-debt`, `[tool]` |
-
-Tool labels are lowercase: `parley`, `manifest`, `quartermaster`, `fence`, `relique`, `trebuchet`, `radoub`
-
-**Body template**:
+The `[Tool]` prefix and the tool label must always agree.
 
 ```bash
 gh issue create --title "[Tool] type: Title" --label "type-label,tool-label" --body "$(cat <<'EOF'
 ## Problem
 
-[What's wrong or what's missing]
+[What is wrong or missing]
 
 ## Expected Behavior
 
-[What should happen instead — omit for enhancements if obvious]
+[What should happen — omit when obvious for an enhancement]
 
 ## Context
 
-[Any relevant details: how discovered, affected files, related issues]
+[How it was found, affected files, related issues]
 
 ---
 
@@ -105,33 +88,17 @@ EOF
 )"
 ```
 
-For **tech-debt** issues, use this body instead:
+Tech-debt issues use **Current State** / **Proposed Change** / **Files Affected** instead.
 
-```markdown
-## Current State
+**Long or pattern-heavy bodies**: stage the text in `NonPublic/_scratch/` and pass
+`--body-file`. Heredocs are fine for short bodies, but a body containing `..`, quotes, or
+backticks can trip the permission guard, and `--body-file` sidesteps the escaping entirely.
 
-[What exists now and why it's a problem]
-
-## Proposed Change
-
-[What should be done]
-
-## Files Affected
-
-- `path/to/file.cs`
-
----
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-```
-
-### Step 4: Refresh Cache
+## Phase 4 — Refresh and report
 
 ```bash
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Refresh-GitHubCache.ps1" -Force
 ```
-
-### Step 5: Report
 
 ```markdown
 ## Issue Created
@@ -143,8 +110,7 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Refresh
 
 ## Notes
 
-- Always search for duplicates before creating
-- Keep titles concise (under 80 characters)
-- Body can be minimal for straightforward issues — don't over-document
-- The `[Tool]` prefix and labels must always match
-- For issues discovered during active development, mention the context (e.g., "Found during #1234")
+- Keep bodies proportional — a straightforward issue does not need documentation.
+- When something surfaces during other work, say so ("Found during #1234") and note what was
+  ruled out. A report that lists what is *not* the cause saves the next person the same dead
+  ends.

--- a/.claude/commands/dependabot.md
+++ b/.claude/commands/dependabot.md
@@ -24,7 +24,7 @@ If no PR numbers provided, discovers all open dependabot PRs.
 
 ## Workflow
 
-### Phase 0: Discovery
+### Phase 1: Discovery
 
 ```bash
 # Find all open dependabot PRs
@@ -42,7 +42,7 @@ Present findings as a table:
 
 **Group overlapping PRs**: If multiple PRs bump the same framework (e.g., Avalonia), note they should be applied together.
 
-### Phase 1: Analysis
+### Phase 2: Analysis
 
 For each PR, assess:
 
@@ -67,7 +67,7 @@ cat Directory.Packages.props | grep -i "[package-name]"
 
 If using `Directory.Packages.props` (Radoub does), all version changes go in ONE file.
 
-### Phase 2: Apply Updates
+### Phase 3: Apply Updates
 
 **Verify clean state**:
 ```bash
@@ -95,7 +95,7 @@ git add Directory.Packages.props
 git commit -m "[Radoub] chore: Initialize dependabot sprint branch for #[anchor]"
 ```
 
-### Phase 3: Build & Test
+### Phase 4: Build & Test
 
 **Restore packages**:
 ```bash
@@ -125,12 +125,12 @@ Record: passed, failed, skipped counts.
 
 | Result | Action |
 |--------|--------|
-| Build + tests pass | Continue to Phase 4 |
+| Build + tests pass | Continue to Phase 5 |
 | Build fails | Investigate, fix if possible, report if not |
 | New test failures | Compare with main branch baseline to confirm they're new |
 | Only pre-existing failures | Note in PR, continue |
 
-### Phase 4: Commit, PR & Report
+### Phase 5: Commit, PR & Report
 
 **Commit the version changes**:
 ```bash

--- a/.claude/commands/documentation.md
+++ b/.claude/commands/documentation.md
@@ -1,129 +1,89 @@
 # Documentation Updates
 
-Update wiki documentation after code changes. Handles user docs (requires review) and developer docs (Claude-authored).
-
-## Upfront Questions
-
-**IMPORTANT**: Gather ALL required user input at the start, then execute autonomously.
-
-Before analyzing or updating documentation, collect these answers in ONE interaction:
-
-1. **Scope**: "Which documentation to update?" [both/dev-only/user-only]
-2. **Commit Confirmation**: "Auto-commit and push developer docs when complete?" [y/n]
-3. **User Docs Location**: "Stage user docs in NonPublic folder for review?" [y/n]
-
-After collecting answers, proceed through all steps without further prompts unless errors occur.
+Update wiki documentation after code changes. Developer docs are Claude-authored and
+committed; user docs are staged for human review.
 
 ## Usage
 
 ```
-/documentation --dev-docs          # Developer documentation only
-/documentation --user-docs         # User documentation only (staged for review)
-/documentation                     # Both types
+/documentation [--dev-docs | --user-docs] [--dry-run] [--verbose]
 ```
 
-## Scope
+No flag does both. Ask once, up front: scope (both / dev-only / user-only), whether to
+auto-commit and push the developer docs, and whether to stage user docs in NonPublic. Then run
+without further prompts unless something errors.
 
-### User Documentation
-- Getting started guides
-- Feature explanations
-- Screenshots and tutorials
-- **Requires human review before publishing**
+Wiki repo: `d:/LOM/workspace/Radoub.wiki/`
 
-### Developer Documentation
-- Architecture diagrams (Mermaid)
-- Data flows
-- Code relationships
-- **Claude-authored, clinical and terse**
+| Doc type | Authored by | Published |
+|----------|-------------|-----------|
+| Developer — architecture, data flows, code relationships | Claude, clinical and terse | Committed after confirmation |
+| User — getting started, feature guides, tutorials | Drafted only | Staged for human review |
 
-## Triggers
+Check developer docs whenever tool code, `Radoub.Formats`, or `Radoub.UI` changes. Refactors
+especially — they move relationships the diagrams describe.
 
-Developer documentation updates should be checked when:
-- Parley code changes
-- Manifest code changes
-- Quartermaster code changes
-- Fence code changes
-- Relique code changes
-- Trebuchet code changes
-- Radoub.Formats changes
-- Radoub.UI changes
-- Refactors (change relationships/references)
+## Phase 1 — Identify
 
-## Workflow
-
-### Step 1: Identify Changed Areas
+### 1.1 Changed files
 
 ```bash
-# Get changed files from current branch vs main
-git diff main...HEAD --name-only
+# Triple-dot (main...HEAD) trips the sandbox path-traversal guard (#2468).
+git diff --name-only "$(git merge-base main HEAD)" HEAD
 ```
 
-Categorize by tool:
-- `Parley/**` → Parley wiki pages
-- `Manifest/**` → Manifest wiki pages
-- `Quartermaster/**` → Quartermaster wiki pages
-- `Radoub.Formats/**` → Radoub-Formats wiki pages
+### 1.2 Map to wiki pages
 
-### Step 2: Map Changes to Wiki Pages
-
-| Code Path | Wiki Page |
+| Code path | Wiki page |
 |-----------|-----------|
-| `Parley/Parley/Services/` | Parley-Developer-Architecture |
-| `Parley/Parley/ViewModels/` | Parley-Developer-Architecture |
+| `Parley/Parley/Services/`, `ViewModels/` | Parley-Developer-Architecture |
 | `Parley/Parley/Views/` | Parley-Developer-Architecture (UI section) |
-| `Manifest/Manifest/Services/` | Manifest-Developer-Architecture |
-| `Quartermaster/Quartermaster/` | Quartermaster-Developer-Architecture |
-| `Relique/Relique/` | Relique-Developer-Architecture |
-| `Radoub.Formats/Radoub.Formats/` | Radoub-Formats |
-| `Radoub.UI/` | Radoub-UI-Developer |
 | Copy/paste logic | Parley-Developer-CopyPaste |
 | Delete behavior | Parley-Developer-Delete-Behavior |
 | Scrap system | Parley-Developer-Scrap-System |
 | Test infrastructure | Parley-Developer-Testing |
+| `Manifest/Manifest/Services/` | Manifest-Developer-Architecture |
+| `Quartermaster/Quartermaster/` | Quartermaster-Developer-Architecture |
+| `Relique/Relique/` | Relique-Developer-Architecture |
+| `Reliquary/Reliquary/` | Reliquary-Developer-Architecture |
+| `Fence/Fence/` | Fence-Developer-Architecture |
+| `Trebuchet/Trebuchet/` | Trebuchet-Developer-Architecture |
+| `Radoub.Formats/` | Radoub-Formats plus the specific format page |
+| `Radoub.UI/` | Radoub-UI-Developer |
 
-### Step 3: Check Freshness Dates
-
-Wiki repo: `d:\LOM\workspace\Radoub.wiki\`
+### 1.3 Check freshness
 
 ```bash
-cd d:\LOM\workspace\Radoub.wiki
-# Check freshness dates at bottom of relevant pages
-grep -l "Page freshness:" *.md | xargs grep "Page freshness:"
+grep -r "Page freshness:" d:/LOM/workspace/Radoub.wiki/*.md
 ```
 
-**Staleness thresholds** (pages older than this with related code changes are STALE):
+A page is stale when it exceeds its threshold **and** related code changed:
 
 | Tool | Threshold |
 |------|-----------|
-| Parley | 60 days |
-| Manifest | 60 days |
-| Quartermaster | 30 days |
-| Fence | 30 days |
-| Relique | 30 days |
-| Trebuchet | 30 days |
-| Radoub.Formats | 30 days |
-| Radoub.UI | 30 days |
+| Parley, Manifest | 60 days |
+| Everything else | 30 days |
 
-Parley and Manifest use the longer window because their codebases are winding down and most changes affecting them are Radoub-wide refactors rather than tool-specific feature work.
+Parley and Manifest get the longer window because their codebases are winding down — most
+changes touching them are Radoub-wide refactors rather than tool work.
 
-### Step 4: Developer Docs Updates
+## Phase 2 — Update developer docs
 
-**Style requirements:**
-- Clinical, terse language
-- No marketing speak
-- Technical accuracy over readability
-- Data flows shown with Mermaid diagrams
-- Small relationships use arrows: `A → B → C`
+Read the page, find the sections the code changed, update the architecture description and
+any Mermaid diagram whose relationships moved, then set the freshness date to today. Stage
+without committing yet.
 
-**Mermaid diagram standards:**
+Correct anything the change made false. A page describing behavior that no longer exists is
+worse than an old date, because it reads as current.
+
+Style: clinical and terse, no marketing, technical accuracy over readability. Small
+relationships inline as `A → B → C`; larger ones as diagrams.
 
 ```mermaid
 flowchart LR
     A[Component] --> B[Service]
     B --> C[Model]
 ```
-
-For complex flows:
 
 ```mermaid
 sequenceDiagram
@@ -136,49 +96,30 @@ sequenceDiagram
     VM-->>UI: Update
 ```
 
-**Update process:**
+## Phase 3 — Draft user docs
 
-1. Read current wiki page
-2. Identify sections affected by code changes
-3. Update architecture descriptions
-4. Update/add Mermaid diagrams for changed data flows
-5. Update freshness date to today
-6. Stage changes (don't commit yet for dev docs)
+Identify user-facing changes from the CHANGELOG, list the pages needing updates, and draft
+them at `NonPublic/[Tool]/wiki-draft-[page-name].md`.
 
-### Step 5: User Docs Updates
+**Never edit user wiki pages directly.** Stage the draft and report it; the human reviews and
+publishes.
 
-**For `--user-docs` flag:**
+## Phase 4 — Commit and report
 
-1. Identify user-facing changes from CHANGELOG
-2. List wiki pages that need updates
-3. Draft updates in NonPublic folder: `[Tool]/NonPublic/wiki-draft-[page-name].md`
-4. Report drafts to user for review
-
-**Do NOT directly update user wiki pages. Stage for review.**
-
-### Step 6: Commit Developer Docs
+Only developer docs, only after confirmation. Use `git -C` rather than `cd` — a `cd` prefix
+is blocked by `.claude/hooks/check-cd-prefix.sh`.
 
 ```bash
-cd d:\LOM\workspace\Radoub.wiki
-git add .
-git status
-```
-
-**Note**: User already answered commit confirmation in upfront questions. If confirmed:
-```bash
-git commit -m "Update developer docs for PR #[number]
+git -C d:/LOM/workspace/Radoub.wiki add .
+git -C d:/LOM/workspace/Radoub.wiki commit -m "Update developer docs for PR #[number]
 
 Pages updated:
 - [page1]
 - [page2]
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
-git push
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+git -C d:/LOM/workspace/Radoub.wiki push
 ```
-
-### Step 7: Generate Summary
 
 ```markdown
 ## Documentation Update Summary
@@ -186,49 +127,28 @@ git push
 **PR**: #[number]
 **Date**: [today]
 
----
-
 ### Developer Documentation
-
 | Page | Status | Changes |
 |------|--------|---------|
 | [Page-Name] | ✅ Updated | [brief description] |
 | [Page-Name] | ⏭️ No changes needed | - |
 
-**Freshness dates updated**: [list pages]
-
 ### User Documentation
-
-| Page | Status | Draft Location |
-|------|--------|----------------|
-| [Page-Name] | 📝 Draft ready | [Tool]/NonPublic/wiki-draft-[name].md |
-| [Page-Name] | ⏭️ No changes needed | - |
-
-**Note**: User docs require review before publishing.
-
----
-
-### Files Updated
-
-Wiki pages:
-- `d:\LOM\workspace\Radoub.wiki\[Page-Name].md`
-
-Draft files (if any):
-- `[Tool]/NonPublic/wiki-draft-[name].md`
+| Page | Status | Draft |
+|------|--------|-------|
+| [Page-Name] | 📝 Ready for review | NonPublic/[Tool]/wiki-draft-[name].md |
 ```
 
-## Page Templates
+## New developer page template
 
-### New Developer Architecture Page
-
-```markdown
+````markdown
 # [Tool]-Developer-Architecture
 
 Technical architecture for [Tool].
 
 ## Overview
 
-[1-2 sentences describing the tool's purpose]
+[1-2 sentences on the tool's purpose]
 
 ## Component Structure
 
@@ -236,15 +156,12 @@ Technical architecture for [Tool].
 flowchart TD
     subgraph Views
         V1[MainWindow]
-        V2[...]
     end
     subgraph ViewModels
         VM1[MainViewModel]
-        VM2[...]
     end
     subgraph Services
         S1[FileService]
-        S2[...]
     end
     V1 --> VM1
     VM1 --> S1
@@ -282,18 +199,4 @@ Dependencies: `ServiceA` → `ServiceB`
 ---
 
 *Page freshness: YYYY-MM-DD*
-```
-
-## Flags
-
-- `--dev-docs`: Developer documentation only (Claude-authored)
-- `--user-docs`: User documentation only (staged for review)
-- `--dry-run`: Show what would be updated without making changes
-- `--verbose`: Show detailed analysis
-
-## Notes
-
-- Always update freshness dates when modifying pages
-- Developer docs are pushed directly after user confirmation
-- User docs are staged in NonPublic for human review
-- Refactors especially need diagram updates (relationships change)
+````

--- a/.claude/commands/init-item.md
+++ b/.claude/commands/init-item.md
@@ -1,17 +1,6 @@
 # Initialize Work Item
 
-Start a new branch for any GitHub issue - automatically detects item type and applies appropriate workflow.
-
-## Upfront Questions
-
-**IMPORTANT**: Gather ALL required user input at the start, then execute autonomously.
-
-Before initializing, collect these answers in ONE interaction (after fetching issue details):
-
-1. **Tool Confirmation** (if ambiguous): "Which tool is this for? [parley/radoub/manifest/quartermaster/fence]"
-2. **Epic Handling** (if epic detected): "This is an epic. Options: [run-research/continue-anyway/cancel]"
-
-After collecting answers, proceed through all steps (branch, CHANGELOG, commit, PR, project board) without further prompts.
+Start a branch for a GitHub issue. Detects the item type and applies the matching workflow.
 
 ## Usage
 
@@ -19,82 +8,61 @@ After collecting answers, proceed through all steps (branch, CHANGELOG, commit, 
 /init-item #[issue-number]
 ```
 
-**Examples:**
-- `/init-item #37` (epic with multiple phases)
-- `/init-item #134` (bug fix)
-- `/init-item #200` (sprint with bundled work)
-- `/init-item #45` (feature request)
+The issue number is required. Works for epics, sprints, features, and fixes alike.
 
-## Workflow
+**Gather all input up front, then run autonomously.** After fetching the issue, ask in one
+interaction: which tool, if the labels are ambiguous; and for an epic, whether to research
+first, continue anyway, or cancel. Then proceed through branch, CHANGELOG, commit, PR, and
+board without further prompts.
 
-### Step 1: Validate Current State
+## Phase 1 — Prepare
+
+### 1.1 Validate and sync
 
 ```bash
 git status
 git fetch origin
-```
-
-- Ensure working directory is clean
-- If dirty, ask user to commit or stash changes first
-
-### Step 2: Sync with Main
-
-```bash
 git checkout main
 git pull origin main
 ```
 
-### Step 3: Fetch Issue Details and Check for Duplicates
+A dirty working directory stops the command — ask the user to commit or stash first.
 
-**Cache-first**: Refresh cache if stale, then read all data from cache. No direct `gh issue view` calls.
+### 1.2 Fetch the issue
+
+Cache-first. Never call `gh issue view` for reads.
 
 ```bash
-# Ensure cache is fresh (auto-refreshes if >1 hour old)
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Refresh-GitHubCache.ps1"
-
-# Get issue details from cache
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View issue -Number [number]
 ```
 
-**Extract from issue**:
-- **Title**: For branch name and PR title
-- **Labels**: To determine item type
-- **Body**: For additional context
-- **Milestone**: For version targeting
+Take the title (branch and PR name), labels (item type), body (context), and milestone.
 
-**Search for similar/duplicate issues**:
+### 1.3 Check for duplicates
 
-Extract key terms from the issue title (remove prefixes like `[Tool]`, `feat:`, `fix:`) and search the cache:
+Strip prefixes like `[Tool]`, `feat:`, `fix:` from the title and search the cache for the
+remaining key terms:
 
 ```bash
-# Search cache for issues with similar keywords
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View search -Query "keyword"
-
-# Filter by tool if needed
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View search -Query "keyword" -Tool parley
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View search -Query "keyword" [-Tool parley]
 ```
 
-**Patterns to detect**:
-- Same tool + same feature area (e.g., two "[Fence] Scripts" issues)
-- Same error/bug description
-- Overlapping file paths mentioned in body
-- Issues that were closed but reopened as new issues
+Look for the same tool plus the same feature area, a repeated error description, overlapping
+file paths, or an issue closed and refiled.
 
-**If similar issues found**, verify their live state before presenting. The cache only contains OPEN issues, but search matches on body text — so an open sprint issue may reference already-closed child issues.
-
-**Verify state of the current issue AND any referenced issue numbers** (e.g. numbers the target issue's body calls out as work items, dependencies, or parents):
+The cache holds only OPEN issues but searches body text, so a match may reference issues that
+have since closed. Verify the target issue and every number its body calls out:
 
 ```bash
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Test-IssueState.ps1" -Numbers "1902,1903,1905"
 ```
 
-Returns a JSON array with live `state` (OPEN/CLOSED) and `closedAt` for each number. Use this to:
+Returns live `state` and `closedAt` per number. Use it to fail fast when the target issue is
+already closed, to flag a sprint still listing closed children as open, and to tell the user
+when a "duplicate" is actually finished work.
 
-- Flag stale references in the target issue (e.g. a sprint still lists closed children as open)
-- Fail fast if the target issue itself is already CLOSED
-- Tell the user when a match is actually a closed/completed issue
-
-Then report to user:
+Report matches and ask whether to continue:
 
 ```markdown
 ### ⚠️ Potentially Related Issues Found
@@ -107,128 +75,82 @@ Then report to user:
 Continue anyway? [y/n]
 ```
 
-**If no similar issues**, proceed silently to Step 3b.
+No matches: proceed silently.
 
-### Step 3b: Check for Pre-Warmed Plan
-
-Search for an existing implementation plan matching the issue number:
+### 1.4 Check for a pre-warmed plan
 
 ```bash
-# Check for pre-warmed plan (created by /pre-warm)
 ls NonPublic/Plans/*-[number]-plan.md 2>/dev/null
 ```
 
-**If found**, announce to user:
+If one exists, tell the user it was prepared in an earlier session and should be reviewed
+before implementation. Otherwise continue silently.
 
-> **Pre-warmed plan found**: `[path]`
-> This plan was prepared in a previous session. Review it before starting implementation.
+## Phase 2 — Classify
 
-**If not found**, proceed silently to Step 4.
+### 2.1 Item type
 
-### Step 4: Determine Item Type and Branch Name
+First matching label wins:
 
-**Branch Naming**: Always use `[tool]/issue-[number]` format.
-- Simple, predictable, easy to track
-- Example: `parley/issue-708`, `radoub/issue-45`
-
-Detect type from labels (in priority order) for PR title and CHANGELOG:
-
-| Label Contains | Type |
+| Label contains | Type |
 |----------------|------|
 | `epic` | Epic |
 | `sprint` | Sprint |
 | `bug`, `fix` | Fix |
 | `refactor` | Refactor |
 | `enhancement`, `feature` | Feature |
-| (none of above) | Feature |
+| none of the above | Feature |
 
-Determine tool from:
-- Labels containing `parley`, `radoub`, or tool names
-- Title prefix like `[Parley]`
-- Default to `parley` if ambiguous (ask user to confirm)
+Labels may be capitalized or namespaced (`Epic`, `type:epic`) — match case-insensitively.
 
-### Step 5: Type-Specific Guidance
+### 2.2 Tool
 
-#### If Epic Detected
+From a tool label, a `[Tool]` title prefix, or the user when ambiguous.
 
-**STOP and inform user:**
+### 2.3 Type-specific handling
 
-> This is an **Epic** (#[number]: [title]).
->
-> Epics require planning before implementation:
->
-> 1. **Research first**: Run `/research #[number]` to investigate approaches
-> 2. **Sprint planning**: Break epic into sprint-sized chunks
-> 3. **Create sprint issues**: Each sprint should have its own issue
->
-> Would you like me to:
-> - [ ] Run `/research #[number]` now
-> - [ ] Continue with epic branch anyway (for simple epics)
-> - [ ] Cancel and plan first
+**Epic** — stop and offer three choices: run `/research #[number]` now, continue with an epic
+branch anyway (fine for simple epics), or cancel and plan first. Epics normally want research,
+sprint-sized chunks, and an issue per sprint before code.
 
-If user chooses to continue, proceed with epic branch naming.
+**Sprint** — one branch and one PR for the bundled work; the CHANGELOG groups every item under
+a single version.
 
-#### If Sprint Detected
+**Fix / Feature** — standard flow, PR titled `[Tool] Fix: [Title] (#N)` or
+`[Tool] Feat: [Title] (#N)`.
 
-Sprints assume **one PR/branch** for the bundled work:
-- Branch: `[tool]/sprint/[milestone-or-name]`
-- PR title: `[Tool] Sprint: [Title]`
-- CHANGELOG: Group all sprint items under single version
+## Phase 3 — Create
 
-#### If Fix Detected
+### 3.1 Branch
 
-Standard fix workflow:
-- Branch: `[tool]/fix/[short-name]`
-- PR title: `[Tool] Fix: [Title] (#[number])`
-
-#### If Feature Detected
-
-Standard feature workflow:
-- Branch: `[tool]/feat/[short-name]`
-- PR title: `[Tool] Feat: [Title] (#[number])`
-
-### Step 6: Create Branch
-
-Use the simple `[tool]/issue-[number]` format:
+Always `[tool]/issue-[number]` — simple and predictable:
 
 ```bash
-git checkout -b [tool]/issue-[number]
+git checkout -b parley/issue-708
 ```
 
-Example: `git checkout -b parley/issue-708`
+### 3.2 CHANGELOG
 
-### Step 7: Update CHANGELOG
+Edit the tool's CHANGELOG (shared-library work goes in the root one). Highlights only, no
+checklists. **Never `[Unreleased]`** — add a versioned section as the first entry after the
+header, dated today, since most PRs merge same-day.
 
-Edit the tool's CHANGELOG file (e.g., `Parley/CHANGELOG.md`). Highlights only — no detailed checklists.
-
-**Never use `[Unreleased]`** — all entries go directly into a versioned section. Add the new version section as the first entry after the header/separator:
-
-**For Sprint:**
 ```markdown
 ## [X.Y.Z-alpha] - YYYY-MM-DD
 **Branch**: `[branch-name]` | **PR**: #TBD
 
-### Sprint: [Sprint Title]
+### Sprint: [Title]
 
-- Item 1 from sprint
-- Item 2 from sprint
-
----
-```
-
-**For Epic/Feature/Fix:**
-```markdown
-## [X.Y.Z-alpha] - YYYY-MM-DD
-**Branch**: `[branch-name]` | **PR**: #TBD
-
-### [Type] [N]: [Title from GitHub]
+- Item 1
+- Item 2
 
 ---
 ```
 
-**Use today's date** (not TBD) - most PRs merge same day.
+For an epic, feature, or fix use `### [Type]: [Title from GitHub]` in place of the sprint
+heading and its bullet list.
 
-### Step 8: Initial Commit
+### 3.3 Commit and push
 
 ```bash
 git add [CHANGELOG file]
@@ -236,7 +158,9 @@ git commit -m "[tool] chore: Initialize [type] branch for #[number]"
 git push -u origin [branch-name]
 ```
 
-### Step 9: Create Draft PR
+### 3.4 Draft PR
+
+Always draft initially.
 
 ```bash
 gh pr create --draft --title "[Tool] [Type]: [Title]" --body "$(cat <<'EOF'
@@ -262,151 +186,23 @@ EOF
 )"
 ```
 
-### Step 10: Update CHANGELOG with PR Number
+### 3.5 Backfill the PR number
 
 ```bash
-# Update PR: #TBD to actual PR number in CHANGELOG
 git add [CHANGELOG file]
 git commit -m "[tool] chore: Add PR number to CHANGELOG"
 git push
 ```
 
-### Step 10b: Refresh Cache
+### 3.6 Project board (sprints and epics only)
 
-After all mutations (PR created, project board updated), refresh the cache so subsequent commands see fresh state:
-
-```bash
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Refresh-GitHubCache.ps1" -Force
-```
-
-### Step 11: Report Summary
-
-Output format varies by type:
-
-**For Epics:**
-```markdown
-## Epic Branch Initialized
-
-**Branch**: [branch-name]
-**PR**: #[pr-number] (draft)
-**Issue**: #[issue-number]
-
-### Reminder
-
-This is an epic. Consider breaking into sprints if not already done.
-Use `/research #[number]` for investigation tasks.
-
-### Next Steps
-1. Review epic scope and create sprint issues if needed
-2. Implement phase by phase
-3. Run `/pre-merge` before each merge
-```
-
-**For Sprints:**
-```markdown
-## Sprint Branch Initialized
-
-**Branch**: [branch-name]
-**PR**: #[pr-number] (draft)
-**Issue**: #[issue-number]
-
-### Sprint Scope
-
-This branch covers all items in the sprint. Update CHANGELOG as you complete each item.
-
-### ⚠️ AI Workflow: Commit Between Items
-
-**Note**: This guidance is for AI assistants (Claude), not humans. Humans may batch commits as they prefer.
-
-**AI should commit and push after completing each discrete sprint item.** This provides:
-- Clear git history for each change
-- Easy rollback if issues arise
-- Simpler code review
-- Protection against losing work if session ends
-
-Example workflow:
-\`\`\`bash
-# After completing item 1
-git add -A && git commit -m "[Tool] feat: Item 1 description (#sprint-issue)"
-git push
-
-# After completing item 2
-git add -A && git commit -m "[Tool] feat: Item 2 description (#sprint-issue)"
-git push
-\`\`\`
-
-### Next Steps
-1. For each item: check TDD table — write tests first if required
-2. Begin work immediately (any order) unless user specifies otherwise
-3. Update CHANGELOG entries as completed
-4. Run `/pre-merge` when sprint complete
-```
-
-**For Features/Fixes:**
-```markdown
-## [Type] Branch Initialized
-
-**Branch**: [branch-name]
-**PR**: #[pr-number] (draft)
-**Issue**: #[issue-number]
-
-### Next Steps
-1. Check TDD table — write tests first if required
-2. Implement the [type]
-3. Run `/pre-merge` to verify all checks pass
-4. Mark PR ready for review
-```
-
-## Error Handling
-
-- **Issue not found**: Error and exit - issue number is required
-- **Dirty working directory**: Prompt user to commit/stash first
-- **Branch already exists**: Ask if user wants to checkout existing or create new
-- **Can't determine tool**: Ask user to specify (parley/radoub)
-- **PR creation fails**: Provide manual command to run
-
-## Label Detection Examples
-
-Labels are extracted from the cache data (no API call needed). Common label patterns:
-- `epic`, `Epic`, `type:epic` → Epic
-- `sprint`, `Sprint`, `type:sprint` → Sprint
-- `bug`, `Bug`, `type:bug` → Fix
-- `enhancement`, `feature`, `type:feature` → Feature
-- `parley`, `Parley`, `tool:parley` → Tool detection
-- `radoub`, `Radoub`, `tool:radoub` → Tool detection
-
-## GitHub Project Integration
-
-**Only add Sprints and Epics to projects** - individual features/fixes don't go on project boards unless explicitly requested.
-
-### When to Add to Project
-
-| Item Type | Add to Project? |
-|-----------|-----------------|
-| Epic | ✅ Yes |
-| Sprint | ✅ Yes |
-| Feature | ❌ No (unless solo work requested) |
-| Fix | ❌ No (unless solo work requested) |
-
-### Project Selection (for Sprints/Epics only)
-
-All tools use the **Radoub project (#3)**.
-
-### Add Sprint/Epic to Project and Set In Progress
-
-After Step 9 (Create Draft PR), **only for sprints and epics**:
+Features and fixes do not go on the board unless the user asks. Everything uses Radoub
+project #3.
 
 ```bash
-# Add to Radoub project (returns item ID)
 ITEM_JSON=$(gh project item-add 3 --owner LordOfMyatar --url https://github.com/LordOfMyatar/Radoub/issues/[number] --format json)
+ITEM_ID=$(echo "$ITEM_JSON" | gh api --jq '.id' 2>/dev/null || echo "$ITEM_JSON" | powershell.exe -NoProfile -Command '$input | ConvertFrom-Json | Select-Object -ExpandProperty id')
 
-# Parse item ID (no jq on this system - use grep/sed or parse from gh output)
-# The gh output includes "id" field. Extract with:
-ITEM_ID=$(echo "$ITEM_JSON" | powershell.exe -NoProfile -Command '$input | ConvertFrom-Json | Select-Object -ExpandProperty id')
-# Or parse directly from JSON output (id is always returned):
-# ITEM_ID=$(echo "$ITEM_JSON" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
-
-# Set status to "In Progress"
 gh project item-edit \
   --id "$ITEM_ID" \
   --project-id PVT_kwHOAotjYs4BHbMq \
@@ -414,11 +210,19 @@ gh project item-edit \
   --single-select-option-id 47fc9ee4
 ```
 
-> **Note**: `jq` is not available in this environment. Use PowerShell `ConvertFrom-Json`, `grep`/`sed`, or `gh`'s `--jq` flag for JSON parsing.
+Needs the `project` scope — `gh auth status` to check, `gh auth refresh -s project` to add.
+Project IDs and field details live in `.claude/github-projects-reference.md`.
 
-### Updated Summary Output
+**Parsing JSON**: use `gh --jq` or PowerShell `ConvertFrom-Json`. There is no `jq` on this
+box, and `grep`/`sed`/`cut` pipelines over JSON break on the first quoted comma.
 
-For **Sprints/Epics**, include project status:
+### 3.7 Refresh the cache
+
+```bash
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Refresh-GitHubCache.ps1" -Force
+```
+
+## Phase 4 — Report
 
 ```markdown
 ## [Type] Branch Initialized
@@ -426,48 +230,41 @@ For **Sprints/Epics**, include project status:
 **Branch**: [branch-name]
 **PR**: #[pr-number] (draft)
 **Issue**: #[issue-number]
-**Project**: [Project Name] - Status: In Progress
+**Project**: Radoub - In Progress          <!-- sprints and epics only -->
 
 ### Next Steps
-...
+1. Check the TDD Policy table — tests first where required
+2. [type-specific line, see below]
+3. Run `/pre-merge` when done
 ```
 
-For **Features/Fixes**, omit project line (not added to board).
+Step 2 varies: an **epic** reviews scope and files sprint issues, then implements phase by
+phase; a **sprint** starts any item immediately unless the user sequences them, updating
+CHANGELOG entries as each lands; a **fix or feature** just implements.
 
-### Prerequisites
+## Working a sprint (AI)
 
-Ensure `project` scope is available:
-```bash
-gh auth status  # Check for 'project' scope
-gh auth refresh -s project  # Add if missing
-```
+This is guidance for Claude, not the human — humans may batch commits however they like.
 
-See `.claude/github-projects-reference.md` for project IDs and field details.
+**Commit and push after each discrete item, then start the next one without asking.** Every
+commit stays reviewable, rollback stays cheap, and an interrupted session loses nothing.
+
+Run the full test suite once at the end during `/pre-merge`, not per item. Targeted tests for
+the item in hand are still expected. Prompt before FlaUI — it takes over the machine.
+
+## Error handling
+
+| Situation | Response |
+|-----------|----------|
+| Issue not found | Error and exit; the issue number is required |
+| Dirty working directory | Ask the user to commit or stash |
+| Branch already exists | Ask whether to check it out or create a new one |
+| Tool ambiguous | Ask the user |
+| PR creation fails | Print the manual command |
 
 ## Notes
 
-- Always use draft PRs initially
-- CHANGELOG version should increment appropriately (check last version)
-- For epics, encourage planning before diving into implementation
-- For sprints, all work goes in one PR but **commit and push after each item**
-- Issue number is required - this command won't work without it
-- **TDD is mandatory** — check the TDD Policy table in CLAUDE.md before writing implementation code. Tests first for features, services, parsers, and reproducible bugs.
-
-## Sprint Workflow Discipline (AI)
-
-**Note**: This guidance is for AI assistants (Claude), not humans.
-
-**AI should** commit and push after completing each discrete item:
-
-1. Complete item → commit → push
-2. Complete next item → commit → push
-3. Repeat until sprint complete
-
-This prevents:
-- Large, tangled commits that are hard to review
-- Losing work if session ends unexpectedly
-- Difficult rollbacks when issues are discovered
-- Confusion about what changed when
-
-**AI should** begin work immediately in any order unless the user specifies a particular sequence.
-
+- **TDD is mandatory** — check the TDD Policy table in CLAUDE.md before writing implementation
+  code. Tests first for features, services, parsers, and reproducible bugs.
+- CHANGELOG versions increment from the previous entry; check the last one.
+- Launch `.ps1` from the Bash tool — PowerShell-tool permission rules never match on Windows.

--- a/.claude/commands/post-merge.md
+++ b/.claude/commands/post-merge.md
@@ -1,195 +1,166 @@
 # Post-Merge Cleanup
 
-Perform cleanup tasks after a PR has been merged to main.
-
-## Defaults & Flags
-
-| Action | Default | Flag to Override |
-|--------|---------|------------------|
-| Branch cleanup | **Yes** — delete local feature branch | `--noclean` to keep it |
-| Release | **No** — skip release creation | `--release` to create one |
-
-No upfront questions needed — just run and go. Flags override defaults.
+Clean up after a PR merges to main.
 
 ## Usage
 
 ```
-/post-merge
-/post-merge #[pr-number]
-/post-merge --noclean          # keep the local branch
-/post-merge --release          # create a GitHub release
-/post-merge #123 --release     # specific PR + release
+/post-merge [#pr-number] [--noclean] [--release]
 ```
 
-If no PR number provided, uses the most recently merged PR.
+Without a PR number, uses the most recently merged PR.
 
-## Workflow
+| Action | Default | Override |
+|--------|---------|----------|
+| Delete the local feature branch | Yes | `--noclean` keeps it |
+| Create a release | No | `--release` runs `/release` |
 
-### Step 1: Identify Merged PR
+No upfront questions — run and go.
+
+## Phase 1 — Sync
+
+### 1.1 Confirm the merge
 
 ```bash
-# Get current branch (should be main after merge)
 git branch --show-current
-
-# Find most recent merge or if PR number provided
-gh pr view [number] --json mergedAt,mergeCommit,number,title,body
+gh pr view [number] --json mergedAt,mergeCommit,number,title,body,headRefName
 ```
 
-Verify the PR was actually merged (not closed without merge).
+Verify it actually merged rather than being closed unmerged. Everything downstream depends on
+this.
 
-### Step 2: Update Local Repository
+### 1.2 Update main and delete the branch
 
 ```bash
 git checkout main
 git pull origin main
+git branch -d [branch-name]      # skip when --noclean
 ```
 
-### Step 3: Clean Up Local Feature Branch
+`git branch -d` refuses to delete unmerged work, which is the safety net — if it objects,
+investigate before forcing.
 
-**Default: Yes** (skip if `--noclean` flag provided)
+## Phase 2 — Close out issues
 
-```bash
-git branch -d [branch-name]
-```
+### 2.1 Close what the PR resolved
 
-### Step 4: Close Related Issues
+Pull the linked issues from the PR body:
 
-**Extract issues from PR body**:
 ```bash
 gh pr view [number] --json body -q '.body' | grep -oEi "(closes|fixes|resolves) #[0-9]+" | grep -oE "[0-9]+"
 ```
 
-**For each issue, check and close if still open**:
+GitHub auto-closes linked issues on merge, so check live state before acting — closing an
+already-closed issue is noise:
+
 ```bash
-gh issue view [issue-number] --json state -q '.state'
-# If OPEN:
-gh issue close [issue-number] --comment "Completed in PR #[pr-number]"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Test-IssueState.ps1" -Numbers "N,N,N"
 ```
 
-### Step 4b: Remove Pre-Warmed Plans for Closed Issues
+Close any that are still OPEN with `gh issue close [N] --comment "Completed in PR #[pr]"`.
 
-Pre-warm plans (`NonPublic/Plans/*-[number]-plan.md`) are throwaway planning artifacts. Once the issue they planned is merged + closed, delete them so stale plans don't accumulate and get picked up by a future `/pre-warm` or `/init-item`.
+**Comment when the closure needs explanation** — an issue closed without code (already
+delivered elsewhere), or one where only part of the scope shipped. A bare auto-close implies
+work happened; say so when it did not.
 
-For each issue number closed in Step 4:
+### 2.2 Remove pre-warm plans
 
 ```bash
 rm -f NonPublic/Plans/*-[number]-plan.md
 ```
 
-Report which plan files were removed (if any). Plans live in `NonPublic/` and are not tracked in git, so no commit is needed.
+Throwaway artifacts. Deleting them stops a future `/pre-warm` or `/init-item` picking up a
+stale plan. Gitignored, so nothing to commit. Report what was removed.
 
-### Step 5: Update Parent Epic (if applicable)
+### 2.3 Update the parent epic
 
-**Extract epic from PR body**:
 ```bash
 gh pr view [number] --json body -q '.body' | grep -oEi "epic[^#]*#[0-9]+" | grep -oE "[0-9]+" | head -1
 ```
 
-If found, add completion comment:
+Check the epic is still open before commenting — a reference may be historical context rather
+than this sprint's parent. When it is the parent:
+
 ```bash
-gh issue comment [epic-number] --body "Sprint completed via PR #[pr-number]: [PR title]"
+gh issue comment [epic] --body "Sprint completed via PR #[pr]: [title]"
 ```
 
-### Step 6: Update Developer Documentation
+## Phase 3 — Documentation (MANDATORY)
 
-**MANDATORY** — do not skip this step.
+Wiki repo: `d:/LOM/workspace/Radoub.wiki/`. Never skip this phase.
 
-**Wiki repo**: `d:\LOM\workspace\Radoub.wiki\`
+### 3.1 Map changes to pages
 
-#### 6a: Map CHANGELOG to Wiki Pages
+Read this PR's CHANGELOG entries and map them:
 
-Read the CHANGELOG entries for this PR/sprint. Map changes to wiki pages:
-
-| CHANGELOG / Code Area | Wiki Page |
-|---|---|
+| Code area | Wiki page |
+|-----------|-----------|
 | Parley services/viewmodels | Parley-Developer-Architecture |
 | Parley copy/paste | Parley-Developer-CopyPaste |
 | Parley delete behavior | Parley-Developer-Delete-Behavior |
 | Parley scrap system | Parley-Developer-Scrap-System |
 | Parley tests | Parley-Developer-Testing |
-| Manifest services | Manifest-Developer-Architecture |
+| Manifest | Manifest-Developer-Architecture |
 | Quartermaster | Quartermaster-Developer-Architecture |
 | Fence | Fence-Developer-Architecture |
 | Trebuchet | Trebuchet-Developer-Architecture |
 | Relique | Relique-Developer-Architecture |
-| Radoub.Formats | Radoub-Formats (+ specific format pages) |
+| Radoub.Formats | Radoub-Formats plus the specific format page |
 | Radoub.UI | Radoub-UI-Developer |
 
-If a mapped wiki page does not exist yet, create it from the developer architecture template in the wiki's CLAUDE.md.
+Missing page: create it from the template in the wiki's CLAUDE.md.
 
-#### 6b: Update Mapped Dev Doc Pages
+### 3.2 Update them
 
-For each mapped page:
-1. Read the current wiki page
-2. Update architecture/data flow sections to reflect code changes from this sprint
-3. Update Mermaid diagrams if component relationships changed
-4. Set `*Page freshness: YYYY-MM-DD*` to today's date
+For each mapped page, update the architecture and data-flow sections to match the new code,
+refresh Mermaid diagrams when relationships changed, and set `*Page freshness: YYYY-MM-DD*`
+to today.
 
-**Style**: Clinical, terse. No marketing speak. Technical accuracy over readability.
+Watch for claims the sprint made false — a page describing behavior this PR changed is worse
+than a stale date, because it reads as current.
 
-#### 6c: 30-Day Freshness Sweep
+Style: clinical and terse. Technical accuracy over readability.
 
-Check ALL wiki pages with freshness dates:
+### 3.3 30-day freshness sweep
+
+Always run it. Never skip because some tickets already exist — check every stale page
+individually, since some are tracked and others are not.
 
 ```bash
 grep -r "Page freshness:" d:/LOM/workspace/Radoub.wiki/*.md
 ```
 
-**Dev doc pages** (`*-Developer-*`) older than 30 days:
-- Review content against current source code
-- Update content if stale, update freshness date to today
+**Developer pages** (`*-Developer-*`) over 30 days: review against current source, update the
+content, then re-date. Do not bump the date without reading the page — that defeats the rule.
 
-**User doc pages** (non-developer pages) older than 30 days:
+**User pages** over 30 days: search for an existing tracking issue first.
 
-For **each** stale user doc page, follow this procedure:
+```bash
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View search -Query "stale wiki page"
+```
 
-1. **Search cache for existing issue** before creating:
-   ```bash
-   powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View search -Query "Review stale wiki page: {Page-Name}"
-   ```
+An umbrella backlog issue may already cover the whole set — add a sweep comment to it rather
+than filing per-page duplicates. If nothing tracks a page, file
+`[Docs] Review stale wiki page: {Page-Name}` labeled `docs` plus the tool.
 
-2. **If an open issue exists**: Report as already tracked — do NOT create a duplicate
-   ```
-   ⏭️ {Page-Name} (stale {N} days) — already tracked in #{existing-number}
-   ```
+```
+⏭️ {Page-Name} (stale {N} days) — already tracked in #{N}
+✅ {Page-Name} (stale {N} days) — NEW issue created: #{N}
+```
 
-3. **If no open issue exists**: Create a new tracking issue
-   - **Title**: `[Docs] Review stale wiki page: {Page-Name}`
-   - **Labels**: `docs` + tool label (e.g., `parley`)
-   - **Body**: Page name, current freshness date, days since last update
-   ```
-   ✅ {Page-Name} (stale {N} days) — NEW issue created: #{new-number}
-   ```
+Wiki changes stay **local**. Do not push.
 
-**IMPORTANT**: Always run the sweep. Never skip it because "we already have some freshness tickets." The sweep must check **every** stale page individually — some may be tracked while others are not.
+### 3.4 Refresh the cache
 
-#### 6d: No Push Required
-
-Changes stay local in the wiki repo. Do not push.
-
-### Step 6e: Refresh Cache
-
-After all mutations (issues closed, epic commented, stale doc issues created), refresh the cache:
+After every mutation — issues closed, epic commented, doc issues filed:
 
 ```bash
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Refresh-GitHubCache.ps1" -Force
 ```
 
-### Step 7: Create Release (if `--release` flag provided)
+## Phase 4 — Report
 
-**Default: No** (skip unless `--release` flag provided)
-
-Invoke:
-```
-/release
-```
-
-The `/release` command handles:
-- Extracting CHANGELOG section for release notes
-- Creating GitHub release with proper tagging
-- Generating release assets if configured
-
-### Step 8: Generate Summary
+Run `/release` first if `--release` was passed.
 
 ```markdown
 ## Post-Merge Summary
@@ -198,31 +169,25 @@ The `/release` command handles:
 **Merged**: [date]
 **Version**: [version from CHANGELOG]
 
----
-
-### Cleanup Completed
-
 | Task | Status |
 |------|--------|
-| Local branch | ✅ Deleted (default) / ⏭️ Kept (--noclean) |
+| Local branch | ✅ Deleted / ⏭️ Kept (--noclean) |
 | Issues closed | ✅ #x, #y / N/A |
 | Pre-warm plans | ✅ Removed [files] / ⏭️ None |
 | Epic updated | ✅ #z / N/A |
-| Dev docs updated | ✅ [list pages] / ⏭️ No mapped pages |
+| Dev docs updated | ✅ [pages] / ⏭️ No mapped pages |
 | Stale user docs | ✅ Issues cut: #a, #b / ⏭️ None stale |
-| Release | ✅ Created vX.Y.Z (--release) / ⏭️ Skipped (default) |
-
----
+| Release | ✅ vX.Y.Z / ⏭️ Skipped |
 
 ### Next Steps
 
-1. [Suggested next issues to work on]
-2. [If the completed work revealed unexpected complexity, suggest: "Consider `/research --spike [topic]` before starting [related work]"]
+1. [Suggested next issues]
+2. [If the work revealed unexpected complexity, suggest `/research --spike [topic]`]
 ```
 
 ## Notes
 
-- Run this after confirming PR was merged successfully
-- Safe to run multiple times (idempotent operations)
-- Branch deletion is local only
-- No validation/tests - that was done in pre-merge
+- Safe to re-run; the operations are idempotent.
+- Branch deletion is local only — the remote branch is GitHub's to clean up.
+- No tests here; `/pre-merge` already validated.
+- Parsing JSON: use `gh --jq` or PowerShell `ConvertFrom-Json`. There is no `jq` on this box.

--- a/.claude/commands/pre-merge.md
+++ b/.claude/commands/pre-merge.md
@@ -8,283 +8,226 @@ Validate the current PR is ready to merge. Runs tests, checks code quality, veri
 /pre-merge [--skip-tests] [--ui-tests] [--full-tests] [--no-auto-ui]
 ```
 
-**Flags**:
-- `--skip-tests` - Skip test execution (validation only)
-- `--ui-tests` - Force include UI integration tests
-- `--full-tests` - Run all tests regardless of what changed
-- `--no-auto-ui` - Disable auto-detection of UI changes (use unit tests only)
+| Flag | Effect |
+|------|--------|
+| `--skip-tests` | Validation only, no test execution |
+| `--ui-tests` | Force UI integration tests |
+| `--full-tests` | Run everything regardless of what changed |
+| `--no-auto-ui` | Disable UI-change auto-detection (unit tests only) |
 
-## Workflow
+## Phase 1 — Gates
 
-### Step 0: Check for Uncommitted Changes
+Three checks that stop or warn before any work happens.
+
+### 1.1 Uncommitted changes
 
 ```bash
 git status --porcelain
 ```
 
-**If output is not empty**:
-- ⚠️ STOP and warn: "Uncommitted changes detected. Commit or stash before running pre-merge."
-- List the uncommitted files
-- Do not proceed with checklist
+Non-empty output: STOP. List the files and warn "Commit or stash before running pre-merge."
+Validating a PR against a dirty tree tests something the PR does not contain.
 
-This prevents running pre-merge with local changes that aren't reflected in the PR.
-
-### Step 0b: Check for Unpushed Commits
+### 1.2 Unpushed commits
 
 ```bash
-# Range syntax (origin/<branch>..HEAD) trips the Bash sandbox path-traversal guard (#2468).
-# Use cherry, which takes two refs as separate args and emits one line per unpushed commit (prefixed '+').
+# Range syntax (origin/<branch>..HEAD) trips the sandbox path-traversal guard (#2468).
+# git cherry takes two refs as separate args, one line per unpushed commit, prefixed '+'.
 git cherry -v "origin/$(git branch --show-current)" HEAD
 ```
 
-**If output is not empty**:
-- ⚠️ STOP and warn: "Unpushed commits detected. Push before running pre-merge."
-- List the unpushed commits
-- Do not proceed with checklist
+Non-empty output: STOP. List the commits and warn "Push before running pre-merge."
 
-This prevents validating a PR that doesn't contain all local commits.
+### 1.3 Was init-item skipped? (warn, never block)
 
-### Step 0c: Verify init-item Was Not Skipped (mandatory gate)
+`/init-item` starts work properly: sync main, branch by convention, seed the CHANGELOG,
+open a draft PR linking the issue, add sprints and epics to the board. Spec-first sessions
+and hand-rolled branches skip it. Catch that here.
 
-`/init-item` is the mandatory start-of-work step (sync main → convention branch → seed CHANGELOG → draft PR linking the issue → board for sprints/epics). Work sometimes starts without it (spec/plan-first sessions, hand-rolled branches). This gate catches a skipped init-item before merge. **Warn loudly; do not hard-block.**
-
-Check two signals:
-
-1. **Branch naming convention** — the branch should match `[tool]/issue-[N]`, `[tool]/feat/[name]`, `[tool]/fix/[name]`, or `[tool]/sprint/[name]`:
-   ```bash
-   git branch --show-current
-   ```
-
-2. **Linked issue** — the PR body should reference an issue (`Closes #N`, `Fixes #N`, `Relates to #N`, or an issue URL). Read the PR body (cache, or `gh pr view --json body -q '.body'`) and the branch name for any `#N` / `issue-N`.
-
-**Decision:**
+Check the branch name against `[tool]/issue-[N]`, `[tool]/feat/[name]`, `[tool]/fix/[name]`,
+or `[tool]/sprint/[name]`, and check the PR body for a linked issue (`Closes #N`, `Fixes #N`,
+`Relates to #N`, or an issue URL).
 
 | Finding | Action |
 |---------|--------|
-| Branch follows convention AND PR links an issue | ✅ init-item satisfied — proceed silently. |
-| PR links an issue but branch name is off-convention | ⚠️ Warn (cosmetic — branch already exists, don't rename). Note in checklist, proceed. |
-| **No issue linked anywhere** (PR body + branch) | ⚠️ **Warn loudly: "init-item was skipped — no linked issue."** Then **create a tracking issue unless the user says this work is intentionally issueless.** Search the cache first to avoid duplicates (per the existing issue-dedup habit); if none exists, `gh issue create` with the right `[Tool]` + type labels, then add `Closes #N` to the PR body and backfill the CHANGELOG PR/issue reference. Only skip issue creation if the user explicitly says "no issue needed." |
-| Sprint/Epic PR not on the project board | ⚠️ Warn and offer to add it (init-item does this for sprints/epics only). |
+| Branch follows convention, PR links an issue | Proceed silently |
+| Issue linked, branch off-convention | Warn; do not rename an existing branch. Note it and proceed |
+| No issue anywhere | Warn loudly, then create a tracking issue — search the cache first for duplicates, `gh issue create` with `[Tool]` and type labels, add `Closes #N` to the PR body, backfill the CHANGELOG reference. Skip only if the user says the work is intentionally issueless |
+| Sprint or epic PR missing from the board | Warn and offer to add it |
 
-Report in the Step 6 checklist under a new **init-item** row (see Step 6).
+Report on the **init-item** row in the Phase 5 checklist. Phase 5.2 refreshes the cache after
+any mutation here.
 
-After any mutation here (issue created, PR body edited), the Step 7b cache refresh covers it.
+## Phase 2 — Analyze
 
-### Step 1: Get PR Info (from cache)
+### 2.1 PR info (cache-first)
 
-**Cache-first**: Refresh cache once here, then read from cache for all subsequent steps (tech debt dedup, stale unreleased check, etc.). Do NOT call the refresh script again during reads — only Step 7b refreshes again if mutations occurred.
+Refresh the cache **once**, here. Every later step reads from it; only Phase 5.2 refreshes
+again, and only after mutations.
 
 ```bash
-# Ensure cache is fresh (ONE call for the entire pre-merge run)
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Refresh-GitHubCache.ps1"
 ```
 
-Match the current branch name against cached PRs to find the PR for this branch. The cache includes: number, title, isDraft, headRefName, reviewDecision.
+Match the branch name against cached PRs. The cache holds number, title, isDraft,
+headRefName, reviewDecision. For the PR body (needed for release notes):
 
-For PR body (needed for release notes), use:
 ```bash
-# Only if PR body is needed and not in cache
 gh pr view --json body -q '.body'
 ```
 
-If no PR exists, warn and stop.
+No PR: warn and stop.
 
-### Step 2: Analyze Changes
+### 2.2 Changed files and test scope
 
 ```bash
-# Triple-dot range (main...HEAD) trips the Bash sandbox path-traversal guard (#2468).
-# Equivalent: diff from the merge-base, computed as a separate two-arg diff.
+# Triple-dot (main...HEAD) trips the path-traversal guard (#2468); diff from the merge-base.
 git diff --name-only "$(git merge-base main HEAD)" HEAD
 ```
 
-**Determine tool and test scope**:
-
-| Changed Path | Tool | Include Shared |
+| Changed path | Tool | Include shared |
 |--------------|------|----------------|
-| `Parley/**` only | Parley | No |
-| `Manifest/**` only | Manifest | No |
-| `Quartermaster/**` only | Quartermaster | No |
-| `Fence/**` only | Fence | No |
-| `Trebuchet/**` only | Trebuchet | No |
+| One tool's directory only | That tool | No |
 | `Radoub.*/**` | All affected | Yes |
 | Multiple tools | All affected | Yes |
 
-**Auto-detect UI changes and target FlaUI tests** (unless `--no-auto-ui`):
+### 2.3 UI-change detection
 
-Check if ANY changed files match UI patterns:
+Unless `--no-auto-ui`, check whether any changed file is UI:
+
 ```bash
-# See #2468: avoid triple-dot range syntax; diff from the merge-base instead.
 git diff --name-only "$(git merge-base main HEAD)" HEAD | grep -E '\.(axaml|axaml\.cs)$|/Views/|/Controls/|/Dialogs/'
 ```
 
-**UI test auto-trigger rules**:
+Any match in `*.axaml`, `*.axaml.cs`, `Views/`, `Controls/`, `Dialogs/`, or `Windows/`
+auto-includes UI tests. Other `.cs` files do not.
 
-| Pattern Match | Auto-include UI Tests |
-|---------------|----------------------|
-| `*.axaml` | Yes |
-| `*.axaml.cs` | Yes |
-| `*/Views/*` | Yes |
-| `*/Controls/*` | Yes |
-| `*/Dialogs/*` | Yes |
-| `*/Windows/*` | Yes |
-| Other `.cs` files | No (unit tests only) |
+Map changed files to a targeted filter so FlaUI runs stay fast:
 
-**Targeted FlaUI test mapping**:
+| Changed file | UIFilter | Why |
+|--------------|----------|-----|
+| `LaunchTestPanel*` | `LaunchTab` | Launch & Test tab only |
+| `ModuleEditorPanel*` | `Category=Workspace` | Module tab workspace |
+| `FactionEditorPanel*` | `Category=Workspace` | Faction tab workspace |
+| `MainWindow.axaml*` | `Category=Smoke` | Top-level layout |
+| `*Toolbar*` | `Toolbar` | Toolbar tests |
+| `*Sidebar*` | `Sidebar` | Sidebar tests |
+| Multiple UI areas | none — run all tool UI tests | Broad change needs full coverage |
+| New dialog or view | skip FlaUI, flag for manual check | No tests exist yet |
 
-When UI changes are detected, map changed files to specific FlaUI test categories or methods instead of running all UI tests. This keeps FlaUI runs fast and focused.
+Plain keywords expand to `FullyQualifiedName~<keyword>`. For traits write `Category=Smoke` or
+`DisplayName~pattern` explicitly. `Name~` does not work with the xUnit VSTest adapter.
 
-| Changed File Pattern | UIFilter | Rationale |
-|---------------------|----------|-----------|
-| `LaunchTestPanel*` | `LaunchTab` | Only tests that interact with the Launch & Test tab |
-| `ModuleEditorPanel*` | `Category=Workspace` | Module tab workspace tests |
-| `FactionEditorPanel*` | `Category=Workspace` | Faction tab workspace tests |
-| `MainWindow.axaml*` | `Category=Smoke` | Smoke tests verify top-level layout |
-| `*Toolbar*` | `Toolbar` | Toolbar-specific tests |
-| `*Sidebar*` | `Sidebar` | Sidebar-specific tests |
-| Multiple UI areas | (no filter — run all tool UI tests) | Broad changes need full coverage |
-| New dialog/view only | (skip FlaUI — no tests exist yet) | Flag for manual verification |
+Precedence: `--ui-tests` → all UI tests, no filter. `--no-auto-ui` → never auto-include.
+`--full-tests` → everything, no filter. Otherwise auto-detect, else unit only.
 
-**UIFilter syntax**: Plain keywords (e.g., `LaunchTab`) auto-expand to `FullyQualifiedName~LaunchTab`. For trait-based filters, use `Category=Smoke` or `DisplayName~pattern` explicitly. `Name~` does NOT work with xUnit VSTest adapter.
+When UI tests are auto-included, report:
 
-**Decision logic**:
-1. If `--ui-tests` flag → always include UI tests (all tool tests, no filter)
-2. If `--no-auto-ui` flag → never auto-include UI tests
-3. If `--full-tests` flag → run everything (no filter)
-4. If UI patterns detected → auto-include targeted UI tests with `-UIFilter`
-5. Otherwise → unit tests only
-
-**Report auto-detection**:
-If UI tests are auto-included, display:
 ```
 ℹ️ UI changes detected - including targeted integration tests
-   Changed UI files: [list first 5 files, then "+ N more" if applicable]
-   UIFilter: [filter expression or "all" if no targeting]
+   Changed UI files: [first 5, then "+ N more"]
+   UIFilter: [expression or "all"]
 ```
 
-### Step 3: Build & Test (single script call)
+## Phase 3 — Build, test, review
 
-**IMPORTANT**: Use full absolute path to run-tests.ps1 since relative paths fail in PowerShell from Bash.
+### 3.1 Run the suite
+
+Use the absolute path — relative paths fail when PowerShell is invoked from Bash.
 
 ```powershell
-# Unit tests only (no UI changes detected, no --ui-tests flag)
+# Unit only (no UI changes, no --ui-tests)
 powershell -ExecutionPolicy Bypass -File "d:\LOM\workspace\Radoub\Radoub.IntegrationTests\run-tests.ps1" -Tool [detected] [-SkipShared] -UnitOnly -TechDebt
 
-# With UI changes auto-detected — targeted filter
+# UI changes auto-detected — targeted
 powershell -ExecutionPolicy Bypass -File "d:\LOM\workspace\Radoub\Radoub.IntegrationTests\run-tests.ps1" -Tool [detected] [-SkipShared] -TechDebt -UIFilter "LaunchTab"
 
-# With --ui-tests flag (all tool UI tests, no filter)
+# --ui-tests (all tool UI tests)
 powershell -ExecutionPolicy Bypass -File "d:\LOM\workspace\Radoub\Radoub.IntegrationTests\run-tests.ps1" -Tool [detected] [-SkipShared] -TechDebt
 
-# With --full-tests flag
+# --full-tests
 powershell -ExecutionPolicy Bypass -File "d:\LOM\workspace\Radoub\Radoub.IntegrationTests\run-tests.ps1" -TechDebt
 ```
 
-**Test scope decision**:
-- If `--skip-tests` → skip entirely
-- If `--full-tests` → run everything (no filter)
-- If `--ui-tests` → all tool UI tests (no filter)
-- If UI changes detected → targeted UI tests with `-UIFilter`
-- If `--no-auto-ui` → force unit-only even if UI files changed
-- Otherwise → unit tests only
+The script covers the privacy scan, tech-debt scan, unit tests, and UI tests unless
+`-UnitOnly`.
 
-The script handles:
-- Privacy scan (hardcoded paths)
-- Tech debt scan (warn >800, issue >1000 lines)
-- Unit tests (tool + shared if needed)
-- UI tests (if not -UnitOnly)
+Omitting `-Tool` runs every suite including all seven UI suites. `-Tool Radoub` is the
+shared-library scope and owns **no** UI tests — pairing it with `-UIOnly` runs nothing and
+reports "Passed 0", which is not a pass.
 
-### Step 3b: Tech Debt Issue Verification
+### 3.2 Tech-debt issues
 
-The tech debt scan uses two thresholds:
-- **>800 lines**: Warning only (logged, no issue required)
-- **>1000 lines**: Issue required (must have a tracking issue)
+Thresholds: over 800 lines warns, over 1000 requires a tracking issue.
 
-For files exceeding **1000 lines**, do NOT assume they are pre-existing. For each:
+For each file over 1000 lines, search the cache before assuming it is known:
 
-1. Search the GitHub issue cache for an existing tech debt issue (includes both open and closed):
-   ```bash
-   powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View search -Query "[filename without path]"
-   ```
+```bash
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View search -Query "[filename]"
+```
 
-2. **If an open issue exists**: Report as tracked tech debt with issue number
-   ```
-   ⚠️ Tech debt: MainWindowViewModel.cs (1288 lines) - tracked in #1335
-   ```
+| Cache result | Report |
+|--------------|--------|
+| Open issue | `⚠️ Tech debt: [file] ([N] lines) - tracked in #NNNN` |
+| Closed issue | `⚠️ Tech debt: [file] ([N] lines) - previously tracked in #NNNN (closed)` |
+| Nothing | Create one, then report `- NEW issue created: #NNNN` |
 
-3. **If a closed issue exists**: The file was previously tracked. Do NOT create a duplicate.
-   ```
-   ⚠️ Tech debt: [filename] ([N] lines) - previously tracked in #XXXX (closed)
-   ```
+```bash
+gh issue create --title "[Tool] Tech Debt: Split [filename] ([N] lines)" \
+  --label "tech-debt,[Tool]" --body "..."
+```
 
-4. **If NO issue exists** (open or closed): Flag as **untracked tech debt** and create an issue:
-   ```bash
-   gh issue create --title "[Tool] Tech Debt: Split [filename] ([N] lines)" \
-     --label "tech-debt,[Tool]" \
-     --body "..."
-   ```
-   Report in checklist:
-   ```
-   ⚠️ Tech debt: MainWindowViewModel.cs (1288 lines) - NEW issue created: #XXXX
-   ```
+Files in the 800–1000 range only need a checklist line. Always search first — a warning is
+"new" only when no issue, open or closed, tracks it.
 
-For files in the **800-1000 line** warning range, just report them in the checklist — no issue needed.
+### 3.3 Code review
 
-**Rule**: Always search the cache first. A tech debt warning is only "new" if no GitHub issue (open or closed) tracks it. Never create duplicates of existing issues.
+Once the build and tests pass, run the `code-review` skill over the branch diff versus
+`main`. A passing build does not catch correctness bugs or duplication.
 
-### Step 3c: Code Review (mandatory after green build/tests)
+Triage: correctness bugs get fixed on this branch now (TDD if the fix needs a test), then
+re-run 3.1. Reuse and simplification findings get applied when low-risk and in scope, else
+filed as tech debt. Out-of-scope findings get a one-line reason.
 
-Once the build and tests pass (Step 3), run the **`code-review`** skill over the branch diff before generating the checklist. This catches correctness bugs and reuse/simplification issues a passing build won't.
+Skip only for `--skip-tests` or a docs-only diff. `/code-review ultra` is the human's deeper
+multi-agent option; pre-merge uses the fast local review.
 
-- Invoke the `/code-review` skill (default effort) on the current branch's diff vs. `main`.
-- Triage findings:
-  - **Correctness bugs** → fix on this branch now (TDD if the fix needs a test), re-run Step 3.
-  - **Reuse/simplification/efficiency** → apply if low-risk and in-scope; otherwise file a tech-debt issue and note it.
-  - **Out-of-scope or false positives** → note and skip with a one-line reason.
-- Report a one-line summary in the Step 6 checklist (see the **Code review** row).
+## Phase 4 — Documentation
 
-Skip only when `--skip-tests` is set or the diff is docs/CHANGELOG-only (no code change). For a deep multi-agent cloud review, the human can run `/code-review ultra` separately — pre-merge uses the fast local review.
+### 4.1 CHANGELOG
 
-### Step 4: CHANGELOG Validation
+Verify the version section exists, the PR number is filled in (not TBD), and the date is
+today or earlier.
 
-Read CHANGELOG and verify:
-- Version section exists
-- PR number filled in (not TBD)
-- Date is today or earlier
+`[Unreleased]` must always be empty — entries go straight into versioned sections. Check
+every affected CHANGELOG; if one has bullets, report it and move them into the most recent
+versioned section as part of this PR.
 
-**[Unreleased] section check**:
+Versions come from NBGV via `version.json`, so no `.csproj` version properties exist to
+check. CHANGELOG versions are for humans and need not match NBGV exactly.
 
-`[Unreleased]` should never contain items — all CHANGELOG entries go directly into versioned sections. Check ALL affected CHANGELOG files for non-empty `[Unreleased]` sections. If any contain bullet points:
+### 4.2 Release notes
 
-1. Report as:
-   ```
-   ⚠️ [CHANGELOG file] has items in [Unreleased] — move them to a versioned section
-   ```
-2. Move the items into the most recent versioned section (or create one) as part of this PR
+Append this PR's work to `NonPublic/release-notes.md` (gitignored, edited between sessions).
 
-**Note**: Version numbers are managed by NBGV via `version.json` files — no `.csproj` version properties to check. CHANGELOG versions are for human tracking only and don't need to match computed NBGV versions exactly.
+Read the current file (create from the template below if missing) and this branch's CHANGELOG
+entries. For each issue the PR closes, check whether it came from a user:
 
-### Step 5: Update Release Notes (NonPublic/release-notes.md)
+```bash
+gh issue view [N] --json labels,author -q '{labels: [.labels[].name], author: .author.login}'
+```
 
-Append this sprint/PR's accomplishments to the running release notes draft.
+| Signal | Mark |
+|--------|------|
+| `user-requested` label | 🎯 (most reliable) |
+| `bug` or `enhancement` label, author is not LordOfMyatar | 🎯 |
+| Authored by LordOfMyatar without `user-requested` | internal, no mark |
 
-**Location**: `NonPublic/release-notes.md` (gitignored — editable between sessions)
+Append user-reported fixes to `## Bug Fixes` with 🎯, feature highlights to `## Highlights`,
+and tool detail to the tool's section. Check the PR and issue numbers are not already
+present, then show the user what was added.
 
-1. **Read the current release notes file** (create from template if missing)
-2. **Read the PR's CHANGELOG entries** (the version section for this branch)
-3. **Check for user-reported issues** in this PR:
-   ```bash
-   # Extract issue numbers from PR body "Closes #N" lines
-   # For each, check if labeled 'bug' or created by someone other than LordOfMyatar
-   gh issue view [N] --json labels,author -q '{labels: [.labels[].name], author: .author.login}'
-   ```
-4. **Append new entries** to the appropriate sections:
-   - Bug fixes from user reports → `## Bug Fixes` with 🎯 prefix
-   - Feature highlights → `## Highlights` (ask user which items to highlight, or auto-add sprint titles)
-   - Tool-specific details → `## [Tool Name]` section
-5. **Avoid duplicates** — check if the PR/issue numbers already appear in the file
-6. **Show the user what was added** so they can edit later
-
-**Template** (if file doesn't exist):
+Template:
 
 ```markdown
 # Release Notes (Draft)
@@ -298,12 +241,11 @@ The `/release` command reads this file to generate GitHub release notes.
 
 ## Highlights
 
-<!-- Move the most impressive items here. These appear in the "What's New" section. -->
-<!-- Mark user-reported fixes with 🎯 to show responsiveness -->
+<!-- Most impressive items. These appear in "What's New". 🎯 marks user-reported fixes. -->
 
 ## Bug Fixes
 
-<!-- 🎯 = reported by user/community (shows responsiveness) -->
+<!-- 🎯 = reported by user/community -->
 
 ## [Tool Name]
 
@@ -323,26 +265,22 @@ The `/release` command reads this file to generate GitHub release notes.
 
 ## Notes
 
-- Items marked with 🎯 were reported by users/community
-- This file is updated by `/pre-merge` and manually between sprints
+- 🎯 = reported by users/community
+- Updated by `/pre-merge` and by hand between sprints
 - `/release` reads this file instead of generating from scratch
 ```
 
-**User-reported detection**:
-- Issue has `user-requested` label → 🎯 (primary signal, most reliable)
-- Issue has `bug` label AND was NOT created by `LordOfMyatar` → 🎯 (fallback heuristic)
-- Issue has `enhancement` label AND was NOT created by `LordOfMyatar` → 🎯 (fallback heuristic)
-- Issue was created by `LordOfMyatar` without `user-requested` label → internal (no 🎯)
-
-### Step 5b: Wiki Freshness Check
+### 4.3 Wiki freshness
 
 ```bash
-grep "Page freshness:" d:\LOM\workspace\Radoub.wiki\[Tool]-Developer-Architecture.md
+grep "Page freshness:" "d:/LOM/workspace/Radoub.wiki/[Tool]-Developer-Architecture.md"
 ```
 
-Flag if >30 days old and code changed.
+Flag when over 30 days old and code changed.
 
-### Step 6: Generate Checklist
+## Phase 5 — Publish
+
+### 5.1 Checklist and PR update
 
 ```markdown
 ## Pre-Merge Checklist for PR #[number]
@@ -355,21 +293,21 @@ Flag if >30 days old and code changed.
 | Check | Status |
 |-------|--------|
 | Privacy scan | ✅/⚠️ |
-| Tech debt | ✅ / ⚠️ Warning (800+) / ⚠️ Tracked (#N) / ⚠️ NEW issue created (#N) |
+| Tech debt | ✅ / ⚠️ Warning (800+) / ⚠️ Tracked (#N) / ⚠️ NEW issue (#N) |
 | Unit tests (local, Windows) | ✅ N passed / ❌ N failed |
 | UI tests | ⏭️ Skipped / 🔄 Auto-triggered / ✅ N passed / ❌ N failed |
-| CI checks (incl. Linux) | ✅ All pass / ⏳ In progress / ❌ [N] failed (see Step 7c) |
+| CI checks (incl. Linux) | ✅ All pass / ⏳ In progress / ❌ [N] failed |
 
-**UI Test Reason**: [Manual --ui-tests / Auto-detected UI changes / Skipped (no UI changes)]
-**UIFilter**: [filter expression / "all" / N/A]
+**UI Test Reason**: [Manual --ui-tests / Auto-detected / Skipped (no UI changes)]
+**UIFilter**: [expression / "all" / N/A]
 
 ### Validation
 | Check | Status |
 |-------|--------|
-| init-item (linked issue + branch convention) | ✅ Satisfied / ⚠️ Skipped — issue #N created / ⚠️ Off-convention branch / ⚠️ No issue (user-confirmed) |
-| Code review (Step 3c) | ✅ Clean / ⚠️ [N] fixed / ⚠️ [N] deferred to issue #M / ➖ Skipped (docs-only) |
+| init-item (linked issue + branch convention) | ✅ Satisfied / ⚠️ Skipped — issue #N created / ⚠️ Off-convention / ⚠️ No issue (user-confirmed) |
+| Code review | ✅ Clean / ⚠️ [N] fixed / ⚠️ [N] deferred to #M / ➖ Skipped (docs-only) |
 | CHANGELOG | ✅/⚠️ |
-| [Unreleased] section | ✅ Empty / ⚠️ Has items (move to versioned section) |
+| [Unreleased] section | ✅ Empty / ⚠️ Has items |
 | Wiki | ✅ Current / ⚠️ Stale |
 
 ### Status
@@ -378,79 +316,70 @@ Flag if >30 days old and code changed.
 **PR**: https://github.com/LordOfMyatar/Radoub/pull/[number]
 ```
 
-### Step 7: Update PR (batched gh commands)
-
 ```bash
-# Single command with && chaining
 gh pr edit [number] --body "[generated body]" && gh pr ready [number] 2>/dev/null || true
 ```
 
-The `|| true` handles case where PR is already ready.
+The `|| true` covers an already-ready PR.
 
-### Step 7b: Refresh Cache (if mutations occurred)
+### 5.2 Refresh cache after mutations
 
-If any tech debt issues were created (`gh issue create`) or the PR was edited, refresh the cache:
+Only if a tech-debt issue was created or the PR body was edited:
 
 ```bash
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Refresh-GitHubCache.ps1" -Force
 ```
 
-### Step 7c: Verify CI Checks (catch cross-platform failures)
+### 5.3 Verify CI (catches Linux-only failures)
 
-Local tests only run on Windows. CI also runs the test suite on **ubuntu-latest**, which catches platform-specific bugs the local run cannot — most commonly path-handling tests that assume Windows semantics (`Path.Combine("C:", ...)` is absolute on Windows but **relative** on Linux, so `Path.GetFullPath` resolves it against the runner CWD and string-equality assertions diverge). The Linux/Windows test split is exactly the gap that slipped a green local pre-merge into a red PR.
-
-After marking the PR ready, check the live CI check status:
+Local tests run on Windows alone. CI also runs ubuntu-latest, which catches platform bugs the
+local run cannot — most often a test asserting a Windows-literal path. `Path.Combine("C:", …)`
+is absolute on Windows but **relative** on Linux, so `Path.GetFullPath` resolves it against
+the runner's CWD and string equality diverges. This gap is exactly what turns a green local
+pre-merge into a red PR.
 
 ```bash
 gh pr checks [number]
 ```
-
-**Interpret the result**:
 
 | State | Action |
 |-------|--------|
-| All checks `pass` | ✅ Report "CI green" in the checklist. |
-| Any check `pending`/`in progress` | ⏳ CI still running. Report "CI in progress — re-run `gh pr checks [number]` before merge." Do NOT claim ready. |
-| Any check `fail` | ❌ **Block.** Pull the failing job's log and fix before declaring ready (see below). |
+| All pass | Report "CI green" |
+| Any pending | Report "CI in progress — re-run before merge." Do not claim ready |
+| Any fail | Block, pull the log, fix |
 
-**On failure**, get the real assertion (not the runner's summary line — the `##[error]Unable to process file command 'env'` / `Invalid format` annotations are often a downstream symptom, not the cause):
+On failure, get the real assertion rather than the runner's summary — `##[error]Unable to
+process file command 'env'` and `Invalid format` annotations are usually downstream symptoms:
 
 ```bash
-# List failing checks and their run/job URLs
-gh pr checks [number]
-
-# Pull only the failed steps for the job ID from the URL
 gh run view --job [jobId] --log-failed 2>&1 | grep -iE "\[FAIL\]|Assert|Expected:|Actual:|error CS|\.cs\(" | head -30
 ```
 
-Common Linux-only failure: a unit test asserts a literal Windows path. Fix the **test** (root paths at `Path.GetTempPath()` and compute the expected value with the same `Path.GetFullPath` the code under test uses) — not the production code, which is usually correct. Re-run local tests, push, and re-check `gh pr checks` until green.
+For the Windows-path case, fix the **test**, not the production code: root paths at
+`Path.GetTempPath()` and compute the expected value with the same `Path.GetFullPath` the code
+under test uses. Re-run locally, push, re-check until green.
 
-**Report in the checklist**:
+A PR is "Ready" only when CI is green or the user explicitly defers. Green-local plus
+unknown-CI is not ready.
 
-```
-| CI checks (incl. Linux) | ✅ All pass / ⏳ In progress / ❌ [N] failed — [job], fix before merge |
-```
-
-A pre-merge is only "Ready" when CI is green (or explicitly deferred by the user). Green-local + unknown-CI is **not** ready.
-
-## Test Script Reference
+## Reference
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File "d:\LOM\workspace\Radoub\Radoub.IntegrationTests\run-tests.ps1" `
-    -Tool [Parley|Quartermaster|Manifest|Fence|Trebuchet] `
+    -Tool [Parley|Quartermaster|Manifest|Fence|Trebuchet|Relique|Reliquary] `
     -SkipShared      # Skip Radoub.* tests
-    -UnitOnly        # Skip UI tests (default for pre-merge)
-    -TechDebt        # Include large file scan
+    -UnitOnly        # Skip UI tests (pre-merge default)
+    -TechDebt        # Include large-file scan
 ```
 
-## Notes
+Notes:
 
-- **`jq` not available**: Use PowerShell (`ConvertFrom-Json`, `Select-String`) or `gh`'s built-in `--jq` flag for JSON parsing. Always use `powershell.exe` (not `pwsh`).
-- Default: unit tests only (fast), unless UI changes detected
-- UI tests auto-triggered when `.axaml`, `Views/`, `Controls/`, `Dialogs/`, or `Windows/` files change
-- Use `--no-auto-ui` to disable auto-detection (force unit-only)
-- Use `--ui-tests` to force UI tests regardless of what changed
-- Shared library changes → include shared tests
-- Wiki updates done separately with `/documentation`
-- **Hands-off keyboard during UI tests** - focus stealing can cause failures
-- **CI runs on Linux too** (Step 7c) - local pre-merge only runs Windows. Always check `gh pr checks` after marking ready; never claim "Ready" on green-local + unknown-CI. The classic miss is a test asserting a Windows-literal path that fails under Linux `Path.GetFullPath`.
+- **No `jq` on this box.** Parse JSON with PowerShell `ConvertFrom-Json` or `gh --jq`. Avoid
+  `sed`/`awk`/`xargs` — they differ from Linux here or mangle Windows paths.
+- Launch `.ps1` from the Bash tool; PowerShell-tool permission rules never match on Windows.
+- Unit tests only by default. UI tests trigger on `.axaml`, `Views/`, `Controls/`, `Dialogs/`,
+  or `Windows/` changes.
+- Shared-library changes pull in shared tests.
+- Wiki updates happen separately via `/documentation`.
+- **Hands off the keyboard during UI tests** — stolen focus fails them.
+- CI runs Linux too (5.3). Never claim Ready on green-local plus unknown-CI.

--- a/.claude/commands/pre-warm.md
+++ b/.claude/commands/pre-warm.md
@@ -1,6 +1,7 @@
 # Pre-Warm Next Sprint
 
-Prepare an implementation plan for an upcoming sprint or issue while the current sprint is still in progress. **Planning only** — no branches, PRs, or code changes.
+Prepare an implementation plan for an upcoming sprint or issue while the current one is still
+running. **Planning only** — no branches, PRs, or code changes. Those happen in `/init-item`.
 
 ## Usage
 
@@ -8,84 +9,66 @@ Prepare an implementation plan for an upcoming sprint or issue while the current
 /pre-warm #[issue-number]
 ```
 
-**Examples:**
-- `/pre-warm #1901` (plan a sprint before it starts)
-- `/pre-warm #2050` (plan an epic before breaking into sprints)
+Plans are written to `NonPublic/Plans/{YYYY-MM-DD}-{issue-number}-plan.md` — gitignored, and
+found later by `/init-item` via `NonPublic/Plans/*-{issue-number}-plan.md`.
 
-## Workflow
+## Phase 1 — Gather
 
-### Step 0: Check for Existing Pre-Warm Plan
-
-Before doing anything else, check whether a plan for this issue already exists:
+### 1.1 Check for an existing plan
 
 ```bash
 ls NonPublic/Plans/*-[number]-plan.md 2>/dev/null
 ```
 
-**If one or more plans exist**, do NOT silently create a new one. Read each, then ask the user how to proceed:
+If one exists, **do not silently write a second**. Read it and ask how to proceed:
 
-- **Update existing** — the prior plan is the spine; refresh it with new findings (re-verify any code line refs and linked issue states, which may be stale).
-- **Supersede** — write a fresh plan and delete the old one(s).
-- **Merge** — combine a richer-but-older plan with newer corrected facts (state which leads).
+| Choice | Meaning |
+|--------|---------|
+| Update | The prior plan is the spine; refresh it with new findings |
+| Supersede | Write fresh, delete the old |
+| Merge | Combine a richer-but-older plan with newer corrected facts — say which leads |
 
-When merging or updating, **re-verify the old plan's hard references** — code moves between sessions (line numbers, file paths) and linked issues may have closed. Confirm before citing.
+When updating or merging, **re-verify the old plan's hard references**. Code moves between
+sessions, so line numbers and file paths drift, and linked issues may have closed. Confirm
+before citing.
 
-**If no plan exists**, proceed to Step 1.
-
-### Step 1: Fetch Issue Details
+### 1.2 Fetch the issue
 
 ```bash
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Refresh-GitHubCache.ps1"
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View issue -Number [number]
 ```
 
-Extract: title, labels, body, child issues (if sprint/epic).
-
-For sprints, also fetch each child issue:
+Take the title, labels, body, and child issues. Fetch each child for a sprint or epic, and
+check their live state — a sprint body often lists children that have since closed:
 
 ```bash
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View issue -Number [child-number]
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Test-IssueState.ps1" -Numbers "N,N,N"
 ```
 
-### Step 2: Research Codebase
+### 1.3 Research the code
 
-For each work item in the sprint/issue:
+Per work item: find the affected files with Grep and Glob, read enough to understand the
+current patterns and dependencies, note any shared-library impact, and flag ordering
+dependencies between items. Use the Explore agent for open-ended sweeps.
 
-1. **Identify affected files** — use Grep/Glob to find relevant code
-2. **Read key sections** — understand current patterns and dependencies
-3. **Note cross-tool impact** — does this change shared libraries?
-4. **Check for blockers** — are there dependencies between items?
+**Verify each item's premise.** An issue written weeks ago may describe a problem already
+fixed, or partly delivered by other work. A plan built on a stale premise wastes the sprint.
 
-Use the Explore agent for deep research when needed.
+## Phase 2 — Design
 
-### Step 3: Invoke Brainstorming Skill
+Invoke the `superpowers:brainstorming` skill and work through scope (in and out), approach
+options with trade-offs, ordering and dependencies, and per-item design. Follow it through to
+a spec document and review.
 
-Use the `superpowers:brainstorming` skill to collaborate with the user on:
-- Scope decisions (what's in, what's out)
-- Approach options (with trade-offs)
-- Ordering and dependencies
-- Design details for each work item
+## Phase 3 — Write and report
 
-Follow the brainstorming flow through to spec document creation and review.
-
-### Step 4: Write Plan
-
-Save the approved design spec to:
-
-```
-NonPublic/Plans/{YYYY-MM-DD}-{issue-number}-plan.md
-```
-
-**Examples:**
-- `NonPublic/Plans/2026-03-23-1901-plan.md`
-- `NonPublic/Plans/2026-04-01-2050-plan.md`
-
-Ensure the directory exists:
 ```bash
 mkdir -p NonPublic/Plans
 ```
 
-### Step 5: Report Summary
+Save the approved spec to `NonPublic/Plans/{YYYY-MM-DD}-{issue-number}-plan.md`, dated the day
+it was written — for example `NonPublic/Plans/2026-03-23-1901-plan.md`.
 
 ```markdown
 ## Pre-Warm Complete
@@ -94,27 +77,11 @@ mkdir -p NonPublic/Plans
 **Plan**: `NonPublic/Plans/{date}-{number}-plan.md`
 
 ### What's Ready
-- [Number] work items planned
+- [N] work items planned
 - Dependencies mapped
 - Implementation order defined
+- [Any item whose premise no longer holds, and why]
 
 ### To Start Work
-Run `/init-item #[number]` — it will detect the pre-warmed plan automatically.
+Run `/init-item #[number]` — it detects the plan automatically.
 ```
-
-## Output Filename Convention
-
-```
-NonPublic/Plans/{YYYY-MM-DD}-{issue-number}-plan.md
-```
-
-- `{YYYY-MM-DD}` — date the plan was created
-- `{issue-number}` — GitHub issue number
-
-## Notes
-
-- **No code changes** — this is planning only
-- **No branches or PRs** — those happen when `/init-item` runs
-- The plan file lives in NonPublic/ and is not committed to git
-- `/init-item` will detect existing plans via glob: `NonPublic/Plans/*-{issue-number}-plan.md`
-- Use this while another sprint is in progress to get ahead

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -2,187 +2,97 @@
 
 Create and push a version tag to trigger the GitHub Actions release workflow.
 
-## Overview
-
-Radoub releases include all tools (Parley, Manifest, Fence, Trebuchet, Quartermaster) in a single bundle. Individual tool releases are not supported - we release the entire Radoub suite together.
-
-## Versioning Strategy
-
-**Radoub uses a simple incrementing version**: `radoub-vX.Y.Z`
-
-The version is determined by:
-1. Find the last `radoub-v*` tag in git
-2. Increment the patch version (Z) for the new release
-3. User can override to bump minor (Y) or major (X) if needed
-
-This avoids the need for a separate Radoub CHANGELOG - the tool changelogs track what changed, and the radoub version just increments each release.
-
-## Release Notes Source
-
-**Draft source**: `NonPublic/release-notes.md` (gitignored) — accumulated by `/pre-merge` during sprints.
-**Synthesis**: User-facing TL;DR is generated from the draft at release time. Per-tool CHANGELOGs hold the per-PR detail.
-**Delivery**: Notes ride on the annotated tag message — `git tag -a -F <tempfile>`. The workflow extracts them via `git tag -l --format='%(contents:body)'`. **No file in repo root. No commit to main. No PR.**
-
-When `NonPublic/release-notes.md` exists:
-- Read it as the draft input
-- Compress the per-PR detail into a TL;DR (paragraph summary + bullet themes)
-- User has had time to edit/curate between sprints
-
-Hard rules:
-- Release notes are NEVER written to the repo root.
-- Per-PR detail belongs in CHANGELOGs, not release notes.
-- See #2236 for the rationale.
-
-## Upfront Questions
-
-**IMPORTANT**: Gather user input in phases, not all at once.
-
-### Phase 1: Review Draft Release Notes (if NonPublic/release-notes.md exists)
-
-1. Read `NonPublic/release-notes.md`
-2. Show the current draft to the user
-3. Ask: "Release notes look good? [y/edit/regenerate]"
-   - **y** → proceed to Phase 2
-   - **edit** → user edits the file manually, then re-run
-   - **regenerate** → fall back to CHANGELOG parsing (old behavior)
-
-### Phase 1 (Fallback): Changelog Highlights Selection (if no NonPublic/release-notes.md)
-
-After reading changelogs:
-1. Parse unreleased changes from each tool's changelog (entries after last release date)
-2. Present a **numbered list** of all changelog items
-3. Ask user: "Which items are highlights? (Enter numbers, e.g., 1,3,5 or 'all' or 'none')"
-4. Selected items become **Highlights** in release notes
-
-### Phase 2: Final Confirmation
-1. Show release summary with selected highlights
-2. Show the computed next version (e.g., `radoub-v0.8.4`)
-3. Ask: "Ready to release? [y/n] or specify version bump [patch/minor/major]"
+Radoub ships as one bundle — Parley, Manifest, Fence, Trebuchet, Quartermaster, Relique,
+Reliquary together. Per-tool releases are not supported.
 
 ## Usage
 
 ```
-/release           # Release Radoub bundle
-/release radoub    # Same as above
+/release           # Release the Radoub bundle
 ```
 
-## Tag Format
+## How versioning works
 
-| Release | Tag Format | Workflow |
-|---------|------------|----------|
-| Radoub (bundled) | `radoub-vX.Y.Z` | `radoub-release.yml` |
+Tags are `radoub-vX.Y.Z`. Find the last one, bump the patch, unless the user asks for minor
+or major. Tool CHANGELOGs record what changed, so the bundle version just increments — no
+separate Radoub CHANGELOG needed.
 
-The workflow produces two artifacts:
-- **Bundled**: Single package with all tools + shared runtime
-- **Unbundled**: Separate tool packages without runtime (smaller, requires .NET installed)
+```bash
+git tag -l "radoub-v*" --sort=-v:refname | head -1
+```
 
-## Prerequisites
+## How release notes work
 
-Before releasing:
-1. All changes committed and pushed to main
-2. Tool CHANGELOGs updated with version sections
-3. All tests passing
-4. PR merged (post-merge is the typical release point)
+The draft lives in `NonPublic/release-notes.md` (gitignored), accumulated by `/pre-merge`
+across sprints and editable by the user in between. At release time it is compressed into a
+user-facing TL;DR and delivered **on the annotated tag message** — the workflow extracts it
+with `git tag -l --format='%(contents:body)'`.
 
-## Instructions
+Three hard rules (#2236):
 
-> **Order hazard**: The NonPublic draft is the only persisted copy of the accumulated
-> highlights. Always synthesize → push the tag → THEN reset the draft. Resetting
-> before push means a failed push leaves nothing to retry from.
+- Release notes are **never** written to the repo root.
+- No commit to main, no PR.
+- Per-PR detail belongs in CHANGELOGs. Release notes are the headline pass.
 
-1. **Verify Clean State**
-   ```bash
-   git status
-   git log --oneline -3
-   ```
-   - Must be on `main` branch
-   - Working directory must be clean
-   - Confirm latest commit is what we want to release
+> **Order hazard.** The NonPublic draft is the only persisted copy of the accumulated
+> highlights. Synthesize → push the tag → **then** reset the draft. Resetting first means a
+> failed push leaves nothing to retry from.
 
-2. **Determine Next Version**
-   ```bash
-   # Find last radoub release tag
-   git tag -l "radoub-v*" --sort=-v:refname | head -1
-   ```
-   - If last was `radoub-v0.8.3`, next is `radoub-v0.8.4` (patch bump)
-   - User can request minor bump (0.9.0) or major bump (1.0.0)
+## Phase 1 — Verify
 
-3. **Load Release Notes**
+```bash
+git status
+git log --oneline -3
+```
 
-   **If `NonPublic/release-notes.md` exists** (preferred path):
-   - Read the file — it contains curated highlights, bug fixes, and tool sections
-   - Fill in the Tool Versions table with NBGV-computed versions
-   - Show draft to user for review (Phase 1 above)
+Must be on `main`, clean, with the latest commit being what should ship. Never release from a
+feature branch or with uncommitted changes. If anything looks off, stop and ask.
 
-   **If `NonPublic/release-notes.md` does NOT exist** (fallback):
-   - Parse tool CHANGELOGs for entries newer than last release date:
-     - `Parley/CHANGELOG.md`
-     - `Manifest/CHANGELOG.md`
-     - `Quartermaster/CHANGELOG.md`
-     - `Fence/CHANGELOG.md`
-     - `Relique/CHANGELOG.md`
-     - `Trebuchet/CHANGELOG.md`
-   - Present numbered list for highlight selection (Phase 1 fallback)
-   - Generate release notes from selection
+Prerequisites: everything merged and pushed, tool CHANGELOGs updated with version sections,
+tests passing. Post-merge is the usual release point.
 
-4. **Synthesize Final Notes (TL;DR style — high-level only)**
+## Phase 2 — Draft the notes
 
-   Release notes are user-facing and must be short. Per-tool CHANGELOGs hold the
-   per-PR detail; release notes are the headline pass.
+### 2.1 With an existing draft (preferred)
 
-   Rules:
-   - One paragraph summary at the top (the headline story).
-   - 4-6 bullet "What changed" themes in plain language.
-   - One short "User-reported fixes" list if applicable.
-   - Tool versions table.
-   - **No** per-PR walls of text. Link to CHANGELOGs for details.
+Read `NonPublic/release-notes.md`, fill the Tool Versions table with NBGV values, and show it
+to the user: "Release notes look good? [y/edit/regenerate]". **edit** means they revise the
+file and re-run; **regenerate** falls through to 2.2.
 
-   Write the synthesized notes to a tempfile:
+### 2.2 Without one (fallback)
 
-   ```bash
-   # Workflow reads release notes from the annotated tag message.
-   # NEVER write release-notes.md to the repo root (#2236).
-   TMP_NOTES=$(mktemp --suffix=.md)
-   # ...write synthesized notes to $TMP_NOTES...
-   ```
+Parse each tool's CHANGELOG for entries newer than the last release date — Parley, Manifest,
+Quartermaster, Fence, Relique, Reliquary, Trebuchet. Present a numbered list and ask which
+items are highlights ("1,3,5", "all", or "none").
 
-5. **Confirm with User**
-   - Show the version and generated highlights
-   - Show recent commits that will be included
-   - Ask user to confirm: "Ready to release radoub-v0.8.4?"
+### 2.3 Synthesize
 
-6. **Create and Push Tag** (notes embedded in tag annotation — no main commit required)
+Release notes are user-facing and short:
 
-   ```bash
-   # Embed the TL;DR notes as the tag's annotated message (-F reads from file).
-   # The workflow extracts the tag body via `git tag -l --format='%(contents:body)'`
-   # and uses it as the GitHub release body. No file in repo root, no PR.
-   git tag -a radoub-vX.Y.Z -F "$TMP_NOTES"
-   git push origin radoub-vX.Y.Z
-   rm "$TMP_NOTES"
-   ```
+- One paragraph up top — the headline story
+- Four to six "What changed" bullets in plain language
+- A short "User-reported fixes" list when applicable
+- The tool versions table
 
-   **Never** write or commit `release-notes.md` to the repo root (#2236).
+No per-PR walls of text; link to CHANGELOGs for detail.
 
-7. **Reset NonPublic Draft** (only after tag push succeeds)
+Write the result to a temp file. `mktemp --suffix` is a GNU extension — on this Windows box
+build the path explicitly instead:
 
-   **Order matters**: reset AFTER `git push origin <tag>` returns success. The
-   NonPublic draft is the only persisted copy of the accumulated highlights —
-   resetting before push means a failed push leaves you with nothing to retry from.
-   If the push fails, do NOT reset; debug + retry.
+```bash
+TMP_NOTES="$TEMP/radoub-release-notes.md"
+# ...write synthesized notes to $TMP_NOTES...
+```
 
-   ```markdown
-   # Release Notes (Draft)
+Tool versions come from NBGV:
 
-   Accumulated since last release: **radoub-vX.Y.Z** (YYYY-MM-DD)
-   ...
-   ```
+```bash
+dotnet nbgv get-version --project Parley -v SemVer2
+```
 
-8. **Provide Release Link**
-   - `https://github.com/LordOfMyatar/Radoub/actions/workflows/radoub-release.yml`
-   - Note: Build takes ~10-15 minutes for all platforms
+## Phase 3 — Confirm
 
-## Output Format
+Show the checklist and wait for an explicit yes. Always confirm the version before tagging.
 
 ```
 ## Release Checklist - Radoub
@@ -194,37 +104,44 @@ Before releasing:
 - [ ] Latest commit: [hash] [message]
 
 ## Tool Versions Included
-- Parley: [NBGV computed version]
-- Manifest: [NBGV computed version]
-- Fence: [NBGV computed version]
+- Parley: [NBGV version]
+- Manifest: [NBGV version]
 
 ## Changes Since Last Release
-[list of changelog entries from all tools]
+[changelog entries across tools]
 
 ## Ready to Release?
-Confirm to create tag `radoub-v0.8.4` and trigger release build.
+Confirm to create tag `radoub-v0.8.4` and trigger the release build.
 ```
 
-**Getting Tool Versions** (NBGV):
+## Phase 4 — Tag and push
+
 ```bash
-# Preferred (no jq needed):
-dotnet nbgv get-version --project Parley -v SemVer2
-dotnet nbgv get-version --project Manifest -v SemVer2
-dotnet nbgv get-version --project Fence -v SemVer2
+git tag -a radoub-vX.Y.Z -F "$TMP_NOTES"
+git push origin radoub-vX.Y.Z
+rm "$TMP_NOTES"
 ```
 
-## Safety Checks
+The notes ride in the tag annotation, so no file lands in the repo and no PR is needed.
 
-- NEVER release from a feature branch
-- NEVER release with uncommitted changes
-- ALWAYS confirm version with user before tagging
-- If anything looks wrong, STOP and ask
+## Phase 5 — Reset the draft
 
-## Bundle Contents
+**Only after the push succeeds.** If it failed, do not reset — debug and retry.
 
-The Radoub release creates a combined package with:
-- Parley dialog editor
-- Manifest journal editor
-- Fence merchant/store editor
-- Shared .NET runtime and dependencies (bundled version)
-- Just the tools (unbundled version - requires .NET 9.0 installed)
+Rewrite `NonPublic/release-notes.md` from the empty template, with the new version and today's
+date on the "Accumulated since last release" line.
+
+Then give the user the build link — roughly 10–15 minutes for all platforms:
+
+```
+https://github.com/LordOfMyatar/Radoub/actions/workflows/radoub-release.yml
+```
+
+## Artifacts
+
+The `radoub-release.yml` workflow produces two packages:
+
+| Package | Contents |
+|---------|----------|
+| Bundled | All tools plus the shared .NET runtime |
+| Unbundled | Tools only — smaller, requires .NET 9.0 installed |

--- a/.claude/commands/research.md
+++ b/.claude/commands/research.md
@@ -1,131 +1,106 @@
 # Research Task
 
-Investigate a GitHub issue or feature request and produce a research summary. Optionally spike with throwaway code on a disposable branch.
-
-## Upfront Questions
-
-**IMPORTANT**: Gather ALL required user input at the start, then execute autonomously.
-
-Before starting research, collect these answers in ONE interaction:
-
-1. **Scope Clarification** (if topic is broad): "What specific aspects should I focus on? [implementation/libraries/architecture/all]"
-2. **Depth**: "Research depth? [quick-scan/thorough/exhaustive]"
-3. **Output Location**: "Save research notes to NonPublic/Research/?" [y/n]"
-
-After collecting answers, proceed through all exploration and analysis without further prompts unless critical ambiguity is discovered.
+Investigate a GitHub issue or topic and produce a research summary. Optionally spike with
+throwaway code in an isolated worktree.
 
 ## Usage
 
 ```
 /research #[issue-number]
 /research [topic description]
-/research --spike #[issue-number]     # Create throwaway branch for prototyping
-/research --spike [topic] --timebox 2h
+/research --spike #[issue-number] [--timebox 2h]
 ```
 
-**Flags**:
-- `--spike` - Create a throwaway branch for hands-on prototyping (branch is deleted after findings captured)
-- `--timebox [duration]` - Set spike timebox (default: 2h, options: 1h/2h/4h)
+| Flag | Effect |
+|------|--------|
+| `--spike` | Hands-on prototyping in a throwaway worktree, deleted after findings are captured |
+| `--timebox` | Spike duration — 1h, 2h (default), or 4h |
 
-## Workflow
+Ask once, up front: which aspects to focus on if the topic is broad, depth
+(quick-scan / thorough / exhaustive), and whether to save notes. Then run without further
+prompts unless a critical ambiguity turns up.
 
-### Step 0: Ensure Cache is Fresh
+Research is **read-only** — no code changes, except under `--spike`.
+
+## Phase 1 — Set up
+
+### 1.1 Refresh the cache
 
 ```bash
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Refresh-GitHubCache.ps1"
 ```
 
-### Step 0b: Create Spike Branch (if `--spike` flag)
+### 1.2 Spike worktree (only with `--spike`)
 
-If `--spike` is passed, create a throwaway branch before starting:
+**Use a worktree, never `git checkout -b` in place.** Branching in the main workspace stashes
+the user's in-progress work and forces a context switch; they almost always have something
+going. Invoke the `superpowers:using-git-worktrees` skill.
 
-```bash
-git stash  # if needed
-git checkout main
-git checkout -b spike/[short-topic]
-```
+Convention: worktree at `../Radoub-spike-<short-topic>/` on branch `spike/<short-topic>`.
 
-Display spike context:
 ```markdown
 ## Spike Started
 
 **Topic**: [topic]
-**Question(s)**: [what we're trying to answer]
-**Timebox**: [duration, default 2h]
-**Started**: [timestamp]
+**Question**: [what we're trying to answer]
+**Timebox**: [duration]
+**Worktree**: ../Radoub-spike-[topic]
 ```
 
-### Step 1: Understand the Request
+## Phase 2 — Investigate
 
-**Cache-first**: Always read from cache. No direct `gh issue view` calls.
+### 2.1 Understand the request
+
+Cache-first; no direct `gh issue view` for reads.
 
 ```bash
-# Get issue details from cache
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View issue -Number [number]
-
-# Search for related issues
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View search -Query "[keyword]"
 ```
 
-Parse the issue to identify:
-- **Goal**: What problem are we solving?
-- **Scope**: What areas of the codebase are affected?
-- **Constraints**: Any technical or design requirements mentioned?
+Extract the goal, the affected areas, and any stated constraints.
 
-If topic description provided, clarify with user if needed.
+**Verify the premise.** An issue's description may no longer match the code — the work may be
+partly done, or the problem may have moved. Check before researching solutions to a problem
+that no longer exists.
 
-### Step 2: Codebase Exploration
+### 2.2 Explore the codebase
 
-Use native tools (not bash grep) for codebase exploration:
-- **Glob** for finding files by pattern
-- **Grep** for searching content
-- **Task tool with Explore agent** for open-ended exploration
+Use the native tools, not bash pipelines: **Glob** for files, **Grep** for content, and the
+**Explore agent** for open-ended sweeps. Look for existing patterns worth reusing, integration
+points, and conflicts or dependencies.
 
-Identify:
-- Existing patterns that could be reused
-- Integration points
-- Potential conflicts or dependencies
+### 2.3 External research
 
-### Step 3: External Research
+When evaluating a library, check: last commit or release (stale beyond two years is a red
+flag), maintainer responsiveness, .NET and Avalonia compatibility, license (MIT or Apache
+preferred), adoption, and whether a better-maintained alternative exists.
 
-If needed, research:
-- Library options (NuGet packages, Python packages)
-- API documentation
-- Best practices for the approach
+Prefer the reference implementations already cloned locally for Aurora-format and rendering
+questions — see the Resources section of CLAUDE.md. Document sources either way.
 
-**When evaluating external libraries**, check maintainability factors:
-- **Last activity**: When was the last commit/release? (Stale > 2 years is a red flag)
-- **Issue responsiveness**: Are maintainers active? Open issue count vs. closed?
-- **Compatibility**: .NET version support, Avalonia/platform compatibility
-- **License**: MIT/Apache preferred, check for restrictions
-- **Adoption**: Download counts, stars, community usage
-- **Alternatives**: Are there better-maintained alternatives?
+### 2.4 Ask clarifying questions
 
-Document sources and key findings.
+Before writing conclusions, surface ambiguous requirements, trade-offs between approaches, and
+any implementation-style preference. Wait for the answer.
 
-### Step 4: Ask Clarifying Questions
+## Phase 3 — Report
 
-Before proceeding, ask about:
-- Ambiguous requirements
-- Trade-offs between approaches
-- User preferences on implementation style
+### 3.1 Write the notes
 
-Wait for user response before continuing.
-
-### Step 5: Generate Research Notes
-
-Create notes in `NonPublic/[Tool]/Research/` (per CLAUDE.md rules — NonPublic is always at repo root):
+`NonPublic/[Tool]/Research/` — NonPublic always lives at the repo root. Use `Radoub/` for
+cross-tool or format work. Spikes go to `spike-[topic].md`.
 
 ```markdown
-# Research: [Issue/Topic Title]
+# Research: [Title]
 
 **Date**: [YYYY-MM-DD]
-**Issue**: #[number] (if applicable)
+**Issue**: #[number]
 **Status**: Research Complete / Needs Clarification
 
 ## Summary
 
-[2-3 sentence overview of findings]
+[2-3 sentences]
 
 ## Key Findings
 
@@ -136,60 +111,32 @@ Create notes in `NonPublic/[Tool]/Research/` (per CLAUDE.md rules — NonPublic 
 - **Risk**: Low/Medium/High
 
 ### Approach B: [Name]
-[Same structure]
 
 ## Recommendation
 
-[Which approach and why]
+[Which and why]
 
 ## Open Questions
 
-- [Questions for user or future investigation]
-
 ## Resources
-
-- [Links to docs, examples, related issues]
 
 ## Code References
 
-- `[file:line]` - [description of relevant code]
+- `[file:line]` — [what it does]
 ```
 
-### Step 6: Report to User
+Keep the notes even when the approach is rejected — it stops the same ground being
+re-researched later.
 
-Summarize findings concisely and present options.
+### 3.2 Clean up the spike
 
-## Output Location
-
-Research notes go in `NonPublic/[Tool]/Research/`:
-- `NonPublic/Parley/Research/` for Parley-related topics
-- `NonPublic/Quartermaster/Research/` for QM research
-- `NonPublic/Radoub/Research/` for cross-tool or format research
-
-For spikes, use: `NonPublic/[Tool]/Research/spike-[topic].md`
-
-## Spike Cleanup (if `--spike` flag was used)
-
-After capturing findings:
+Capture findings **first**, then remove the worktree and delete the branch. Never merge a
+spike.
 
 ```bash
-# Switch back to previous branch
-git checkout -  # or git checkout main
-
-# Delete the spike branch (local and remote if pushed)
+git worktree remove ../Radoub-spike-[topic]
 git branch -D spike/[short-topic]
-git push origin --delete spike/[short-topic] 2>/dev/null  # ignore if not pushed
 ```
 
-**Important rules for spikes:**
-- **Never merge a spike branch** — spikes are throwaway
-- **Always capture findings** before deleting the branch
-- **Respect the timebox** — if time runs out, document what you have and stop
-- **One question at a time** — log new questions as open questions for future research
-
-## Notes
-
-- Research is read-only — no code changes (unless `--spike` flag, which allows throwaway prototyping)
-- Ask before making assumptions
-- Document sources for future reference
-- Keep notes even if approach is rejected (prevents re-research)
+Respect the timebox: when it runs out, write up what you have and stop. Log new questions as
+open questions rather than chasing them.

--- a/.claude/scripts/Prune-DeadPermissionRules.ps1
+++ b/.claude/scripts/Prune-DeadPermissionRules.ps1
@@ -1,0 +1,68 @@
+# Removes allow rules that can never match from .claude/settings.local.json.
+#
+# Four categories of unreachable rule:
+#   1. Doubled backslashes  - upstream anthropics/claude-code#57013; the saved rule
+#                             has \\ where the real command has \, so it never matches.
+#   2. PowerShell(...)      - the PowerShell tool's rules never match on Windows
+#                             (#57013/#60289/#42318). Every such rule is dead.
+#   3. cd-prefix rules      - .claude/hooks/check-cd-prefix.sh blocks the command
+#                             before permissions are consulted.
+#   4. Rules containing ..  - the Bash(*..*) / PowerShell(*..*) deny guard wins.
+#
+# Writes a timestamped .bak next to the settings file. Run with -WhatIf to preview.
+
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [string]$SettingsPath = 'd:\LOM\workspace\Radoub\.claude\settings.local.json'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $SettingsPath)) { throw "Settings file not found: $SettingsPath" }
+
+$raw  = Get-Content $SettingsPath -Raw
+$json = $raw | ConvertFrom-Json
+$before = @($json.permissions.allow)
+
+$bs2 = [string][char]92 + [char]92
+
+function Test-Unreachable([string]$rule) {
+    if ($rule -match [regex]::Escape($bs2)) { return 'doubled-backslash' }
+    if ($rule -like 'PowerShell(*')         { return 'powershell-tool' }
+    # Any cd-into-the-repo prefix, quoted or not, either slash style, either case.
+    if ($rule -match '(?i)cd\s+"?[dD]:[\\/]LOM') { return 'cd-prefix-hook' }
+    if ($rule -like '*..*')                 { return 'deny-shadowed' }
+    return $null
+}
+
+$removed = @()
+$kept    = @()
+foreach ($r in $before) {
+    $why = Test-Unreachable $r
+    if ($why) { $removed += [pscustomobject]@{ Reason = $why; Rule = $r } }
+    else      { $kept += $r }
+}
+
+Write-Output "Settings : $SettingsPath"
+Write-Output "Before   : $($before.Count) allow rules"
+Write-Output "Removing : $($removed.Count)"
+$removed | Group-Object Reason | Sort-Object Name | ForEach-Object {
+    "  {0,-20} {1}" -f $_.Name, $_.Count
+}
+Write-Output "After    : $($kept.Count)"
+
+if ($removed.Count -eq 0) { Write-Output "Nothing to do."; return }
+
+if ($PSCmdlet.ShouldProcess($SettingsPath, "Remove $($removed.Count) unreachable allow rules")) {
+    $stamp  = Get-Date -Format 'yyyyMMdd_HHmmss'
+    $backup = "$SettingsPath.$stamp.bak"
+    Copy-Item $SettingsPath $backup
+    Write-Output "Backup   : $backup"
+
+    $json.permissions.allow = $kept
+    $json | ConvertTo-Json -Depth 100 | Set-Content $SettingsPath -Encoding UTF8
+
+    # Re-read to prove the result still parses.
+    $check = Get-Content $SettingsPath -Raw | ConvertFrom-Json
+    Write-Output "Verified : $($check.permissions.allow.Count) allow rules, JSON parses"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -542,13 +542,32 @@ powershell.exe -Command "\$data = Get-Content file.json | ConvertFrom-Json; \$da
 
 ### Which tool for which task
 
-Columns name the Claude Code tool, not the shell language.
+The column names the Claude Code **tool** that dispatches the call, not the language you
+write in. Launching a `.ps1` from Bash still runs PowerShell — Bash is only the dispatcher
+whose allowlist works.
 
 | Task | Tool |
 |------|------|
-| Git, GitHub CLI, file operations | Bash |
+| Git, GitHub CLI, simple file operations | Bash |
 | Any `.ps1` — data processing, JSON parsing | Bash |
 | Process control, PS7 loading net9.0 DLLs | PowerShell |
+
+**Write the logic in PowerShell, not POSIX pipelines.** This is a Windows box: `jq` is not
+installed, and `sed`/`awk`/`xargs` differ from their Linux behavior or mangle Windows paths.
+Reaching for them wastes a cycle on a command that fails or, worse, silently produces the
+wrong answer. Put real work in a `.ps1` and launch it from Bash.
+
+| Instead of | Use |
+|------------|-----|
+| `jq '.field' f.json` | `Get-Content f.json \| ConvertFrom-Json` then `.field` |
+| `sed`/`awk` field munging | `Select-String`, `-split`, `-replace`, `ForEach-Object` |
+| `xargs` | `ForEach-Object` over the pipeline |
+| `wc -l` | `(Get-Content f \| Measure-Object -Line).Lines` |
+| `grep -c` on structured data | parse it as an object, then `.Count` |
+
+Bash is fine for what it does well here: `git`, `gh`, `ls`, `cp`, `mkdir`, and single-purpose
+`grep` over plain text. Anything involving JSON, objects, or multi-step transformation belongs
+in PowerShell.
 
 ### Bash on Windows (Git Bash)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,49 +278,48 @@ UI uniformity, file-browser adoption, versioning, common mistakes). Not auto-loa
 
 ## Testing Requirements
 
-**Before Committing**:
-- Run tool-specific tests (see tool CLAUDE.md)
-- Verify affected tool(s) build successfully
-- Check for hardcoded paths (privacy)
-- Verify cross-platform compatibility if applicable
+**Before committing**: run the affected tool's tests, confirm it builds, and check for
+hardcoded paths.
 
-**UI Test Stability (FlaUI + Avalonia)**:
-- Avalonia apps can crash with `SkiaSharp.SKCanvas.Flush()` errors if closed during mid-render
-- Use `App.Close()` to target the specific test process (not Alt+F4, which goes to focused window)
-- Add delays before closing to let Avalonia's compositor finish pending renders
-- Wait for process to fully exit between tests to prevent resource conflicts
-- See `FlaUITestBase.StopApplication()` for reference implementation
-- **Sequential execution is enforced (#1526)**: `Radoub.IntegrationTests/AssemblyInfo.cs` carries `[assembly: CollectionBehavior(DisableTestParallelization = true)]` for within-assembly serialization. `FlaUITestBase` acquires a named system mutex (`Global\Radoub.FlaUI.SerialExecution`, 30 s timeout) for cross-process serialization — terminal + IDE Test Explorer collisions block on the mutex with a clear error rather than racing for desktop focus.
+**Before a PR to main**: all tools build, all tests pass, private docs are in
+`NonPublic/`, public docs are approved, and each affected tool's CHANGELOG has a
+versioned section — never `[Unreleased]`.
 
-**FlaUI Window Focus (CRITICAL)**:
-- **NEVER use direct `Keyboard.TypeSimultaneously()` calls** - keystrokes go to focused window, not necessarily test app
-- **ALWAYS use focus-safe helpers** from `FlaUITestBase`:
-  - `SendCtrlS()`, `SendCtrlZ()`, `SendCtrlY()`, `SendCtrlD()` etc.
-  - `SendKeyboardShortcut(VirtualKeyShort.CONTROL, VirtualKeyShort.KEY_X)` for custom shortcuts
-  - `EnsureFocused()` before any keyboard input if not using helpers
-- **Why**: During test runs, VSCode or other apps can steal focus. Keyboard shortcuts like Ctrl+Shift+E open VSCode's file explorer instead of triggering test app actions.
-- See `FlaUITestBase.EnsureFocused()` for focus verification pattern
+### Test output (MANDATORY)
 
-**Test Output (MANDATORY)**:
-- **NEVER pipe test output through `tail` or `head`** — this discards failures and leads to false "all tests pass" claims
-- Run tests with `run_in_background`, then grep the output file for results:
-  ```bash
-  # Run tests (output goes to a file automatically)
-  dotnet test Radoub.sln --no-build  # with run_in_background=true
+**Never pipe test output through `tail` or `head`.** It discards failures and produces
+false "all tests pass" claims. Run in the background, then grep the output file:
 
-  # After completion, grep the output file for summary + failures
-  grep -E "^(Failed|Passed|  Failed)" $OUTPUT_FILE
-  ```
-- The `Failed!` and `Passed!` summary lines plus any `  Failed` detail lines give full visibility without reading thousands of lines
-- If failures appear, read the full output file for stack traces and error details
+```bash
+dotnet test Radoub.sln --no-build   # with run_in_background=true
+grep -E "^(Failed|Passed|  Failed)" $OUTPUT_FILE
+```
 
-**Before PRs to Main**:
-- All tools must build
-- All tool tests must pass
-- Private documentation to the Private folder
-- Public Documentation approved before push
-- CHANGELOG updated for affected tools (highlights only — see CHANGELOG Management)
-- **CHANGELOG uses versioned sections only** — never use `[Unreleased]`
+The `Failed!`/`Passed!` summary plus `  Failed` detail lines give full visibility. Read
+the whole file when failures appear.
+
+### FlaUI window focus (CRITICAL)
+
+**Never call `Keyboard.TypeSimultaneously()` directly** — keystrokes reach the focused
+window, which may not be the test app. VSCode stealing focus turns Ctrl+Shift+E into its
+file explorer instead of a test action.
+
+Use `FlaUITestBase` helpers instead: `SendCtrlS()`, `SendCtrlZ()`, `SendCtrlY()`,
+`SendCtrlD()`, or `SendKeyboardShortcut(VirtualKeyShort.CONTROL, VirtualKeyShort.KEY_X)`
+for custom combinations. Call `EnsureFocused()` before any raw keyboard input.
+
+### FlaUI stability (Avalonia)
+
+Closing an Avalonia app mid-render crashes it in `SkiaSharp.SKCanvas.Flush()`. Close via
+`App.Close()` — not Alt+F4, which hits whatever holds focus — after a delay that lets the
+compositor drain, and wait for the process to exit before the next test. See
+`FlaUITestBase.StopApplication()`.
+
+Execution is serialized two ways (#1526): `AssemblyInfo.cs` carries
+`[assembly: CollectionBehavior(DisableTestParallelization = true)]` within the assembly,
+and `FlaUITestBase` holds a named system mutex (`Global\Radoub.FlaUI.SerialExecution`,
+30 s timeout) across processes. A terminal run colliding with IDE Test Explorer blocks on
+the mutex with a clear error instead of racing for the desktop.
 
 ---
 
@@ -599,30 +598,42 @@ Write-Host "Found $($results.Count) items"
 
 ## Code Quality Standards
 
-**Game Data Sourcing (MANDATORY)**:
-- **NEVER hardcode game data** (races, classes, feats, skills, appearances, etc.)
-- **ALWAYS populate from 2DA files and TLK strings** via IGameDataService
-- Support custom content (CEP, PRC, etc.) that adds/modifies 2DA entries
-- Hardcoded fallbacks are acceptable ONLY when 2DA/TLK lookup fails
-- If the data exists in a game file, load it from the game file
-- This ensures compatibility with all modules, custom content packs, and community expansions
+**Game data (MANDATORY)**: never hardcode races, classes, feats, skills, appearances, or
+anything else the game files carry. Load it from 2DA and TLK through `IGameDataService`,
+so CEP, PRC, and other custom content that adds or modifies entries keeps working.
+Hardcode a fallback only for when the lookup itself fails.
 
-**Path Handling**:
-- Use `Environment.GetFolderPath()` with `SpecialFolder` constants
-- Validate paths with `Path.GetFullPath()` for traversal prevention
-- Use `ProcessStartInfo.ArgumentList` instead of string concatenation
+**Paths**: resolve with `Environment.GetFolderPath()` and `SpecialFolder` constants,
+validate with `Path.GetFullPath()` against traversal, and pass arguments via
+`ProcessStartInfo.ArgumentList` rather than string concatenation.
 
-**Exception Handling**:
-- Never use bare `catch` blocks - catch specific types
-- Always log exceptions (at minimum `LogLevel.WARN`)
-- Never silently swallow exceptions
-- **UI handlers that mutate the editor model must wrap the `model.Add(...) → RefreshUI() → MarkDirty()` sequence in try/catch and roll back the model change if the refresh throws.** A populate-time validation filter is not enough — UI controls (ComboBox selections, tree expansion) hold stale state across refreshes, and a bad-state combo can crash deep in the Avalonia render loop instead of in your handler. See `MainWindow.ItemProperties.TryAddProperty` (Relique, #2166) for the canonical single-add pattern: outer catch for `CreateItemProperty`, inner catch for `RefreshAssignedProperties` that removes the just-added entry. Combine with a validation-table recheck at add-time (defense in depth) so each layer covers the other's gaps. **The same rollback discipline applies to batch-add, remove, and clear-all handlers** — these are easy to miss because the mutation is a loop or a single `Clear()`/`RemoveAt()` rather than one `Add()`. Extract the mutate-refresh-rollback logic into a pure helper so it is unit-testable without FlaUI: see `Relique/Services/PropertyListMutator.cs` (`BatchAdd`/`RemoveAt`/`ClearAll`, #2258) for the reusable pattern. **Reliquary and other single-resource blueprint editors derive their handler structure from Relique — fixes to this pattern in Relique should propagate to sibling tools.**
+**Hygiene**: no commented-out code — git remembers. TODOs cite an issue
+(`// TODO (#123): description`). Methods stay under 100 lines. Debug code goes before
+the commit.
 
-**Code Hygiene**:
-- No commented-out code blocks - use git history
-- TODOs must reference GitHub issues: `// TODO (#123): description`
-- Keep methods under 100 lines
-- Remove debug/test code before committing
+### Exception handling
+
+Catch specific types, never bare `catch`. Log every exception at `LogLevel.WARN` or
+above. Never swallow one silently.
+
+**UI handlers that mutate the editor model must roll back when the refresh throws.**
+Wrap the `model.Add(...)` → `RefreshUI()` → `MarkDirty()` sequence in try/catch and undo
+the model change on failure. Validation at populate time is not enough: ComboBox
+selections and tree expansion hold stale state across refreshes, so a bad-state combo
+crashes deep in the Avalonia render loop rather than in your handler. Recheck the
+validation table at add time too — each layer covers the other's gaps.
+
+The canonical single-add pattern is `MainWindow.ItemProperties.TryAddProperty` (Relique,
+#2166): an outer catch for `CreateItemProperty`, an inner catch for
+`RefreshAssignedProperties` that removes the entry it just added.
+
+**Batch-add, remove, and clear-all handlers need the same discipline** and are easy to
+miss, because the mutation is a loop or a lone `Clear()`/`RemoveAt()` instead of an
+`Add()`. Extract mutate-refresh-rollback into a pure helper so it unit-tests without
+FlaUI — see `Relique/Services/PropertyListMutator.cs` (#2258).
+
+Reliquary and the other single-resource blueprint editors inherit their handler
+structure from Relique, so propagate fixes to this pattern across the siblings.
 
 ---
 
@@ -831,64 +842,26 @@ Claude compares, fixes, regenerates. Remove the temporary diagnostic logging bef
 
 ## Agent Skills (Radoub-tuned, originally from obra/superpowers)
 
-Skills in `.claude/skills/` provide structured methodologies. Claude **must** follow these skills when their trigger conditions are met — no user invocation needed, no skipping without explicit user override.
+Skills in `.claude/skills/<name>/SKILL.md` are mandatory when their trigger fires — no
+user invocation needed, no skipping without an explicit override.
 
-**These are project-owned copies, not a vendored upstream mirror.** They started as
-obra/superpowers skills and are tuned for Radoub. Edit them freely to fit this repo; do not
-"resync" them from upstream. The `superpowers:*` plugin skills may also be present in a
-session — when both exist, the unprefixed `.claude/skills/` copy is the Radoub-authoritative
-one.
+**Where a skill conflicts with this file, CLAUDE.md wins.** Most often the TDD Policy
+table above, whose **No** rows (AXAML, config, docs, investigation-first bug fixes) are
+narrower than the generic skill's "always".
 
-**Where a skill conflicts with this file, CLAUDE.md wins** — in particular the TDD Policy
-table above, whose **No** rows (UI layout/AXAML, config, docs, investigation-first bug fixes)
-are narrower than the generic skill's "always".
+| Skill | Apply when |
+|-------|------------|
+| **systematic-debugging** | Any bug, test failure, build error, round-trip failure, or unexplained behavior — especially when tempted to try a quick fix. Work all four phases: root cause → pattern → hypothesis → implementation. |
+| **test-driven-development** | Implementing a feature or fixing a reproducible bug. Scope is the TDD Policy table, not the skill's broader claim. |
+| **verification-before-completion** | Before any completion claim, commit, PR, or next sprint item. Run the command, show the output, then claim. |
 
-### Installed Skills
+They chain: debug to find root cause → TDD to write the failing test and fix → verify with
+evidence.
 
-| Skill | Location | Trigger |
-|-------|----------|---------|
-| **systematic-debugging** | `.claude/skills/systematic-debugging/` | Any bug, test failure, unexpected behavior, or build error |
-| **test-driven-development** | `.claude/skills/test-driven-development/` | Implementing new features or bug fixes that need tests |
-| **verification-before-completion** | `.claude/skills/verification-before-completion/` | Before claiming work is done, tests pass, or build succeeds |
-
-### When to Apply Each Skill
-
-**systematic-debugging** — Apply when:
-- Test failures occur (unit, integration, or FlaUI)
-- Build errors or warnings appear
-- Binary format round-trip validation fails
-- Unexpected runtime behavior reported
-- **Especially** when tempted to "just try a quick fix"
-- Follow all four phases: Root Cause → Pattern Analysis → Hypothesis → Implementation
-
-**test-driven-development** — Apply when:
-- Adding new features (format parsers, UI controls, services)
-- Fixing bugs (write failing test reproducing the bug first)
-- Adding to Radoub.Formats (GFF fields, 2DA parsing, etc.)
-- **Exception**: UI layout/styling work, generated code, config files — ask user
-
-**verification-before-completion** — Apply when:
-- About to mark a TodoWrite task as completed
-- About to commit or create a PR
-- About to claim "tests pass" or "build succeeds"
-- Moving to the next sprint item
-- **Rule**: Run `dotnet test` or `dotnet build` and show the output. No "should work" claims.
-
-### Skill Interaction
-
-The skills chain naturally:
-1. Bug reported → **systematic-debugging** (find root cause)
-2. Root cause found → **test-driven-development** (write failing test, then fix)
-3. Fix implemented → **verification-before-completion** (prove it works with evidence)
-
-### Managing Skills
-
-Skill files live in `.claude/skills/<name>/SKILL.md` — one tree, no symlinks, committed to
-the repo. To change a skill's guidance, edit that file directly.
-
-Originally seeded from https://github.com/obra/superpowers (MIT License). Re-running the
-upstream installer would overwrite Radoub-specific tuning — don't, unless you intend to
-re-apply the local changes afterward.
+These are project-owned copies, seeded from https://github.com/obra/superpowers (MIT) and
+tuned for Radoub. Edit them freely; do not resync from upstream, which would overwrite the
+tuning. When a session also loads the `superpowers:*` plugin skills, the unprefixed local
+copy is authoritative.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -533,9 +533,33 @@ Follow the same standards as Parley (see `Parley/CLAUDE.md`):
 
 ## Shell Usage on Windows
 
+### Run .ps1 Scripts Through the Bash Tool, Not the PowerShell Tool (HARD RULE)
+
+**Every `.ps1` invocation goes through the Bash tool.** The PowerShell tool's
+permission rules do not match on Windows, so it prompts on every call no matter how
+the allow rule is written — an upstream bug (anthropics/claude-code#57013, #60289,
+#42318), not a syntax problem. Do not try to fix it by adding allow rules; they
+become dead entries.
+
+Controlled test (2026-07-20, same script and args, only the tool/path varied):
+
+| Tool | Path form | Result |
+|------|-----------|--------|
+| Bash | relative `".claude/scripts/X.ps1"` | no prompt |
+| Bash | absolute `"d:\LOM\...\X.ps1"` | no prompt |
+| PowerShell | absolute, with `& ` call operator | prompts |
+| PowerShell | relative, no call operator | prompts |
+
+The deciding variable is the **tool**. Path form and the `&` call operator do not
+matter — Bash works with either path style.
+
+**Carve-out**: the PowerShell tool is still correct for genuine PowerShell work
+that is not a script invocation — `Get-Process`/`Stop-Process`, or PS7 loading
+net9.0 Radoub DLLs. Those prompt too; that is unavoidable.
+
 ### Prefer Script Files Over Inline Commands
 
-**DO**: Use `powershell.exe -File` with PowerShell scripts (NEVER use `pwsh` — it launches Microsoft Store)
+**DO**: Use `powershell.exe -File` **via the Bash tool** (NEVER use `pwsh` — it launches Microsoft Store)
 ```bash
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View status
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Refresh-GitHubCache.ps1" -Force
@@ -549,13 +573,20 @@ powershell.exe -Command "\$data = Get-Content file.json | ConvertFrom-Json; \$da
 
 ### When to Use Each Shell
 
-| Task | Use | Example |
-|------|-----|---------|
+| Task | Tool | Example |
+|------|------|---------|
 | Git operations | Bash | `git status`, `git commit` |
 | GitHub CLI | Bash | `gh issue view 123`, `gh pr create` |
 | File operations | Bash | `cp`, `mkdir -p`, `rm -f` |
-| Complex data processing | PowerShell script | `Get-CacheData.ps1` |
-| JSON parsing | PowerShell script | Custom `.ps1` files |
+| Running any `.ps1` | **Bash** | `powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View list` |
+| Complex data processing | **Bash** running a `.ps1` | `Get-CacheData.ps1` |
+| JSON parsing | **Bash** running a `.ps1` | Custom `.ps1` files |
+| Process control | PowerShell tool | `Get-Process`, `Stop-Process` (prompts — unavoidable) |
+| PS7 loading net9.0 DLLs | PowerShell tool | absolute PS7 path (prompts — unavoidable) |
+
+The "Use" column is the **Claude Code tool**, not the shell language. A `.ps1` still
+runs under PowerShell — it is just launched from the Bash tool so the allowlist
+matches. See the hard rule above.
 
 ### Bash on Windows (Git Bash)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,79 +326,53 @@ UI uniformity, file-browser adoption, versioning, common mistakes). Not auto-loa
 
 ## Sprint Workflow
 
-**Per Sprint Item**: For each item, follow this order:
-1. **TDD check** — does this item need tests first? (See TDD Policy table above)
-2. **Implement** — write code (after tests if TDD required)
-3. **Verify** — run tests, confirm build
-4. **Commit and push** — one commit per item
+Per item: TDD check (see the TDD Policy table) → implement → verify → commit and
+push. One commit per discrete item, each referencing the sprint issue. Every commit
+should leave a working state, so a bad item is easy to revert or bisect.
 
-**Commit Between Sprint Items**:
-- Commit after completing each discrete item within a sprint
-- This provides clear history and makes rollback easier
-- Use descriptive commit messages that reference the sprint issue
-
-**Example Sprint Workflow**:
 ```
-# After completing UTC reader
 git add . && git commit -m "[Radoub] feat: Add UTC reader for creature blueprints (#549)"
-
-# After completing UTC writer
-git add . && git commit -m "[Radoub] feat: Add UTC writer for creature blueprints (#549)"
-
-# After completing tests
-git add . && git commit -m "[Radoub] test: Add UTC round-trip tests (#549)"
 ```
 
-**Benefits**:
-- Each commit represents a working state
-- Easier to review individual changes
-- Simpler to bisect if issues arise
-- Clear progress tracking in git history
+### Sprint completion — manual spot-check list
 
-**Sprint Completion — Manual Spot-Check List**:
+Before `/pre-merge`, list what a human must verify. Skip the list only when the
+sprint is purely internal — refactoring, tests, or docs — or fully covered by
+automated tests.
 
-When all sprint items are done (before `/pre-merge`), generate a **manual spot-check list** if the sprint included any changes that need human visual/behavioral verification.
+Write spot-checks for:
 
-**Include spot-checks when the sprint has:**
-- UI visual changes (new icons, color changes, layout, theme updates)
-- User-facing behavior (new shortcuts, menu items, dialog behavior)
-- Event/notification wiring (events that should trigger visible UI updates)
-- File format changes (round-trip with real files)
-- **Platform-dependent behavior — flag with a `(Linux)` tag** when a change touches code
-  whose behavior or backend differs between Windows and Linux/macOS. Development happens on
-  Windows, so anything with a Linux-specific dependency needs a human to verify it on a Linux
-  box. Common triggers:
-  - **Filesystem**: path handling, case sensitivity, separators, symlinks, permissions, temp-dir
-    resolution (`Path.GetTempPath()`, `SpecialFolder`), file locking/delete-while-open semantics
-  - **Audio / TTS**: different backends per platform (e.g. Windows `System.Speech` vs Linux
-    Piper/`espeak-ng`, macOS `say`), sound playback (`aplay`/`afplay`), stop/cancel semantics
-    that differ (see #2523 — `Stop()` fires completion sync on Windows, silent on Piper)
-  - **Process launch**: external editors, spawned CLIs, argument quoting, PATH lookup
-  - **Native/interop**: SkiaSharp/OpenGL rendering, platform packages, `[SupportedOSPlatform]` code
+- UI visuals: icons, colors, layout, themes
+- User-facing behavior: shortcuts, menu items, dialogs
+- Event wiring that should produce a visible update
+- File format changes — round-trip a real file
+- Platform-dependent behavior, tagged `(Linux)` (see below)
 
-**Skip spot-checks when:**
-- Changes are purely internal (refactoring, test-only, documentation)
-- Everything is fully covered by automated tests with no visual component
+Format:
 
-**Format:**
 ```markdown
 ### Manual Spot-Checks
 
 Verify in the running app before `/pre-merge`:
 
-- [ ] [Specific thing to check] — [where/how to verify]
-- [ ] [Another thing] — [steps to reproduce]
+- [ ] [Specific thing] — [where/how to verify]
 - [ ] (Linux) [Platform-specific thing] — verify on a Linux box, not just Windows
 ```
 
-**Rules:**
-- Be specific — "check the UI" is not useful
-- Include how to trigger the behavior
-- Only list things automated tests can't verify
-- **Tag Linux-specific items with `(Linux)`** and say what Linux dependency makes it differ
-  (filesystem, TTS/audio backend, process launch, native interop). If unsure whether behavior
-  is platform-identical, err toward flagging it — a Windows-only check can silently pass while
-  the Linux path is broken.
+Be specific and say how to trigger the behavior; "check the UI" helps nobody. List
+only what automated tests cannot cover.
+
+**Linux tagging.** Development happens on Windows, so a Windows-only check can pass
+while the Linux path is broken. Tag any item whose backend differs and name the
+dependency. When unsure, tag it. Common triggers:
+
+- **Filesystem**: case sensitivity, separators, symlinks, permissions, temp-dir
+  resolution (`Path.GetTempPath()`, `SpecialFolder`), delete-while-open semantics
+- **Audio/TTS**: Windows `System.Speech` vs Linux Piper/`espeak-ng` vs macOS `say`;
+  playback (`aplay`/`afplay`); stop semantics (#2523 — `Stop()` fires completion
+  synchronously on Windows, silently on Piper)
+- **Process launch**: external editors, spawned CLIs, argument quoting, PATH lookup
+- **Native/interop**: SkiaSharp/OpenGL, platform packages, `[SupportedOSPlatform]`
 - Keep it short (3-8 items typical)
 
 **Example** (for a sprint with a new FlowView icon + theme fixes + a TTS stop fix):
@@ -533,60 +507,49 @@ Follow the same standards as Parley (see `Parley/CLAUDE.md`):
 
 ## Shell Usage on Windows
 
-### Run .ps1 Scripts Through the Bash Tool, Not the PowerShell Tool (HARD RULE)
+### Launch every .ps1 from the Bash tool (HARD RULE)
 
-**Every `.ps1` invocation goes through the Bash tool.** The PowerShell tool's
-permission rules do not match on Windows, so it prompts on every call no matter how
-the allow rule is written — an upstream bug (anthropics/claude-code#57013, #60289,
-#42318), not a syntax problem. Do not try to fix it by adding allow rules; they
-become dead entries.
+PowerShell-tool permission rules never match on Windows, so that tool prompts on
+every call however the allow rule is written. This is an upstream bug
+(anthropics/claude-code#57013, #60289, #42318). Adding allow rules does not fix it;
+they become dead entries.
 
-Controlled test (2026-07-20, same script and args, only the tool/path varied):
+Canonical form — never `pwsh`, which launches the Microsoft Store:
 
-| Tool | Path form | Result |
-|------|-----------|--------|
-| Bash | relative `".claude/scripts/X.ps1"` | no prompt |
-| Bash | absolute `"d:\LOM\...\X.ps1"` | no prompt |
-| PowerShell | absolute, with `& ` call operator | prompts |
-| PowerShell | relative, no call operator | prompts |
-
-The deciding variable is the **tool**. Path form and the `&` call operator do not
-matter — Bash works with either path style.
-
-**Carve-out**: the PowerShell tool is still correct for genuine PowerShell work
-that is not a script invocation — `Get-Process`/`Stop-Process`, or PS7 loading
-net9.0 Radoub DLLs. Those prompt too; that is unavoidable.
-
-### Prefer Script Files Over Inline Commands
-
-**DO**: Use `powershell.exe -File` **via the Bash tool** (NEVER use `pwsh` — it launches Microsoft Store)
 ```bash
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View status
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Refresh-GitHubCache.ps1" -Force
 ```
 
-**AVOID**: Inline PowerShell with `-Command` (escaping nightmare)
+Controlled test, 2026-07-20, varying only the tool and path:
+
+| Tool | Path | Result |
+|------|------|--------|
+| Bash | relative | no prompt |
+| Bash | absolute | no prompt |
+| PowerShell | absolute, with `&` | prompts |
+| PowerShell | relative, no `&` | prompts |
+
+The tool decides. Path form and the `&` call operator do not matter.
+
+Reserve the PowerShell tool for work that is not a script call — `Get-Process`,
+`Stop-Process`, PS7 loading net9.0 DLLs. Those prompt unavoidably.
+
+Avoid inline `-Command`; escaping breaks it:
+
 ```bash
-# BAD - requires \$ escaping, breaks easily
+# BAD - requires \$ escaping
 powershell.exe -Command "\$data = Get-Content file.json | ConvertFrom-Json; \$data.property"
 ```
 
-### When to Use Each Shell
+### Which tool for which task
 
-| Task | Tool | Example |
-|------|------|---------|
-| Git operations | Bash | `git status`, `git commit` |
-| GitHub CLI | Bash | `gh issue view 123`, `gh pr create` |
-| File operations | Bash | `cp`, `mkdir -p`, `rm -f` |
-| Running any `.ps1` | **Bash** | `powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".claude/scripts/Get-CacheData.ps1" -View list` |
-| Complex data processing | **Bash** running a `.ps1` | `Get-CacheData.ps1` |
-| JSON parsing | **Bash** running a `.ps1` | Custom `.ps1` files |
-| Process control | PowerShell tool | `Get-Process`, `Stop-Process` (prompts — unavoidable) |
-| PS7 loading net9.0 DLLs | PowerShell tool | absolute PS7 path (prompts — unavoidable) |
+Columns name the Claude Code tool, not the shell language.
 
-The "Use" column is the **Claude Code tool**, not the shell language. A `.ps1` still
-runs under PowerShell — it is just launched from the Bash tool so the allowlist
-matches. See the hard rule above.
+| Task | Tool |
+|------|------|
+| Git, GitHub CLI, file operations | Bash |
+| Any `.ps1` — data processing, JSON parsing | Bash |
+| Process control, PS7 loading net9.0 DLLs | PowerShell |
 
 ### Bash on Windows (Git Bash)
 


### PR DESCRIPTION
## Summary

Housekeeping pass over `CLAUDE.md` and all ten slash commands, plus one correctness rule about how PowerShell scripts get launched. Docs and tooling only — no product code.

**No linked issue by design.** This is pure housekeeping started from an observation mid-session, so `/init-item` was skipped deliberately. `/pre-merge` will flag that as an init-item warning; it is expected here.

## 1. The PowerShell-tool rule

PowerShell-tool permission rules never match on Windows, so those calls prompt on every invocation no matter how the allow rule is written. Upstream, not a project misconfiguration:

- anthropics/claude-code#57013 — Windows PowerShell allow rules never match (JSON deserializes doubled backslashes; the command runs with single ones; literal comparison)
- anthropics/claude-code#60289 — trailing wildcards do not pre-approve `.exe` invocations
- anthropics/claude-code#42318 — PowerShell permission parsing is deliberately less hardened than Bash

Controlled test, same script and arguments, varying only tool and path form:

| Tool | Path | Result |
|------|------|--------|
| Bash | relative | no prompt |
| Bash | absolute backslash | no prompt |
| PowerShell | absolute, with `&` | prompts |
| PowerShell | relative, no `&` | prompts |

The tool is the deciding variable; path form and the `&` call operator are irrelevant. Also verified prompt-free from Bash: `Get-CacheData.ps1`, `Test-IssueState.ps1`, and PS7 `pwsh.exe` 7.6.2.

The rule ships with its counterpart, which matters just as much: **Bash is the dispatcher, PowerShell is the language.** This is a Windows box with no `jq`, and `sed`/`awk`/`xargs` either differ from Linux or mangle paths. Without that half, "launch from Bash" reads as an invitation to write POSIX pipelines. Includes a translation table (`jq` → `ConvertFrom-Json`, `xargs` → `ForEach-Object`, `wc -l` → `Measure-Object`).

Carve-out preserved: the PowerShell tool stays correct for non-script work (`Get-Process`, `Stop-Process`, PS7 loading net9.0 DLLs). Those prompt unavoidably.

## 2. Permission-rule cleanup

`.claude/settings.local.json` went from 216 to 152 allow rules. All 64 removed were unreachable:

| Category | Count | Why dead |
|----------|-------|----------|
| Doubled backslash | 20 | Upstream #57013 |
| PowerShell-tool | 35 | Upstream — never match |
| `cd`-prefix | 6 | `check-cd-prefix.sh` blocks before permissions are consulted |
| Contains `..` | 3 | The traversal deny rule overrides the allow |

The last two are genuine cross-layer conflicts — a hook and a deny rule each silently overriding allows that look active.

New `.claude/scripts/Prune-DeadPermissionRules.ps1` does this repeatably, with `-WhatIf`, a timestamped backup, and a post-write parse check. Verified afterward that `git`, `gh`, and the cache scripts still run prompt-free. Re-run after all subsequent work: zero new dead rules.

## 3. Prose and structure

Strunk's omit-needless-words over the longest sections, then every slash command.

**CLAUDE.md: 5,747 → 4,967 words** (Sprint Workflow 645→427, Shell Usage 635→457, Agent Skills 418→201, Testing 380→264, Code Quality 337→286).

**Slash commands: 12,466 → 9,065 words (27%)**, and every one now numbers 1→N in phases. Previously: `/pre-merge` had 15 steps needing 8 letter suffixes (`0`, `0b`, `0c`, `3b`, `3c`, `5b`, `7b`, `7c`), `/backlog` had two Step 3s, `/post-merge` jumped 6→6e, `/dependabot` started at Phase 0.

Cuts were redundancy, not content: three near-identical commit examples, a Benefits list restating the rule above it, Linux triggers duplicated across two blocks, the sprint-commit discipline stated three times in `/init-item`, and the tag-then-reset order hazard stated three times in `/release`.

## Bugs found while rewriting

Five things that were wrong, not just wordy:

1. **`/documentation` used `git diff main...HEAD`** — the triple-dot range the sandbox guard denies (#2468). Also carried a `cd d:\...` prefix the hook blocks and a stale `Claude Opus 4.6` co-author line.
2. **`/research` contradicted the documented spike convention** — `git stash` + `checkout -b` in place, which disrupts in-progress work. Now uses a worktree.
3. **`/init-item` recommended `grep`/`sed` for JSON** three lines below its own "no jq" warning. Those pipelines break on the first quoted comma.
4. **`/post-merge` used `gh issue view` for reads**, against the cache-first rule, and did not check live state before closing issues GitHub had already auto-closed on merge.
5. **CLAUDE.md's Agent Skills entry said TDD exceptions should "ask user"**, contradicting the TDD Policy table's outright **No** for AXAML, config, and docs. The table is authoritative.

Also folded in lessons from the sprint that preceded this: verify an issue's premise still holds before planning against it, prefer an umbrella issue over per-page duplicates in the freshness sweep, and never bump a freshness date without reading the page.

## Verification

Every issue reference, API name, project ID, and rule was keyword-checked after each rewrite. Numbering audited across all ten commands — no `Step 0`, no letter suffixes, no duplicate numbers, no stale cross-references.

Docs and tooling only; no product code touched, so the test suite is unaffected.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
