### PR TITLE
[Radoub] Fix: Move startup cleanup off the first-paint path (#2647)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Startup-Cleanup] - 2026-07-20
-**Branch**: `radoub/issue-2647` | **PR**: #TBD
+**Branch**: `radoub/issue-2647` | **PR**: #2673
 
 ### Fix: Move startup cleanup off the first-paint path (#2647)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Startup-Cleanup] - 2026-07-20
+**Branch**: `radoub/issue-2647` | **PR**: #TBD
+
+### Fix: Move startup cleanup off the first-paint path (#2647)
+
+- Log-session and backup cleanup now run on a background thread after the window opens, via the new shared `StartupCleanupCoordinator`, instead of blocking startup in `Program.Main` and `App.Initialize`.
+- Removed a duplicate session sweep: every tool ran the same recursive delete twice per launch, once in `UnifiedLogger.Configure` and again in `App.Initialize`.
+- `CleanupOldSessions` now refuses to delete the live session directory, which matters once the sweep runs concurrently with active logging.
+- Measured impact on a machine with normal retention is small (~5 ms) — the sweep is cheap precisely because retention keeps history short. The correctness fixes are the substantive part.
+
+---
+
 ## [Cross-Tool-UX] - 2026-07-19
 **Branch**: `radoub/issue-2653` | **PR**: #2663
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Log-session and backup cleanup now run on a background thread after the window opens, via the new shared `StartupCleanupCoordinator`, instead of blocking startup in `Program.Main` and `App.Initialize`.
 - Removed a duplicate session sweep: every tool ran the same recursive delete twice per launch, once in `UnifiedLogger.Configure` and again in `App.Initialize`.
-- `CleanupOldSessions` now refuses to delete the live session directory, which matters once the sweep runs concurrently with active logging.
+- `CleanupOldSessions` now refuses to delete the live session directory, which matters once the sweep runs concurrently with active logging. The live session counts toward the retention total, so `LogRetentionSessions` still means "sessions kept on disk".
 - Measured impact on a machine with normal retention is small (~5 ms) — the sweep is cheap precisely because retention keeps history short. The correctness fixes are the substantive part.
 
 ---

--- a/Fence/Fence/App.axaml.cs
+++ b/Fence/Fence/App.axaml.cs
@@ -34,12 +34,8 @@ public partial class App : Application
 
         ApplyFontSettings();
 
-        // Clean up old log sessions
-        UnifiedLogger.CleanupOldSessions(SettingsService.Instance.LogRetentionSessions);
-
-        // Clean up old backups
-        Radoub.UI.Services.BackupCleanupService.CleanupExpiredBackups(
-            Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
+        // Log-session and backup cleanup run after first paint (#2647) — see
+        // MainWindow's Opened handler.
 
         // Initialize spell-checking (async, non-blocking)
         _ = SpellCheckService.Instance.InitializeAsync();

--- a/Fence/Fence/Views/MainWindow.axaml.cs
+++ b/Fence/Fence/Views/MainWindow.axaml.cs
@@ -167,6 +167,11 @@ public partial class MainWindow : Window, INotifyPropertyChanged
         // Fire and forget - don't block UI thread
         // Service init and palette loading happen in background
         _ = InitializeAndLoadAsync(_windowCts.Token);
+
+        // Startup housekeeping, off the first-paint path (#2647)
+        Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
+            SettingsService.Instance.LogRetentionSessions,
+            Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
     }
 
     private async Task InitializeAndLoadAsync(CancellationToken token)

--- a/Fence/Fence/Views/MainWindow.axaml.cs
+++ b/Fence/Fence/Views/MainWindow.axaml.cs
@@ -160,6 +160,12 @@ public partial class MainWindow : Window, INotifyPropertyChanged
     {
         Opened -= OnWindowOpened;
 
+        // Startup housekeeping, off the first-paint path (#2647). Kicked off first so it
+        // cannot be skipped by a startup failure below.
+        Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
+            SettingsService.Instance.LogRetentionSessions,
+            Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
+
         _windowCts = new CancellationTokenSource();
 
         UpdateStatusBar("Initializing...");
@@ -167,11 +173,6 @@ public partial class MainWindow : Window, INotifyPropertyChanged
         // Fire and forget - don't block UI thread
         // Service init and palette loading happen in background
         _ = InitializeAndLoadAsync(_windowCts.Token);
-
-        // Startup housekeeping, off the first-paint path (#2647)
-        Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
-            SettingsService.Instance.LogRetentionSessions,
-            Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
     }
 
     private async Task InitializeAndLoadAsync(CancellationToken token)

--- a/Manifest/Manifest/App.axaml.cs
+++ b/Manifest/Manifest/App.axaml.cs
@@ -38,12 +38,8 @@ public partial class App : Application
         // Apply font settings
         ApplyFontSettings();
 
-        // Clean up old log sessions
-        UnifiedLogger.CleanupOldSessions(SettingsService.Instance.LogRetentionSessions);
-
-        // Clean up old backups
-        Radoub.UI.Services.BackupCleanupService.CleanupExpiredBackups(
-            Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
+        // Log-session and backup cleanup run after first paint (#2647) — see
+        // MainWindow's Opened handler.
 
         // Initialize spell-checking (async, non-blocking)
         _ = SpellCheckService.Instance.InitializeAsync();

--- a/Manifest/Manifest/Views/MainWindow.axaml.cs
+++ b/Manifest/Manifest/Views/MainWindow.axaml.cs
@@ -130,6 +130,12 @@ public partial class MainWindow : Window, INotifyPropertyChanged
         // Only handle once
         Opened -= OnWindowOpened;
 
+        // Startup housekeeping, off the first-paint path (#2647). Kicked off before the try
+        // block so a startup-load failure cannot skip retention cleanup.
+        Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
+            SettingsService.Instance.LogRetentionSessions,
+            Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
+
         // #2254 — async void with no guard previously swallowed any startup exception,
         // leaving the app silently empty. Wrap in try/catch + cancellation (QM Lifecycle pattern).
         _windowCts = new System.Threading.CancellationTokenSource();
@@ -140,11 +146,6 @@ public partial class MainWindow : Window, INotifyPropertyChanged
             await HandleStartupFileAsync();
 
             UnifiedLogger.LogStartupMilestone("Manifest ready (services + startup load complete)");
-
-            // Startup housekeeping, off the first-paint path (#2647)
-            Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
-                SettingsService.Instance.LogRetentionSessions,
-                Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
         }
         catch (OperationCanceledException)
         {

--- a/Manifest/Manifest/Views/MainWindow.axaml.cs
+++ b/Manifest/Manifest/Views/MainWindow.axaml.cs
@@ -140,6 +140,11 @@ public partial class MainWindow : Window, INotifyPropertyChanged
             await HandleStartupFileAsync();
 
             UnifiedLogger.LogStartupMilestone("Manifest ready (services + startup load complete)");
+
+            // Startup housekeeping, off the first-paint path (#2647)
+            Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
+                SettingsService.Instance.LogRetentionSessions,
+                Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
         }
         catch (OperationCanceledException)
         {

--- a/Parley/Parley/Views/MainWindow.Lifecycle.cs
+++ b/Parley/Parley/Views/MainWindow.Lifecycle.cs
@@ -23,6 +23,13 @@ namespace DialogEditor.Views
         /// </summary>
         private async void OnWindowOpened(object? sender, EventArgs e)
         {
+            // Startup housekeeping, off the first-paint path (#2647). Kicked off first so a
+            // throw from the startup loads below cannot skip retention cleanup — it depends on
+            // nothing here and returns immediately.
+            Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
+                _services.Settings.LogRetentionSessions,
+                Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
+
             // #1961: Auto-detect resource paths deferred from SettingsService constructor
             _services.Settings.DeferredAutoDetectPaths();
 
@@ -67,11 +74,6 @@ namespace DialogEditor.Views
             _ = WarmupGameDataServiceAsync();
 
             UnifiedLogger.LogStartupMilestone("Parley ready (services + startup load complete)");
-
-            // Startup housekeeping, off the first-paint path (#2647)
-            Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
-                _services.Settings.LogRetentionSessions,
-                Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
         }
 
         /// <summary>

--- a/Parley/Parley/Views/MainWindow.Lifecycle.cs
+++ b/Parley/Parley/Views/MainWindow.Lifecycle.cs
@@ -67,6 +67,11 @@ namespace DialogEditor.Views
             _ = WarmupGameDataServiceAsync();
 
             UnifiedLogger.LogStartupMilestone("Parley ready (services + startup load complete)");
+
+            // Startup housekeeping, off the first-paint path (#2647)
+            Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
+                _services.Settings.LogRetentionSessions,
+                Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
         }
 
         /// <summary>

--- a/Parley/Parley/Views/MainWindow.axaml.cs
+++ b/Parley/Parley/Views/MainWindow.axaml.cs
@@ -305,13 +305,8 @@ namespace DialogEditor.Views
             UnifiedLogger.LogApplication(LogLevel.INFO, "Parley MainWindow initialized");
             UnifiedLogger.LogStartupMilestone("Parley MainWindow constructed");
 
-            // Cleanup old log sessions on startup (#1232: use DI-resolved settings)
-            var retentionCount = _services.Settings.LogRetentionSessions;
-            UnifiedLogger.CleanupOldSessions(retentionCount);
-
-            // Clean up old backups
-            Radoub.UI.Services.BackupCleanupService.CleanupExpiredBackups(
-                Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
+            // Log-session and backup cleanup run after first paint (#2647) — see
+            // OnWindowOpened.
         }
 
         /// <summary>

--- a/Quartermaster/Quartermaster/App.axaml.cs
+++ b/Quartermaster/Quartermaster/App.axaml.cs
@@ -38,12 +38,8 @@ public partial class App : Application
         // Apply font settings
         ApplyFontSettings();
 
-        // Clean up old log sessions
-        UnifiedLogger.CleanupOldSessions(SettingsService.Instance.LogRetentionSessions);
-
-        // Clean up old backups
-        Radoub.UI.Services.BackupCleanupService.CleanupExpiredBackups(
-            Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
+        // Log-session and backup cleanup run after first paint (#2647) — see
+        // MainWindow's Opened handler.
 
         // Initialize spell-checking (async, non-blocking)
         // No cancellation needed - singleton service that should complete during app lifetime

--- a/Quartermaster/Quartermaster/Views/MainWindow.Lifecycle.cs
+++ b/Quartermaster/Quartermaster/Views/MainWindow.Lifecycle.cs
@@ -34,6 +34,11 @@ public partial class MainWindow
         // Fire and forget - don't block UI thread
         // Service init and all loading happens in background
         _ = InitializeAndLoadAsync(_windowCts.Token);
+
+        // Startup housekeeping, off the first-paint path (#2647)
+        Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
+            SettingsService.Instance.LogRetentionSessions,
+            Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
     }
 
     private async Task InitializeAndLoadAsync(CancellationToken token)

--- a/Quartermaster/Quartermaster/Views/MainWindow.Lifecycle.cs
+++ b/Quartermaster/Quartermaster/Views/MainWindow.Lifecycle.cs
@@ -24,6 +24,12 @@ public partial class MainWindow
     {
         Opened -= OnWindowOpened;
 
+        // Startup housekeeping, off the first-paint path (#2647). Kicked off first so it
+        // cannot be skipped by a startup failure below.
+        Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
+            SettingsService.Instance.LogRetentionSessions,
+            Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
+
         // Create cancellation token for async operations
         _windowCts = new CancellationTokenSource();
 
@@ -34,11 +40,6 @@ public partial class MainWindow
         // Fire and forget - don't block UI thread
         // Service init and all loading happens in background
         _ = InitializeAndLoadAsync(_windowCts.Token);
-
-        // Startup housekeeping, off the first-paint path (#2647)
-        Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
-            SettingsService.Instance.LogRetentionSessions,
-            Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
     }
 
     private async Task InitializeAndLoadAsync(CancellationToken token)

--- a/Radoub.Formats/Radoub.Formats.Tests/UnifiedLoggerCleanupTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/UnifiedLoggerCleanupTests.cs
@@ -42,7 +42,8 @@ public class UnifiedLoggerCleanupTests : IDisposable
         var middle = CreateSession(now.AddHours(-1));
         var oldest = CreateSession(now.AddHours(-2));
 
-        UnifiedLogger.CleanupOldSessions(2, _tempRoot);
+        UnifiedLogger.CleanupOldSessions(
+            2, _tempRoot, protectedSessionDirectory: UnifiedLogger.NoProtectedSession);
 
         Assert.True(Directory.Exists(newest));
         Assert.True(Directory.Exists(middle));
@@ -67,9 +68,11 @@ public class UnifiedLoggerCleanupTests : IDisposable
     }
 
     [Fact]
-    public void CleanupOldSessions_ProtectedSessionDoesNotConsumeRetentionSlot()
+    public void CleanupOldSessions_ProtectedSessionConsumesARetentionSlot()
     {
-        // Protecting the live session must not silently evict an extra recent session.
+        // retainSessionCount is a TOTAL including the live session, matching the meaning
+        // LogRetentionSessions had before the live-session guard existed. With retain: 2 and a
+        // protected session, exactly one other session survives — not two (#2647 review).
         var now = DateTime.Now;
         var liveSession = CreateSession(now.AddHours(-5));
         var newest = CreateSession(now);
@@ -79,7 +82,40 @@ public class UnifiedLoggerCleanupTests : IDisposable
 
         Assert.True(Directory.Exists(liveSession));
         Assert.True(Directory.Exists(newest));
-        Assert.True(Directory.Exists(second));
+        Assert.False(Directory.Exists(second));
+
+        // Total on disk equals the requested retention.
+        Assert.Equal(2, Directory.GetDirectories(_tempRoot, "Session_*").Length);
+    }
+
+    [Fact]
+    public void CleanupOldSessions_ExplicitBaseDirectoryStillProtectsLiveSession()
+    {
+        // Passing a base directory explicitly must NOT silently disarm the guard — protection
+        // is opt-out via the sentinel only (#2647 review).
+        var now = DateTime.Now;
+        var liveSession = CreateSession(now.AddHours(-5));
+        CreateSession(now);
+        CreateSession(now.AddHours(-1));
+
+        UnifiedLogger.CleanupOldSessions(1, _tempRoot, protectedSessionDirectory: liveSession);
+
+        Assert.True(Directory.Exists(liveSession));
+    }
+
+    [Fact]
+    public void CleanupOldSessions_NoProtectedSessionSentinel_SweepsPurelyByAge()
+    {
+        // With no live session in the swept root, retention applies to every directory.
+        var now = DateTime.Now;
+        var newest = CreateSession(now);
+        var older = CreateSession(now.AddHours(-1));
+
+        UnifiedLogger.CleanupOldSessions(
+            1, _tempRoot, protectedSessionDirectory: UnifiedLogger.NoProtectedSession);
+
+        Assert.True(Directory.Exists(newest));
+        Assert.False(Directory.Exists(older));
     }
 
     [Fact]
@@ -100,7 +136,8 @@ public class UnifiedLoggerCleanupTests : IDisposable
         Directory.CreateDirectory(stray);
         var valid = CreateSession(now);
 
-        UnifiedLogger.CleanupOldSessions(1, _tempRoot);
+        UnifiedLogger.CleanupOldSessions(
+            1, _tempRoot, protectedSessionDirectory: UnifiedLogger.NoProtectedSession);
 
         Assert.True(Directory.Exists(valid));
         Assert.True(Directory.Exists(stray));   // untouched, not crashed on

--- a/Radoub.Formats/Radoub.Formats.Tests/UnifiedLoggerCleanupTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/UnifiedLoggerCleanupTests.cs
@@ -1,0 +1,108 @@
+using Radoub.Formats.Logging;
+using Xunit;
+
+namespace Radoub.Formats.Tests;
+
+/// <summary>
+/// Retention/exclusion behavior for log-session cleanup (#2647).
+///
+/// Cleanup moved off the synchronous first-paint path, which makes it concurrent with
+/// active logging rather than sequential-before-it. These tests pin the invariant that
+/// protects the live session directory from a concurrent sweep.
+/// </summary>
+public class UnifiedLoggerCleanupTests : IDisposable
+{
+    private readonly string _tempRoot;
+
+    public UnifiedLoggerCleanupTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "RadoubLogCleanupTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, true);
+    }
+
+    private string CreateSession(DateTime timestamp)
+    {
+        var dir = Path.Combine(_tempRoot, $"Session_{timestamp:yyyyMMdd_HHmmss}");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "Application.log"), "log data");
+        return dir;
+    }
+
+    [Fact]
+    public void CleanupOldSessions_KeepsMostRecentSessions()
+    {
+        var now = DateTime.Now;
+        var newest = CreateSession(now);
+        var middle = CreateSession(now.AddHours(-1));
+        var oldest = CreateSession(now.AddHours(-2));
+
+        UnifiedLogger.CleanupOldSessions(2, _tempRoot);
+
+        Assert.True(Directory.Exists(newest));
+        Assert.True(Directory.Exists(middle));
+        Assert.False(Directory.Exists(oldest));
+    }
+
+    [Fact]
+    public void CleanupOldSessions_NeverDeletesProtectedSession_EvenWhenBeyondRetention()
+    {
+        // The live session must survive a sweep that would otherwise evict it by age.
+        // Backgrounding cleanup (#2647) makes this reachable: a long-running app's session
+        // ages past the retention window while newer sessions from other launches pile up.
+        var now = DateTime.Now;
+        var liveSession = CreateSession(now.AddHours(-5));   // oldest by timestamp
+        CreateSession(now);
+        CreateSession(now.AddHours(-1));
+        CreateSession(now.AddHours(-2));
+
+        UnifiedLogger.CleanupOldSessions(2, _tempRoot, protectedSessionDirectory: liveSession);
+
+        Assert.True(Directory.Exists(liveSession));
+    }
+
+    [Fact]
+    public void CleanupOldSessions_ProtectedSessionDoesNotConsumeRetentionSlot()
+    {
+        // Protecting the live session must not silently evict an extra recent session.
+        var now = DateTime.Now;
+        var liveSession = CreateSession(now.AddHours(-5));
+        var newest = CreateSession(now);
+        var second = CreateSession(now.AddHours(-1));
+
+        UnifiedLogger.CleanupOldSessions(2, _tempRoot, protectedSessionDirectory: liveSession);
+
+        Assert.True(Directory.Exists(liveSession));
+        Assert.True(Directory.Exists(newest));
+        Assert.True(Directory.Exists(second));
+    }
+
+    [Fact]
+    public void CleanupOldSessions_HandlesNonExistentDirectory()
+    {
+        var missing = Path.Combine(_tempRoot, "does-not-exist");
+
+        var ex = Record.Exception(() => UnifiedLogger.CleanupOldSessions(2, missing));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void CleanupOldSessions_IgnoresUnparseableDirectoryNames()
+    {
+        var now = DateTime.Now;
+        var stray = Path.Combine(_tempRoot, "Session_not-a-timestamp");
+        Directory.CreateDirectory(stray);
+        var valid = CreateSession(now);
+
+        UnifiedLogger.CleanupOldSessions(1, _tempRoot);
+
+        Assert.True(Directory.Exists(valid));
+        Assert.True(Directory.Exists(stray));   // untouched, not crashed on
+    }
+}

--- a/Radoub.Formats/Radoub.Formats/Logging/UnifiedLogger.cs
+++ b/Radoub.Formats/Radoub.Formats/Logging/UnifiedLogger.cs
@@ -324,16 +324,25 @@ public static class UnifiedLogger
     }
 
     /// <summary>
+    /// Sentinel for <see cref="CleanupOldSessions"/>: sweep without protecting any session.
+    /// Only valid when the root being swept holds no live session.
+    /// </summary>
+    public static readonly string NoProtectedSession = new("\0__no_protected_session__");
+
+    /// <summary>
     /// Cleans up old log sessions based on session count retention.
     /// Keeps the N most recent sessions and deletes older ones.
     /// </summary>
-    /// <param name="retainSessionCount">Number of recent sessions to keep.</param>
+    /// <param name="retainSessionCount">
+    /// Total number of sessions to keep on disk, including the live one. The live session is
+    /// never deleted, so it occupies one of these slots.
+    /// </param>
     /// <param name="baseDirectory">Log root to sweep. Defaults to the configured session root.</param>
     /// <param name="protectedSessionDirectory">
-    /// A session directory that must never be deleted regardless of age, and which does not
-    /// consume a retention slot. Defaults to the live session (#2647): cleanup now runs
-    /// concurrently with active logging rather than before it, so the directory currently
-    /// open for appending has to be excluded explicitly.
+    /// A session directory that must never be deleted regardless of age. Defaults to the live
+    /// session (#2647): cleanup now runs concurrently with active logging rather than before
+    /// it, so the directory currently open for appending has to be excluded explicitly. Pass
+    /// <see cref="NoProtectedSession"/> to sweep a root with no live session (tests).
     /// </param>
     public static void CleanupOldSessions(
         int retainSessionCount,
@@ -343,14 +352,20 @@ public static class UnifiedLogger
         try
         {
             var logRoot = baseDirectory ?? _baseLogDirectory;
-            var protectedDir = protectedSessionDirectory
-                ?? (baseDirectory == null ? _sessionDirectory : null);
+
+            // Protection is deliberately NOT keyed off baseDirectory: passing the real log
+            // root explicitly must not silently disarm the live-session guard. Opting out
+            // requires the explicit NoProtectedSession sentinel.
+            var protectedDir = ReferenceEquals(protectedSessionDirectory, NoProtectedSession)
+                ? null
+                : protectedSessionDirectory ?? _sessionDirectory;
 
             if (!Directory.Exists(logRoot))
                 return;
 
             var sessionDirs = Directory.GetDirectories(logRoot, "Session_*");
             var sessions = new List<(string Path, DateTime Timestamp)>();
+            bool protectedSessionPresent = false;
 
             foreach (var sessionDir in sessionDirs)
             {
@@ -363,6 +378,7 @@ public static class UnifiedLogger
                             Path.GetFullPath(protectedDir).TrimEnd(Path.DirectorySeparatorChar),
                             StringComparison.OrdinalIgnoreCase))
                     {
+                        protectedSessionPresent = true;
                         continue;
                     }
 
@@ -388,9 +404,16 @@ public static class UnifiedLogger
             // Sort by timestamp descending (newest first)
             sessions.Sort((a, b) => b.Timestamp.CompareTo(a.Timestamp));
 
+            // retainSessionCount is a total, so the protected session claims one slot. Without
+            // this the live session would be retained on top of N others (#2647 review), which
+            // silently redefines the user's LogRetentionSessions setting as N+1.
+            var retainOthers = protectedSessionPresent
+                ? Math.Max(0, retainSessionCount - 1)
+                : retainSessionCount;
+
             // Delete sessions beyond retention count
             int deletedCount = 0;
-            for (int i = retainSessionCount; i < sessions.Count; i++)
+            for (int i = retainOthers; i < sessions.Count; i++)
             {
                 try
                 {

--- a/Radoub.Formats/Radoub.Formats/Logging/UnifiedLogger.cs
+++ b/Radoub.Formats/Radoub.Formats/Logging/UnifiedLogger.cs
@@ -56,9 +56,10 @@ public static class UnifiedLogger
 
         _configured = true;
 
-        // Initialize and cleanup old sessions
+        // Session cleanup is NOT done here (#2647). Configure runs in Program.Main before
+        // Avalonia starts, so a recursive session-tree delete here blocks first paint.
+        // Tools call RunDeferredCleanup() after the window is open instead.
         EnsureInitialized();
-        CleanupOldSessions(_retainSessions);
 
         LogApplication(LogLevel.INFO, $"{_appName} logging initialized (level: {_currentLogLevel})");
     }
@@ -326,20 +327,45 @@ public static class UnifiedLogger
     /// Cleans up old log sessions based on session count retention.
     /// Keeps the N most recent sessions and deletes older ones.
     /// </summary>
-    public static void CleanupOldSessions(int retainSessionCount)
+    /// <param name="retainSessionCount">Number of recent sessions to keep.</param>
+    /// <param name="baseDirectory">Log root to sweep. Defaults to the configured session root.</param>
+    /// <param name="protectedSessionDirectory">
+    /// A session directory that must never be deleted regardless of age, and which does not
+    /// consume a retention slot. Defaults to the live session (#2647): cleanup now runs
+    /// concurrently with active logging rather than before it, so the directory currently
+    /// open for appending has to be excluded explicitly.
+    /// </param>
+    public static void CleanupOldSessions(
+        int retainSessionCount,
+        string? baseDirectory = null,
+        string? protectedSessionDirectory = null)
     {
         try
         {
-            if (!Directory.Exists(_baseLogDirectory))
+            var logRoot = baseDirectory ?? _baseLogDirectory;
+            var protectedDir = protectedSessionDirectory
+                ?? (baseDirectory == null ? _sessionDirectory : null);
+
+            if (!Directory.Exists(logRoot))
                 return;
 
-            var sessionDirs = Directory.GetDirectories(_baseLogDirectory, "Session_*");
+            var sessionDirs = Directory.GetDirectories(logRoot, "Session_*");
             var sessions = new List<(string Path, DateTime Timestamp)>();
 
             foreach (var sessionDir in sessionDirs)
             {
                 try
                 {
+                    // Never sweep the live session — it is open for appending.
+                    if (protectedDir != null &&
+                        string.Equals(
+                            Path.GetFullPath(sessionDir).TrimEnd(Path.DirectorySeparatorChar),
+                            Path.GetFullPath(protectedDir).TrimEnd(Path.DirectorySeparatorChar),
+                            StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
                     var dirName = Path.GetFileName(sessionDir);
                     if (dirName.StartsWith("Session_") && dirName.Length >= 23)
                     {

--- a/Radoub.UI/Radoub.UI.Tests/Services/StartupCleanupCoordinatorTests.cs
+++ b/Radoub.UI/Radoub.UI.Tests/Services/StartupCleanupCoordinatorTests.cs
@@ -1,0 +1,59 @@
+using Radoub.UI.Services;
+using Xunit;
+
+namespace Radoub.UI.Tests.Services;
+
+/// <summary>
+/// Coverage for the deferred startup-cleanup entry point (#2647).
+/// </summary>
+public class StartupCleanupCoordinatorTests : IDisposable
+{
+    public StartupCleanupCoordinatorTests() => StartupCleanupCoordinator.ResetForTests();
+
+    public void Dispose() => StartupCleanupCoordinator.ResetForTests();
+
+    [Fact]
+    public void RunDeferredCleanup_ReturnsImmediately_DoesNotBlockCaller()
+    {
+        // The whole point is to keep this off the first-paint path: the call must return
+        // without waiting on any directory walk.
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
+        StartupCleanupCoordinator.RunDeferredCleanup(10, 30);
+
+        sw.Stop();
+        Assert.True(sw.ElapsedMilliseconds < 500,
+            $"RunDeferredCleanup blocked for {sw.ElapsedMilliseconds} ms");
+    }
+
+    [Fact]
+    public void RunDeferredCleanup_DoesNotThrowIntoCaller()
+    {
+        // Called from UI event handlers — a cleanup failure must never fault the handler.
+        var ex = Record.Exception(() => StartupCleanupCoordinator.RunDeferredCleanup(10, 30));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void RunDeferredCleanup_IsIdempotent_SecondCallIsNoOp()
+    {
+        // Tools may wire this to both Loaded and Opened; the sweep must still run once.
+        StartupCleanupCoordinator.RunDeferredCleanup(10, 30);
+
+        var ex = Record.Exception(() => StartupCleanupCoordinator.RunDeferredCleanup(10, 30));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void ResetForTests_AllowsAFreshRun()
+    {
+        StartupCleanupCoordinator.RunDeferredCleanup(10, 30);
+        StartupCleanupCoordinator.ResetForTests();
+
+        var ex = Record.Exception(() => StartupCleanupCoordinator.RunDeferredCleanup(10, 30));
+
+        Assert.Null(ex);
+    }
+}

--- a/Radoub.UI/Radoub.UI/Services/StartupCleanupCoordinator.cs
+++ b/Radoub.UI/Radoub.UI/Services/StartupCleanupCoordinator.cs
@@ -1,0 +1,60 @@
+using Radoub.Formats.Logging;
+
+namespace Radoub.UI.Services;
+
+/// <summary>
+/// Runs startup housekeeping (log-session retention, backup expiry) off the first-paint
+/// path (#2647).
+///
+/// Both sweeps walk directories and recursively delete — 100 ms-1 s of blocking I/O
+/// depending on how much history has accumulated. Neither result is needed to paint a
+/// window, so tools invoke this once from their window's Opened handler instead of from
+/// App.Initialize / Program.Main.
+/// </summary>
+public static class StartupCleanupCoordinator
+{
+    private static int _started;
+
+    /// <summary>
+    /// Kick off cleanup on a background thread. Safe to call from a UI event handler:
+    /// returns immediately and never throws into the caller.
+    ///
+    /// Idempotent per process — repeat calls are ignored, so a tool that wires this to
+    /// both Loaded and Opened still sweeps once.
+    /// </summary>
+    public static void RunDeferredCleanup(int logRetentionSessions, int backupRetentionDays)
+    {
+        // Interlocked, not a plain bool: Loaded/Opened can both fire before the first
+        // sweep finishes.
+        if (Interlocked.Exchange(ref _started, 1) != 0)
+            return;
+
+        _ = Task.Run(() =>
+        {
+            try
+            {
+                UnifiedLogger.CleanupOldSessions(logRetentionSessions);
+            }
+            catch (Exception ex)
+            {
+                UnifiedLogger.LogApplication(LogLevel.WARN,
+                    $"Deferred log-session cleanup failed: {ex.Message}");
+            }
+
+            try
+            {
+                BackupCleanupService.CleanupExpiredBackups(backupRetentionDays);
+            }
+            catch (Exception ex)
+            {
+                UnifiedLogger.LogApplication(LogLevel.WARN,
+                    $"Deferred backup cleanup failed: {ex.Message}");
+            }
+        });
+    }
+
+    /// <summary>
+    /// Test hook: allow a fresh run within the same process.
+    /// </summary>
+    internal static void ResetForTests() => Interlocked.Exchange(ref _started, 0);
+}

--- a/Reliquary/Reliquary/App.axaml.cs
+++ b/Reliquary/Reliquary/App.axaml.cs
@@ -38,12 +38,8 @@ public partial class App : Application
         // Apply font settings
         ApplyFontSettings();
 
-        // Clean up old log sessions
-        UnifiedLogger.CleanupOldSessions(SettingsService.Instance.LogRetentionSessions);
-
-        // Clean up old backups
-        BackupCleanupService.CleanupExpiredBackups(
-            RadoubSettings.Instance.BackupRetentionDays);
+        // Log-session and backup cleanup run after first paint (#2647) — see
+        // MainWindow's Opened handler.
     }
 
     public override void OnFrameworkInitializationCompleted()

--- a/Reliquary/Reliquary/Views/MainWindow.Services.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.Services.cs
@@ -90,6 +90,11 @@ public partial class MainWindow
             LoadPlaceable(startupFile);
 
         UnifiedLogger.LogStartupMilestone("Reliquary ready (services + startup load complete)");
+
+        // Startup housekeeping, off the first-paint path (#2647)
+        Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
+            SettingsService.Instance.LogRetentionSessions,
+            RadoubSettings.Instance.BackupRetentionDays);
     }
 
     private static string? GetModuleWorkingDirectory()

--- a/Reliquary/Reliquary/Views/MainWindow.Services.cs
+++ b/Reliquary/Reliquary/Views/MainWindow.Services.cs
@@ -39,6 +39,12 @@ public partial class MainWindow
         if (_servicesInitialized) return;
         _servicesInitialized = true;
 
+        // Startup housekeeping, off the first-paint path (#2647). Kicked off first so a throw
+        // from the service init below cannot skip retention cleanup.
+        Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
+            SettingsService.Instance.LogRetentionSessions,
+            RadoubSettings.Instance.BackupRetentionDays);
+
         await Task.Run(() =>
         {
             _gameData = new GameDataService();
@@ -90,11 +96,6 @@ public partial class MainWindow
             LoadPlaceable(startupFile);
 
         UnifiedLogger.LogStartupMilestone("Reliquary ready (services + startup load complete)");
-
-        // Startup housekeeping, off the first-paint path (#2647)
-        Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
-            SettingsService.Instance.LogRetentionSessions,
-            RadoubSettings.Instance.BackupRetentionDays);
     }
 
     private static string? GetModuleWorkingDirectory()

--- a/Relique/Relique/App.axaml.cs
+++ b/Relique/Relique/App.axaml.cs
@@ -38,12 +38,8 @@ public partial class App : Application
         // Apply font settings
         ApplyFontSettings();
 
-        // Clean up old log sessions
-        UnifiedLogger.CleanupOldSessions(SettingsService.Instance.LogRetentionSessions);
-
-        // Clean up old backups
-        BackupCleanupService.CleanupExpiredBackups(
-            RadoubSettings.Instance.BackupRetentionDays);
+        // Log-session and backup cleanup run after first paint (#2647) — see
+        // MainWindow's Opened handler.
     }
 
     public override void OnFrameworkInitializationCompleted()

--- a/Relique/Relique/Views/MainWindow.Lifecycle.cs
+++ b/Relique/Relique/Views/MainWindow.Lifecycle.cs
@@ -20,6 +20,12 @@ public partial class MainWindow
     {
         Opened -= OnWindowOpened;
 
+        // Startup housekeeping, off the first-paint path (#2647). Kicked off first so a throw
+        // from the loads below cannot skip retention cleanup.
+        Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
+            SettingsService.Instance.LogRetentionSessions,
+            RadoubSettings.Instance.BackupRetentionDays);
+
         // Initialize game data service on background thread (#1959)
         await InitializeGameDataAsync();
 
@@ -45,11 +51,6 @@ public partial class MainWindow
         }
 
         UpdateStatus("Ready");
-
-        // Startup housekeeping, off the first-paint path (#2647)
-        Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
-            SettingsService.Instance.LogRetentionSessions,
-            RadoubSettings.Instance.BackupRetentionDays);
     }
 
     private async Task InitializeGameDataAsync()

--- a/Relique/Relique/Views/MainWindow.Lifecycle.cs
+++ b/Relique/Relique/Views/MainWindow.Lifecycle.cs
@@ -45,6 +45,11 @@ public partial class MainWindow
         }
 
         UpdateStatus("Ready");
+
+        // Startup housekeeping, off the first-paint path (#2647)
+        Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
+            SettingsService.Instance.LogRetentionSessions,
+            RadoubSettings.Instance.BackupRetentionDays);
     }
 
     private async Task InitializeGameDataAsync()

--- a/Trebuchet/Trebuchet/App.axaml.cs
+++ b/Trebuchet/Trebuchet/App.axaml.cs
@@ -55,12 +55,8 @@ public partial class App : Application
         // via Dispatcher.Post, so our inline ApplyFontSettings above runs too early)
         ThemeManager.Instance.ThemeApplied += (_, _) => ApplyFontSettings();
 
-        // Clean up old log sessions
-        UnifiedLogger.CleanupOldSessions(SettingsService.Instance.LogRetentionSessions);
-
-        // Clean up old backups
-        Radoub.UI.Services.BackupCleanupService.CleanupExpiredBackups(
-            Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
+        // Log-session and backup cleanup run after first paint (#2647) — see
+        // MainWindow's Opened handler.
     }
 
     public override void OnFrameworkInitializationCompleted()

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
@@ -100,6 +100,12 @@ public partial class MainWindow : Window
     {
         Opened -= OnWindowOpened;
 
+        // Startup housekeeping, off the first-paint path (#2647). Kicked off first so a throw
+        // from the module/faction loads below cannot skip retention cleanup.
+        Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
+            SettingsService.Instance.LogRetentionSessions,
+            Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
+
         if (_viewModel != null)
             UpdateModuleNameColor(_viewModel);
 
@@ -124,11 +130,6 @@ public partial class MainWindow : Window
         {
             _viewModel?.OpenSettingsCommand.Execute(null);
         }
-
-        // Startup housekeeping, off the first-paint path (#2647)
-        Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
-            SettingsService.Instance.LogRetentionSessions,
-            Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
     }
 
     private void RestoreWindowState()

--- a/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
+++ b/Trebuchet/Trebuchet/Views/MainWindow.axaml.cs
@@ -124,6 +124,11 @@ public partial class MainWindow : Window
         {
             _viewModel?.OpenSettingsCommand.Execute(null);
         }
+
+        // Startup housekeeping, off the first-paint path (#2647)
+        Radoub.UI.Services.StartupCleanupCoordinator.RunDeferredCleanup(
+            SettingsService.Instance.LogRetentionSessions,
+            Radoub.Formats.Settings.RadoubSettings.Instance.BackupRetentionDays);
     }
 
     private void RestoreWindowState()


### PR DESCRIPTION
## Summary

Startup cleanup (log sessions + expired backups) ran synchronously before first paint, and
the session sweep ran **twice per launch** — once in `UnifiedLogger.Configure` (which runs in
`Program.Main`, before Avalonia starts) and again in each tool's `App.Initialize`. Both now run
once, on a background thread, kicked off from each tool's window `Opened` handler via the new
shared `StartupCleanupCoordinator`.

`CleanupOldSessions` also gained an explicit guard for the live session directory. The old
ordering made that safe by accident — cleanup finished before logging got busy — but a
concurrent sweep deletes session trees while the current session's log file is open for
appending, so the exclusion is now explicit.

## On the measured impact — the issue overstated it

The issue estimated 100 ms-1 s of blocking I/O. **Measured on this machine: ~5 ms**
(4 ms session enumeration across all 7 tools, 1 ms backup tree walk; 21 sessions, 15 backup
files).

The estimate assumed accumulated history that the retention policy prevents from existing —
retention caps sessions at 3 per tool, so there is very little to walk. No before/after
`[Startup]` delta was captured because launch-to-launch noise is far larger than a 5 ms signal;
the I/O was measured directly instead.

**This is a correctness and robustness fix, not a speed-up.** Flagging that rather than
reporting a perf win the evidence does not support.

## Code review — 4 findings, all fixed on this branch

A pre-merge review of the first implementation found three correctness problems and a coverage
gap. All are fixed in the second commit:

1. **Reachability regression (the real bug).** `RunDeferredCleanup` was placed *last* in each
   `Opened` handler, behind awaits that can throw. In Manifest it sat inside a `try` whose
   catch blocks did not run it — opening a corrupt `.jrl` skipped cleanup for that launch.
   Parley/Relique/Reliquary/Trebuchet have unguarded `async void` handlers with awaits before
   the call. The failure mode was backwards: a session that just logged an exception is the one
   that most wants retention applied. Now the **first statement** in all 7 handlers — it
   depends on nothing they do and returns immediately.

2. **Retention silently became N+1.** The protected live session was skipped via `continue`
   before entering the retention list, so it never consumed a slot — `LogRetentionSessions = 10`
   would keep 11. It now claims a slot, preserving the setting's meaning ("sessions kept on
   disk"). The original test asserted the wrong contract and was rewritten.

3. **Guard coupling.** Protection defaulted to `null` whenever an explicit `baseDirectory` was
   passed, so a future caller naming the real log root would silently disarm the live-session
   guard. Opting out now requires the explicit `NoProtectedSession` sentinel.

4. **Zero coverage** on the new shared service (a "Yes" row under the repo TDD policy).
   `StartupCleanupCoordinatorTests` added.

## Related Issues

- Closes #2647
- Relates to #2128 (cross-tool perf umbrella)

Sibling #2648 was closed as refuted during the same verification pass — both claims were false
(all 7 tools call `DiscoverThemes` identically; the "double discovery" log pair is the catalog
cache working correctly).

## Tests

- **6,422 passed, 0 failed** across all 10 projects (1 pre-existing skip).
- 11 targeted tests: 7 in `UnifiedLoggerCleanupTests` (retention totals, live-session
  protection, explicit-root guard, sentinel, missing dir, malformed names) + 4 in
  `StartupCleanupCoordinatorTests` (non-blocking, no-throw, idempotent, reset).
- Privacy scan PASS, theme scan PASS.
- Tech debt: `Fence/Fence/Views/MainWindow.axaml.cs` at 942 lines (800-1000 warn band; this PR
  adds 5 lines).
- **FlaUI skipped** — auto-detection matched 14 files on path, but zero `.axaml` markup
  changed; every tool hunk is a comment swap plus one identical 3-line call. Nothing FlaUI can
  observe.

## Manual spot-checks

- [ ] Cleanup still happens: set `LogRetentionSessions` low, launch a tool 4-5×, confirm
      `~/Radoub/{Tool}/Logs/` settles at exactly that many `Session_*` dirs (not one above).
- [ ] Live session survives: newest session dir exists with a non-empty log after those runs.
- [ ] Close a tool within ~2 s of launch — clean exit, no hang, no cleanup error in the log.
- [ ] (Linux) Same retention check — `Directory.Delete(recursive)` and delete-while-open differ
      from Windows.

## Checklist

- [x] Implementation complete
- [x] Tests added/updated
- [x] CHANGELOG updated with date
- [x] Code review findings addressed
- [ ] Documentation updated (if needed)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
