### PR TITLE
[Radoub] Sprint: Prose concision across authored text and code comments

### DIFF
--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -90,6 +90,9 @@ EOF
 
 Tech-debt issues use **Current State** / **Proposed Change** / **Files Affected** instead.
 
+**Before creating**: run the drafted body through the concision pass
+(`elements-of-style:writing-clearly-and-concisely`). See Commit & PR Standards in CLAUDE.md.
+
 **Long or pattern-heavy bodies**: stage the text in `NonPublic/_scratch/` and pass
 `--body-file`. Heredocs are fine for short bodies, but a body containing `..`, quotes, or
 backticks can trip the permission guard, and `--body-file` sidesteps the escaping entirely.

--- a/.claude/commands/documentation.md
+++ b/.claude/commands/documentation.md
@@ -77,7 +77,9 @@ Correct anything the change made false. A page describing behavior that no longe
 worse than an old date, because it reads as current.
 
 Style: clinical and terse, no marketing, technical accuracy over readability. Small
-relationships inline as `A → B → C`; larger ones as diagrams.
+relationships inline as `A → B → C`; larger ones as diagrams. Run drafted prose through the
+concision pass (`elements-of-style:writing-clearly-and-concisely`) — wiki pages are long-lived
+and read often, so they repay the tokens. See Commit & PR Standards in CLAUDE.md.
 
 ```mermaid
 flowchart LR

--- a/.claude/commands/init-item.md
+++ b/.claude/commands/init-item.md
@@ -160,7 +160,9 @@ git push -u origin [branch-name]
 
 ### 3.4 Draft PR
 
-Always draft initially.
+Always draft initially. Run the PR body through the concision pass
+(`elements-of-style:writing-clearly-and-concisely`) before creating it — see Commit & PR
+Standards in CLAUDE.md.
 
 ```bash
 gh pr create --draft --title "[Tool] [Type]: [Title]" --body "$(cat <<'EOF'

--- a/.claude/commands/pre-merge.md
+++ b/.claude/commands/pre-merge.md
@@ -178,7 +178,8 @@ gh issue create --title "[Tool] Tech Debt: Split [filename] ([N] lines)" \
 ```
 
 Files in the 800–1000 range only need a checklist line. Always search first — a warning is
-"new" only when no issue, open or closed, tracks it.
+"new" only when no issue, open or closed, tracks it. Run the issue body through the concision
+pass (`elements-of-style:writing-clearly-and-concisely`) before creating it.
 
 ### 3.3 Code review
 
@@ -315,6 +316,10 @@ Flag when over 30 days old and code changed.
 
 **PR**: https://github.com/LordOfMyatar/Radoub/pull/[number]
 ```
+
+Run the generated body through the concision pass
+(`elements-of-style:writing-clearly-and-concisely`) before publishing it — this is the PR
+description reviewers actually read. See Commit & PR Standards in CLAUDE.md.
 
 ```bash
 gh pr edit [number] --body "[generated body]" && gh pr ready [number] 2>/dev/null || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Prose-Concision] - 2026-07-20
+**Branch**: `radoub/issue-2671` | **PR**: #TBD
+
+### Sprint: Prose concision across authored text and code comments
+
+- Wired the `writing-clearly-and-concisely` skill into the slash commands that author commit messages, PR bodies, and issue text (#2671).
+- Swept code comments repo-wide for concision, shared libraries first, one commit per tool (#2672).
+
+---
+
 ## [Startup-Cleanup] - 2026-07-20
 **Branch**: `radoub/issue-2647` | **PR**: #2673
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Prose-Concision] - 2026-07-20
-**Branch**: `radoub/issue-2671` | **PR**: #TBD
+**Branch**: `radoub/issue-2671` | **PR**: #2675
 
 ### Sprint: Prose concision across authored text and code comments
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Sprint: Prose concision across authored text and code comments
 
 - Wired the `writing-clearly-and-concisely` skill into the slash commands that author commit messages, PR bodies, and issue text (#2671).
-- Swept code comments repo-wide for concision, shared libraries first, one commit per tool (#2672).
+- Swept `Radoub.Formats` and `Radoub.UI` comments for concision, collapsing verbose XML doc blocks and dropping summaries that only restated the identifier (#2672). Per-tool sweeps follow in #2689–#2695.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,29 @@ If work affects multiple tools:
 
 ---
 
-## Commit Standards
+## Commit & PR Standards
+
+### Concision pass (MANDATORY)
+
+Before publishing any authored prose — a commit message, PR body, PR review comment, or
+GitHub issue body or comment — run the draft through the
+`elements-of-style:writing-clearly-and-concisely` skill.
+
+Verbosity is the target, not style debate. The skill runs as a compression pass on text you
+have already drafted; it does not decide what to say. Four rules carry most of the weight:
+omit needless words, use active voice, prefer definite and concrete language, and put the
+emphatic word at the end.
+
+The existing sentence caps — 3 sentences for a commit, 15 for a PR — are hard limits, not
+goals. The concision pass tightens what fits inside them, so a commit already under three
+sentences still gets the pass.
+
+The skill's `elements-of-style.md` reference costs ~12,000 tokens. Do not read it for a
+one-line commit message; apply the four rules directly. Read it, or dispatch a subagent to
+copyedit against it, when the text is long enough to be worth the tokens — a substantial PR
+body or issue.
+
+### Commit messages
 
 Use tool prefixes in commit messages:
 

--- a/Radoub.Formats/Radoub.Formats/Are/AreFile.cs
+++ b/Radoub.Formats/Radoub.Formats/Are/AreFile.cs
@@ -9,224 +9,126 @@ namespace Radoub.Formats.Are;
 /// </summary>
 public class AreFile
 {
-    /// <summary>
-    /// File type signature - should be "ARE "
-    /// </summary>
+    /// <summary>File type signature - should be "ARE "</summary>
     public string FileType { get; set; } = "ARE ";
 
-    /// <summary>
-    /// File version - typically "V3.2"
-    /// </summary>
+    /// <summary>File version - typically "V3.2"</summary>
     public string FileVersion { get; set; } = "V3.2";
 
-    // Identity fields
-
-    /// <summary>
-    /// Area resource reference (should match filename)
-    /// </summary>
+    /// <summary>Area resource reference (should match filename)</summary>
     public string ResRef { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Area tag, used for scripting
-    /// </summary>
+    /// <summary>Area tag, used for scripting</summary>
     public string Tag { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Localized area name
-    /// </summary>
+    /// <summary>Localized area name</summary>
     public CExoLocString Name { get; set; } = new();
 
-    /// <summary>
-    /// Module designer comments
-    /// </summary>
+    /// <summary>Module designer comments</summary>
     public string Comments { get; set; } = string.Empty;
 
-    // Dimensions
-
-    /// <summary>
-    /// Area width in tiles (west-east)
-    /// </summary>
+    /// <summary>Area width in tiles (west-east)</summary>
     public int Width { get; set; }
 
-    /// <summary>
-    /// Area height in tiles (north-south)
-    /// </summary>
+    /// <summary>Area height in tiles (north-south)</summary>
     public int Height { get; set; }
 
-    /// <summary>
-    /// ResRef of the tileset (.SET) file used by the area
-    /// </summary>
+    /// <summary>ResRef of the tileset (.SET) file used by the area</summary>
     public string TileSet { get; set; } = string.Empty;
 
-    // Environment / Lighting
-
-    /// <summary>
-    /// 1 if day/night transitions occur, 0 otherwise
-    /// </summary>
+    /// <summary>1 if day/night transitions occur, 0 otherwise</summary>
     public byte DayNightCycle { get; set; } = 1;
 
-    /// <summary>
-    /// 1 if area is always night (only meaningful when DayNightCycle=0)
-    /// </summary>
+    /// <summary>1 if area is always night (only meaningful when DayNightCycle=0)</summary>
     public byte IsNight { get; set; }
 
-    /// <summary>
-    /// Index into environment.2da
-    /// </summary>
+    /// <summary>Index into environment.2da</summary>
     public byte LightingScheme { get; set; }
 
-    /// <summary>
-    /// Daytime ambient light color (BGR format)
-    /// </summary>
+    /// <summary>Daytime ambient light color (BGR format)</summary>
     public uint SunAmbientColor { get; set; }
 
-    /// <summary>
-    /// Daytime diffuse light color (BGR format)
-    /// </summary>
+    /// <summary>Daytime diffuse light color (BGR format)</summary>
     public uint SunDiffuseColor { get; set; }
 
-    /// <summary>
-    /// 1 if shadows appear during the day
-    /// </summary>
+    /// <summary>1 if shadows appear during the day</summary>
     public byte SunShadows { get; set; }
 
-    /// <summary>
-    /// Daytime fog amount (0-15)
-    /// </summary>
+    /// <summary>Daytime fog amount (0-15)</summary>
     public byte SunFogAmount { get; set; }
 
-    /// <summary>
-    /// Daytime fog color (BGR format)
-    /// </summary>
+    /// <summary>Daytime fog color (BGR format)</summary>
     public uint SunFogColor { get; set; }
 
-    /// <summary>
-    /// Nighttime ambient light color (BGR format)
-    /// </summary>
+    /// <summary>Nighttime ambient light color (BGR format)</summary>
     public uint MoonAmbientColor { get; set; }
 
-    /// <summary>
-    /// Nighttime diffuse light color (BGR format)
-    /// </summary>
+    /// <summary>Nighttime diffuse light color (BGR format)</summary>
     public uint MoonDiffuseColor { get; set; }
 
-    /// <summary>
-    /// 1 if shadows appear at night
-    /// </summary>
+    /// <summary>1 if shadows appear at night</summary>
     public byte MoonShadows { get; set; }
 
-    /// <summary>
-    /// Nighttime fog amount (0-15)
-    /// </summary>
+    /// <summary>Nighttime fog amount (0-15)</summary>
     public byte MoonFogAmount { get; set; }
 
-    /// <summary>
-    /// Nighttime fog color (BGR format)
-    /// </summary>
+    /// <summary>Nighttime fog color (BGR format)</summary>
     public uint MoonFogColor { get; set; }
 
-    /// <summary>
-    /// Shadow opacity (0-100)
-    /// </summary>
+    /// <summary>Shadow opacity (0-100)</summary>
     public byte ShadowOpacity { get; set; }
 
-    // Weather
-
-    /// <summary>
-    /// Percent chance of lightning (0-100)
-    /// </summary>
+    /// <summary>Percent chance of lightning (0-100)</summary>
     public int ChanceLightning { get; set; }
 
-    /// <summary>
-    /// Percent chance of rain (0-100)
-    /// </summary>
+    /// <summary>Percent chance of rain (0-100)</summary>
     public int ChanceRain { get; set; }
 
-    /// <summary>
-    /// Percent chance of snow (0-100)
-    /// </summary>
+    /// <summary>Percent chance of snow (0-100)</summary>
     public int ChanceSnow { get; set; }
 
-    /// <summary>
-    /// Wind strength (0=none, 1=weak, 2=strong)
-    /// </summary>
+    /// <summary>Wind strength (0=none, 1=weak, 2=strong)</summary>
     public int WindPower { get; set; }
 
-    // Area flags and settings
-
-    /// <summary>
-    /// Bit flags: 0x0001=interior, 0x0002=underground, 0x0004=natural
-    /// </summary>
+    /// <summary>Bit flags: 0x0001=interior, 0x0002=underground, 0x0004=natural</summary>
     public uint Flags { get; set; }
 
-    /// <summary>
-    /// Index into loadscreens.2da
-    /// </summary>
+    /// <summary>Index into loadscreens.2da</summary>
     public ushort LoadScreenID { get; set; }
 
-    /// <summary>
-    /// 1 if resting is not allowed
-    /// </summary>
+    /// <summary>1 if resting is not allowed</summary>
     public byte NoRest { get; set; }
 
-    /// <summary>
-    /// Index into pvpsettings.2da
-    /// </summary>
+    /// <summary>Index into pvpsettings.2da</summary>
     public byte PlayerVsPlayer { get; set; }
 
-    /// <summary>
-    /// Index into skyboxes.2da (0=no skybox)
-    /// </summary>
+    /// <summary>Index into skyboxes.2da (0=no skybox)</summary>
     public byte SkyBox { get; set; }
 
-    /// <summary>
-    /// Modifier to Listen skill checks made in area
-    /// </summary>
+    /// <summary>Modifier to Listen skill checks made in area</summary>
     public int ModListenCheck { get; set; }
 
-    /// <summary>
-    /// Modifier to Spot skill checks made in area
-    /// </summary>
+    /// <summary>Modifier to Spot skill checks made in area</summary>
     public int ModSpotCheck { get; set; }
 
-    /// <summary>
-    /// Revision number, increments each save
-    /// </summary>
+    /// <summary>Revision number, increments each save</summary>
     public uint Version { get; set; } = 1;
 
-    /// <summary>
-    /// Deprecated, always -1
-    /// </summary>
+    /// <summary>Deprecated, always -1</summary>
     public int Creator_ID { get; set; } = -1;
 
-    /// <summary>
-    /// Deprecated, always -1
-    /// </summary>
+    /// <summary>Deprecated, always -1</summary>
     public int ID { get; set; } = -1;
 
     // Scripts
 
-    /// <summary>
-    /// OnEnter event script
-    /// </summary>
     public string OnEnter { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnExit event script
-    /// </summary>
     public string OnExit { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnHeartbeat event script
-    /// </summary>
     public string OnHeartbeat { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnUserDefined event script
-    /// </summary>
     public string OnUserDefined { get; set; } = string.Empty;
-
-    // Tile list
 
     /// <summary>
     /// List of tiles in the area. Tile at index i is at position (i % Width, i / Width).
@@ -239,53 +141,33 @@ public class AreFile
 /// </summary>
 public class AreaTile
 {
-    /// <summary>
-    /// Index into tileset's tile list
-    /// </summary>
+    /// <summary>Index into tileset's tile list</summary>
     public int Tile_ID { get; set; }
 
-    /// <summary>
-    /// Orientation: 0=normal, 1=90CCW, 2=180CCW, 3=270CCW
-    /// </summary>
+    /// <summary>Orientation: 0=normal, 1=90CCW, 2=180CCW, 3=270CCW</summary>
     public int Tile_Orientation { get; set; }
 
-    /// <summary>
-    /// Height transition level (never negative)
-    /// </summary>
+    /// <summary>Height transition level (never negative)</summary>
     public int Tile_Height { get; set; }
 
-    /// <summary>
-    /// MainLight1 color index into lightcolor.2da (0=off/absent)
-    /// </summary>
+    /// <summary>MainLight1 color index into lightcolor.2da (0=off/absent)</summary>
     public byte Tile_MainLight1 { get; set; }
 
-    /// <summary>
-    /// MainLight2 color index into lightcolor.2da (0=off/absent)
-    /// </summary>
+    /// <summary>MainLight2 color index into lightcolor.2da (0=off/absent)</summary>
     public byte Tile_MainLight2 { get; set; }
 
-    /// <summary>
-    /// SourceLight1 color/animation (0=off, 1-15=on)
-    /// </summary>
+    /// <summary>SourceLight1 color/animation (0=off, 1-15=on)</summary>
     public byte Tile_SrcLight1 { get; set; }
 
-    /// <summary>
-    /// SourceLight2 color/animation (0=off, 1-15=on)
-    /// </summary>
+    /// <summary>SourceLight2 color/animation (0=off, 1-15=on)</summary>
     public byte Tile_SrcLight2 { get; set; }
 
-    /// <summary>
-    /// AnimLoop01 on tile model (1=play, 0=stop)
-    /// </summary>
+    /// <summary>AnimLoop01 on tile model (1=play, 0=stop)</summary>
     public int Tile_AnimLoop1 { get; set; }
 
-    /// <summary>
-    /// AnimLoop02 on tile model (1=play, 0=stop)
-    /// </summary>
+    /// <summary>AnimLoop02 on tile model (1=play, 0=stop)</summary>
     public int Tile_AnimLoop2 { get; set; }
 
-    /// <summary>
-    /// AnimLoop03 on tile model (1=play, 0=stop)
-    /// </summary>
+    /// <summary>AnimLoop03 on tile model (1=play, 0=stop)</summary>
     public int Tile_AnimLoop3 { get; set; }
 }

--- a/Radoub.Formats/Radoub.Formats/Are/AreReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Are/AreReader.cs
@@ -9,18 +9,14 @@ namespace Radoub.Formats.Are;
 /// </summary>
 public static class AreReader
 {
-    /// <summary>
-    /// Read an ARE file from a file path.
-    /// </summary>
+    /// <summary>Read an ARE file from a file path.</summary>
     public static AreFile Read(string filePath)
     {
         var buffer = File.ReadAllBytes(filePath);
         return Read(buffer);
     }
 
-    /// <summary>
-    /// Read an ARE file from a stream.
-    /// </summary>
+    /// <summary>Read an ARE file from a stream.</summary>
     public static AreFile Read(Stream stream)
     {
         using var ms = new MemoryStream();
@@ -28,9 +24,7 @@ public static class AreReader
         return Read(ms.ToArray());
     }
 
-    /// <summary>
-    /// Read an ARE file from a byte buffer.
-    /// </summary>
+    /// <summary>Read an ARE file from a byte buffer.</summary>
     public static AreFile Read(byte[] buffer)
     {
         var gff = GffReader.Read(buffer);
@@ -53,17 +47,14 @@ public static class AreReader
             FileType = gff.FileType,
             FileVersion = gff.FileVersion,
 
-            // Identity
             ResRef = root.GetFieldValue<string>("ResRef", string.Empty),
             Tag = root.GetFieldValue<string>("Tag", string.Empty),
             Comments = root.GetFieldValue<string>("Comments", string.Empty),
 
-            // Dimensions
             Width = root.GetFieldValue<int>("Width", 0),
             Height = root.GetFieldValue<int>("Height", 0),
             TileSet = root.GetFieldValue<string>("Tileset", string.Empty),
 
-            // Environment / Lighting
             DayNightCycle = root.GetFieldValue<byte>("DayNightCycle", 1),
             IsNight = root.GetFieldValue<byte>("IsNight", 0),
             LightingScheme = root.GetFieldValue<byte>("LightingScheme", 0),
@@ -79,13 +70,11 @@ public static class AreReader
             MoonFogColor = root.GetFieldValue<uint>("MoonFogColor", 0),
             ShadowOpacity = root.GetFieldValue<byte>("ShadowOpacity", 0),
 
-            // Weather
             ChanceLightning = root.GetFieldValue<int>("ChanceLightning", 0),
             ChanceRain = root.GetFieldValue<int>("ChanceRain", 0),
             ChanceSnow = root.GetFieldValue<int>("ChanceSnow", 0),
             WindPower = root.GetFieldValue<int>("WindPower", 0),
 
-            // Flags and settings
             Flags = root.GetFieldValue<uint>("Flags", 0),
             LoadScreenID = root.GetFieldValue<ushort>("LoadScreenID", 0),
             NoRest = root.GetFieldValue<byte>("NoRest", 0),
@@ -97,17 +86,14 @@ public static class AreReader
             Creator_ID = root.GetFieldValue<int>("Creator_ID", -1),
             ID = root.GetFieldValue<int>("ID", -1),
 
-            // Scripts
             OnEnter = root.GetFieldValue<string>("OnEnter", string.Empty),
             OnExit = root.GetFieldValue<string>("OnExit", string.Empty),
             OnHeartbeat = root.GetFieldValue<string>("OnHeartbeat", string.Empty),
             OnUserDefined = root.GetFieldValue<string>("OnUserDefined", string.Empty)
         };
 
-        // Localized name
         are.Name = ParseLocString(root, "Name") ?? new CExoLocString();
 
-        // Tile list
         ParseTileList(root, are);
 
         return are;

--- a/Radoub.Formats/Radoub.Formats/Are/AreWriter.cs
+++ b/Radoub.Formats/Radoub.Formats/Are/AreWriter.cs
@@ -10,27 +10,21 @@ namespace Radoub.Formats.Are;
 /// </summary>
 public static class AreWriter
 {
-    /// <summary>
-    /// Write an ARE file to a file path.
-    /// </summary>
+    /// <summary>Write an ARE file to a file path.</summary>
     public static void Write(AreFile are, string filePath)
     {
         var buffer = Write(are);
         File.WriteAllBytes(filePath, buffer);
     }
 
-    /// <summary>
-    /// Write an ARE file to a stream.
-    /// </summary>
+    /// <summary>Write an ARE file to a stream.</summary>
     public static void Write(AreFile are, Stream stream)
     {
         var buffer = Write(are);
         stream.Write(buffer, 0, buffer.Length);
     }
 
-    /// <summary>
-    /// Write an ARE file to a byte buffer.
-    /// </summary>
+    /// <summary>Write an ARE file to a byte buffer.</summary>
     public static byte[] Write(AreFile are)
     {
         var gff = BuildGffFile(are);
@@ -53,19 +47,16 @@ public static class AreWriter
     {
         var root = new GffStruct { Type = 0xFFFFFFFF };
 
-        // Identity
         AddCResRefField(root, "ResRef", are.ResRef);
         AddCExoStringField(root, "Tag", are.Tag);
         AddLocStringField(root, "Name", are.Name);
         if (!string.IsNullOrEmpty(are.Comments))
             AddCExoStringField(root, "Comments", are.Comments);
 
-        // Dimensions
         AddIntField(root, "Width", are.Width);
         AddIntField(root, "Height", are.Height);
         AddCResRefField(root, "Tileset", are.TileSet);
 
-        // Environment / Lighting
         AddByteField(root, "DayNightCycle", are.DayNightCycle);
         AddByteField(root, "IsNight", are.IsNight);
         AddByteField(root, "LightingScheme", are.LightingScheme);
@@ -81,13 +72,11 @@ public static class AreWriter
         AddDwordField(root, "MoonFogColor", are.MoonFogColor);
         AddByteField(root, "ShadowOpacity", are.ShadowOpacity);
 
-        // Weather
         AddIntField(root, "ChanceLightning", are.ChanceLightning);
         AddIntField(root, "ChanceRain", are.ChanceRain);
         AddIntField(root, "ChanceSnow", are.ChanceSnow);
         AddIntField(root, "WindPower", are.WindPower);
 
-        // Flags and settings
         AddDwordField(root, "Flags", are.Flags);
         AddWordField(root, "LoadScreenID", are.LoadScreenID);
         AddByteField(root, "NoRest", are.NoRest);
@@ -99,7 +88,6 @@ public static class AreWriter
         AddIntField(root, "Creator_ID", are.Creator_ID);
         AddIntField(root, "ID", are.ID);
 
-        // Scripts
         if (!string.IsNullOrEmpty(are.OnEnter))
             AddCResRefField(root, "OnEnter", are.OnEnter);
         if (!string.IsNullOrEmpty(are.OnExit))
@@ -109,7 +97,6 @@ public static class AreWriter
         if (!string.IsNullOrEmpty(are.OnUserDefined))
             AddCResRefField(root, "OnUserDefined", are.OnUserDefined);
 
-        // Tile list
         AddTileList(root, are.Tiles);
 
         return root;

--- a/Radoub.Formats/Radoub.Formats/Bic/BicFile.cs
+++ b/Radoub.Formats/Radoub.Formats/Bic/BicFile.cs
@@ -12,9 +12,6 @@ namespace Radoub.Formats.Bic;
 /// </summary>
 public class BicFile : UtcFile
 {
-    /// <summary>
-    /// Creates a new BicFile with default values.
-    /// </summary>
     public BicFile()
     {
         FileType = "BIC ";
@@ -26,18 +23,15 @@ public class BicFile : UtcFile
     /// and initializing BIC-specific fields with defaults.
     /// Use this to convert a creature blueprint to a player character.
     /// </summary>
-    /// <param name="utc">Source UtcFile to convert</param>
     /// <param name="gameData">Optional game-data service. When supplied, NWN rules
     /// (XP per level, per-class hit die, skill count, epic threshold) are sourced
     /// from 2DA instead of stock-game constants — required for correct LvlStat data
     /// with non-stock classes/content. When null, the stock defaults are used and a
     /// warning is logged once.</param>
-    /// <returns>New BicFile with copied properties</returns>
     public static BicFile FromUtcFile(UtcFile utc, IGameDataService? gameData = null)
     {
         if (utc is BicFile existingBic)
         {
-            // Already a BicFile, just ensure FileType is correct
             existingBic.FileType = "BIC ";
             return existingBic;
         }
@@ -95,16 +89,9 @@ public class BicFile : UtcFile
         // Creates one entry per character level with minimal data
         bic.LvlStatList = GenerateLvlStatList(bic, gameData);
 
-        // ============================================================
-        // PORTRAIT HANDLING (UTC → BIC)
-        // ============================================================
-        // BIC files use the Portrait string field (e.g., "po_hu_m_01_")
-        // PortraitId is typically 0 for player characters
-        // The Portrait string is what actually displays in-game
-        //
-        // If UTC has PortraitId but no Portrait string, we should preserve PortraitId
-        // (CopyBaseProperties already copied both fields)
-        // Only set a fallback if NEITHER is set
+        // BIC displays the Portrait string (e.g. "po_hu_m_01_"); PortraitId is
+        // typically 0 for PCs. CopyBaseProperties copied both — only fall back
+        // when NEITHER is set.
         if (bic.PortraitId == 0 && string.IsNullOrEmpty(bic.Portrait))
         {
             bic.Portrait = "po_hu_m_99_";
@@ -207,11 +194,9 @@ public class BicFile : UtcFile
         // Standard factions: 0=PC, 1=Hostile, 2=Commoner, 3=Merchant, 4=Defender
         utc.FactionID = 2;
 
-        // Set blueprint name (TemplateResRef) - MUST match the saved filename
-        // If target filename provided, use it; otherwise generate from first/last name
+        // TemplateResRef MUST match the saved filename
         if (!string.IsNullOrEmpty(targetResRef))
         {
-            // Sanitize and lowercase the provided ResRef
             utc.TemplateResRef = SanitizeForResRef(targetResRef).ToLowerInvariant();
             if (utc.TemplateResRef.Length > 16)
                 utc.TemplateResRef = utc.TemplateResRef.Substring(0, 16);
@@ -221,30 +206,17 @@ public class BicFile : UtcFile
             utc.TemplateResRef = GenerateBlueprintName(this);
         }
 
-        // Generate Tag from first/last name (uppercase, truncated if needed)
         // Tags have a 32 character limit in practice
         utc.Tag = GenerateTag(this);
 
-        // Set default NWN creature scripts
-        // BIC files don't have scripts (they inherit from module), so we set defaults for UTC
+        // BIC files don't have scripts (they inherit from module), so set UTC defaults
         SetDefaultScripts(utc);
 
-        // ============================================================
-        // PORTRAIT HANDLING (BIC → UTC)
-        // ============================================================
-        // BIC files typically have:
-        //   - PortraitId = 0
-        //   - Portrait = "po_hu_m_01_" (the actual portrait string)
-        //
-        // UTC files can use either:
-        //   - PortraitId > 0 (references portraits.2da row)
-        //   - Portrait string (used when PortraitId = 0)
-        //
-        // CopyBaseProperties already copied both PortraitId and Portrait.
-        // The Portrait string from BIC IS the character's actual portrait.
-        // We preserve it as-is. Only set fallback if NEITHER field is set.
-        //
-        // Aurora Toolset shows "must specify valid portrait" if both are empty.
+        // UTC accepts either PortraitId > 0 (row in portraits.2da) or the Portrait
+        // string (used when PortraitId = 0). BIC normally carries only the string,
+        // which IS the character's real portrait, so preserve it as-is and fall back
+        // only when NEITHER is set — Aurora Toolset errors "must specify valid
+        // portrait" if both are empty.
         if (utc.PortraitId == 0 && string.IsNullOrEmpty(utc.Portrait))
         {
             utc.Portrait = "po_hu_m_99_";
@@ -263,7 +235,6 @@ public class BicFile : UtcFile
         if (string.IsNullOrEmpty(baseName))
             return "creature";
 
-        // Convert to lowercase, replace spaces with underscore, remove invalid characters
         var sanitized = SanitizeForResRef(baseName);
 
         // Truncate to 16 characters (Aurora Engine limit)
@@ -283,7 +254,6 @@ public class BicFile : UtcFile
         if (string.IsNullOrEmpty(baseName))
             return "CREATURE";
 
-        // Convert to uppercase, replace spaces with underscore, remove invalid characters
         var sanitized = SanitizeForResRef(baseName);
 
         // Truncate to 32 characters (practical Tag limit)
@@ -293,10 +263,7 @@ public class BicFile : UtcFile
         return sanitized.ToUpperInvariant();
     }
 
-    /// <summary>
-    /// Gets combined first + last name for name generation.
-    /// Uses English localized string (language ID 0).
-    /// </summary>
+    /// <summary>Combined first + last name, from the English localized string (language ID 0).</summary>
     private static string GetNameForGeneration(BicFile bic)
     {
         var firstName = GetLocalizedString(bic.FirstName);
@@ -311,9 +278,7 @@ public class BicFile : UtcFile
         return string.Empty;
     }
 
-    /// <summary>
-    /// Gets the English string from a CExoLocString, or empty if not present.
-    /// </summary>
+    /// <summary>Gets the English string from a CExoLocString, or empty if not present.</summary>
     private static string GetLocalizedString(CExoLocString locString)
     {
         // Try English (language ID 0)
@@ -359,8 +324,7 @@ public class BicFile : UtcFile
     /// </summary>
     private static void SetDefaultScripts(UtcFile utc)
     {
-        // OC default creature scripts
-        // Only set if the field is empty (preserve any existing scripts)
+        // Only set if empty (preserve any existing scripts)
         if (string.IsNullOrEmpty(utc.ScriptAttacked))
             utc.ScriptAttacked = "nw_c2_default5";
         if (string.IsNullOrEmpty(utc.ScriptDamaged))
@@ -389,9 +353,7 @@ public class BicFile : UtcFile
             utc.ScriptUserDefine = "nw_c2_defaultd";
     }
 
-    /// <summary>
-    /// Deep clone a CExoLocString to avoid shared references.
-    /// </summary>
+    /// <summary>Deep clone a CExoLocString to avoid shared references.</summary>
     private static CExoLocString CloneLocString(CExoLocString source)
     {
         var clone = new CExoLocString
@@ -611,23 +573,15 @@ public class BicFile : UtcFile
 
     // Player-specific fields (Table 2.6.1)
 
-    /// <summary>
-    /// Character's age (entered during character creation).
-    /// </summary>
+    /// <summary>Character's age (entered during character creation).</summary>
     public int Age { get; set; }
 
-    /// <summary>
-    /// Total experience points earned.
-    /// </summary>
     public uint Experience { get; set; }
 
-    /// <summary>
-    /// Amount of gold carried by the character.
-    /// </summary>
     public uint Gold { get; set; }
 
     /// <summary>
-    /// QuickBar slot assignments (36 slots).
+    /// 36 slots.
     /// Elements 0-11: Normal QuickBar
     /// Elements 12-23: Shift-QuickBar
     /// Elements 24-35: Control-QuickBar
@@ -635,7 +589,6 @@ public class BicFile : UtcFile
     public List<QuickBarSlot> QBList { get; set; } = new();
 
     /// <summary>
-    /// Faction reputation amounts.
     /// Each entry is the player's rating (0-100) with a faction,
     /// in the same order as the module's repute.fac FactionList.
     /// </summary>
@@ -655,34 +608,22 @@ public class BicFile : UtcFile
 /// </summary>
 public class LevelStatEntry
 {
-    /// <summary>
-    /// Class taken at this level (index into classes.2da).
-    /// </summary>
+    /// <summary>Class taken at this level (index into classes.2da).</summary>
     public byte LvlStatClass { get; set; }
 
-    /// <summary>
-    /// Hit die roll result for this level (0 = not rolled/average).
-    /// </summary>
+    /// <summary>Hit die roll result for this level (0 = not rolled/average).</summary>
     public byte LvlStatHitDie { get; set; }
 
-    /// <summary>
-    /// Whether this is an epic level (level 21+).
-    /// </summary>
+    /// <summary>Whether this is an epic level (level 21+).</summary>
     public byte EpicLevel { get; set; }
 
-    /// <summary>
-    /// Remaining skill points (usually 0 for completed characters).
-    /// </summary>
+    /// <summary>Remaining skill points (usually 0 for completed characters).</summary>
     public short SkillPoints { get; set; }
 
-    /// <summary>
-    /// Skills trained at this level. 28 entries (one per skill), value = ranks added.
-    /// </summary>
+    /// <summary>Skills trained at this level. 28 entries (one per skill), value = ranks added.</summary>
     public List<byte> SkillList { get; set; } = new();
 
-    /// <summary>
-    /// Feats gained at this level.
-    /// </summary>
+    /// <summary>Feats gained at this level.</summary>
     public List<ushort> FeatList { get; set; } = new();
 }
 
@@ -702,81 +643,50 @@ public class QuickBarSlot
 
     // Item-specific fields (ObjectType = 1)
 
-    /// <summary>
-    /// Object ID of the item in inventory (items only).
-    /// </summary>
+    /// <summary>Object ID of the item in inventory (items only).</summary>
     public uint ItemInvSlot { get; set; }
 
-    /// <summary>
-    /// X position of item in inventory (items only).
-    /// </summary>
+    /// <summary>X position of item in inventory (items only).</summary>
     public byte ItemReposX { get; set; }
 
-    /// <summary>
-    /// Y position of item in inventory (items only).
-    /// </summary>
+    /// <summary>Y position of item in inventory (items only).</summary>
     public byte ItemReposY { get; set; }
 
-    /// <summary>
-    /// X position in container (0xFF if not in container).
-    /// </summary>
+    /// <summary>X position in container (0xFF if not in container).</summary>
     public byte ContReposX { get; set; } = 0xFF;
 
-    /// <summary>
-    /// Y position in container (0xFF if not in container).
-    /// </summary>
+    /// <summary>Y position in container (0xFF if not in container).</summary>
     public byte ContReposY { get; set; } = 0xFF;
 
-    /// <summary>
-    /// Cast property index (0xFF if no cast property).
-    /// </summary>
+    /// <summary>Cast property index (0xFF if no cast property).</summary>
     public byte CastPropIndex { get; set; } = 0xFF;
 
-    /// <summary>
-    /// Cast sub-property index (0xFF if no subproperty).
-    /// </summary>
+    /// <summary>Cast sub-property index (0xFF if no subproperty).</summary>
     public byte CastSubPropIdx { get; set; } = 0xFF;
 
     // Spell/Skill/Feat/Mode fields (ObjectType = 2, 3, 4, 10)
 
-    /// <summary>
-    /// Index into spells.2da, skills.2da, feat.2da, or mode type.
-    /// </summary>
+    /// <summary>Index into spells.2da, skills.2da, feat.2da, or mode type.</summary>
     public int INTParam1 { get; set; }
 
-    /// <summary>
-    /// Index into creature's ClassList (spells only).
-    /// </summary>
+    /// <summary>Index into creature's ClassList (spells only).</summary>
     public byte MultiClass { get; set; }
 
-    /// <summary>
-    /// MetaMagic flags on a spell (spells only).
-    /// </summary>
+    /// <summary>MetaMagic flags on a spell (spells only).</summary>
     public byte MetaType { get; set; }
 
-    /// <summary>
-    /// Domain level for cleric domain spells (0 for most spells).
-    /// </summary>
+    /// <summary>Domain level for cleric domain spells (0 for most spells).</summary>
     public byte DomainLevel { get; set; }
 
-    /// <summary>
-    /// Secondary parameter (varies by object type).
-    /// </summary>
+    /// <summary>Secondary parameter (varies by object type).</summary>
     public int SecondaryItem { get; set; }
 
-    /// <summary>
-    /// Command sub-type for associate commands.
-    /// </summary>
+    /// <summary>Command sub-type for associate commands.</summary>
     public int CommandSubType { get; set; }
 
-    /// <summary>
-    /// Command label for associate commands.
-    /// </summary>
+    /// <summary>Command label for associate commands.</summary>
     public string CommandLabel { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Returns true if slot is empty.
-    /// </summary>
     public bool IsEmpty => ObjectType == 0;
 }
 
@@ -804,9 +714,6 @@ public static class QuickBarObjectType
     public const byte CancelPolymorph = 43;
     public const byte SpellLikeAbility = 44;
 
-    /// <summary>
-    /// Get human-readable name for a quickbar object type.
-    /// </summary>
     public static string GetTypeName(byte type) => type switch
     {
         Empty => "Empty",

--- a/Radoub.Formats/Radoub.Formats/Bic/BicReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Bic/BicReader.cs
@@ -10,18 +10,12 @@ namespace Radoub.Formats.Bic;
 /// </summary>
 public static class BicReader
 {
-    /// <summary>
-    /// Read a BIC file from a file path.
-    /// </summary>
     public static BicFile Read(string filePath)
     {
         var buffer = File.ReadAllBytes(filePath);
         return Read(buffer);
     }
 
-    /// <summary>
-    /// Read a BIC file from a stream.
-    /// </summary>
     public static BicFile Read(Stream stream)
     {
         using var ms = new MemoryStream();
@@ -29,15 +23,10 @@ public static class BicReader
         return Read(ms.ToArray());
     }
 
-    /// <summary>
-    /// Read a BIC file from a byte buffer.
-    /// </summary>
     public static BicFile Read(byte[] buffer)
     {
-        // Parse as GFF first
         var gff = GffReader.Read(buffer);
 
-        // Validate file type
         if (gff.FileType.TrimEnd() != "BIC")
         {
             throw new InvalidDataException(
@@ -244,13 +233,13 @@ public static class BicReader
                 Domain2 = classStruct.GetFieldValue<byte>("Domain2", 0)
             };
 
-            // Parse known spells (KnownList0-9) - used by Bards, Sorcerers, PC Wizards
+            // KnownList0-9 - used by Bards, Sorcerers, PC Wizards
             for (int level = 0; level < 10; level++)
             {
                 ParseKnownSpellList(classStruct, creatureClass, level);
             }
 
-            // Parse memorized spells (MemorizedList0-9) - used by Wizards, Clerics, etc.
+            // MemorizedList0-9 - used by Wizards, Clerics, etc.
             for (int level = 0; level < 10; level++)
             {
                 ParseMemorizedSpellList(classStruct, creatureClass, level);
@@ -478,7 +467,6 @@ public static class BicReader
                 SkillPoints = lvlStruct.GetFieldValue<short>("SkillPoints", 0)
             };
 
-            // Parse SkillList
             var skillListField = lvlStruct.GetField("SkillList");
             if (skillListField?.Value is GffList skillList)
             {
@@ -489,7 +477,6 @@ public static class BicReader
                 }
             }
 
-            // Parse FeatList
             var featListField = lvlStruct.GetField("FeatList");
             if (featListField?.Value is GffList featList)
             {

--- a/Radoub.Formats/Radoub.Formats/Bic/BicWriter.cs
+++ b/Radoub.Formats/Radoub.Formats/Bic/BicWriter.cs
@@ -11,27 +11,18 @@ namespace Radoub.Formats.Bic;
 /// </summary>
 public static class BicWriter
 {
-    /// <summary>
-    /// Write a BIC file to a file path.
-    /// </summary>
     public static void Write(BicFile bic, string filePath)
     {
         var buffer = Write(bic);
         File.WriteAllBytes(filePath, buffer);
     }
 
-    /// <summary>
-    /// Write a BIC file to a stream.
-    /// </summary>
     public static void Write(BicFile bic, Stream stream)
     {
         var buffer = Write(bic);
         stream.Write(buffer, 0, buffer.Length);
     }
 
-    /// <summary>
-    /// Write a BIC file to a byte buffer.
-    /// </summary>
     public static byte[] Write(BicFile bic)
     {
         var gff = BuildGffFile(bic);
@@ -234,20 +225,18 @@ public static class BicWriter
             AddIntField(classStruct, "Class", cls.Class);
             AddShortField(classStruct, "ClassLevel", cls.ClassLevel);
 
-            // Write domains (Cleric)
+            // Domains (Cleric)
             if (cls.Domain1 != 0 || cls.Domain2 != 0)
             {
                 AddByteField(classStruct, "Domain1", cls.Domain1);
                 AddByteField(classStruct, "Domain2", cls.Domain2);
             }
 
-            // Write known spells (KnownList0-9)
             for (int level = 0; level < 10; level++)
             {
                 AddKnownSpellList(classStruct, cls.KnownSpells[level], level);
             }
 
-            // Write memorized spells (MemorizedList0-9)
             for (int level = 0; level < 10; level++)
             {
                 AddMemorizedSpellList(classStruct, cls.MemorizedSpells[level], level);
@@ -374,10 +363,8 @@ public static class BicWriter
             var qbStruct = new GffStruct { Type = 0 };
             AddByteField(qbStruct, "QBObjectType", slot.ObjectType);
 
-            // Only add additional fields if slot is not empty
             if (slot.ObjectType != QuickBarObjectType.Empty)
             {
-                // Common fields
                 AddIntField(qbStruct, "QBINTParam1", slot.INTParam1);
 
                 switch (slot.ObjectType)
@@ -436,7 +423,6 @@ public static class BicWriter
         var list = new GffList();
         foreach (var entry in lvlStats)
         {
-            // StructID 0 (standard struct type)
             var lvlStruct = new GffStruct { Type = 0 };
 
             AddByteField(lvlStruct, "LvlStatClass", entry.LvlStatClass);
@@ -444,7 +430,7 @@ public static class BicWriter
             AddByteField(lvlStruct, "EpicLevel", entry.EpicLevel);
             AddShortField(lvlStruct, "SkillPoints", entry.SkillPoints);
 
-            // Add SkillList (28 entries, one per skill)
+            // SkillList: 28 entries, one per skill
             var skillList = new GffList();
             foreach (var rank in entry.SkillList)
             {
@@ -454,7 +440,7 @@ public static class BicWriter
             }
             AddListField(lvlStruct, "SkillList", skillList);
 
-            // Add FeatList (feats gained at this level)
+            // FeatList: feats gained at this level
             var featList = new GffList();
             foreach (var feat in entry.FeatList)
             {

--- a/Radoub.Formats/Radoub.Formats/Common/Language.cs
+++ b/Radoub.Formats/Radoub.Formats/Common/Language.cs
@@ -29,19 +29,13 @@ public enum Gender
     Female = 1
 }
 
-/// <summary>
-/// Helper methods for language and gender handling.
-/// </summary>
+/// <summary>Helper methods for language and gender handling.</summary>
 public static class LanguageHelper
 {
-    /// <summary>
-    /// Invalid StrRef value (0xFFFFFFFF) indicating no TLK reference.
-    /// </summary>
+    /// <summary>Invalid StrRef value (0xFFFFFFFF) indicating no TLK reference.</summary>
     public const uint InvalidStrRef = 0xFFFFFFFF;
 
-    /// <summary>
-    /// Threshold for custom TLK StrRefs. Values >= this use alternate TLK.
-    /// </summary>
+    /// <summary>Threshold for custom TLK StrRefs. Values >= this use alternate TLK.</summary>
     public const uint CustomTlkThreshold = 0x01000000; // 16777216
 
     /// <summary>
@@ -53,33 +47,25 @@ public static class LanguageHelper
         return ((uint)language * 2) + (uint)gender;
     }
 
-    /// <summary>
-    /// Extract language from a combined ID.
-    /// </summary>
+    /// <summary>Extract language from a combined ID.</summary>
     public static Language GetLanguage(uint combinedId)
     {
         return (Language)(combinedId / 2);
     }
 
-    /// <summary>
-    /// Extract gender from a combined ID.
-    /// </summary>
+    /// <summary>Extract gender from a combined ID.</summary>
     public static Gender GetGender(uint combinedId)
     {
         return (Gender)(combinedId % 2);
     }
 
-    /// <summary>
-    /// Parse combined ID into language and gender components.
-    /// </summary>
+    /// <summary>Parse combined ID into language and gender components.</summary>
     public static (Language language, Gender gender) ParseCombinedId(uint combinedId)
     {
         return (GetLanguage(combinedId), GetGender(combinedId));
     }
 
-    /// <summary>
-    /// Get display name for a language.
-    /// </summary>
+    /// <summary>Get display name for a language.</summary>
     public static string GetDisplayName(Language language)
     {
         return language switch
@@ -98,9 +84,7 @@ public static class LanguageHelper
         };
     }
 
-    /// <summary>
-    /// Get the two-letter language code used in NWN:EE folder structure.
-    /// </summary>
+    /// <summary>Get the two-letter language code used in NWN:EE folder structure.</summary>
     public static string GetLanguageCode(Language language)
     {
         return language switch
@@ -119,9 +103,7 @@ public static class LanguageHelper
         };
     }
 
-    /// <summary>
-    /// Parse a language code to Language enum.
-    /// </summary>
+    /// <summary>Parse a language code to Language enum.</summary>
     public static Language? FromLanguageCode(string code)
     {
         return code?.ToLowerInvariant() switch
@@ -140,25 +122,19 @@ public static class LanguageHelper
         };
     }
 
-    /// <summary>
-    /// Check if a StrRef is valid (not 0xFFFFFFFF).
-    /// </summary>
+    /// <summary>Check if a StrRef is valid (not 0xFFFFFFFF).</summary>
     public static bool IsValidStrRef(uint strRef)
     {
         return strRef != InvalidStrRef;
     }
 
-    /// <summary>
-    /// Check if a StrRef refers to the custom/alternate TLK.
-    /// </summary>
+    /// <summary>Check if a StrRef refers to the custom/alternate TLK.</summary>
     public static bool IsCustomTlkStrRef(uint strRef)
     {
         return strRef >= CustomTlkThreshold && strRef != InvalidStrRef;
     }
 
-    /// <summary>
-    /// Get the actual index into a TLK file, removing the custom TLK flag if present.
-    /// </summary>
+    /// <summary>Get the actual index into a TLK file, removing the custom TLK flag if present.</summary>
     public static uint GetTlkIndex(uint strRef)
     {
         if (strRef == InvalidStrRef)

--- a/Radoub.Formats/Radoub.Formats/Common/PathHelper.cs
+++ b/Radoub.Formats/Radoub.Formats/Common/PathHelper.cs
@@ -73,9 +73,7 @@ public static class PathHelper
         }
     }
 
-    /// <summary>
-    /// Expands a path from storage - replaces ~ with user home directory.
-    /// </summary>
+    /// <summary>Expands a path from storage - replaces ~ with user home directory.</summary>
     /// <param name="path">The contracted path to expand.</param>
     /// <returns>Path with ~ replaced by user home directory, or original path if no ~.</returns>
     /// <example>
@@ -190,9 +188,7 @@ public static class PathHelper
         return null;
     }
 
-    /// <summary>
-    /// Contracts a list of paths for storage.
-    /// </summary>
+    /// <summary>Contracts a list of paths for storage.</summary>
     /// <param name="paths">List of paths to contract.</param>
     /// <returns>New list with all paths contracted.</returns>
     public static List<string> ContractPaths(IEnumerable<string> paths)
@@ -200,9 +196,7 @@ public static class PathHelper
         return paths.Select(ContractPath).ToList();
     }
 
-    /// <summary>
-    /// Expands a list of paths from storage.
-    /// </summary>
+    /// <summary>Expands a list of paths from storage.</summary>
     /// <param name="paths">List of paths to expand.</param>
     /// <returns>New list with all paths expanded.</returns>
     public static List<string> ExpandPaths(IEnumerable<string> paths)

--- a/Radoub.Formats/Radoub.Formats/Common/ResourceTypes.cs
+++ b/Radoub.Formats/Radoub.Formats/Common/ResourceTypes.cs
@@ -129,9 +129,7 @@ public static class ResourceTypes
     public const ushort Bif = 9998;
     public const ushort Key = 9999;
 
-    /// <summary>
-    /// Get the file extension for a resource type.
-    /// </summary>
+    /// <summary>Get the file extension for a resource type.</summary>
     public static string GetExtension(ushort resourceType)
     {
         return resourceType switch
@@ -194,9 +192,7 @@ public static class ResourceTypes
         };
     }
 
-    /// <summary>
-    /// Get the resource type from a file extension.
-    /// </summary>
+    /// <summary>Get the resource type from a file extension.</summary>
     public static ushort FromExtension(string extension)
     {
         var ext = extension.TrimStart('.').ToLowerInvariant();

--- a/Radoub.Formats/Radoub.Formats/Common/TlkHelper.cs
+++ b/Radoub.Formats/Radoub.Formats/Common/TlkHelper.cs
@@ -34,9 +34,7 @@ public static class TlkHelper
                !trimmed.Equals("DELETE_ME", StringComparison.OrdinalIgnoreCase);
     }
 
-    /// <summary>
-    /// Check if a 2DA label is a garbage/placeholder entry that should be skipped.
-    /// </summary>
+    /// <summary>Check if a 2DA label is a garbage/placeholder entry that should be skipped.</summary>
     /// <param name="label">The 2DA label to check</param>
     /// <returns>True if the label represents deleted/padding content</returns>
     public static bool IsGarbageLabel(string label)

--- a/Radoub.Formats/Radoub.Formats/Dlg/DlgFile.cs
+++ b/Radoub.Formats/Radoub.Formats/Dlg/DlgFile.cs
@@ -9,14 +9,10 @@ namespace Radoub.Formats.Dlg;
 /// </summary>
 public class DlgFile
 {
-    /// <summary>
-    /// File type signature - should be "DLG "
-    /// </summary>
+    /// <summary>File type signature - should be "DLG "</summary>
     public string FileType { get; set; } = "DLG ";
 
-    /// <summary>
-    /// File version - typically "V3.2"
-    /// </summary>
+    /// <summary>File version - typically "V3.2"</summary>
     public string FileVersion { get; set; } = "V3.2";
 
     /// <summary>
@@ -31,34 +27,22 @@ public class DlgFile
     /// </summary>
     public uint DelayReply { get; set; }
 
-    /// <summary>
-    /// Word count for the dialog (used by toolset statistics).
-    /// </summary>
+    /// <summary>Word count for the dialog (used by toolset statistics).</summary>
     public uint NumWords { get; set; }
 
-    /// <summary>
-    /// Script to run when conversation ends normally.
-    /// </summary>
+    /// <summary>Script to run when conversation ends normally.</summary>
     public string EndConversation { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script to run when conversation is aborted.
-    /// </summary>
+    /// <summary>Script to run when conversation is aborted.</summary>
     public string EndConverAbort { get; set; } = string.Empty;
 
-    /// <summary>
-    /// If true, prevents camera zoom during conversation.
-    /// </summary>
+    /// <summary>If true, prevents camera zoom during conversation.</summary>
     public bool PreventZoomIn { get; set; }
 
-    /// <summary>
-    /// List of NPC dialog entries (spoken by NPCs).
-    /// </summary>
+    /// <summary>NPC dialog entries (spoken by NPCs).</summary>
     public List<DlgEntry> Entries { get; set; } = new();
 
-    /// <summary>
-    /// List of PC dialog replies (spoken by the player).
-    /// </summary>
+    /// <summary>PC dialog replies (spoken by the player).</summary>
     public List<DlgReply> Replies { get; set; } = new();
 
     /// <summary>
@@ -73,54 +57,34 @@ public class DlgFile
 /// </summary>
 public class DlgEntry
 {
-    /// <summary>
-    /// Speaker tag override. If empty, uses conversation owner.
-    /// </summary>
+    /// <summary>Speaker tag override. If empty, uses conversation owner.</summary>
     public string Speaker { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Animation to play during this line.
-    /// </summary>
+    /// <summary>Animation to play during this line.</summary>
     public uint Animation { get; set; }
 
-    /// <summary>
-    /// If true, animation loops until the line completes.
-    /// </summary>
+    /// <summary>If true, animation loops until the line completes.</summary>
     public bool AnimLoop { get; set; }
 
-    /// <summary>
-    /// Localized dialog text.
-    /// </summary>
+    /// <summary>Localized dialog text.</summary>
     public CExoLocString Text { get; set; } = new();
 
-    /// <summary>
-    /// Script to run when this entry is displayed.
-    /// </summary>
+    /// <summary>Script to run when this entry is displayed.</summary>
     public string Script { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script action parameters (name/value pairs).
-    /// </summary>
+    /// <summary>Script action parameters (name/value pairs).</summary>
     public List<DlgParam> ActionParams { get; set; } = new();
 
-    /// <summary>
-    /// Delay override for this specific entry (0xFFFFFFFF = use default).
-    /// </summary>
+    /// <summary>Delay override for this specific entry (0xFFFFFFFF = use default).</summary>
     public uint Delay { get; set; } = 0xFFFFFFFF;
 
-    /// <summary>
-    /// Toolset comment (not shown in game).
-    /// </summary>
+    /// <summary>Toolset comment (not shown in game).</summary>
     public string Comment { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Sound file to play with this line.
-    /// </summary>
+    /// <summary>Sound file to play with this line.</summary>
     public string Sound { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Quest tag to update.
-    /// </summary>
+    /// <summary>Quest tag to update.</summary>
     public string Quest { get; set; } = string.Empty;
 
     /// <summary>
@@ -129,9 +93,7 @@ public class DlgEntry
     /// </summary>
     public uint QuestEntry { get; set; } = 0xFFFFFFFF;
 
-    /// <summary>
-    /// Links to player replies following this entry.
-    /// </summary>
+    /// <summary>Links to player replies following this entry.</summary>
     public List<DlgLink> RepliesList { get; set; } = new();
 }
 
@@ -140,49 +102,31 @@ public class DlgEntry
 /// </summary>
 public class DlgReply
 {
-    /// <summary>
-    /// Animation to play during this line.
-    /// </summary>
+    /// <summary>Animation to play during this line.</summary>
     public uint Animation { get; set; }
 
-    /// <summary>
-    /// If true, animation loops until the line completes.
-    /// </summary>
+    /// <summary>If true, animation loops until the line completes.</summary>
     public bool AnimLoop { get; set; }
 
-    /// <summary>
-    /// Localized dialog text.
-    /// </summary>
+    /// <summary>Localized dialog text.</summary>
     public CExoLocString Text { get; set; } = new();
 
-    /// <summary>
-    /// Script to run when this reply is selected.
-    /// </summary>
+    /// <summary>Script to run when this reply is selected.</summary>
     public string Script { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script action parameters (name/value pairs).
-    /// </summary>
+    /// <summary>Script action parameters (name/value pairs).</summary>
     public List<DlgParam> ActionParams { get; set; } = new();
 
-    /// <summary>
-    /// Delay override for this specific reply (0xFFFFFFFF = use default).
-    /// </summary>
+    /// <summary>Delay override for this specific reply (0xFFFFFFFF = use default).</summary>
     public uint Delay { get; set; } = 0xFFFFFFFF;
 
-    /// <summary>
-    /// Toolset comment (not shown in game).
-    /// </summary>
+    /// <summary>Toolset comment (not shown in game).</summary>
     public string Comment { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Sound file to play with this line.
-    /// </summary>
+    /// <summary>Sound file to play with this line.</summary>
     public string Sound { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Quest tag to update.
-    /// </summary>
+    /// <summary>Quest tag to update.</summary>
     public string Quest { get; set; } = string.Empty;
 
     /// <summary>
@@ -191,9 +135,7 @@ public class DlgReply
     /// </summary>
     public uint QuestEntry { get; set; } = 0xFFFFFFFF;
 
-    /// <summary>
-    /// Links to NPC entries following this reply.
-    /// </summary>
+    /// <summary>Links to NPC entries following this reply.</summary>
     public List<DlgLink> EntriesList { get; set; } = new();
 }
 
@@ -203,9 +145,7 @@ public class DlgReply
 /// </summary>
 public class DlgLink
 {
-    /// <summary>
-    /// Index into the target list (Entries or Replies).
-    /// </summary>
+    /// <summary>Index into the target list (Entries or Replies).</summary>
     public uint Index { get; set; }
 
     /// <summary>
@@ -214,9 +154,7 @@ public class DlgLink
     /// </summary>
     public string Active { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Condition script parameters (name/value pairs).
-    /// </summary>
+    /// <summary>Condition script parameters (name/value pairs).</summary>
     public List<DlgParam> ConditionParams { get; set; } = new();
 
     /// <summary>
@@ -225,9 +163,7 @@ public class DlgLink
     /// </summary>
     public bool IsChild { get; set; }
 
-    /// <summary>
-    /// Comment for this link (only present when IsChild=true).
-    /// </summary>
+    /// <summary>Comment for this link (only present when IsChild=true).</summary>
     public string LinkComment { get; set; } = string.Empty;
 }
 
@@ -237,13 +173,7 @@ public class DlgLink
 /// </summary>
 public class DlgParam
 {
-    /// <summary>
-    /// Parameter key/name.
-    /// </summary>
     public string Key { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Parameter value.
-    /// </summary>
     public string Value { get; set; } = string.Empty;
 }

--- a/Radoub.Formats/Radoub.Formats/Dlg/DlgReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Dlg/DlgReader.cs
@@ -9,18 +9,14 @@ namespace Radoub.Formats.Dlg;
 /// </summary>
 public static class DlgReader
 {
-    /// <summary>
-    /// Read a DLG file from a file path.
-    /// </summary>
+    /// <summary>Read a DLG file from a file path.</summary>
     public static DlgFile Read(string filePath)
     {
         var buffer = File.ReadAllBytes(filePath);
         return Read(buffer);
     }
 
-    /// <summary>
-    /// Read a DLG file from a stream.
-    /// </summary>
+    /// <summary>Read a DLG file from a stream.</summary>
     public static DlgFile Read(Stream stream)
     {
         using var ms = new MemoryStream();
@@ -28,15 +24,11 @@ public static class DlgReader
         return Read(ms.ToArray());
     }
 
-    /// <summary>
-    /// Read a DLG file from a byte buffer.
-    /// </summary>
+    /// <summary>Read a DLG file from a byte buffer.</summary>
     public static DlgFile Read(byte[] buffer)
     {
-        // Parse as GFF first
         var gff = GffReader.Read(buffer);
 
-        // Validate file type
         if (gff.FileType.TrimEnd() != "DLG")
         {
             throw new InvalidDataException(
@@ -55,7 +47,6 @@ public static class DlgReader
             FileType = gff.FileType,
             FileVersion = gff.FileVersion,
 
-            // Root level fields
             DelayEntry = root.GetFieldValue<uint>("DelayEntry", 0),
             DelayReply = root.GetFieldValue<uint>("DelayReply", 0),
             NumWords = root.GetFieldValue<uint>("NumWords", 0),
@@ -64,7 +55,6 @@ public static class DlgReader
             PreventZoomIn = root.GetFieldValue<byte>("PreventZoomIn", 0) != 0
         };
 
-        // Parse EntryList
         var entriesField = root.GetField("EntryList");
         if (entriesField?.Value is GffList entriesList)
         {
@@ -74,7 +64,6 @@ public static class DlgReader
             }
         }
 
-        // Parse ReplyList
         var repliesField = root.GetField("ReplyList");
         if (repliesField?.Value is GffList repliesList)
         {
@@ -84,7 +73,6 @@ public static class DlgReader
             }
         }
 
-        // Parse StartingList
         var startingField = root.GetField("StartingList");
         if (startingField?.Value is GffList startingList)
         {
@@ -112,10 +100,8 @@ public static class DlgReader
             QuestEntry = entryStruct.GetFieldValue<uint>("QuestEntry", 0xFFFFFFFF)
         };
 
-        // Parse localized text
         entry.Text = ParseLocString(entryStruct, "Text") ?? new CExoLocString();
 
-        // Parse ActionParams
         var actionParamsField = entryStruct.GetField("ActionParams");
         if (actionParamsField?.Value is GffList actionParamsList)
         {
@@ -125,7 +111,7 @@ public static class DlgReader
             }
         }
 
-        // Parse RepliesList (links to replies)
+        // RepliesList holds links to replies, not the replies themselves
         var repliesListField = entryStruct.GetField("RepliesList");
         if (repliesListField?.Value is GffList repliesList)
         {
@@ -152,10 +138,8 @@ public static class DlgReader
             QuestEntry = replyStruct.GetFieldValue<uint>("QuestEntry", 0xFFFFFFFF)
         };
 
-        // Parse localized text
         reply.Text = ParseLocString(replyStruct, "Text") ?? new CExoLocString();
 
-        // Parse ActionParams
         var actionParamsField = replyStruct.GetField("ActionParams");
         if (actionParamsField?.Value is GffList actionParamsList)
         {
@@ -165,7 +149,7 @@ public static class DlgReader
             }
         }
 
-        // Parse EntriesList (links to entries)
+        // EntriesList holds links to entries, not the entries themselves
         var entriesListField = replyStruct.GetField("EntriesList");
         if (entriesListField?.Value is GffList entriesList)
         {
@@ -188,7 +172,6 @@ public static class DlgReader
             LinkComment = linkStruct.GetFieldValue<string>("LinkComment", string.Empty)
         };
 
-        // Parse ConditionParams
         var conditionParamsField = linkStruct.GetField("ConditionParams");
         if (conditionParamsField?.Value is GffList conditionParamsList)
         {

--- a/Radoub.Formats/Radoub.Formats/Dlg/DlgWriter.cs
+++ b/Radoub.Formats/Radoub.Formats/Dlg/DlgWriter.cs
@@ -10,27 +10,21 @@ namespace Radoub.Formats.Dlg;
 /// </summary>
 public static class DlgWriter
 {
-    /// <summary>
-    /// Write a DLG file to a file path.
-    /// </summary>
+    /// <summary>Write a DLG file to a file path.</summary>
     public static void Write(DlgFile dlg, string filePath)
     {
         var buffer = Write(dlg);
         File.WriteAllBytes(filePath, buffer);
     }
 
-    /// <summary>
-    /// Write a DLG file to a stream.
-    /// </summary>
+    /// <summary>Write a DLG file to a stream.</summary>
     public static void Write(DlgFile dlg, Stream stream)
     {
         var buffer = Write(dlg);
         stream.Write(buffer, 0, buffer.Length);
     }
 
-    /// <summary>
-    /// Write a DLG file to a byte buffer.
-    /// </summary>
+    /// <summary>Write a DLG file to a byte buffer.</summary>
     public static byte[] Write(DlgFile dlg)
     {
         var gff = BuildGffFile(dlg);
@@ -61,19 +55,16 @@ public static class DlgWriter
         AddDwordField(root, "NumWords", dlg.NumWords);
         AddByteField(root, "PreventZoomIn", (byte)(dlg.PreventZoomIn ? 1 : 0));
 
-        // EntryList
         var entryList = new GffList();
         foreach (var entry in dlg.Entries)
             entryList.Elements.Add(BuildEntryStruct(entry));
         AddListField(root, "EntryList", entryList);
 
-        // ReplyList
         var replyList = new GffList();
         foreach (var reply in dlg.Replies)
             replyList.Elements.Add(BuildReplyStruct(reply));
         AddListField(root, "ReplyList", replyList);
 
-        // StartingList
         var startingList = new GffList();
         foreach (var link in dlg.StartingList)
             startingList.Elements.Add(BuildLinkStruct(link));
@@ -111,7 +102,6 @@ public static class DlgWriter
             AddDwordField(entryStruct, "QuestEntry", entry.QuestEntry);
         }
 
-        // RepliesList
         var repliesList = new GffList();
         foreach (var link in entry.RepliesList)
             repliesList.Elements.Add(BuildLinkStruct(link));
@@ -148,7 +138,6 @@ public static class DlgWriter
             AddDwordField(replyStruct, "QuestEntry", reply.QuestEntry);
         }
 
-        // EntriesList
         var entriesList = new GffList();
         foreach (var link in reply.EntriesList)
             entriesList.Elements.Add(BuildLinkStruct(link));

--- a/Radoub.Formats/Radoub.Formats/Fac/FacFile.cs
+++ b/Radoub.Formats/Radoub.Formats/Fac/FacFile.cs
@@ -7,14 +7,10 @@ namespace Radoub.Formats.Fac;
 /// </summary>
 public class FacFile
 {
-    /// <summary>
-    /// File type signature - should be "FAC "
-    /// </summary>
+    /// <summary>File type signature - should be "FAC "</summary>
     public string FileType { get; set; } = "FAC ";
 
-    /// <summary>
-    /// File version - typically "V3.2"
-    /// </summary>
+    /// <summary>File version - typically "V3.2"</summary>
     public string FileVersion { get; set; } = "V3.2";
 
     /// <summary>
@@ -23,9 +19,7 @@ public class FacFile
     /// </summary>
     public List<Faction> FactionList { get; set; } = new();
 
-    /// <summary>
-    /// Reputation matrix - how each faction feels about every other faction.
-    /// </summary>
+    /// <summary>Reputation matrix - how each faction feels about every other faction.</summary>
     public List<Reputation> RepList { get; set; } = new();
 }
 
@@ -34,13 +28,10 @@ public class FacFile
 /// </summary>
 public class Faction
 {
-    /// <summary>
-    /// Name of the faction (e.g., "PC", "Hostile", "Commoner").
-    /// </summary>
+    /// <summary>Name of the faction (e.g., "PC", "Hostile", "Commoner").</summary>
     public string FactionName { get; set; } = string.Empty;
 
     /// <summary>
-    /// Global effect flag.
     /// If true (1), all members of this faction immediately change standings when one member does.
     /// If false (0), each member maintains individual standings.
     /// Example: Killing one Guard causes all Guards to hate you (global) vs killing a deer doesn't affect other deer (not global).
@@ -60,14 +51,10 @@ public class Faction
 /// </summary>
 public class Reputation
 {
-    /// <summary>
-    /// Index into FactionList - the faction being perceived.
-    /// </summary>
+    /// <summary>Index into FactionList - the faction being perceived.</summary>
     public uint FactionID1 { get; set; }
 
-    /// <summary>
-    /// Index into FactionList - the faction doing the perceiving.
-    /// </summary>
+    /// <summary>Index into FactionList - the faction doing the perceiving.</summary>
     public uint FactionID2 { get; set; }
 
     /// <summary>

--- a/Radoub.Formats/Radoub.Formats/Fac/FacReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Fac/FacReader.cs
@@ -8,27 +8,21 @@ namespace Radoub.Formats.Fac;
 /// </summary>
 public static class FacReader
 {
-    /// <summary>
-    /// Read a FAC file from a file path.
-    /// </summary>
+    /// <summary>Read a FAC file from a file path.</summary>
     public static FacFile Read(string filePath)
     {
         var gff = GffReader.Read(filePath);
         return ParseFac(gff);
     }
 
-    /// <summary>
-    /// Read a FAC file from a stream.
-    /// </summary>
+    /// <summary>Read a FAC file from a stream.</summary>
     public static FacFile Read(Stream stream)
     {
         var gff = GffReader.Read(stream);
         return ParseFac(gff);
     }
 
-    /// <summary>
-    /// Read a FAC file from a byte buffer.
-    /// </summary>
+    /// <summary>Read a FAC file from a byte buffer.</summary>
     public static FacFile Read(byte[] buffer)
     {
         var gff = GffReader.Read(buffer);
@@ -45,7 +39,6 @@ public static class FacReader
 
         var root = gff.RootStruct;
 
-        // Parse FactionList
         var factionListField = root.GetField("FactionList");
         if (factionListField?.Value is GffList factionList)
         {
@@ -61,7 +54,6 @@ public static class FacReader
             }
         }
 
-        // Parse RepList (reputation relationships)
         var repListField = root.GetField("RepList");
         if (repListField?.Value is GffList repList)
         {

--- a/Radoub.Formats/Radoub.Formats/Fac/FacWriter.cs
+++ b/Radoub.Formats/Radoub.Formats/Fac/FacWriter.cs
@@ -8,27 +8,21 @@ namespace Radoub.Formats.Fac;
 /// </summary>
 public static class FacWriter
 {
-    /// <summary>
-    /// Write a FAC file to a file path.
-    /// </summary>
+    /// <summary>Write a FAC file to a file path.</summary>
     public static void Write(FacFile fac, string filePath)
     {
         var buffer = Write(fac);
         File.WriteAllBytes(filePath, buffer);
     }
 
-    /// <summary>
-    /// Write a FAC file to a stream.
-    /// </summary>
+    /// <summary>Write a FAC file to a stream.</summary>
     public static void Write(FacFile fac, Stream stream)
     {
         var buffer = Write(fac);
         stream.Write(buffer, 0, buffer.Length);
     }
 
-    /// <summary>
-    /// Write a FAC file to a byte buffer.
-    /// </summary>
+    /// <summary>Write a FAC file to a byte buffer.</summary>
     public static byte[] Write(FacFile fac)
     {
         var gff = new GffFile
@@ -39,7 +33,6 @@ public static class FacWriter
 
         gff.RootStruct = new GffStruct { Type = 0xFFFFFFFF };
 
-        // Build FactionList
         var factionStructs = new List<GffStruct>();
         foreach (var faction in fac.FactionList)
         {
@@ -51,7 +44,6 @@ public static class FacWriter
         }
         GffFieldBuilder.AddListField(gff.RootStruct, "FactionList", factionStructs);
 
-        // Build RepList
         var repStructs = new List<GffStruct>();
         foreach (var rep in fac.RepList)
         {

--- a/Radoub.Formats/Radoub.Formats/Gff/GffFieldBuilder.cs
+++ b/Radoub.Formats/Radoub.Formats/Gff/GffFieldBuilder.cs
@@ -7,9 +7,6 @@ namespace Radoub.Formats.Gff;
 /// </summary>
 public static class GffFieldBuilder
 {
-    /// <summary>
-    /// Add a BYTE field to a struct.
-    /// </summary>
     public static void AddByteField(GffStruct parent, string label, byte value)
     {
         parent.Fields.Add(new GffField
@@ -20,9 +17,6 @@ public static class GffFieldBuilder
         });
     }
 
-    /// <summary>
-    /// Add a CHAR field to a struct.
-    /// </summary>
     public static void AddCharField(GffStruct parent, string label, sbyte value)
     {
         parent.Fields.Add(new GffField
@@ -33,9 +27,6 @@ public static class GffFieldBuilder
         });
     }
 
-    /// <summary>
-    /// Add a WORD field to a struct.
-    /// </summary>
     public static void AddWordField(GffStruct parent, string label, ushort value)
     {
         parent.Fields.Add(new GffField
@@ -46,9 +37,6 @@ public static class GffFieldBuilder
         });
     }
 
-    /// <summary>
-    /// Add a SHORT field to a struct.
-    /// </summary>
     public static void AddShortField(GffStruct parent, string label, short value)
     {
         parent.Fields.Add(new GffField
@@ -59,9 +47,6 @@ public static class GffFieldBuilder
         });
     }
 
-    /// <summary>
-    /// Add a DWORD field to a struct.
-    /// </summary>
     public static void AddDwordField(GffStruct parent, string label, uint value)
     {
         parent.Fields.Add(new GffField
@@ -72,9 +57,6 @@ public static class GffFieldBuilder
         });
     }
 
-    /// <summary>
-    /// Add an INT field to a struct.
-    /// </summary>
     public static void AddIntField(GffStruct parent, string label, int value)
     {
         parent.Fields.Add(new GffField
@@ -85,9 +67,6 @@ public static class GffFieldBuilder
         });
     }
 
-    /// <summary>
-    /// Add a DWORD64 field to a struct.
-    /// </summary>
     public static void AddDword64Field(GffStruct parent, string label, ulong value)
     {
         parent.Fields.Add(new GffField
@@ -98,9 +77,6 @@ public static class GffFieldBuilder
         });
     }
 
-    /// <summary>
-    /// Add an INT64 field to a struct.
-    /// </summary>
     public static void AddInt64Field(GffStruct parent, string label, long value)
     {
         parent.Fields.Add(new GffField
@@ -111,9 +87,6 @@ public static class GffFieldBuilder
         });
     }
 
-    /// <summary>
-    /// Add a FLOAT field to a struct.
-    /// </summary>
     public static void AddFloatField(GffStruct parent, string label, float value)
     {
         parent.Fields.Add(new GffField
@@ -124,9 +97,6 @@ public static class GffFieldBuilder
         });
     }
 
-    /// <summary>
-    /// Add a DOUBLE field to a struct.
-    /// </summary>
     public static void AddDoubleField(GffStruct parent, string label, double value)
     {
         parent.Fields.Add(new GffField
@@ -137,9 +107,6 @@ public static class GffFieldBuilder
         });
     }
 
-    /// <summary>
-    /// Add a CExoString field to a struct.
-    /// </summary>
     public static void AddCExoStringField(GffStruct parent, string label, string value)
     {
         parent.Fields.Add(new GffField
@@ -150,9 +117,6 @@ public static class GffFieldBuilder
         });
     }
 
-    /// <summary>
-    /// Add a CResRef field to a struct.
-    /// </summary>
     public static void AddCResRefField(GffStruct parent, string label, string value)
     {
         parent.Fields.Add(new GffField
@@ -163,9 +127,6 @@ public static class GffFieldBuilder
         });
     }
 
-    /// <summary>
-    /// Add a CExoLocString field to a struct.
-    /// </summary>
     public static void AddLocStringField(GffStruct parent, string label, CExoLocString locString)
     {
         parent.Fields.Add(new GffField
@@ -176,9 +137,7 @@ public static class GffFieldBuilder
         });
     }
 
-    /// <summary>
-    /// Add a VOID (raw bytes) field to a struct.
-    /// </summary>
+    /// <summary>Add a VOID (raw bytes) field to a struct.</summary>
     public static void AddVoidField(GffStruct parent, string label, byte[] data)
     {
         parent.Fields.Add(new GffField
@@ -189,9 +148,6 @@ public static class GffFieldBuilder
         });
     }
 
-    /// <summary>
-    /// Add a Struct field to a struct.
-    /// </summary>
     public static void AddStructField(GffStruct parent, string label, GffStruct value)
     {
         parent.Fields.Add(new GffField
@@ -202,9 +158,7 @@ public static class GffFieldBuilder
         });
     }
 
-    /// <summary>
-    /// Add a List field to a struct. Automatically sets the list count.
-    /// </summary>
+    /// <summary>Add a List field to a struct. Automatically sets the list count.</summary>
     public static void AddListField(GffStruct parent, string label, GffList list)
     {
         list.Count = (uint)list.Elements.Count;
@@ -216,9 +170,7 @@ public static class GffFieldBuilder
         });
     }
 
-    /// <summary>
-    /// Add a List field to a struct from a collection of structs.
-    /// </summary>
+    /// <summary>Add a List field to a struct from a collection of structs.</summary>
     public static void AddListField(GffStruct parent, string label, IEnumerable<GffStruct> elements)
     {
         var list = new GffList();

--- a/Radoub.Formats/Radoub.Formats/Gff/GffFile.cs
+++ b/Radoub.Formats/Radoub.Formats/Gff/GffFile.cs
@@ -7,40 +7,26 @@ namespace Radoub.Formats.Gff;
 /// </summary>
 public class GffFile
 {
-    /// <summary>
-    /// File type signature (4 bytes, e.g., "DLG ", "UTC ", "JRL ").
-    /// </summary>
+    /// <summary>File type signature (4 bytes, e.g., "DLG ", "UTC ", "JRL ").</summary>
     public string FileType { get; set; } = string.Empty;
 
-    /// <summary>
-    /// File version (4 bytes, typically "V3.2").
-    /// </summary>
+    /// <summary>File version (4 bytes, typically "V3.2").</summary>
     public string FileVersion { get; set; } = string.Empty;
 
-    /// <summary>
-    /// The root struct containing all data.
-    /// </summary>
+    /// <summary>The root struct containing all data.</summary>
     public GffStruct RootStruct { get; set; } = new();
 
-    /// <summary>
-    /// All structs in the file (indexed by struct array position).
-    /// </summary>
+    /// <summary>All structs in the file (indexed by struct array position).</summary>
     public List<GffStruct> Structs { get; set; } = new();
 
-    /// <summary>
-    /// All fields in the file (indexed by field array position).
-    /// </summary>
+    /// <summary>All fields in the file (indexed by field array position).</summary>
     public List<GffField> Fields { get; set; } = new();
 
-    /// <summary>
-    /// All labels in the file (indexed by label array position).
-    /// </summary>
+    /// <summary>All labels in the file (indexed by label array position).</summary>
     public List<GffLabel> Labels { get; set; } = new();
 }
 
-/// <summary>
-/// GFF file header containing offsets and counts for all sections.
-/// </summary>
+/// <summary>GFF file header containing offsets and counts for all sections.</summary>
 public class GffHeader
 {
     public string FileType { get; set; } = string.Empty;
@@ -59,14 +45,10 @@ public class GffHeader
     public uint ListIndicesCount { get; set; }
 }
 
-/// <summary>
-/// A struct in GFF format, containing zero or more fields.
-/// </summary>
+/// <summary>A struct in GFF format, containing zero or more fields.</summary>
 public class GffStruct
 {
-    /// <summary>
-    /// Struct type ID (application-specific meaning).
-    /// </summary>
+    /// <summary>Struct type ID (application-specific meaning).</summary>
     public uint Type { get; set; }
 
     /// <summary>
@@ -75,19 +57,12 @@ public class GffStruct
     /// </summary>
     public uint DataOrDataOffset { get; set; }
 
-    /// <summary>
-    /// Number of fields in this struct.
-    /// </summary>
     public uint FieldCount { get; set; }
 
-    /// <summary>
-    /// The fields belonging to this struct (populated during parsing).
-    /// </summary>
+    /// <summary>The fields belonging to this struct (populated during parsing).</summary>
     public List<GffField> Fields { get; set; } = new();
 
-    /// <summary>
-    /// Get a field by label (case-insensitive).
-    /// </summary>
+    /// <summary>Get a field by label (case-insensitive).</summary>
     public GffField? GetField(string label)
     {
         return Fields.FirstOrDefault(f => f.Label.Equals(label, StringComparison.OrdinalIgnoreCase));
@@ -103,17 +78,15 @@ public class GffStruct
         if (field?.Value == null)
             return defaultValue;
 
-        // Direct type match
         if (field.Value is T value)
             return value;
 
-        // Handle numeric type conversions (common in GFF files where DWORD/INT are sometimes swapped)
+        // Numeric conversions: GFF files sometimes swap DWORD/INT for the same field.
         var targetType = typeof(T);
         var sourceValue = field.Value;
 
         try
         {
-            // Convert numeric types
             if (targetType == typeof(int))
             {
                 return (T)(object)Convert.ToInt32(sourceValue);
@@ -156,24 +129,16 @@ public class GffStruct
     }
 }
 
-/// <summary>
-/// A field in GFF format, containing typed data.
-/// </summary>
+/// <summary>A field in GFF format, containing typed data.</summary>
 public class GffField
 {
-    /// <summary>
-    /// Field type (see constants below).
-    /// </summary>
+    /// <summary>Field type (see constants below).</summary>
     public uint Type { get; set; }
 
-    /// <summary>
-    /// Index into the labels array.
-    /// </summary>
+    /// <summary>Index into the labels array.</summary>
     public uint LabelIndex { get; set; }
 
-    /// <summary>
-    /// The field's label/name (populated during parsing).
-    /// </summary>
+    /// <summary>The field's label/name (populated during parsing).</summary>
     public string Label { get; set; } = string.Empty;
 
     /// <summary>
@@ -182,9 +147,7 @@ public class GffField
     /// </summary>
     public uint DataOrDataOffset { get; set; }
 
-    /// <summary>
-    /// The parsed value (type depends on field Type).
-    /// </summary>
+    /// <summary>The parsed value (type depends on field Type).</summary>
     public object? Value { get; set; }
 
     // Field type constants from GFF specification
@@ -224,27 +187,18 @@ public class GffField
     public bool IsList => Type == List;
 }
 
-/// <summary>
-/// A label (field name) in GFF format. Max 16 characters.
-/// </summary>
+/// <summary>A label (field name) in GFF format. Max 16 characters.</summary>
 public class GffLabel
 {
     public string Text { get; set; } = string.Empty;
 }
 
-/// <summary>
-/// A list of structs in GFF format.
-/// </summary>
+/// <summary>A list of structs in GFF format.</summary>
 public class GffList
 {
-    /// <summary>
-    /// Number of struct references in this list.
-    /// </summary>
     public uint Count { get; set; }
 
-    /// <summary>
-    /// The structs in this list (populated during parsing).
-    /// </summary>
+    /// <summary>The structs in this list (populated during parsing).</summary>
     public List<GffStruct> Elements { get; set; } = new();
 }
 
@@ -254,14 +208,10 @@ public class GffList
 /// </summary>
 public class CExoLocString
 {
-    /// <summary>
-    /// String reference into TLK file (0xFFFFFFFF = no TLK reference).
-    /// </summary>
+    /// <summary>String reference into TLK file (0xFFFFFFFF = no TLK reference).</summary>
     public uint StrRef { get; set; } = 0xFFFFFFFF;
 
-    /// <summary>
-    /// Number of localized substrings (used during binary parsing).
-    /// </summary>
+    /// <summary>Number of localized substrings (used during binary parsing).</summary>
     public uint SubStringCount { get; set; }
 
     /// <summary>
@@ -270,47 +220,34 @@ public class CExoLocString
     /// </summary>
     public Dictionary<uint, string> LocalizedStrings { get; set; } = new();
 
-    /// <summary>
-    /// Get string for a specific language ID.
-    /// </summary>
+    /// <summary>Get string for a specific language ID.</summary>
     public string GetString(uint languageId = 0)
     {
         return LocalizedStrings.TryGetValue(languageId, out var text) ? text : string.Empty;
     }
 
-    /// <summary>
-    /// Set string for a specific language ID.
-    /// </summary>
+    /// <summary>Set string for a specific language ID.</summary>
     public void SetString(uint languageId, string text)
     {
         LocalizedStrings[languageId] = text;
     }
 
-    /// <summary>
-    /// Get the default string (English male, or first available).
-    /// </summary>
+    /// <summary>Get the default string: English male (language ID 0), else first available.</summary>
     public string GetDefault()
     {
-        // Try English male (0) first, then any available language
         if (LocalizedStrings.TryGetValue(0, out var english))
             return english;
         return LocalizedStrings.Values.FirstOrDefault() ?? string.Empty;
     }
 
-    /// <summary>
-    /// True if no strings and no TLK reference.
-    /// </summary>
+    /// <summary>True if no strings and no TLK reference.</summary>
     public bool IsEmpty => LocalizedStrings.Count == 0 && StrRef == 0xFFFFFFFF;
 }
 
-/// <summary>
-/// Extension methods for GFF field types.
-/// </summary>
+/// <summary>Extension methods for GFF field types.</summary>
 public static class GffFieldTypeExtensions
 {
-    /// <summary>
-    /// Returns true if the field type stores its value directly in DataOrDataOffset.
-    /// </summary>
+    /// <summary>True if the field type stores its value directly in DataOrDataOffset.</summary>
     public static bool IsSimpleType(this uint fieldType)
     {
         return fieldType switch
@@ -337,9 +274,7 @@ public static class GffFieldTypeExtensions
         };
     }
 
-    /// <summary>
-    /// Get the human-readable name for a field type.
-    /// </summary>
+    /// <summary>Get the human-readable name for a field type.</summary>
     public static string GetTypeName(this uint fieldType)
     {
         return fieldType switch

--- a/Radoub.Formats/Radoub.Formats/Gff/GffReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Gff/GffReader.cs
@@ -19,18 +19,14 @@ public static class GffReader
         NwnEncoding = Encoding.GetEncoding(1252);
     }
 
-    /// <summary>
-    /// Read a GFF file from a file path.
-    /// </summary>
+    /// <summary>Read a GFF file from a file path.</summary>
     public static GffFile Read(string filePath)
     {
         var buffer = File.ReadAllBytes(filePath);
         return Read(buffer);
     }
 
-    /// <summary>
-    /// Read a GFF file from a stream.
-    /// </summary>
+    /// <summary>Read a GFF file from a stream.</summary>
     public static GffFile Read(Stream stream)
     {
         using var ms = new MemoryStream();
@@ -38,9 +34,7 @@ public static class GffReader
         return Read(ms.ToArray());
     }
 
-    /// <summary>
-    /// Read a GFF file from a byte buffer.
-    /// </summary>
+    /// <summary>Read a GFF file from a byte buffer.</summary>
     public static GffFile Read(byte[] buffer)
     {
         if (buffer.Length < HeaderSize)
@@ -80,9 +74,7 @@ public static class GffReader
         return gff;
     }
 
-    /// <summary>
-    /// Parse GFF header from buffer (exposed for testing).
-    /// </summary>
+    /// <summary>Parse GFF header from buffer (exposed for testing).</summary>
     public static GffHeader ParseHeader(byte[] buffer)
     {
         if (buffer.Length < HeaderSize)
@@ -452,9 +444,7 @@ public static class GffReader
         return locString;
     }
 
-    /// <summary>
-    /// Read a struct by direct index (for Struct type fields where DataOrDataOffset is the index).
-    /// </summary>
+    /// <summary>Read a struct by direct index (for Struct type fields where DataOrDataOffset is the index).</summary>
     private static GffStruct? ReadStructByIndex(uint structIndex, GffStruct[] structs)
     {
         if (structIndex >= structs.Length)

--- a/Radoub.Formats/Radoub.Formats/Gff/GffWriter.cs
+++ b/Radoub.Formats/Radoub.Formats/Gff/GffWriter.cs
@@ -18,27 +18,21 @@ public static class GffWriter
         NwnEncoding = Encoding.GetEncoding(1252);
     }
 
-    /// <summary>
-    /// Write a GFF file to a file path.
-    /// </summary>
+    /// <summary>Write a GFF file to a file path.</summary>
     public static void Write(GffFile gff, string filePath)
     {
         var buffer = Write(gff);
         File.WriteAllBytes(filePath, buffer);
     }
 
-    /// <summary>
-    /// Write a GFF file to a stream.
-    /// </summary>
+    /// <summary>Write a GFF file to a stream.</summary>
     public static void Write(GffFile gff, Stream stream)
     {
         var buffer = Write(gff);
         stream.Write(buffer, 0, buffer.Length);
     }
 
-    /// <summary>
-    /// Write a GFF file to a byte buffer.
-    /// </summary>
+    /// <summary>Write a GFF file to a byte buffer.</summary>
     public static byte[] Write(GffFile gff)
     {
         // Collect all unique items

--- a/Radoub.Formats/Radoub.Formats/Gff/VarTableHelper.cs
+++ b/Radoub.Formats/Radoub.Formats/Gff/VarTableHelper.cs
@@ -10,19 +10,13 @@ namespace Radoub.Formats.Gff;
 /// </summary>
 public static class VarTableHelper
 {
-    /// <summary>
-    /// The GFF field name for the VarTable list.
-    /// </summary>
+    /// <summary>The GFF field name for the VarTable list.</summary>
     public const string VarTableFieldName = "VarTable";
 
-    /// <summary>
-    /// StructID for Variable structs in a VarTable.
-    /// </summary>
+    /// <summary>StructID for Variable structs in a VarTable.</summary>
     public const uint VariableStructId = 0;
 
-    /// <summary>
-    /// StructID for Location structs within location-type variables.
-    /// </summary>
+    /// <summary>StructID for Location structs within location-type variables.</summary>
     public const uint LocationStructId = 1;
 
     #region Reading
@@ -51,9 +45,6 @@ public static class VarTableHelper
         return variables;
     }
 
-    /// <summary>
-    /// Read a single variable from a Variable struct.
-    /// </summary>
     private static Variable? ReadVariable(GffStruct varStruct)
     {
         var name = varStruct.GetFieldValue<string>("Name", string.Empty);
@@ -85,9 +76,6 @@ public static class VarTableHelper
         return variable;
     }
 
-    /// <summary>
-    /// Read a location value from a Variable struct.
-    /// </summary>
     private static VariableLocation? ReadLocationValue(GffStruct varStruct)
     {
         var valueField = varStruct.GetField("Value");
@@ -106,9 +94,7 @@ public static class VarTableHelper
         };
     }
 
-    /// <summary>
-    /// Get a variable by name from a VarTable.
-    /// </summary>
+    /// <summary>Get a variable by name from a VarTable.</summary>
     /// <param name="root">The GFF struct containing the VarTable field.</param>
     /// <param name="name">The variable name (case-sensitive).</param>
     /// <returns>The variable if found, null otherwise.</returns>
@@ -118,45 +104,30 @@ public static class VarTableHelper
         return variables.FirstOrDefault(v => v.Name == name);
     }
 
-    /// <summary>
-    /// Get an integer variable value.
-    /// </summary>
     public static int GetInt(GffStruct root, string name, int defaultValue = 0)
     {
         var variable = GetVariable(root, name);
         return variable?.Type == VariableType.Int ? variable.GetInt() : defaultValue;
     }
 
-    /// <summary>
-    /// Get a float variable value.
-    /// </summary>
     public static float GetFloat(GffStruct root, string name, float defaultValue = 0.0f)
     {
         var variable = GetVariable(root, name);
         return variable?.Type == VariableType.Float ? variable.GetFloat() : defaultValue;
     }
 
-    /// <summary>
-    /// Get a string variable value.
-    /// </summary>
     public static string GetString(GffStruct root, string name, string defaultValue = "")
     {
         var variable = GetVariable(root, name);
         return variable?.Type == VariableType.String ? variable.GetString() : defaultValue;
     }
 
-    /// <summary>
-    /// Get an object variable value.
-    /// </summary>
     public static uint GetObjectId(GffStruct root, string name, uint defaultValue = 0x7F000000)
     {
         var variable = GetVariable(root, name);
         return variable?.Type == VariableType.Object ? variable.GetObjectId() : defaultValue;
     }
 
-    /// <summary>
-    /// Get a location variable value.
-    /// </summary>
     public static VariableLocation? GetLocation(GffStruct root, string name)
     {
         var variable = GetVariable(root, name);
@@ -194,9 +165,6 @@ public static class VarTableHelper
         AddListField(root, VarTableFieldName, list);
     }
 
-    /// <summary>
-    /// Build a Variable GFF struct from a Variable object.
-    /// </summary>
     private static GffStruct BuildVariableStruct(Variable variable)
     {
         var varStruct = new GffStruct { Type = VariableStructId };
@@ -227,9 +195,7 @@ public static class VarTableHelper
         return varStruct;
     }
 
-    /// <summary>
-    /// Add a location struct as the Value field.
-    /// </summary>
+    /// <summary>Add a location struct as the Value field.</summary>
     private static void AddLocationStruct(GffStruct parent, VariableLocation? location)
     {
         var locStruct = new GffStruct { Type = LocationStructId };
@@ -267,49 +233,32 @@ public static class VarTableHelper
         WriteVarTable(root, variables);
     }
 
-    /// <summary>
-    /// Set an integer variable.
-    /// </summary>
     public static void SetInt(GffStruct root, string name, int value)
     {
         SetVariable(root, Variable.CreateInt(name, value));
     }
 
-    /// <summary>
-    /// Set a float variable.
-    /// </summary>
     public static void SetFloat(GffStruct root, string name, float value)
     {
         SetVariable(root, Variable.CreateFloat(name, value));
     }
 
-    /// <summary>
-    /// Set a string variable.
-    /// </summary>
     public static void SetString(GffStruct root, string name, string value)
     {
         SetVariable(root, Variable.CreateString(name, value));
     }
 
-    /// <summary>
-    /// Set an object variable.
-    /// </summary>
     public static void SetObjectId(GffStruct root, string name, uint objectId)
     {
         SetVariable(root, Variable.CreateObject(name, objectId));
     }
 
-    /// <summary>
-    /// Set a location variable.
-    /// </summary>
     public static void SetLocation(GffStruct root, string name, VariableLocation location)
     {
         SetVariable(root, Variable.CreateLocation(name, location));
     }
 
-    /// <summary>
-    /// Delete a variable from a VarTable by name.
-    /// </summary>
+    /// <summary>Delete a variable from a VarTable by name.</summary>
     /// <param name="root">The GFF struct containing the VarTable.</param>
     /// <param name="name">The variable name to delete.</param>
     /// <returns>True if the variable was found and deleted.</returns>
@@ -327,25 +276,19 @@ public static class VarTableHelper
         return false;
     }
 
-    /// <summary>
-    /// Check if a variable exists in a VarTable.
-    /// </summary>
+    /// <summary>Check if a variable exists in a VarTable.</summary>
     public static bool HasVariable(GffStruct root, string name)
     {
         return GetVariable(root, name) != null;
     }
 
-    /// <summary>
-    /// Get all variable names from a VarTable.
-    /// </summary>
+    /// <summary>Get all variable names from a VarTable.</summary>
     public static List<string> GetVariableNames(GffStruct root)
     {
         return ReadVarTable(root).Select(v => v.Name).ToList();
     }
 
-    /// <summary>
-    /// Clear all variables from a VarTable.
-    /// </summary>
+    /// <summary>Clear all variables from a VarTable.</summary>
     public static void ClearVariables(GffStruct root)
     {
         var existingField = root.GetField(VarTableFieldName);

--- a/Radoub.Formats/Radoub.Formats/Gff/Variable.cs
+++ b/Radoub.Formats/Radoub.Formats/Gff/Variable.cs
@@ -29,14 +29,9 @@ public enum VariableType : uint
 /// </summary>
 public class Variable
 {
-    /// <summary>
-    /// The variable name as set by SetLocal*() script functions.
-    /// </summary>
+    /// <summary>The variable name as set by SetLocal*() script functions.</summary>
     public string Name { get; set; } = string.Empty;
 
-    /// <summary>
-    /// The variable's data type.
-    /// </summary>
     public VariableType Type { get; set; }
 
     /// <summary>
@@ -49,34 +44,21 @@ public class Variable
     /// </summary>
     public object? Value { get; set; }
 
-    /// <summary>
-    /// Get the value as an integer. Returns 0 if type mismatch.
-    /// </summary>
+    /// <summary>Value as an integer; 0 on type mismatch.</summary>
     public int GetInt() => Value is int i ? i : 0;
 
-    /// <summary>
-    /// Get the value as a float. Returns 0.0f if type mismatch.
-    /// </summary>
+    /// <summary>Value as a float; 0.0f on type mismatch.</summary>
     public float GetFloat() => Value is float f ? f : 0.0f;
 
-    /// <summary>
-    /// Get the value as a string. Returns empty string if type mismatch.
-    /// </summary>
+    /// <summary>Value as a string; empty string on type mismatch.</summary>
     public string GetString() => Value is string s ? s : string.Empty;
 
-    /// <summary>
-    /// Get the value as an object ID. Returns 0x7F000000 (OBJECT_INVALID) if type mismatch.
-    /// </summary>
+    /// <summary>Value as an object ID; 0x7F000000 (OBJECT_INVALID) on type mismatch.</summary>
     public uint GetObjectId() => Value is uint u ? u : 0x7F000000;
 
-    /// <summary>
-    /// Get the value as a location. Returns null if type mismatch.
-    /// </summary>
+    /// <summary>Value as a location; null on type mismatch.</summary>
     public VariableLocation? GetLocation() => Value as VariableLocation;
 
-    /// <summary>
-    /// Create an integer variable.
-    /// </summary>
     public static Variable CreateInt(string name, int value) => new()
     {
         Name = name,
@@ -84,9 +66,6 @@ public class Variable
         Value = value
     };
 
-    /// <summary>
-    /// Create a float variable.
-    /// </summary>
     public static Variable CreateFloat(string name, float value) => new()
     {
         Name = name,
@@ -94,9 +73,6 @@ public class Variable
         Value = value
     };
 
-    /// <summary>
-    /// Create a string variable.
-    /// </summary>
     public static Variable CreateString(string name, string value) => new()
     {
         Name = name,
@@ -104,9 +80,6 @@ public class Variable
         Value = value
     };
 
-    /// <summary>
-    /// Create an object reference variable.
-    /// </summary>
     public static Variable CreateObject(string name, uint objectId) => new()
     {
         Name = name,
@@ -114,9 +87,6 @@ public class Variable
         Value = objectId
     };
 
-    /// <summary>
-    /// Create a location variable.
-    /// </summary>
     public static Variable CreateLocation(string name, VariableLocation location) => new()
     {
         Name = name,
@@ -134,21 +104,16 @@ public class VariableLocation
     /// <summary>ObjectId of the area containing the location.</summary>
     public uint Area { get; set; }
 
-    /// <summary>X coordinate of the location.</summary>
     public float PositionX { get; set; }
 
-    /// <summary>Y coordinate of the location.</summary>
     public float PositionY { get; set; }
 
-    /// <summary>Z coordinate of the location.</summary>
     public float PositionZ { get; set; }
 
-    /// <summary>X component of the facing direction.</summary>
+    /// <summary>Orientation is the facing direction vector.</summary>
     public float OrientationX { get; set; }
 
-    /// <summary>Y component of the facing direction.</summary>
     public float OrientationY { get; set; }
 
-    /// <summary>Z component of the facing direction.</summary>
     public float OrientationZ { get; set; }
 }

--- a/Radoub.Formats/Radoub.Formats/Ifo/IfoFile.cs
+++ b/Radoub.Formats/Radoub.Formats/Ifo/IfoFile.cs
@@ -9,44 +9,23 @@ namespace Radoub.Formats.Ifo;
 /// </summary>
 public class IfoFile
 {
-    /// <summary>
-    /// File type signature - should be "IFO "
-    /// </summary>
+    /// <summary>File type signature - should be "IFO "</summary>
     public string FileType { get; set; } = "IFO ";
 
-    /// <summary>
-    /// File version - typically "V3.2"
-    /// </summary>
+    /// <summary>File version - typically "V3.2"</summary>
     public string FileVersion { get; set; } = "V3.2";
 
-    // Module Metadata
-
-    /// <summary>
-    /// Localized module name.
-    /// </summary>
     public CExoLocString ModuleName { get; set; } = new();
 
-    /// <summary>
-    /// Localized module description.
-    /// </summary>
     public CExoLocString ModuleDescription { get; set; } = new();
 
-    /// <summary>
-    /// Module tag (max 32 characters).
-    /// </summary>
+    /// <summary>Module tag (max 32 characters).</summary>
     public string Tag { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Module ID - unique identifier.
-    /// </summary>
     public string ModuleId { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Custom TLK file reference (without .tlk extension).
-    /// </summary>
+    /// <summary>Custom TLK file reference (without .tlk extension).</summary>
     public string CustomTlk { get; set; } = string.Empty;
-
-    // Version/Requirements
 
     /// <summary>
     /// Minimum game version required (e.g., "1.69", "1.89").
@@ -60,248 +39,123 @@ public class IfoFile
     /// </summary>
     public ushort ExpansionPack { get; set; }
 
-    // HAK Configuration
-
     /// <summary>
-    /// List of HAK files required by this module.
-    /// Ordered by priority (first has highest priority).
-    /// HAK names without .hak extension.
+    /// HAK files required by this module, ordered by priority (first = highest).
+    /// Names carry no .hak extension.
     /// </summary>
     public List<string> HakList { get; set; } = new();
 
-    // Time Settings
-
-    /// <summary>
-    /// Hour when dawn begins (0-23).
-    /// </summary>
+    /// <summary>Hour when dawn begins (0-23).</summary>
     public byte DawnHour { get; set; } = 6;
 
-    /// <summary>
-    /// Hour when dusk begins (0-23).
-    /// </summary>
+    /// <summary>Hour when dusk begins (0-23).</summary>
     public byte DuskHour { get; set; } = 18;
 
-    /// <summary>
-    /// Real-time minutes per in-game hour (1-255).
-    /// </summary>
+    /// <summary>Real-time minutes per in-game hour (1-255).</summary>
     public byte MinutesPerHour { get; set; } = 2;
 
-    /// <summary>
-    /// Starting year for new games.
-    /// </summary>
+    /// <summary>Starting year for new games.</summary>
     public uint StartYear { get; set; } = 1372;
 
-    /// <summary>
-    /// Starting month for new games (1-12).
-    /// </summary>
+    /// <summary>Starting month for new games (1-12).</summary>
     public byte StartMonth { get; set; } = 1;
 
-    /// <summary>
-    /// Starting day for new games (1-28).
-    /// </summary>
+    /// <summary>Starting day for new games (1-28).</summary>
     public byte StartDay { get; set; } = 1;
 
-    /// <summary>
-    /// Starting hour for new games (0-23).
-    /// </summary>
+    /// <summary>Starting hour for new games (0-23).</summary>
     public byte StartHour { get; set; } = 13;
 
-    // Entry Point
-
-    /// <summary>
-    /// Area ResRef where players start.
-    /// </summary>
+    /// <summary>Area ResRef where players start.</summary>
     public string EntryArea { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Entry point X coordinate.
-    /// </summary>
     public float EntryX { get; set; }
 
-    /// <summary>
-    /// Entry point Y coordinate.
-    /// </summary>
     public float EntryY { get; set; }
 
-    /// <summary>
-    /// Entry point Z coordinate.
-    /// </summary>
     public float EntryZ { get; set; }
 
-    /// <summary>
-    /// Entry point facing direction X component.
-    /// </summary>
+    /// <summary>Entry point facing direction X component.</summary>
     public float EntryDirX { get; set; }
 
-    /// <summary>
-    /// Entry point facing direction Y component.
-    /// </summary>
+    /// <summary>Entry point facing direction Y component.</summary>
     public float EntryDirY { get; set; } = 1.0f;
 
     // Module Scripts
 
-    /// <summary>
-    /// Script run when module loads.
-    /// </summary>
     public string OnModuleLoad { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script run when client enters.
-    /// </summary>
     public string OnClientEnter { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script run when client leaves.
-    /// </summary>
     public string OnClientLeave { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Module heartbeat script.
-    /// </summary>
     public string OnHeartbeat { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script run when item is acquired.
-    /// </summary>
     public string OnAcquireItem { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script run when item is activated.
-    /// </summary>
     public string OnActivateItem { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script run when item is unacquired.
-    /// </summary>
     public string OnUnacquireItem { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script run when player dies.
-    /// </summary>
     public string OnPlayerDeath { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script run when player is dying.
-    /// </summary>
     public string OnPlayerDying { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script run when player rests.
-    /// </summary>
     public string OnPlayerRest { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script run when player equips an item.
-    /// </summary>
     public string OnPlayerEquipItem { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script run when player unequips an item.
-    /// </summary>
     public string OnPlayerUnequipItem { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script run when player levels up.
-    /// </summary>
     public string OnPlayerLevelUp { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script run on user-defined event.
-    /// </summary>
     public string OnUserDefined { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script run when respawn button is clicked.
-    /// </summary>
+    /// <summary>Script run when respawn button is clicked.</summary>
     public string OnSpawnButtonDown { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script run when cutscene is aborted.
-    /// </summary>
     public string OnCutsceneAbort { get; set; } = string.Empty;
 
     // NWN:EE Extended Scripts (1.69+)
 
-    /// <summary>
-    /// Script run when module starts (after OnModuleLoad).
-    /// </summary>
+    /// <summary>Script run when module starts (after OnModuleLoad).</summary>
     public string OnModuleStart { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script run when player sends a chat message.
-    /// </summary>
     public string OnPlayerChat { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script run when player targets something.
-    /// </summary>
     public string OnPlayerTarget { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script run on player GUI events.
-    /// </summary>
     public string OnPlayerGuiEvent { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script run on player tile actions.
-    /// </summary>
     public string OnPlayerTileAction { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script run on NUI (New User Interface) events. (NWN:EE 1.80+)
-    /// </summary>
+    /// <summary>Script run on NUI (New User Interface) events. (NWN:EE 1.80+)</summary>
     public string OnNuiEvent { get; set; } = string.Empty;
 
-    // Other Settings
-
-    /// <summary>
-    /// XP scale percentage (0-200, 100 = normal).
-    /// </summary>
+    /// <summary>XP scale percentage (0-200, 100 = normal).</summary>
     public byte XPScale { get; set; } = 100;
 
-    /// <summary>
-    /// Module creator's name (from toolset).
-    /// </summary>
+    /// <summary>Module creator's name (from toolset).</summary>
     public string Creator { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Module version set by creator.
-    /// </summary>
+    /// <summary>Module version set by creator.</summary>
     public uint ModuleVersion { get; set; }
 
-    /// <summary>
-    /// Whether this is a savegame (not a module).
-    /// </summary>
+    /// <summary>Whether this is a savegame (not a module).</summary>
     public byte IsSaveGame { get; set; }
 
-    /// <summary>
-    /// Startup movie to play.
-    /// </summary>
     public string StartMovie { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Default BIC (character) file for new characters.
-    /// </summary>
+    /// <summary>Default BIC (character) file for new characters.</summary>
     public string DefaultBic { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Module UUID for identification.
-    /// </summary>
     public string ModuleUuid { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Party control setting (0 = DM control, 1 = Player control).
-    /// </summary>
+    /// <summary>Party control setting (0 = DM control, 1 = Player control).</summary>
     public byte PartyControl { get; set; }
 
-    // Area List (read-only for editing)
-
-    /// <summary>
-    /// List of area ResRefs in the module (read-only reference).
-    /// </summary>
+    /// <summary>Area ResRefs in the module (read-only reference).</summary>
     public List<string> AreaList { get; set; } = new();
-
-    // Local Variables
 
     /// <summary>
     /// Local variables stored on the module.
@@ -311,19 +165,11 @@ public class IfoFile
 
     // Additional Lists (preserved for round-trip)
 
-    /// <summary>
-    /// Expansion list (additional expansion data).
-    /// </summary>
     public List<GffStruct> ExpansionList { get; set; } = new();
 
-    /// <summary>
-    /// Cutscene list (cutscene definitions).
-    /// </summary>
     public List<GffStruct> CutSceneList { get; set; } = new();
 
-    /// <summary>
-    /// Global variable list (savegame only).
-    /// </summary>
+    /// <summary>Global variable list (savegame only).</summary>
     public List<GffStruct> GlobalVarList { get; set; } = new();
 }
 

--- a/Radoub.Formats/Radoub.Formats/Ifo/IfoReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Ifo/IfoReader.cs
@@ -8,27 +8,21 @@ namespace Radoub.Formats.Ifo;
 /// </summary>
 public static class IfoReader
 {
-    /// <summary>
-    /// Read an IFO file from a file path.
-    /// </summary>
+    /// <summary>Read an IFO file from a file path.</summary>
     public static IfoFile Read(string filePath)
     {
         var buffer = File.ReadAllBytes(filePath);
         return Read(buffer);
     }
 
-    /// <summary>
-    /// Read an IFO file from a byte buffer.
-    /// </summary>
+    /// <summary>Read an IFO file from a byte buffer.</summary>
     public static IfoFile Read(byte[] buffer)
     {
         var gff = GffReader.Read(buffer);
         return FromGff(gff);
     }
 
-    /// <summary>
-    /// Read an IFO file from a stream.
-    /// </summary>
+    /// <summary>Read an IFO file from a stream.</summary>
     public static IfoFile Read(Stream stream)
     {
         using var ms = new MemoryStream();
@@ -36,9 +30,7 @@ public static class IfoReader
         return Read(ms.ToArray());
     }
 
-    /// <summary>
-    /// Convert a GFF file to an IfoFile model.
-    /// </summary>
+    /// <summary>Convert a GFF file to an IfoFile model.</summary>
     public static IfoFile FromGff(GffFile gff)
     {
         var ifo = new IfoFile
@@ -51,21 +43,17 @@ public static class IfoReader
         if (root == null)
             return ifo;
 
-        // Module Metadata
         ifo.ModuleName = ReadLocString(root, "Mod_Name");
         ifo.ModuleDescription = ReadLocString(root, "Mod_Description");
         ifo.Tag = root.GetFieldValue<string>("Mod_Tag", string.Empty);
         ifo.ModuleId = root.GetFieldValue<string>("Mod_ID", string.Empty);
         ifo.CustomTlk = root.GetFieldValue<string>("Mod_CustomTlk", string.Empty);
 
-        // Version/Requirements
         ifo.MinGameVersion = root.GetFieldValue<string>("Mod_MinGameVer", "1.69");
         ifo.ExpansionPack = root.GetFieldValue<ushort>("Expansion_Pack", 0);
 
-        // HAK List
         ifo.HakList = ReadHakList(root);
 
-        // Time Settings
         ifo.DawnHour = root.GetFieldValue<byte>("Mod_DawnHour", 6);
         ifo.DuskHour = root.GetFieldValue<byte>("Mod_DuskHour", 18);
         ifo.MinutesPerHour = root.GetFieldValue<byte>("Mod_MinPerHour", 2);
@@ -74,7 +62,6 @@ public static class IfoReader
         ifo.StartDay = root.GetFieldValue<byte>("Mod_StartDay", 1);
         ifo.StartHour = root.GetFieldValue<byte>("Mod_StartHour", 13);
 
-        // Entry Point
         ifo.EntryArea = root.GetFieldValue<string>("Mod_Entry_Area", string.Empty);
         ifo.EntryX = root.GetFieldValue<float>("Mod_Entry_X", 0.0f);
         ifo.EntryY = root.GetFieldValue<float>("Mod_Entry_Y", 0.0f);
@@ -108,7 +95,6 @@ public static class IfoReader
         ifo.OnPlayerTileAction = root.GetFieldValue<string>("Mod_OnPlrTileAct", string.Empty);
         ifo.OnNuiEvent = root.GetFieldValue<string>("Mod_OnNuiEvent", string.Empty);
 
-        // Other Settings
         ifo.XPScale = root.GetFieldValue<byte>("Mod_XPScale", 100);
         ifo.Creator = root.GetFieldValue<string>("Mod_Creator_ID", string.Empty);
         ifo.ModuleVersion = root.GetFieldValue<uint>("Mod_Version", 0);
@@ -118,10 +104,8 @@ public static class IfoReader
         ifo.ModuleUuid = root.GetFieldValue<string>("Mod_UUID", string.Empty);
         ifo.PartyControl = root.GetFieldValue<byte>("Mod_PartyControl", 0);
 
-        // Area List
         ifo.AreaList = ReadAreaList(root);
 
-        // Local Variables
         ifo.VarTable = VarTableHelper.ReadVarTable(root);
 
         // Additional Lists (preserved for round-trip)
@@ -132,9 +116,7 @@ public static class IfoReader
         return ifo;
     }
 
-    /// <summary>
-    /// Read a generic list of GffStructs for round-trip preservation.
-    /// </summary>
+    /// <summary>Read a generic list of GffStructs for round-trip preservation.</summary>
     private static List<GffStruct> ReadGenericList(GffStruct root, string fieldName)
     {
         var result = new List<GffStruct>();
@@ -146,9 +128,7 @@ public static class IfoReader
         return result;
     }
 
-    /// <summary>
-    /// Read a localized string field.
-    /// </summary>
+    /// <summary>Read a localized string field.</summary>
     private static CExoLocString ReadLocString(GffStruct root, string fieldName)
     {
         var field = root.GetField(fieldName);
@@ -169,9 +149,7 @@ public static class IfoReader
         return new CExoLocString();
     }
 
-    /// <summary>
-    /// Read the HAK list from a GFF struct.
-    /// </summary>
+    /// <summary>Read the HAK list from a GFF struct.</summary>
     private static List<string> ReadHakList(GffStruct root)
     {
         var hakList = new List<string>();
@@ -190,9 +168,7 @@ public static class IfoReader
         return hakList;
     }
 
-    /// <summary>
-    /// Read the area list from a GFF struct.
-    /// </summary>
+    /// <summary>Read the area list from a GFF struct.</summary>
     private static List<string> ReadAreaList(GffStruct root)
     {
         var areaList = new List<string>();

--- a/Radoub.Formats/Radoub.Formats/Ifo/IfoVersionRequirements.cs
+++ b/Radoub.Formats/Radoub.Formats/Ifo/IfoVersionRequirements.cs
@@ -6,34 +6,22 @@ namespace Radoub.Formats.Ifo;
 /// </summary>
 public static class IfoVersionRequirements
 {
-    /// <summary>
-    /// Base NWN 1.69 (Diamond Edition) - universal compatibility.
-    /// </summary>
+    /// <summary>Base NWN 1.69 (Diamond Edition) - universal compatibility.</summary>
     public const string Version169 = "1.69";
 
-    /// <summary>
-    /// NWN:EE initial release.
-    /// </summary>
+    /// <summary>NWN:EE initial release.</summary>
     public const string Version174 = "1.74";
 
-    /// <summary>
-    /// NWSync support added.
-    /// </summary>
+    /// <summary>NWSync support added.</summary>
     public const string Version177 = "1.77";
 
-    /// <summary>
-    /// Targeting mode scripts added.
-    /// </summary>
+    /// <summary>Targeting mode scripts added.</summary>
     public const string Version180 = "1.80";
 
-    /// <summary>
-    /// GUI and tile action events added.
-    /// </summary>
+    /// <summary>GUI and tile action events added.</summary>
     public const string Version185 = "1.85";
 
-    /// <summary>
-    /// DefaultBic and PartyControl added.
-    /// </summary>
+    /// <summary>DefaultBic and PartyControl added.</summary>
     public const string Version187 = "1.87";
 
     /// <summary>
@@ -98,13 +86,11 @@ public static class IfoVersionRequirements
     /// <summary>
     /// Gets information about EE-only fields that have values in the given IFO file.
     /// </summary>
-    /// <param name="ifo">The IFO file to check.</param>
     /// <returns>List of (fieldName, displayName, minVersion, currentValue) for fields with values.</returns>
     public static List<(string FieldName, string DisplayName, string MinVersion, string Value)> GetPopulatedEeFields(IfoFile ifo)
     {
         var result = new List<(string, string, string, string)>();
 
-        // Check each EE-only field
         if (!string.IsNullOrEmpty(ifo.OnModuleStart))
             result.Add(("Mod_OnModStart", "OnModuleStart script", Version174, ifo.OnModuleStart));
 
@@ -136,11 +122,7 @@ public static class IfoVersionRequirements
         return result;
     }
 
-    /// <summary>
-    /// Gets fields that would be incompatible with a target version.
-    /// </summary>
-    /// <param name="ifo">The IFO file to check.</param>
-    /// <param name="targetVersion">The target minimum game version.</param>
+    /// <summary>Gets fields that would be incompatible with a target version.</summary>
     /// <returns>Fields that require a higher version than the target.</returns>
     public static List<(string FieldName, string DisplayName, string MinVersion, string Value)> GetIncompatibleFields(
         IfoFile ifo, string targetVersion)
@@ -151,10 +133,7 @@ public static class IfoVersionRequirements
             .ToList();
     }
 
-    /// <summary>
-    /// Gets the highest version required by any populated field in the IFO.
-    /// </summary>
-    /// <param name="ifo">The IFO file to check.</param>
+    /// <summary>Gets the highest version required by any populated field in the IFO.</summary>
     /// <returns>The highest required version, or "1.69" if no EE fields are populated.</returns>
     public static string GetRequiredVersion(IfoFile ifo)
     {
@@ -174,14 +153,9 @@ public static class IfoVersionRequirements
 /// </summary>
 public class GameVersionComparer : IComparer<string>
 {
-    /// <summary>
-    /// Singleton instance for use in LINQ operations.
-    /// </summary>
+    /// <summary>Singleton instance for use in LINQ operations.</summary>
     public static readonly GameVersionComparer Instance = new();
 
-    /// <summary>
-    /// Compares two version strings.
-    /// </summary>
     /// <returns>
     /// Less than 0 if x &lt; y, 0 if equal, greater than 0 if x &gt; y.
     /// </returns>
@@ -207,11 +181,8 @@ public class GameVersionComparer : IComparer<string>
         return 0;
     }
 
-    /// <summary>
-    /// Checks if a module version supports a required version.
-    /// </summary>
+    /// <summary>Checks if a module version supports a required version.</summary>
     /// <param name="moduleVersion">The module's MinGameVersion.</param>
-    /// <param name="requiredVersion">The version required by a field.</param>
     /// <returns>True if moduleVersion >= requiredVersion.</returns>
     public static bool Supports(string moduleVersion, string requiredVersion)
     {

--- a/Radoub.Formats/Radoub.Formats/Ifo/IfoWriter.cs
+++ b/Radoub.Formats/Radoub.Formats/Ifo/IfoWriter.cs
@@ -9,18 +9,14 @@ namespace Radoub.Formats.Ifo;
 /// </summary>
 public static class IfoWriter
 {
-    /// <summary>
-    /// Write an IFO file to a file path.
-    /// </summary>
+    /// <summary>Write an IFO file to a file path.</summary>
     public static void Write(IfoFile ifo, string filePath)
     {
         var gff = ToGff(ifo);
         GffWriter.Write(gff, filePath);
     }
 
-    /// <summary>
-    /// Write an IFO file to a byte array.
-    /// </summary>
+    /// <summary>Write an IFO file to a byte array.</summary>
     public static byte[] Write(IfoFile ifo)
     {
         var gff = ToGff(ifo);
@@ -29,18 +25,14 @@ public static class IfoWriter
         return ms.ToArray();
     }
 
-    /// <summary>
-    /// Write an IFO file to a stream.
-    /// </summary>
+    /// <summary>Write an IFO file to a stream.</summary>
     public static void Write(IfoFile ifo, Stream stream)
     {
         var gff = ToGff(ifo);
         GffWriter.Write(gff, stream);
     }
 
-    /// <summary>
-    /// Convert an IfoFile model to GFF format.
-    /// </summary>
+    /// <summary>Convert an IfoFile model to GFF format.</summary>
     public static GffFile ToGff(IfoFile ifo)
     {
         var gff = new GffFile
@@ -52,18 +44,15 @@ public static class IfoWriter
 
         var root = gff.RootStruct;
 
-        // Module Metadata
         AddLocStringField(root, "Mod_Name", ifo.ModuleName);
         AddLocStringField(root, "Mod_Description", ifo.ModuleDescription);
         AddCExoStringField(root, "Mod_Tag", ifo.Tag);
         AddCExoStringField(root, "Mod_ID", ifo.ModuleId);
         AddCExoStringField(root, "Mod_CustomTlk", ifo.CustomTlk);
 
-        // Version/Requirements
         AddCExoStringField(root, "Mod_MinGameVer", ifo.MinGameVersion);
         AddWordField(root, "Expansion_Pack", ifo.ExpansionPack);
 
-        // Time Settings
         AddByteField(root, "Mod_DawnHour", ifo.DawnHour);
         AddByteField(root, "Mod_DuskHour", ifo.DuskHour);
         AddByteField(root, "Mod_MinPerHour", ifo.MinutesPerHour);
@@ -72,7 +61,6 @@ public static class IfoWriter
         AddByteField(root, "Mod_StartDay", ifo.StartDay);
         AddByteField(root, "Mod_StartHour", ifo.StartHour);
 
-        // Entry Point
         AddCResRefField(root, "Mod_Entry_Area", ifo.EntryArea);
         AddFloatField(root, "Mod_Entry_X", ifo.EntryX);
         AddFloatField(root, "Mod_Entry_Y", ifo.EntryY);
@@ -104,7 +92,6 @@ public static class IfoWriter
         AddCResRefField(root, "Mod_OnPlrTileAct", ifo.OnPlayerTileAction);
         AddCResRefField(root, "Mod_OnNuiEvent", ifo.OnNuiEvent);
 
-        // Other Settings
         AddByteField(root, "Mod_XPScale", ifo.XPScale);
         AddCExoStringField(root, "Mod_Creator_ID", ifo.Creator);
         AddDwordField(root, "Mod_Version", ifo.ModuleVersion);
@@ -125,15 +112,13 @@ public static class IfoWriter
         WriteGenericList(root, "Mod_CutSceneList", ifo.CutSceneList);
         WriteGenericList(root, "Mod_GVar_List", ifo.GlobalVarList);
 
-        // Local Variables
         VarTableHelper.WriteVarTable(root, ifo.VarTable);
 
         return gff;
     }
 
     /// <summary>
-    /// Write a generic list of GffStructs for round-trip preservation.
-    /// Always writes the list (even if empty) to ensure round-trip compatibility.
+    /// Write a generic list of GffStructs, always (even if empty) for round-trip compatibility.
     /// </summary>
     private static void WriteGenericList(GffStruct root, string fieldName, List<GffStruct> elements)
     {
@@ -143,8 +128,7 @@ public static class IfoWriter
     }
 
     /// <summary>
-    /// Write the HAK list to a GFF struct.
-    /// Always writes the list (even if empty) to ensure round-trip compatibility.
+    /// Write the HAK list, always (even if empty) for round-trip compatibility.
     /// </summary>
     private static void WriteHakList(GffStruct root, List<string> hakList)
     {
@@ -160,8 +144,7 @@ public static class IfoWriter
     }
 
     /// <summary>
-    /// Write the area list to a GFF struct.
-    /// Always writes the list (even if empty) to ensure round-trip compatibility.
+    /// Write the area list, always (even if empty) for round-trip compatibility.
     /// </summary>
     private static void WriteAreaList(GffStruct root, List<string> areaList)
     {

--- a/Radoub.Formats/Radoub.Formats/Itp/ItpFile.cs
+++ b/Radoub.Formats/Radoub.Formats/Itp/ItpFile.cs
@@ -7,14 +7,10 @@ namespace Radoub.Formats.Itp;
 /// </summary>
 public class ItpFile
 {
-    /// <summary>
-    /// File type signature - should be "ITP "
-    /// </summary>
+    /// <summary>File type signature - should be "ITP "</summary>
     public string FileType { get; set; } = "ITP ";
 
-    /// <summary>
-    /// File version - typically "V3.2"
-    /// </summary>
+    /// <summary>File version - typically "V3.2"</summary>
     public string FileVersion { get; set; } = "V3.2";
 
     /// <summary>
@@ -23,19 +19,13 @@ public class ItpFile
     /// </summary>
     public ushort? ResType { get; set; }
 
-    /// <summary>
-    /// Next usable category ID. Only present in skeleton palettes.
-    /// </summary>
+    /// <summary>Next usable category ID. Only present in skeleton palettes.</summary>
     public byte? NextUseableId { get; set; }
 
-    /// <summary>
-    /// Root nodes (MAIN list) of the palette tree.
-    /// </summary>
+    /// <summary>Root nodes (MAIN list) of the palette tree.</summary>
     public List<PaletteNode> MainNodes { get; set; } = new();
 
-    /// <summary>
-    /// Get all category nodes from the palette tree (flattened).
-    /// </summary>
+    /// <summary>Get all category nodes from the palette tree (flattened).</summary>
     public IEnumerable<PaletteCategoryNode> GetCategories()
     {
         return FlattenCategories(MainNodes);
@@ -69,14 +59,10 @@ public class ItpFile
 /// </summary>
 public abstract class PaletteNode
 {
-    /// <summary>
-    /// TLK string reference for node name.
-    /// </summary>
+    /// <summary>TLK string reference for node name.</summary>
     public uint? StrRef { get; set; }
 
-    /// <summary>
-    /// Direct name (used when StrRef is not present).
-    /// </summary>
+    /// <summary>Direct name (used when StrRef is not present).</summary>
     public string? Name { get; set; }
 
     /// <summary>
@@ -85,9 +71,7 @@ public abstract class PaletteNode
     /// </summary>
     public string? DeleteMe { get; set; }
 
-    /// <summary>
-    /// Display type (0=DISPLAY_IF_NOT_EMPTY, 1=NEVER, 2=CUSTOM).
-    /// </summary>
+    /// <summary>Display type (0=DISPLAY_IF_NOT_EMPTY, 1=NEVER, 2=CUSTOM).</summary>
     public byte? DisplayType { get; set; }
 }
 
@@ -96,9 +80,7 @@ public abstract class PaletteNode
 /// </summary>
 public class PaletteBranchNode : PaletteNode
 {
-    /// <summary>
-    /// Child nodes (can be branches or categories).
-    /// </summary>
+    /// <summary>Child nodes (can be branches or categories).</summary>
     public List<PaletteNode> Children { get; set; } = new();
 }
 
@@ -107,24 +89,15 @@ public class PaletteBranchNode : PaletteNode
 /// </summary>
 public class PaletteCategoryNode : PaletteNode
 {
-    /// <summary>
-    /// The unique ID for this category (matches PaletteID in blueprints).
-    /// </summary>
+    /// <summary>The unique ID for this category (matches PaletteID in blueprints).</summary>
     public byte Id { get; set; }
 
-    /// <summary>
-    /// Blueprint nodes under this category (in standard/custom palettes).
-    /// </summary>
+    /// <summary>Blueprint nodes under this category (in standard/custom palettes).</summary>
     public List<PaletteBlueprintNode> Blueprints { get; set; } = new();
 
-    /// <summary>
-    /// Nested category/branch nodes under this category (#2280).
-    /// </summary>
+    /// <summary>Nested category/branch nodes under this category (#2280).</summary>
     public List<PaletteNode> Children { get; set; } = new();
 
-    /// <summary>
-    /// Convenience: child nodes that are categories.
-    /// </summary>
     public IEnumerable<PaletteCategoryNode> ChildCategories =>
         Children.OfType<PaletteCategoryNode>();
 }
@@ -135,19 +108,13 @@ public class PaletteCategoryNode : PaletteNode
 /// </summary>
 public class PaletteBlueprintNode : PaletteNode
 {
-    /// <summary>
-    /// ResRef of the blueprint file.
-    /// </summary>
+    /// <summary>ResRef of the blueprint file.</summary>
     public string ResRef { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Challenge rating (creature palettes only).
-    /// </summary>
+    /// <summary>Challenge rating (creature palettes only).</summary>
     public float? ChallengeRating { get; set; }
 
-    /// <summary>
-    /// Faction name (creature palettes only).
-    /// </summary>
+    /// <summary>Faction name (creature palettes only).</summary>
     public string? Faction { get; set; }
 }
 
@@ -156,18 +123,12 @@ public class PaletteBlueprintNode : PaletteNode
 /// </summary>
 public static class PaletteDisplayType
 {
-    /// <summary>
-    /// Node appears only if it has children.
-    /// </summary>
+    /// <summary>Node appears only if it has children.</summary>
     public const byte DisplayIfNotEmpty = 0;
 
-    /// <summary>
-    /// Node never appears in toolset.
-    /// </summary>
+    /// <summary>Node never appears in toolset.</summary>
     public const byte DisplayNever = 1;
 
-    /// <summary>
-    /// Node only appears in custom palette or when assigning categories.
-    /// </summary>
+    /// <summary>Node only appears in custom palette or when assigning categories.</summary>
     public const byte DisplayCustom = 2;
 }

--- a/Radoub.Formats/Radoub.Formats/Itp/ItpReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Itp/ItpReader.cs
@@ -9,9 +9,7 @@ namespace Radoub.Formats.Itp;
 /// </summary>
 public static class ItpReader
 {
-    /// <summary>
-    /// Read an ITP file from a byte array.
-    /// </summary>
+    /// <summary>Read an ITP file from a byte array.</summary>
     public static ItpFile? Read(byte[] data)
     {
         try
@@ -32,17 +30,13 @@ public static class ItpReader
         }
     }
 
-    /// <summary>
-    /// Read an ITP file from an already-parsed GFF file.
-    /// </summary>
+    /// <summary>Read an ITP file from an already-parsed GFF file.</summary>
     public static ItpFile Read(GffFile gff)
     {
         return ParseItp(gff);
     }
 
-    /// <summary>
-    /// Read an ITP file from a file path.
-    /// </summary>
+    /// <summary>Read an ITP file from a file path.</summary>
     public static ItpFile? Read(string filePath)
     {
         var data = File.ReadAllBytes(filePath);
@@ -73,7 +67,6 @@ public static class ItpReader
             itp.NextUseableId = nextId;
         }
 
-        // MAIN list - the root of the tree
         var mainField = root.GetField("MAIN");
         if (mainField?.Value is GffList mainList)
         {
@@ -128,14 +121,12 @@ public static class ItpReader
 
         ParseCommonFields(nodeStruct, node);
 
-        // CR - creature challenge rating
         var crField = nodeStruct.GetField("CR");
         if (crField?.Value is float cr)
         {
             node.ChallengeRating = cr;
         }
 
-        // FACTION - creature faction
         var factionField = nodeStruct.GetField("FACTION");
         if (factionField?.Value is string faction)
         {
@@ -181,7 +172,6 @@ public static class ItpReader
 
         ParseCommonFields(nodeStruct, node);
 
-        // Parse children
         if (listField?.Value is GffList list)
         {
             foreach (var childStruct in list.Elements)
@@ -199,28 +189,27 @@ public static class ItpReader
 
     private static void ParseCommonFields(GffStruct nodeStruct, PaletteNode node)
     {
-        // STRREF - TLK reference
+        // STRREF holds a TLK reference
         var strRefField = nodeStruct.GetField("STRREF");
         if (strRefField?.Value is uint strRef)
         {
             node.StrRef = strRef;
         }
 
-        // NAME - direct name
         var nameField = nodeStruct.GetField("NAME");
         if (nameField?.Value is string name)
         {
             node.Name = name;
         }
 
-        // DELETE_ME - editing convenience field
+        // DELETE_ME is an editing-convenience field, skeleton palettes only
         var deleteField = nodeStruct.GetField("DELETE_ME");
         if (deleteField?.Value is string deleteMe)
         {
             node.DeleteMe = deleteMe;
         }
 
-        // TYPE - display type
+        // TYPE carries the display type
         var typeField = nodeStruct.GetField("TYPE");
         if (typeField?.Value is byte displayType)
         {

--- a/Radoub.Formats/Radoub.Formats/Itp/ItpWriter.cs
+++ b/Radoub.Formats/Radoub.Formats/Itp/ItpWriter.cs
@@ -11,24 +11,18 @@ namespace Radoub.Formats.Itp;
 /// </summary>
 public static class ItpWriter
 {
-    /// <summary>
-    /// Write an ITP file to a file path.
-    /// </summary>
+    /// <summary>Write an ITP file to a file path.</summary>
     public static void Write(ItpFile itp, string filePath)
         => File.WriteAllBytes(filePath, Write(itp));
 
-    /// <summary>
-    /// Write an ITP file to a stream.
-    /// </summary>
+    /// <summary>Write an ITP file to a stream.</summary>
     public static void Write(ItpFile itp, Stream stream)
     {
         var buffer = Write(itp);
         stream.Write(buffer, 0, buffer.Length);
     }
 
-    /// <summary>
-    /// Write an ITP file to a byte buffer.
-    /// </summary>
+    /// <summary>Write an ITP file to a byte buffer.</summary>
     public static byte[] Write(ItpFile itp)
     {
         var gff = new GffFile

--- a/Radoub.Formats/Radoub.Formats/Jrl/JrlFile.cs
+++ b/Radoub.Formats/Radoub.Formats/Jrl/JrlFile.cs
@@ -8,33 +8,22 @@ namespace Radoub.Formats.Jrl;
 /// </summary>
 public class JrlFile
 {
-    /// <summary>
-    /// File type signature - should be "JRL "
-    /// </summary>
+    /// <summary>File type signature - should be "JRL "</summary>
     public string FileType { get; set; } = "JRL ";
 
-    /// <summary>
-    /// File version - typically "V3.2"
-    /// </summary>
+    /// <summary>File version - typically "V3.2"</summary>
     public string FileVersion { get; set; } = "V3.2";
 
-    /// <summary>
-    /// List of journal categories (quests)
-    /// </summary>
+    /// <summary>Journal categories (quests)</summary>
     public List<JournalCategory> Categories { get; set; } = new();
 
-    /// <summary>
-    /// Find a category by tag (case-insensitive)
-    /// </summary>
+    /// <summary>Find a category by tag (case-insensitive)</summary>
     public JournalCategory? FindCategory(string tag)
     {
         return Categories.FirstOrDefault(c =>
             c.Tag.Equals(tag, StringComparison.OrdinalIgnoreCase));
     }
 
-    /// <summary>
-    /// Get all quest tags
-    /// </summary>
     public IEnumerable<string> GetQuestTags()
     {
         return Categories.Select(c => c.Tag);
@@ -46,44 +35,25 @@ public class JrlFile
 /// </summary>
 public class JournalCategory
 {
-    /// <summary>
-    /// Quest tag identifier (max 32 characters)
-    /// </summary>
+    /// <summary>Quest tag identifier (max 32 characters)</summary>
     public string Tag { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Quest name (localized string)
-    /// </summary>
     public CExoLocString Name { get; set; } = new();
 
-    /// <summary>
-    /// Priority for sorting (lower = higher priority)
-    /// </summary>
+    /// <summary>Priority for sorting (lower = higher priority)</summary>
     public uint Priority { get; set; }
 
-    /// <summary>
-    /// XP reward for completing this quest
-    /// </summary>
+    /// <summary>XP reward for completing this quest</summary>
     public uint XP { get; set; }
 
-    /// <summary>
-    /// Optional comment (editor use)
-    /// </summary>
+    /// <summary>Optional comment (editor use)</summary>
     public string Comment { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Picture resource reference
-    /// </summary>
+    /// <summary>Picture resource reference</summary>
     public string Picture { get; set; } = string.Empty;
 
-    /// <summary>
-    /// List of journal entries for this quest
-    /// </summary>
     public List<JournalEntry> Entries { get; set; } = new();
 
-    /// <summary>
-    /// Find entry by ID
-    /// </summary>
     public JournalEntry? FindEntry(uint id)
     {
         return Entries.FirstOrDefault(e => e.ID == id);
@@ -95,18 +65,11 @@ public class JournalCategory
 /// </summary>
 public class JournalEntry
 {
-    /// <summary>
-    /// Entry ID (unique within category)
-    /// </summary>
+    /// <summary>Entry ID (unique within category)</summary>
     public uint ID { get; set; }
 
-    /// <summary>
-    /// Entry text (localized string)
-    /// </summary>
     public CExoLocString Text { get; set; } = new();
 
-    /// <summary>
-    /// Whether this entry marks quest completion
-    /// </summary>
+    /// <summary>Whether this entry marks quest completion</summary>
     public bool End { get; set; }
 }

--- a/Radoub.Formats/Radoub.Formats/Jrl/JrlReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Jrl/JrlReader.cs
@@ -8,18 +8,14 @@ namespace Radoub.Formats.Jrl;
 /// </summary>
 public static class JrlReader
 {
-    /// <summary>
-    /// Read a JRL file from a file path.
-    /// </summary>
+    /// <summary>Read a JRL file from a file path.</summary>
     public static JrlFile Read(string filePath)
     {
         var buffer = File.ReadAllBytes(filePath);
         return Read(buffer);
     }
 
-    /// <summary>
-    /// Read a JRL file from a stream.
-    /// </summary>
+    /// <summary>Read a JRL file from a stream.</summary>
     public static JrlFile Read(Stream stream)
     {
         using var ms = new MemoryStream();
@@ -27,15 +23,11 @@ public static class JrlReader
         return Read(ms.ToArray());
     }
 
-    /// <summary>
-    /// Read a JRL file from a byte buffer.
-    /// </summary>
+    /// <summary>Read a JRL file from a byte buffer.</summary>
     public static JrlFile Read(byte[] buffer)
     {
-        // Parse as GFF first
         var gff = GffReader.Read(buffer);
 
-        // Validate file type
         if (gff.FileType.TrimEnd() != "JRL")
         {
             throw new InvalidDataException(
@@ -48,7 +40,6 @@ public static class JrlReader
             FileVersion = gff.FileVersion
         };
 
-        // Parse Categories list from root struct
         var categoriesField = gff.RootStruct.GetField("Categories");
         if (categoriesField != null && categoriesField.IsList && categoriesField.Value is GffList categoriesList)
         {
@@ -76,14 +67,12 @@ public static class JrlReader
             Picture = categoryStruct.GetFieldValue<string>("Picture", string.Empty)
         };
 
-        // Parse Name (CExoLocString)
         var nameField = categoryStruct.GetField("Name");
         if (nameField != null && nameField.IsCExoLocString && nameField.Value is CExoLocString nameLocString)
         {
             category.Name = nameLocString;
         }
 
-        // Parse EntryList
         var entryListField = categoryStruct.GetField("EntryList");
         if (entryListField != null && entryListField.IsList && entryListField.Value is GffList entryList)
         {
@@ -108,7 +97,6 @@ public static class JrlReader
             End = entryStruct.GetFieldValue<ushort>("End", 0) != 0
         };
 
-        // Parse Text (CExoLocString)
         var textField = entryStruct.GetField("Text");
         if (textField != null && textField.IsCExoLocString && textField.Value is CExoLocString textLocString)
         {

--- a/Radoub.Formats/Radoub.Formats/Jrl/JrlWriter.cs
+++ b/Radoub.Formats/Radoub.Formats/Jrl/JrlWriter.cs
@@ -8,30 +8,23 @@ namespace Radoub.Formats.Jrl;
 /// </summary>
 public static class JrlWriter
 {
-    /// <summary>
-    /// Write a JRL file to a file path.
-    /// </summary>
+    /// <summary>Write a JRL file to a file path.</summary>
     public static void Write(JrlFile jrl, string filePath)
     {
         var buffer = Write(jrl);
         File.WriteAllBytes(filePath, buffer);
     }
 
-    /// <summary>
-    /// Write a JRL file to a stream.
-    /// </summary>
+    /// <summary>Write a JRL file to a stream.</summary>
     public static void Write(JrlFile jrl, Stream stream)
     {
         var buffer = Write(jrl);
         stream.Write(buffer, 0, buffer.Length);
     }
 
-    /// <summary>
-    /// Write a JRL file to a byte buffer.
-    /// </summary>
+    /// <summary>Write a JRL file to a byte buffer.</summary>
     public static byte[] Write(JrlFile jrl)
     {
-        // Build GFF structure from JRL
         var gff = new GffFile
         {
             FileType = jrl.FileType.PadRight(4).Substring(0, 4),
@@ -41,7 +34,6 @@ public static class JrlWriter
         // Root struct (type 0xFFFFFFFF for root)
         gff.RootStruct = new GffStruct { Type = 0xFFFFFFFF };
 
-        // Build Categories list
         var categoriesList = new GffList();
         foreach (var category in jrl.Categories)
         {
@@ -50,7 +42,6 @@ public static class JrlWriter
         }
         categoriesList.Count = (uint)categoriesList.Elements.Count;
 
-        // Add Categories field to root
         gff.RootStruct.Fields.Add(new GffField
         {
             Type = GffField.List,
@@ -58,7 +49,6 @@ public static class JrlWriter
             Value = categoriesList
         });
 
-        // Use GffWriter to produce binary
         return GffWriter.Write(gff);
     }
 
@@ -66,7 +56,6 @@ public static class JrlWriter
     {
         var categoryStruct = new GffStruct { Type = 0 };
 
-        // Tag (CExoString)
         categoryStruct.Fields.Add(new GffField
         {
             Type = GffField.CExoString,
@@ -74,7 +63,6 @@ public static class JrlWriter
             Value = category.Tag
         });
 
-        // Name (CExoLocString)
         categoryStruct.Fields.Add(new GffField
         {
             Type = GffField.CExoLocString,
@@ -82,7 +70,6 @@ public static class JrlWriter
             Value = category.Name
         });
 
-        // Priority (DWORD)
         categoryStruct.Fields.Add(new GffField
         {
             Type = GffField.DWORD,
@@ -90,7 +77,6 @@ public static class JrlWriter
             Value = category.Priority
         });
 
-        // XP (DWORD)
         categoryStruct.Fields.Add(new GffField
         {
             Type = GffField.DWORD,
@@ -98,7 +84,7 @@ public static class JrlWriter
             Value = category.XP
         });
 
-        // Comment (CExoString) - only if not empty
+        // Omitted from the struct entirely when empty
         if (!string.IsNullOrEmpty(category.Comment))
         {
             categoryStruct.Fields.Add(new GffField
@@ -109,7 +95,7 @@ public static class JrlWriter
             });
         }
 
-        // Picture (CResRef) - only if not empty
+        // Omitted from the struct entirely when empty
         if (!string.IsNullOrEmpty(category.Picture))
         {
             categoryStruct.Fields.Add(new GffField
@@ -120,7 +106,6 @@ public static class JrlWriter
             });
         }
 
-        // EntryList
         var entryList = new GffList();
         foreach (var entry in category.Entries)
         {
@@ -143,7 +128,6 @@ public static class JrlWriter
     {
         var entryStruct = new GffStruct { Type = 0 };
 
-        // ID (DWORD)
         entryStruct.Fields.Add(new GffField
         {
             Type = GffField.DWORD,
@@ -151,7 +135,6 @@ public static class JrlWriter
             Value = entry.ID
         });
 
-        // Text (CExoLocString)
         entryStruct.Fields.Add(new GffField
         {
             Type = GffField.CExoLocString,

--- a/Radoub.Formats/Radoub.Formats/Logging/LoggerConfig.cs
+++ b/Radoub.Formats/Radoub.Formats/Logging/LoggerConfig.cs
@@ -12,9 +12,7 @@ public class LoggerConfig
     /// </summary>
     public required string AppName { get; init; }
 
-    /// <summary>
-    /// Minimum log level to output. Default is INFO.
-    /// </summary>
+    /// <summary>Minimum log level to output. Default is INFO.</summary>
     public LogLevel LogLevel { get; init; } = LogLevel.INFO;
 
     /// <summary>

--- a/Radoub.Formats/Radoub.Formats/Logging/LoggingSettings.cs
+++ b/Radoub.Formats/Radoub.Formats/Logging/LoggingSettings.cs
@@ -8,9 +8,7 @@ namespace Radoub.Formats.Logging;
 /// </summary>
 public class LoggingSettings
 {
-    /// <summary>
-    /// Default values for new instances.
-    /// </summary>
+    /// <summary>Default values for new instances.</summary>
     public static readonly int DefaultRetentionSessions = 3;
     public static readonly LogLevel DefaultLogLevel = LogLevel.INFO;
 
@@ -20,30 +18,22 @@ public class LoggingSettings
     /// </summary>
     public int LogRetentionSessions { get; set; } = DefaultRetentionSessions;
 
-    /// <summary>
-    /// Minimum log level to output.
-    /// </summary>
+    /// <summary>Minimum log level to output.</summary>
     public LogLevel LogLevel { get; set; } = DefaultLogLevel;
 
-    /// <summary>
-    /// Clamps retention sessions to valid range (1-10).
-    /// </summary>
+    /// <summary>Clamps retention sessions to valid range (1-10).</summary>
     public void Normalize()
     {
         LogRetentionSessions = Math.Max(1, Math.Min(10, LogRetentionSessions));
     }
 
-    /// <summary>
-    /// Applies these settings to the UnifiedLogger.
-    /// </summary>
+    /// <summary>Applies these settings to the UnifiedLogger.</summary>
     public void ApplyToLogger()
     {
         UnifiedLogger.SetLogLevel(LogLevel);
     }
 
-    /// <summary>
-    /// Creates a LoggerConfig for initialization.
-    /// </summary>
+    /// <summary>Creates a LoggerConfig for initialization.</summary>
     /// <param name="appName">The application name for the log directory.</param>
     /// <param name="debugCallback">Optional callback for debug console integration.</param>
     public LoggerConfig ToLoggerConfig(string appName, Action<string>? debugCallback = null)
@@ -58,18 +48,12 @@ public class LoggingSettings
     }
 }
 
-/// <summary>
-/// Extended logging settings for tools that support a debug panel (e.g., Parley).
-/// </summary>
+/// <summary>Extended logging settings for tools that support a debug panel (e.g., Parley).</summary>
 public class ExtendedLoggingSettings : LoggingSettings
 {
-    /// <summary>
-    /// Filter level for the debug window display.
-    /// </summary>
+    /// <summary>Filter level for the debug window display.</summary>
     public LogLevel DebugLogFilterLevel { get; set; } = LogLevel.INFO;
 
-    /// <summary>
-    /// Whether the debug window/panel is visible.
-    /// </summary>
+    /// <summary>Whether the debug window/panel is visible.</summary>
     public bool DebugWindowVisible { get; set; } = false;
 }

--- a/Radoub.Formats/Radoub.Formats/Logging/PrivacyHelper.cs
+++ b/Radoub.Formats/Radoub.Formats/Logging/PrivacyHelper.cs
@@ -8,9 +8,7 @@ public static class PrivacyHelper
 {
     private static readonly string? UserProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
-    /// <summary>
-    /// Sanitize a file path for logging - replaces home directory with ~
-    /// </summary>
+    /// <summary>Sanitize a file path for logging - replaces home directory with ~</summary>
     public static string? SanitizePath(string? path)
     {
         if (path == null)
@@ -27,9 +25,7 @@ public static class PrivacyHelper
         return path;
     }
 
-    /// <summary>
-    /// Detects if a string appears to be a file path based on heuristics.
-    /// </summary>
+    /// <summary>Detects if a string appears to be a file path based on heuristics.</summary>
     private static bool LooksLikePath(string text)
     {
         if (string.IsNullOrEmpty(text) || text.Length < 3)

--- a/Radoub.Formats/Radoub.Formats/Logging/UnifiedLogger.cs
+++ b/Radoub.Formats/Radoub.Formats/Logging/UnifiedLogger.cs
@@ -78,9 +78,7 @@ public static class UnifiedLogger
         }
     }
 
-    /// <summary>
-    /// Check if the logger has been configured.
-    /// </summary>
+    /// <summary>Check if the logger has been configured.</summary>
     public static bool IsConfigured => _configured;
 
     /// <summary>
@@ -212,9 +210,7 @@ public static class UnifiedLogger
         _currentFileName = Path.GetFileNameWithoutExtension(filePath);
     }
 
-    /// <summary>
-    /// Get the current file context (for propagating across threads).
-    /// </summary>
+    /// <summary>Get the current file context (for propagating across threads).</summary>
     public static string? GetFileContext() => _currentFileName;
 
     /// <summary>
@@ -230,45 +226,33 @@ public static class UnifiedLogger
     // Configuration & Utilities
     // ========================================================================
 
-    /// <summary>
-    /// Change the log level at runtime.
-    /// </summary>
+    /// <summary>Change the log level at runtime.</summary>
     public static void SetLogLevel(LogLevel level)
     {
         _currentLogLevel = level;
         LogApplication(LogLevel.INFO, $"Log level set to {level}");
     }
 
-    /// <summary>
-    /// Get the current log level.
-    /// </summary>
+    /// <summary>Get the current log level.</summary>
     public static LogLevel CurrentLogLevel => _currentLogLevel;
 
-    /// <summary>
-    /// Set callback for debug console integration.
-    /// </summary>
+    /// <summary>Set callback for debug console integration.</summary>
     public static void SetDebugConsoleCallback(Action<string>? callback)
     {
         _debugConsoleCallback = callback;
     }
 
-    /// <summary>
-    /// Get the current session ID.
-    /// </summary>
+    /// <summary>Get the current session ID.</summary>
     public static string GetCurrentSessionId() => SessionId;
 
-    /// <summary>
-    /// Get the session log directory path.
-    /// </summary>
+    /// <summary>Get the session log directory path.</summary>
     public static string GetSessionDirectory()
     {
         EnsureInitialized();
         return _sessionDirectory;
     }
 
-    /// <summary>
-    /// Creates a log file path in the session directory for external components.
-    /// </summary>
+    /// <summary>Creates a log file path in the session directory for external components.</summary>
     public static string CreateSessionLogPath(string logFileName)
     {
         EnsureInitialized();
@@ -279,9 +263,7 @@ public static class UnifiedLogger
     // Privacy Helpers (delegated to PrivacyHelper for convenience)
     // ========================================================================
 
-    /// <summary>
-    /// Sanitize a file path for logging - replaces home directory with ~
-    /// </summary>
+    /// <summary>Sanitize a file path for logging - replaces home directory with ~</summary>
     public static string? SanitizePath(string? path) => PrivacyHelper.SanitizePath(path);
 
     // ========================================================================

--- a/Radoub.Formats/Radoub.Formats/Resolver/GameResourceConfig.cs
+++ b/Radoub.Formats/Radoub.Formats/Resolver/GameResourceConfig.cs
@@ -1,8 +1,6 @@
 namespace Radoub.Formats.Resolver;
 
-/// <summary>
-/// Configuration for GameResourceResolver specifying game paths and resource locations.
-/// </summary>
+/// <summary>Configuration for GameResourceResolver specifying game paths and resource locations.</summary>
 public class GameResourceConfig
 {
     /// <summary>
@@ -11,9 +9,7 @@ public class GameResourceConfig
     /// </summary>
     public string? ModuleDirectory { get; set; }
 
-    /// <summary>
-    /// Path to the NWN installation data directory (contains .key files and data/).
-    /// </summary>
+    /// <summary>Path to the NWN installation data directory (contains .key files and data/).</summary>
     public string? GameDataPath { get; set; }
 
     /// <summary>
@@ -22,9 +18,7 @@ public class GameResourceConfig
     /// </summary>
     public string? OverridePath { get; set; }
 
-    /// <summary>
-    /// Paths to HAK files to search, in priority order (first = highest priority).
-    /// </summary>
+    /// <summary>Paths to HAK files to search, in priority order (first = highest priority).</summary>
     public List<string> HakPaths { get; set; } = new();
 
     /// <summary>
@@ -33,9 +27,7 @@ public class GameResourceConfig
     /// </summary>
     public string? TlkPath { get; set; }
 
-    /// <summary>
-    /// Path to the module's custom TLK file (for StrRefs >= 16777216).
-    /// </summary>
+    /// <summary>Path to the module's custom TLK file (for StrRefs >= 16777216).</summary>
     public string? CustomTlkPath { get; set; }
 
     /// <summary>
@@ -57,9 +49,7 @@ public class GameResourceConfig
     /// </summary>
     public bool EnableHakScanning { get; set; } = false;
 
-    /// <summary>
-    /// Create a config for a standard NWN:EE installation.
-    /// </summary>
+    /// <summary>Create a config for a standard NWN:EE installation.</summary>
     public static GameResourceConfig ForNwnEE(string installPath)
     {
         var dataPath = Path.Combine(installPath, "data");
@@ -72,9 +62,7 @@ public class GameResourceConfig
         };
     }
 
-    /// <summary>
-    /// Create a config for classic NWN (Diamond/GoG).
-    /// </summary>
+    /// <summary>Create a config for classic NWN (Diamond/GoG).</summary>
     public static GameResourceConfig ForNwnClassic(string installPath)
     {
         return new GameResourceConfig

--- a/Radoub.Formats/Radoub.Formats/Resolver/GameResourceResolver.cs
+++ b/Radoub.Formats/Radoub.Formats/Resolver/GameResourceResolver.cs
@@ -28,9 +28,7 @@ public class GameResourceResolver : IDisposable
     private bool _disposed;
     private bool _keyIndexLoaded;
 
-    /// <summary>
-    /// Create a new resolver with the specified configuration.
-    /// </summary>
+    /// <summary>Create a new resolver with the specified configuration.</summary>
     public GameResourceResolver(GameResourceConfig config)
     {
         _config = config ?? throw new ArgumentNullException(nameof(config));
@@ -174,9 +172,7 @@ public class GameResourceResolver : IDisposable
         return _baseTlk?.GetString(strRef);
     }
 
-    /// <summary>
-    /// Get a TLK entry by StrRef (includes sound info).
-    /// </summary>
+    /// <summary>Get a TLK entry by StrRef (includes sound info).</summary>
     public TlkEntry? GetTlkEntry(uint strRef)
     {
         const uint CustomTlkOffset = 16777216;

--- a/Radoub.Formats/Radoub.Formats/Resolver/KeyIndexCache.cs
+++ b/Radoub.Formats/Radoub.Formats/Resolver/KeyIndexCache.cs
@@ -168,9 +168,7 @@ public class KeyIndexCache
         }
     }
 
-    /// <summary>
-    /// Save KEY index data to binary cache.
-    /// </summary>
+    /// <summary>Save KEY index data to binary cache.</summary>
     public static void Save(string keyFilePath, CachedKeyIndex index)
     {
         try
@@ -215,9 +213,7 @@ public class KeyIndexCache
         }
     }
 
-    /// <summary>
-    /// Delete the cached KEY index (both binary and JSON).
-    /// </summary>
+    /// <summary>Delete the cached KEY index (both binary and JSON).</summary>
     public static void Clear()
     {
         try
@@ -255,9 +251,7 @@ public class KeyIndexCache
     }
 }
 
-/// <summary>
-/// Internal JSON cache file structure (for migration only).
-/// </summary>
+/// <summary>Internal JSON cache file structure (for migration only).</summary>
 internal class KeyIndexCacheFile
 {
     public int Version { get; set; }
@@ -268,27 +262,21 @@ internal class KeyIndexCacheFile
     public List<CachedResourceEntry> Resources { get; set; } = new();
 }
 
-/// <summary>
-/// Cached KEY index data ready for use.
-/// </summary>
+/// <summary>Cached KEY index data ready for use.</summary>
 public class CachedKeyIndex
 {
     public List<CachedBifEntry> BifFiles { get; set; } = new();
     public List<CachedResourceEntry> Resources { get; set; } = new();
 }
 
-/// <summary>
-/// Cached BIF file entry.
-/// </summary>
+/// <summary>Cached BIF file entry.</summary>
 public class CachedBifEntry
 {
     public string Filename { get; set; } = string.Empty;
     public uint FileSize { get; set; }
 }
 
-/// <summary>
-/// Cached resource entry - minimal data needed for lookups.
-/// </summary>
+/// <summary>Cached resource entry - minimal data needed for lookups.</summary>
 public class CachedResourceEntry
 {
     public string ResRef { get; set; } = string.Empty;

--- a/Radoub.Formats/Radoub.Formats/Resolver/ResourceResult.cs
+++ b/Radoub.Formats/Radoub.Formats/Resolver/ResourceResult.cs
@@ -1,8 +1,6 @@
 namespace Radoub.Formats.Resolver;
 
-/// <summary>
-/// Source of a resolved resource.
-/// </summary>
+/// <summary>Source of a resolved resource.</summary>
 public enum ResourceSource
 {
     /// <summary>Resource found in module directory (loose file).</summary>
@@ -18,19 +16,13 @@ public enum ResourceSource
     Bif
 }
 
-/// <summary>
-/// Result of a resource lookup including source information.
-/// </summary>
+/// <summary>Result of a resource lookup including source information.</summary>
 public class ResourceResult
 {
-    /// <summary>
-    /// The resource data.
-    /// </summary>
+    /// <summary>The resource data.</summary>
     public byte[] Data { get; }
 
-    /// <summary>
-    /// Where the resource was found.
-    /// </summary>
+    /// <summary>Where the resource was found.</summary>
     public ResourceSource Source { get; }
 
     /// <summary>
@@ -39,14 +31,10 @@ public class ResourceResult
     /// </summary>
     public string SourcePath { get; }
 
-    /// <summary>
-    /// The ResRef of the resource.
-    /// </summary>
+    /// <summary>The ResRef of the resource.</summary>
     public string ResRef { get; }
 
-    /// <summary>
-    /// The resource type.
-    /// </summary>
+    /// <summary>The resource type.</summary>
     public ushort ResourceType { get; }
 
     public ResourceResult(byte[] data, ResourceSource source, string sourcePath, string resRef, ushort resourceType)
@@ -59,28 +47,18 @@ public class ResourceResult
     }
 }
 
-/// <summary>
-/// Information about an available resource (without loading data).
-/// </summary>
+/// <summary>Information about an available resource (without loading data).</summary>
 public class ResourceInfo
 {
-    /// <summary>
-    /// The ResRef of the resource.
-    /// </summary>
+    /// <summary>The ResRef of the resource.</summary>
     public string ResRef { get; set; } = string.Empty;
 
-    /// <summary>
-    /// The resource type.
-    /// </summary>
+    /// <summary>The resource type.</summary>
     public ushort ResourceType { get; set; }
 
-    /// <summary>
-    /// Where the resource is located.
-    /// </summary>
+    /// <summary>Where the resource is located.</summary>
     public ResourceSource Source { get; set; }
 
-    /// <summary>
-    /// Path to the source file/archive.
-    /// </summary>
+    /// <summary>Path to the source file/archive.</summary>
     public string SourcePath { get; set; } = string.Empty;
 }

--- a/Radoub.Formats/Radoub.Formats/Search/Models/FieldDefinition.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Models/FieldDefinition.cs
@@ -1,8 +1,6 @@
 namespace Radoub.Formats.Search;
 
-/// <summary>
-/// Describes a single searchable field within a GFF file type.
-/// </summary>
+/// <summary>Describes a single searchable field within a GFF file type.</summary>
 public class FieldDefinition
 {
     /// <summary>Display name shown in UI (e.g., "Speaker", "First Name")</summary>

--- a/Radoub.Formats/Radoub.Formats/Search/Models/ReplaceOperation.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Models/ReplaceOperation.cs
@@ -1,8 +1,6 @@
 namespace Radoub.Formats.Search;
 
-/// <summary>
-/// A single replace instruction for a matched field.
-/// </summary>
+/// <summary>A single replace instruction for a matched field.</summary>
 public class ReplaceOperation
 {
     /// <summary>The match to replace</summary>

--- a/Radoub.Formats/Radoub.Formats/Search/Models/ReplaceResult.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Models/ReplaceResult.cs
@@ -1,8 +1,6 @@
 namespace Radoub.Formats.Search;
 
-/// <summary>
-/// Result of a single replace operation.
-/// </summary>
+/// <summary>Result of a single replace operation.</summary>
 public class ReplaceResult
 {
     public required bool Success { get; init; }

--- a/Radoub.Formats/Radoub.Formats/Search/Models/SearchCriteria.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Models/SearchCriteria.cs
@@ -2,21 +2,16 @@ using System.Text.RegularExpressions;
 
 namespace Radoub.Formats.Search;
 
-/// <summary>
-/// Defines what to search for and how to match.
-/// </summary>
+/// <summary>Defines what to search for and how to match.</summary>
 public class SearchCriteria
 {
     /// <summary>Search pattern (plain text or regex)</summary>
     public required string Pattern { get; init; }
 
-    /// <summary>Treat Pattern as a regular expression</summary>
     public bool IsRegex { get; init; }
 
-    /// <summary>Case-sensitive matching</summary>
     public bool CaseSensitive { get; init; }
 
-    /// <summary>Match whole words only</summary>
     public bool WholeWord { get; init; }
 
     /// <summary>
@@ -59,9 +54,7 @@ public class SearchCriteria
     /// </summary>
     public Func<uint, string?>? TlkResolver { get; init; }
 
-    /// <summary>
-    /// Validates the pattern. Returns null if valid, error message if invalid.
-    /// </summary>
+    /// <summary>Validates the pattern. Returns null if valid, error message if invalid.</summary>
     public string? Validate()
     {
         if (string.IsNullOrEmpty(Pattern))
@@ -97,14 +90,10 @@ public class SearchCriteria
         return new Regex(pattern, options);
     }
 
-    /// <summary>
-    /// Returns the TLK resolver to pass to SearchLocString, or null if StrRef search is disabled.
-    /// </summary>
+    /// <summary>Returns the TLK resolver to pass to SearchLocString, or null if StrRef search is disabled.</summary>
     public Func<uint, string?>? EffectiveTlkResolver => SearchStrRefs ? TlkResolver : null;
 
-    /// <summary>
-    /// Returns true if the given field definition passes all filters.
-    /// </summary>
+    /// <summary>Returns true if the given field definition passes all filters.</summary>
     public bool MatchesField(FieldDefinition field)
     {
         if (FieldFilter != null && !FieldFilter.Contains(field.Name))

--- a/Radoub.Formats/Radoub.Formats/Search/Models/SearchEnums.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Models/SearchEnums.cs
@@ -1,8 +1,6 @@
 namespace Radoub.Formats.Search;
 
-/// <summary>
-/// Type of GFF field being searched. Determines matching behavior.
-/// </summary>
+/// <summary>Type of GFF field being searched. Determines matching behavior.</summary>
 public enum SearchFieldType
 {
     /// <summary>CExoLocString — search all language variants</summary>
@@ -21,9 +19,7 @@ public enum SearchFieldType
     Variable
 }
 
-/// <summary>
-/// Logical category for grouping fields in UI.
-/// </summary>
+/// <summary>Logical category for grouping fields in UI.</summary>
 public enum SearchFieldCategory
 {
     /// <summary>Player-facing text (dialog, names, descriptions)</summary>

--- a/Radoub.Formats/Radoub.Formats/Search/Models/SearchMatch.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Models/SearchMatch.cs
@@ -1,11 +1,8 @@
 namespace Radoub.Formats.Search;
 
-/// <summary>
-/// A single search match within a GFF file.
-/// </summary>
+/// <summary>A single search match within a GFF file.</summary>
 public class SearchMatch
 {
-    /// <summary>Which field definition matched</summary>
     public required FieldDefinition Field { get; init; }
 
     /// <summary>The text that matched the pattern</summary>
@@ -17,7 +14,6 @@ public class SearchMatch
     /// <summary>Character offset of match within FullFieldValue</summary>
     public int MatchOffset { get; init; }
 
-    /// <summary>Length of the match</summary>
     public int MatchLength { get; init; }
 
     /// <summary>
@@ -35,9 +31,7 @@ public class SearchMatch
     public override string ToString() => $"{Field.Name}: \"{MatchedText}\" at offset {MatchOffset}";
 }
 
-/// <summary>
-/// Location within a DLG file tree.
-/// </summary>
+/// <summary>Location within a DLG file tree.</summary>
 public class DlgMatchLocation
 {
     public required DlgNodeType NodeType { get; init; }

--- a/Radoub.Formats/Radoub.Formats/Search/Providers/DlgSearchProvider.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Providers/DlgSearchProvider.cs
@@ -101,16 +101,13 @@ public class DlgSearchProvider : SearchProviderBase, IFileSearchProvider
         return results;
     }
 
-    /// <summary>
-    /// Navigate the GFF tree to find the struct that contains the field to replace.
-    /// </summary>
+    /// <summary>Navigate the GFF tree to find the struct that contains the field to replace.</summary>
     private static GffStruct? FindTargetStruct(GffStruct root, DlgMatchLocation loc)
     {
         // Root-level fields (EndConversation, EndConverAbort) — NodeIndex is null
         if (loc.NodeIndex == null && !loc.IsOnLink)
             return root;
 
-        // Get the appropriate list (EntryList or ReplyList or StartingList)
         if (loc.IsOnLink)
             return FindLinkStruct(root, loc);
 
@@ -152,7 +149,6 @@ public class DlgSearchProvider : SearchProviderBase, IFileSearchProvider
             parentStruct = list.Elements[loc.NodeIndex.Value];
         }
 
-        // Now find the link list within the parent
         var linkListLabel = loc.NodeType == DlgNodeType.Entry ? "RepliesList" :
                             loc.NodeType == DlgNodeType.Reply ? "EntriesList" : "StartingList";
         var linkListField = parentStruct.GetField(linkListLabel);

--- a/Radoub.Formats/Radoub.Formats/Search/Providers/FacSearchProvider.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Providers/FacSearchProvider.cs
@@ -84,9 +84,7 @@ public class FacSearchProvider : SearchProviderBase, IFileSearchProvider
     }
 }
 
-/// <summary>
-/// Location within a FAC faction file.
-/// </summary>
+/// <summary>Location within a FAC faction file.</summary>
 public class FacMatchLocation
 {
     public required int FactionIndex { get; init; }

--- a/Radoub.Formats/Radoub.Formats/Search/Providers/GitSearchProvider.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Providers/GitSearchProvider.cs
@@ -11,9 +11,7 @@ namespace Radoub.Formats.Search;
 /// </summary>
 public class GitSearchProvider : SearchProviderBase, IFileSearchProvider
 {
-    /// <summary>
-    /// Known instance list labels mapped to human-readable type names.
-    /// </summary>
+    /// <summary>Known instance list labels mapped to human-readable type names.</summary>
     private static readonly (string ListLabel, string TypeName)[] InstanceLists =
     {
         ("Creature List", "Creature"),
@@ -187,9 +185,7 @@ public class GitSearchProvider : SearchProviderBase, IFileSearchProvider
     }
 }
 
-/// <summary>
-/// Location within a GIT file — identifies the instance type, index, and tag.
-/// </summary>
+/// <summary>Location within a GIT file — identifies the instance type, index, and tag.</summary>
 public class GitMatchLocation
 {
     public required string InstanceType { get; init; }

--- a/Radoub.Formats/Radoub.Formats/Search/Providers/IFileSearchProvider.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Providers/IFileSearchProvider.cs
@@ -14,9 +14,7 @@ public interface IFileSearchProvider
     /// <summary>File extensions this provider handles (e.g., ".dlg")</summary>
     IReadOnlyList<string> Extensions { get; }
 
-    /// <summary>
-    /// Search a parsed GFF file for matches.
-    /// </summary>
+    /// <summary>Search a parsed GFF file for matches.</summary>
     IReadOnlyList<SearchMatch> Search(GffFile gffFile, SearchCriteria criteria);
 
     /// <summary>

--- a/Radoub.Formats/Radoub.Formats/Search/Providers/ItpSearchProvider.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Providers/ItpSearchProvider.cs
@@ -211,9 +211,7 @@ public class ItpSearchProvider : SearchProviderBase, IFileSearchProvider
     };
 }
 
-/// <summary>
-/// Location within an ITP palette tree.
-/// </summary>
+/// <summary>Location within an ITP palette tree.</summary>
 public class ItpMatchLocation
 {
     public required ItpNodeType NodeType { get; init; }

--- a/Radoub.Formats/Radoub.Formats/Search/Providers/JrlSearchProvider.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Providers/JrlSearchProvider.cs
@@ -170,9 +170,7 @@ public class JrlSearchProvider : SearchProviderBase, IFileSearchProvider
     }
 }
 
-/// <summary>
-/// Location within a JRL file hierarchy.
-/// </summary>
+/// <summary>Location within a JRL file hierarchy.</summary>
 public class JrlMatchLocation
 {
     public required int CategoryIndex { get; init; }

--- a/Radoub.Formats/Radoub.Formats/Search/Providers/SearchProviderBase.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Providers/SearchProviderBase.cs
@@ -9,9 +9,7 @@ namespace Radoub.Formats.Search;
 /// </summary>
 public abstract class SearchProviderBase
 {
-    /// <summary>
-    /// Search a plain string field for matches.
-    /// </summary>
+    /// <summary>Search a plain string field for matches.</summary>
     protected static List<SearchMatch> SearchString(
         string value, FieldDefinition field, Regex pattern, object? location)
     {
@@ -89,9 +87,7 @@ public abstract class SearchProviderBase
         return matches;
     }
 
-    /// <summary>
-    /// Search VarTable variable names and string values.
-    /// </summary>
+    /// <summary>Search VarTable variable names and string values.</summary>
     protected static List<SearchMatch> SearchVarTable(
         GffStruct root, FieldDefinition field, Regex pattern, object? location)
     {
@@ -362,9 +358,7 @@ public abstract class SearchProviderBase
         };
     }
 
-    /// <summary>
-    /// Search script parameter key/value pairs.
-    /// </summary>
+    /// <summary>Search script parameter key/value pairs.</summary>
     protected static List<SearchMatch> SearchParams(
         IEnumerable<(string Key, string Value)> parameters,
         FieldDefinition field, Regex pattern, object? location)

--- a/Radoub.Formats/Radoub.Formats/Search/Providers/UtmSearchProvider.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Providers/UtmSearchProvider.cs
@@ -24,9 +24,7 @@ public class UtmSearchProvider : SearchProviderBase, IFileSearchProvider
 
     private readonly Func<string, string?>? _itemNameResolver;
 
-    /// <summary>
-    /// Create a UtmSearchProvider with optional item name resolution.
-    /// </summary>
+    /// <summary>Create a UtmSearchProvider with optional item name resolution.</summary>
     /// <param name="itemNameResolver">Optional callback that resolves an item ResRef to its display name.
     /// When provided, inventory items are searchable by their resolved name (e.g., "Club" instead of "nw_wblcl001").</param>
     public UtmSearchProvider(Func<string, string?>? itemNameResolver = null)

--- a/Radoub.Formats/Radoub.Formats/Search/Registry/SearchFieldRegistry.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Registry/SearchFieldRegistry.cs
@@ -8,9 +8,7 @@ public class SearchFieldRegistry
 {
     private readonly Dictionary<ushort, List<FieldDefinition>> _fieldsByType = new();
 
-    /// <summary>
-    /// Register searchable fields for a file type.
-    /// </summary>
+    /// <summary>Register searchable fields for a file type.</summary>
     public void RegisterFileType(ushort resourceType, params FieldDefinition[] fields)
     {
         if (!_fieldsByType.ContainsKey(resourceType))
@@ -30,9 +28,7 @@ public class SearchFieldRegistry
             : Array.Empty<FieldDefinition>();
     }
 
-    /// <summary>
-    /// Get fields filtered by category for a file type.
-    /// </summary>
+    /// <summary>Get fields filtered by category for a file type.</summary>
     public IReadOnlyList<FieldDefinition> GetFieldsByCategory(
         ushort resourceType, SearchFieldCategory category)
     {
@@ -42,26 +38,20 @@ public class SearchFieldRegistry
             .AsReadOnly();
     }
 
-    /// <summary>
-    /// Get all registered file types.
-    /// </summary>
+    /// <summary>Get all registered file types.</summary>
     public IReadOnlyList<ushort> GetAllFileTypes()
     {
         return _fieldsByType.Keys.ToList().AsReadOnly();
     }
 
-    /// <summary>
-    /// Check if a field supports replace for a given file type.
-    /// </summary>
+    /// <summary>Check if a field supports replace for a given file type.</summary>
     public bool IsReplaceable(ushort resourceType, string fieldName)
     {
         return GetSearchableFields(resourceType)
             .Any(f => f.Name == fieldName && f.IsReplaceable);
     }
 
-    /// <summary>
-    /// Returns true if the file type has any registered fields.
-    /// </summary>
+    /// <summary>Returns true if the file type has any registered fields.</summary>
     public bool IsRegistered(ushort resourceType)
     {
         return _fieldsByType.ContainsKey(resourceType);

--- a/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefValidationResult.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefValidationResult.cs
@@ -1,8 +1,6 @@
 namespace Radoub.Formats.Search.Rename;
 
-/// <summary>
-/// Outcome of validating and normalizing a proposed ResRef name.
-/// </summary>
+/// <summary>Outcome of validating and normalizing a proposed ResRef name.</summary>
 public record ResRefValidationResult
 {
     /// <summary>True if the name is acceptable (possibly with a warning or auto-suffix).</summary>

--- a/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefValidator.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/Rename/ResRefValidator.cs
@@ -10,9 +10,7 @@ public class ResRefValidator
 {
     private const int MaxLength = 16;
 
-    /// <summary>
-    /// Validates and normalizes a proposed ResRef name.
-    /// </summary>
+    /// <summary>Validates and normalizes a proposed ResRef name.</summary>
     /// <param name="proposedName">Raw user input. May include extension; will be trimmed and lowercased.</param>
     /// <param name="existingNames">Existing ResRefs in the target scope, used for collision detection.
     /// Caller must EXCLUDE the name being renamed — otherwise renaming "louis" → "louis" would falsely

--- a/Radoub.Formats/Radoub.Formats/Search/SearchProviderFactory.cs
+++ b/Radoub.Formats/Radoub.Formats/Search/SearchProviderFactory.cs
@@ -1,8 +1,6 @@
 namespace Radoub.Formats.Search;
 
-/// <summary>
-/// Maps resource types to their search providers.
-/// </summary>
+/// <summary>Maps resource types to their search providers.</summary>
 public class SearchProviderFactory
 {
     private readonly Dictionary<ushort, IFileSearchProvider> _providers = new();
@@ -30,9 +28,7 @@ public class SearchProviderFactory
             : _fallback;
     }
 
-    /// <summary>
-    /// Returns true if a dedicated (non-fallback) provider exists for this type.
-    /// </summary>
+    /// <summary>Returns true if a dedicated (non-fallback) provider exists for this type.</summary>
     public bool HasDedicatedProvider(ushort resourceType)
     {
         return _providers.ContainsKey(resourceType);

--- a/Radoub.Formats/Radoub.Formats/Services/BaseItemTypeService.cs
+++ b/Radoub.Formats/Radoub.Formats/Services/BaseItemTypeService.cs
@@ -19,9 +19,7 @@ public class BaseItemTypeService
         _gameDataService = gameDataService;
     }
 
-    /// <summary>
-    /// Get all valid base item types from baseitems.2da.
-    /// </summary>
+    /// <summary>Get all valid base item types from baseitems.2da.</summary>
     public List<BaseItemTypeInfo> GetBaseItemTypes()
     {
         if (_cachedTypes != null)
@@ -51,7 +49,6 @@ public class BaseItemTypeService
             if (TlkHelper.IsGarbageLabel(label))
                 continue;
 
-            // Get display name from TLK
             var nameStrRef = baseItems.GetValue(i, "Name");
             string displayName;
             if (nameStrRef != null && nameStrRef != "****")
@@ -164,9 +161,7 @@ public class BaseItemTypeService
         };
     }
 
-    /// <summary>
-    /// Clear cached types (call when game paths change).
-    /// </summary>
+    /// <summary>Clear cached types (call when game paths change).</summary>
     public void ClearCache()
     {
         _cachedTypes = null;

--- a/Radoub.Formats/Radoub.Formats/Services/GameDataService.cs
+++ b/Radoub.Formats/Radoub.Formats/Services/GameDataService.cs
@@ -23,17 +23,13 @@ public class GameDataService : IGameDataService
     private readonly object _lock = new();
     private bool _disposed;
 
-    /// <summary>
-    /// Create a GameDataService using RadoubSettings for configuration.
-    /// </summary>
+    /// <summary>Create a GameDataService using RadoubSettings for configuration.</summary>
     public GameDataService()
     {
         InitializeFromSettings();
     }
 
-    /// <summary>
-    /// Create a GameDataService with explicit configuration.
-    /// </summary>
+    /// <summary>Create a GameDataService with explicit configuration.</summary>
     public GameDataService(GameResourceConfig config)
     {
         _resolver = new GameResourceResolver(config);
@@ -54,11 +50,9 @@ public class GameDataService : IGameDataService
 
         lock (_lock)
         {
-            // Check cache first (including negative cache)
             if (_twoDACache.TryGetValue(name, out var cached))
                 return cached;
 
-            // Load from resolver
             var twoDA = LoadTwoDA(name);
             _twoDACache[name] = twoDA; // Cache even if null (negative cache)
             return twoDA;
@@ -81,7 +75,6 @@ public class GameDataService : IGameDataService
             if (_resolver == null)
                 return false;
 
-            // Check cache first
             if (_twoDACache.TryGetValue(name, out var cached))
                 return cached != null;
 
@@ -212,14 +205,12 @@ public class GameDataService : IGameDataService
     {
         lock (_lock)
         {
-            // Dispose existing resolver
             _resolver?.Dispose();
             _resolver = null;
             _baseTlk = null;
             _customTlk = null;
             _twoDACache.Clear();
 
-            // Reinitialize from settings
             InitializeFromSettings();
         }
     }
@@ -288,11 +279,8 @@ public class GameDataService : IGameDataService
         var config = BuildConfig(settings);
         _resolver = new GameResourceResolver(config);
 
-        // Load TLK
         var tlkPath = settings.GetTlkPath(settings.EffectiveLanguage, settings.PreferredGender);
         LoadBaseTlk(tlkPath);
-
-        // Load custom TLK if configured
         LoadCustomTlk(config.CustomTlkPath);
 
         UnifiedLogger.Log(LogLevel.INFO, $"GameDataService initialized: IsConfigured={IsConfigured}", "GameDataService", "GameData");
@@ -305,7 +293,6 @@ public class GameDataService : IGameDataService
             CacheArchives = true
         };
 
-        // Base game path
         if (!string.IsNullOrEmpty(settings.BaseGameInstallPath))
         {
             var dataPath = Path.Combine(settings.BaseGameInstallPath, "data");
@@ -318,7 +305,6 @@ public class GameDataService : IGameDataService
             }
         }
 
-        // Override path
         if (!string.IsNullOrEmpty(settings.NeverwinterNightsPath))
         {
             var overridePath = Path.Combine(settings.NeverwinterNightsPath, "override");
@@ -328,9 +314,8 @@ public class GameDataService : IGameDataService
             }
         }
 
-        // HAK paths from additional search paths (not default hak folder)
+        // Only explicitly configured additional search paths, not the default hak folder.
         // Module-aware HAK scanning is handled by ConfigureModuleHaks() (#1314)
-        // This path only handles explicitly configured additional search paths
         var additionalHakPaths = settings.HakSearchPaths;
         if (additionalHakPaths.Count > 0)
         {
@@ -346,7 +331,6 @@ public class GameDataService : IGameDataService
             }
         }
 
-        // TLK path
         var tlkPath = settings.GetTlkPath(settings.EffectiveLanguage, settings.PreferredGender);
         if (!string.IsNullOrEmpty(tlkPath) && File.Exists(tlkPath))
         {
@@ -522,7 +506,6 @@ public class GameDataService : IGameDataService
             return new List<PaletteCategory>();
         }
 
-        // Load the skeleton palette ITP
         var data = FindResource(paletteName, ResourceTypes.Itp);
         if (data == null)
         {
@@ -537,7 +520,6 @@ public class GameDataService : IGameDataService
             return new List<PaletteCategory>();
         }
 
-        // Extract categories with resolved names
         var categories = new List<PaletteCategory>();
         ExtractCategories(itp.MainNodes, categories, null);
 
@@ -561,10 +543,8 @@ public class GameDataService : IGameDataService
             if (node.DisplayType == PaletteDisplayType.DisplayNever)
                 continue;
 
-            // Get node name
             var name = GetNodeName(node);
 
-            // Skip invalid/placeholder names
             if (string.IsNullOrEmpty(name) || IsInvalidCategoryName(name))
                 continue;
 
@@ -604,11 +584,9 @@ public class GameDataService : IGameDataService
 
     private string? GetNodeName(PaletteNode node)
     {
-        // Try direct name first
         if (!string.IsNullOrEmpty(node.Name))
             return node.Name;
 
-        // Try TLK resolution
         if (node.StrRef.HasValue && node.StrRef.Value != 0xFFFFFFFF)
         {
             var tlkString = GetString(node.StrRef.Value);
@@ -623,15 +601,12 @@ public class GameDataService : IGameDataService
 
     private static bool IsInvalidCategoryName(string name)
     {
-        // Check against known invalid names
         if (InvalidCategoryNames.Contains(name))
             return true;
 
-        // Check for names that are just numbers or whitespace
         if (string.IsNullOrWhiteSpace(name))
             return true;
 
-        // Check for names that start with common invalid prefixes
         if (name.StartsWith("Bad", StringComparison.OrdinalIgnoreCase) ||
             name.StartsWith("Delete", StringComparison.OrdinalIgnoreCase) ||
             name.StartsWith("Unused", StringComparison.OrdinalIgnoreCase))
@@ -642,7 +617,6 @@ public class GameDataService : IGameDataService
 
     private static string? GetPaletteNameForResource(ushort resourceType)
     {
-        // Map resource types to their skeleton palette names
         return resourceType switch
         {
             ResourceTypes.Utc => "creaturepal",   // Creature

--- a/Radoub.Formats/Radoub.Formats/Services/GarbageFilterService.cs
+++ b/Radoub.Formats/Radoub.Formats/Services/GarbageFilterService.cs
@@ -16,9 +16,7 @@ public class GarbageFilterService
     private readonly List<string> _exactPatterns = new();
     private readonly List<string> _rawFilters;
 
-    /// <summary>
-    /// Singleton instance backed by RadoubSettings.
-    /// </summary>
+    /// <summary>Singleton instance backed by RadoubSettings.</summary>
     public static GarbageFilterService Instance
     {
         get
@@ -34,9 +32,7 @@ public class GarbageFilterService
         }
     }
 
-    /// <summary>
-    /// Create with explicit filter list (for testing or custom scenarios).
-    /// </summary>
+    /// <summary>Create with explicit filter list (for testing or custom scenarios).</summary>
     public GarbageFilterService(IReadOnlyList<string> filters)
     {
         _rawFilters = filters.Where(f => !string.IsNullOrWhiteSpace(f)).ToList();
@@ -80,14 +76,10 @@ public class GarbageFilterService
         return false;
     }
 
-    /// <summary>
-    /// Get the current filter list (raw patterns including "=" prefixes).
-    /// </summary>
+    /// <summary>Get the current filter list (raw patterns including "=" prefixes).</summary>
     public IReadOnlyList<string> GetFilters() => _rawFilters.AsReadOnly();
 
-    /// <summary>
-    /// Reset singleton (for testing or after settings reload).
-    /// </summary>
+    /// <summary>Reset singleton (for testing or after settings reload).</summary>
     public static void ResetInstance()
     {
         lock (_lock)

--- a/Radoub.Formats/Radoub.Formats/Services/IGameDataService.cs
+++ b/Radoub.Formats/Radoub.Formats/Services/IGameDataService.cs
@@ -18,63 +18,33 @@ public interface IGameDataService : IDisposable
 {
     #region 2DA Access
 
-    /// <summary>
-    /// Get a 2DA file by name (without extension).
-    /// Returns cached instance if previously loaded.
-    /// </summary>
+    /// <summary>Get a 2DA file by name (without extension); cached after first load.</summary>
     /// <param name="name">2DA name, e.g., "baseitems", "itempropdef"</param>
-    /// <returns>Parsed 2DA file, or null if not found</returns>
     TwoDAFile? Get2DA(string name);
 
-    /// <summary>
-    /// Get a cell value from a 2DA file.
-    /// Convenience method combining Get2DA + GetValue.
-    /// </summary>
-    /// <param name="twoDAName">2DA name, e.g., "baseitems"</param>
+    /// <summary>Get a cell value from a 2DA file (Get2DA + GetValue).</summary>
     /// <param name="rowIndex">Row index (0-based)</param>
     /// <param name="columnName">Column name (case-insensitive)</param>
-    /// <returns>Cell value, or null if not found/empty</returns>
     string? Get2DAValue(string twoDAName, int rowIndex, string columnName);
 
-    /// <summary>
-    /// Check if a 2DA file exists.
-    /// </summary>
     bool Has2DA(string name);
 
-    /// <summary>
-    /// Clear all cached 2DA files.
-    /// Call when resource paths change.
-    /// </summary>
+    /// <summary>Clear all cached 2DA files. Call when resource paths change.</summary>
     void ClearCache();
 
     #endregion
 
     #region TLK String Resolution
 
-    /// <summary>
-    /// Resolve a TLK string reference to text.
-    /// Automatically handles custom TLK (StrRef >= 16777216).
-    /// </summary>
-    /// <param name="strRef">String reference</param>
-    /// <returns>Resolved string, or null if not found</returns>
+    /// <summary>Resolve a TLK StrRef to text. Handles custom TLK (StrRef >= 16777216).</summary>
     string? GetString(uint strRef);
 
-    /// <summary>
-    /// Resolve a TLK string reference from a string value.
-    /// Handles "****" and invalid values gracefully.
-    /// </summary>
-    /// <param name="strRefStr">String containing a numeric StrRef</param>
-    /// <returns>Resolved string, or null if invalid/not found</returns>
+    /// <summary>Resolve a TLK StrRef given as text. Handles "****" and invalid values gracefully.</summary>
     string? GetString(string? strRefStr);
 
-    /// <summary>
-    /// Check if a custom TLK is loaded.
-    /// </summary>
     bool HasCustomTlk { get; }
 
-    /// <summary>
-    /// Set the custom TLK path for module-specific strings.
-    /// </summary>
+    /// <summary>Set the custom TLK path for module-specific strings.</summary>
     /// <param name="path">Path to custom TLK file, or null to clear</param>
     void SetCustomTlk(string? path);
 
@@ -82,13 +52,7 @@ public interface IGameDataService : IDisposable
 
     #region Resource Access
 
-    /// <summary>
-    /// Find a resource by ResRef and type.
-    /// Searches Override → HAK → BIF.
-    /// </summary>
-    /// <param name="resRef">Resource reference name</param>
-    /// <param name="resourceType">Resource type ID</param>
-    /// <returns>Resource data, or null if not found</returns>
+    /// <summary>Find a resource by ResRef and type. Searches Override → HAK → BIF.</summary>
     byte[]? FindResource(string resRef, ushort resourceType);
 
     /// <summary>
@@ -96,47 +60,26 @@ public interface IGameDataService : IDisposable
     /// Use for resources that must come from the base game regardless of HAK overrides
     /// (e.g., standard race skeletons that CEP HAKs may replace with incompatible versions).
     /// </summary>
-    /// <param name="resRef">Resource reference name</param>
-    /// <param name="resourceType">Resource type ID</param>
-    /// <returns>Resource data, or null if not found</returns>
     byte[]? FindBaseResource(string resRef, ushort resourceType);
 
-    /// <summary>
-    /// Find a resource including source information (which file it came from).
-    /// Resolution order: Override → HAK → BIF.
-    /// </summary>
+    /// <summary>Find a resource including which file it came from. Order: Override → HAK → BIF.</summary>
     Radoub.Formats.Resolver.ResourceResult? FindResourceWithSource(string resRef, ushort resourceType);
 
-    /// <summary>
-    /// List all resources of a specific type.
-    /// </summary>
-    /// <param name="resourceType">Resource type ID</param>
-    /// <returns>Enumerable of resource info</returns>
+    /// <summary>List all resources of a specific type.</summary>
     IEnumerable<GameResourceInfo> ListResources(ushort resourceType);
 
     #endregion
 
     #region Soundset Access
 
-    /// <summary>
-    /// Get a soundset file by its ID from soundset.2da.
-    /// </summary>
-    /// <param name="soundsetId">Soundset ID (row index in soundset.2da)</param>
-    /// <returns>Parsed SSF file, or null if not found</returns>
+    /// <summary>Get a soundset file by its ID.</summary>
+    /// <param name="soundsetId">Row index in soundset.2da</param>
     SsfFile? GetSoundset(int soundsetId);
 
-    /// <summary>
-    /// Get a soundset file by its ResRef.
-    /// </summary>
-    /// <param name="resRef">SSF ResRef (without extension)</param>
-    /// <returns>Parsed SSF file, or null if not found</returns>
+    /// <summary>Get a soundset file by its ResRef (without extension).</summary>
     SsfFile? GetSoundsetByResRef(string resRef);
 
-    /// <summary>
-    /// Get the ResRef for a soundset from soundset.2da.
-    /// </summary>
-    /// <param name="soundsetId">Soundset ID</param>
-    /// <returns>SSF ResRef, or null if not found</returns>
+    /// <summary>Get the SSF ResRef for a soundset from soundset.2da.</summary>
     string? GetSoundsetResRef(int soundsetId);
 
     #endregion
@@ -144,19 +87,14 @@ public interface IGameDataService : IDisposable
     #region Palette Access
 
     /// <summary>
-    /// Get palette categories for a specific resource type.
+    /// Get palette categories for a resource type.
     /// Loads from skeleton palette (e.g., creaturepal.itp for UTC).
     /// </summary>
     /// <param name="resourceType">Resource type ID (e.g., 2027 for UTC)</param>
-    /// <returns>List of palette categories with IDs and names</returns>
     IEnumerable<PaletteCategory> GetPaletteCategories(ushort resourceType);
 
-    /// <summary>
-    /// Get palette category name by ID.
-    /// </summary>
-    /// <param name="resourceType">Resource type ID</param>
+    /// <summary>Get palette category name by ID.</summary>
     /// <param name="categoryId">Category ID (PaletteID from blueprint)</param>
-    /// <returns>Category name, or null if not found</returns>
     string? GetPaletteCategoryName(ushort resourceType, byte categoryId);
 
     #endregion
@@ -235,15 +173,10 @@ public interface IGameDataService : IDisposable
 
     #region Configuration
 
-    /// <summary>
-    /// Whether the service is configured with valid game paths.
-    /// </summary>
+    /// <summary>Whether the service is configured with valid game paths.</summary>
     bool IsConfigured { get; }
 
-    /// <summary>
-    /// Reload configuration from settings.
-    /// Call after settings change.
-    /// </summary>
+    /// <summary>Reload configuration from settings. Call after settings change.</summary>
     void ReloadConfiguration();
 
     /// <summary>
@@ -258,35 +191,21 @@ public interface IGameDataService : IDisposable
     #endregion
 }
 
-/// <summary>
-/// Information about a game resource.
-/// </summary>
+/// <summary>Information about a game resource.</summary>
 public class GameResourceInfo
 {
-    /// <summary>
-    /// Resource reference name (without extension).
-    /// </summary>
+    /// <summary>Resource reference name (without extension).</summary>
     public required string ResRef { get; init; }
 
-    /// <summary>
-    /// Resource type ID.
-    /// </summary>
     public required ushort ResourceType { get; init; }
 
-    /// <summary>
-    /// Source of the resource (Override, HAK, Module, BIF).
-    /// </summary>
     public required GameResourceSource Source { get; init; }
 
-    /// <summary>
-    /// Path to the source file (for override files) or archive.
-    /// </summary>
+    /// <summary>Path to the source file (for override files) or archive.</summary>
     public string? SourcePath { get; init; }
 }
 
-/// <summary>
-/// Source of a game resource in the resolution chain.
-/// </summary>
+/// <summary>Source of a game resource in the resolution chain.</summary>
 public enum GameResourceSource
 {
     /// <summary>Override folder (highest priority)</summary>
@@ -302,28 +221,18 @@ public enum GameResourceSource
     Bif
 }
 
-/// <summary>
-/// Represents a palette category from an ITP file.
-/// </summary>
+/// <summary>Represents a palette category from an ITP file.</summary>
 public class PaletteCategory
 {
-    /// <summary>
-    /// Category ID (matches PaletteID in blueprints).
-    /// </summary>
+    /// <summary>Category ID (matches PaletteID in blueprints).</summary>
     public byte Id { get; init; }
 
-    /// <summary>
-    /// Display name (resolved from TLK or direct name).
-    /// </summary>
+    /// <summary>Display name (resolved from TLK or direct name).</summary>
     public required string Name { get; init; }
 
-    /// <summary>
-    /// Parent branch path for tree display (e.g., "Animals/Domestic").
-    /// </summary>
+    /// <summary>Parent branch path for tree display (e.g., "Animals/Domestic").</summary>
     public string? ParentPath { get; init; }
 
-    /// <summary>
-    /// Full display path (Parent + Name).
-    /// </summary>
+    /// <summary>Full display path (Parent + Name).</summary>
     public string FullPath => string.IsNullOrEmpty(ParentPath) ? Name : $"{ParentPath}/{Name}";
 }

--- a/Radoub.Formats/Radoub.Formats/Services/IImageService.cs
+++ b/Radoub.Formats/Radoub.Formats/Services/IImageService.cs
@@ -15,9 +15,7 @@ public interface IImageService
     /// <returns>Decoded image, or null if decoding fails</returns>
     ImageData? DecodeImage(byte[] data, string format);
 
-    /// <summary>
-    /// Decode an image from a game resource.
-    /// </summary>
+    /// <summary>Decode an image from a game resource.</summary>
     /// <param name="resRef">Resource reference name</param>
     /// <param name="resourceType">Resource type ID (3=TGA, 6=PLT, 2033=DDS)</param>
     /// <returns>Decoded image, or null if not found or decoding fails</returns>
@@ -32,9 +30,7 @@ public interface IImageService
     /// <returns>Decoded icon image, or null if not found</returns>
     ImageData? GetItemIcon(int baseItemType, int modelNumber = 0);
 
-    /// <summary>
-    /// Get a portrait image by ResRef.
-    /// </summary>
+    /// <summary>Get a portrait image by ResRef.</summary>
     /// <param name="resRef">Portrait ResRef (e.g., "po_elf_m_")</param>
     /// <returns>Decoded portrait image, or null if not found</returns>
     ImageData? GetPortrait(string resRef);
@@ -78,19 +74,13 @@ public interface IImageService
     void ClearCache();
 }
 
-/// <summary>
-/// Decoded image data in RGBA format.
-/// </summary>
+/// <summary>Decoded image data in RGBA format.</summary>
 public class ImageData
 {
-    /// <summary>
-    /// Image width in pixels.
-    /// </summary>
+    /// <summary>Image width in pixels.</summary>
     public int Width { get; }
 
-    /// <summary>
-    /// Image height in pixels.
-    /// </summary>
+    /// <summary>Image height in pixels.</summary>
     public int Height { get; }
 
     /// <summary>
@@ -106,9 +96,7 @@ public class ImageData
         Pixels = pixels;
     }
 
-    /// <summary>
-    /// Get the color at a specific pixel coordinate.
-    /// </summary>
+    /// <summary>Get the color at a specific pixel coordinate.</summary>
     public (byte r, byte g, byte b, byte a) GetPixel(int x, int y)
     {
         if (x < 0 || x >= Width || y < 0 || y >= Height)

--- a/Radoub.Formats/Radoub.Formats/Services/IPlaceableAppearanceService.cs
+++ b/Radoub.Formats/Radoub.Formats/Services/IPlaceableAppearanceService.cs
@@ -9,33 +9,21 @@ namespace Radoub.Formats.Services;
 /// </summary>
 public interface IPlaceableAppearanceService
 {
-    /// <summary>
-    /// Gets the appearance entry for an ID, or null if the row is padding/missing.
-    /// </summary>
+    /// <summary>Gets the appearance entry for an ID, or null if the row is padding/missing.</summary>
     PlaceableAppearance? GetById(uint id);
 
-    /// <summary>
-    /// Gets all real placeable appearances (padding rows skipped). Cached.
-    /// </summary>
+    /// <summary>Gets all real placeable appearances (padding rows skipped). Cached.</summary>
     IReadOnlyList<PlaceableAppearance> GetAll();
 
-    /// <summary>
-    /// Gets the MDL model name (ModelName column) for an appearance ID, or null.
-    /// </summary>
+    /// <summary>Gets the MDL model name (ModelName column) for an appearance ID, or null.</summary>
     string? GetModelName(uint id);
 
-    /// <summary>
-    /// Gets the display name (TLK via StrRef, falling back to LABEL, then a synthetic name).
-    /// </summary>
+    /// <summary>Gets the display name (TLK via StrRef, falling back to LABEL, then a synthetic name).</summary>
     string GetDisplayName(uint id);
 
-    /// <summary>
-    /// Clears the cached <see cref="GetAll"/> snapshot. Call after the 2DA chain changes.
-    /// </summary>
+    /// <summary>Clears the cached <see cref="GetAll"/> snapshot. Call after the 2DA chain changes.</summary>
     void InvalidateCache();
 }
 
-/// <summary>
-/// A single placeable appearance from placeables.2da.
-/// </summary>
+/// <summary>A single placeable appearance from placeables.2da.</summary>
 public record PlaceableAppearance(uint Id, string Label, string ModelName, string DisplayName);

--- a/Radoub.Formats/Radoub.Formats/Settings/RadoubSettings.Persistence.cs
+++ b/Radoub.Formats/Radoub.Formats/Settings/RadoubSettings.Persistence.cs
@@ -6,9 +6,7 @@ using Radoub.Formats.Logging;
 
 namespace Radoub.Formats.Settings;
 
-/// <summary>
-/// Persistence logic for RadoubSettings: Load, Save, AutoDetect, and SettingsData DTO.
-/// </summary>
+/// <summary>Persistence logic for RadoubSettings: Load, Save, AutoDetect, and SettingsData DTO.</summary>
 public partial class RadoubSettings
 {
     private void AutoDetectPaths()

--- a/Radoub.Formats/Radoub.Formats/Settings/RadoubSettings.cs
+++ b/Radoub.Formats/Radoub.Formats/Settings/RadoubSettings.cs
@@ -15,9 +15,7 @@ public partial class RadoubSettings : INotifyPropertyChanged
     private static RadoubSettings? _instance;
     private static readonly object _lock = new();
 
-    /// <summary>
-    /// Singleton instance of shared settings.
-    /// </summary>
+    /// <summary>Singleton instance of shared settings.</summary>
     public static RadoubSettings Instance
     {
         get
@@ -156,9 +154,7 @@ public partial class RadoubSettings : INotifyPropertyChanged
             "RadoubSettings", "Settings");
     }
 
-    /// <summary>
-    /// Base game installation path (Steam/GOG - contains data\ folder with BIF/KEY files).
-    /// </summary>
+    /// <summary>Base game installation path (Steam/GOG - contains data\ folder with BIF/KEY files).</summary>
     public string BaseGameInstallPath
     {
         get => _baseGameInstallPath;
@@ -175,9 +171,7 @@ public partial class RadoubSettings : INotifyPropertyChanged
         set { if (SetProperty(ref _neverwinterNightsPath, value ?? "")) SaveSettings(); }
     }
 
-    /// <summary>
-    /// Currently active module path.
-    /// </summary>
+    /// <summary>Currently active module path.</summary>
     public string CurrentModulePath
     {
         get => _currentModulePath;
@@ -214,9 +208,7 @@ public partial class RadoubSettings : INotifyPropertyChanged
     /// </summary>
     public IReadOnlyList<string> HakSearchPaths => _hakSearchPaths.AsReadOnly();
 
-    /// <summary>
-    /// Add a HAK search path if not already present.
-    /// </summary>
+    /// <summary>Add a HAK search path if not already present.</summary>
     public void AddHakSearchPath(string path)
     {
         if (string.IsNullOrWhiteSpace(path)) return;
@@ -230,9 +222,6 @@ public partial class RadoubSettings : INotifyPropertyChanged
         }
     }
 
-    /// <summary>
-    /// Remove a HAK search path.
-    /// </summary>
     public bool RemoveHakSearchPath(string path)
     {
         if (string.IsNullOrWhiteSpace(path)) return false;
@@ -249,9 +238,7 @@ public partial class RadoubSettings : INotifyPropertyChanged
         return false;
     }
 
-    /// <summary>
-    /// Clear all additional HAK search paths.
-    /// </summary>
+    /// <summary>Clear all additional HAK search paths.</summary>
     public void ClearHakSearchPaths()
     {
         if (_hakSearchPaths.Count > 0)
@@ -262,9 +249,7 @@ public partial class RadoubSettings : INotifyPropertyChanged
         }
     }
 
-    /// <summary>
-    /// Set all HAK search paths at once.
-    /// </summary>
+    /// <summary>Set all HAK search paths at once.</summary>
     public void SetHakSearchPaths(IEnumerable<string> paths)
     {
         _hakSearchPaths.Clear();
@@ -289,7 +274,6 @@ public partial class RadoubSettings : INotifyPropertyChanged
     /// </summary>
     public IEnumerable<string> GetAllHakSearchPaths()
     {
-        // Default hak folder from NeverwinterNightsPath
         if (!string.IsNullOrEmpty(_neverwinterNightsPath))
         {
             var defaultHakPath = Path.Combine(_neverwinterNightsPath, "hak");
@@ -299,7 +283,6 @@ public partial class RadoubSettings : INotifyPropertyChanged
             }
         }
 
-        // Additional search paths
         foreach (var path in _hakSearchPaths)
         {
             if (Directory.Exists(path))
@@ -340,22 +323,16 @@ public partial class RadoubSettings : INotifyPropertyChanged
         set { if (SetProperty(ref _defaultLanguage, value)) SaveSettings(); }
     }
 
-    /// <summary>
-    /// Get the preferred language as enum, or DefaultLanguage if auto-detect.
-    /// </summary>
+    /// <summary>Preferred language as enum, or null when set to auto-detect.</summary>
     public Language? PreferredLanguage
     {
         get => string.IsNullOrEmpty(_tlkLanguage) ? null : LanguageHelper.FromLanguageCode(_tlkLanguage);
     }
 
-    /// <summary>
-    /// Get the effective language for display (PreferredLanguage or DefaultLanguage).
-    /// </summary>
+    /// <summary>Effective display language (PreferredLanguage or DefaultLanguage).</summary>
     public Language EffectiveLanguage => PreferredLanguage ?? _defaultLanguage;
 
-    /// <summary>
-    /// Get the preferred gender for TLK strings.
-    /// </summary>
+    /// <summary>Preferred gender for TLK strings.</summary>
     public Gender PreferredGender => _tlkUseFemale ? Gender.Female : Gender.Male;
 
     /// <summary>
@@ -368,41 +345,30 @@ public partial class RadoubSettings : INotifyPropertyChanged
         set { if (SetProperty(ref _sharedThemeId, value ?? "")) SaveSettings(); }
     }
 
-    /// <summary>
-    /// Check if a shared theme is configured.
-    /// </summary>
     public bool HasSharedTheme => !string.IsNullOrEmpty(_sharedThemeId);
 
-    /// <summary>
-    /// Shared font size applied to all tools. Trebuchet is the sole authority.
-    /// </summary>
+    /// <summary>Shared font size applied to all tools. Trebuchet is the sole authority.</summary>
     public double SharedFontSize
     {
         get => _sharedFontSize;
         set { if (SetProperty(ref _sharedFontSize, Math.Max(8, Math.Min(32, value)))) SaveSettings(); }
     }
 
-    /// <summary>
-    /// Shared font family applied to all tools. Trebuchet is the sole authority.
-    /// </summary>
+    /// <summary>Shared font family applied to all tools. Trebuchet is the sole authority.</summary>
     public string SharedFontFamily
     {
         get => _sharedFontFamily;
         set { if (SetProperty(ref _sharedFontFamily, value ?? "Segoe UI")) SaveSettings(); }
     }
 
-    /// <summary>
-    /// Shared log level for all tools.
-    /// </summary>
+    /// <summary>Shared log level for all tools.</summary>
     public LogLevel SharedLogLevel
     {
         get => _sharedLogLevel;
         set { if (SetProperty(ref _sharedLogLevel, value)) SaveSettings(); }
     }
 
-    /// <summary>
-    /// Shared log retention sessions (1-10).
-    /// </summary>
+    /// <summary>Shared log retention sessions (1-10).</summary>
     public int SharedLogRetentionSessions
     {
         get => _sharedLogRetentionSessions;
@@ -413,24 +379,16 @@ public partial class RadoubSettings : INotifyPropertyChanged
         }
     }
 
-    /// <summary>
-    /// If true, tools use shared logging settings instead of their own.
-    /// </summary>
+    /// <summary>If true, tools use shared logging settings instead of their own.</summary>
     public bool UseSharedLogging
     {
         get => _useSharedLogging;
         set { if (SetProperty(ref _useSharedLogging, value)) SaveSettings(); }
     }
 
-    /// <summary>
-    /// Check if shared logging is enabled.
-    /// </summary>
     public bool HasSharedLogging => _useSharedLogging;
 
-    /// <summary>
-    /// Get a LoggingSettings instance from shared settings.
-    /// Tools can use this to initialize their logging.
-    /// </summary>
+    /// <summary>LoggingSettings built from shared settings, for tools to initialize logging.</summary>
     public LoggingSettings GetSharedLoggingSettings()
     {
         return new LoggingSettings
@@ -440,9 +398,7 @@ public partial class RadoubSettings : INotifyPropertyChanged
         };
     }
 
-    /// <summary>
-    /// Backup retention in days (1-90). Backups older than this are deleted on startup.
-    /// </summary>
+    /// <summary>Backup retention in days (1-90). Backups older than this are deleted on startup.</summary>
     public int BackupRetentionDays
     {
         get => _backupRetentionDays;
@@ -460,9 +416,7 @@ public partial class RadoubSettings : INotifyPropertyChanged
     /// </summary>
     public IReadOnlyList<string> GarbageFilters => _garbageFilters.AsReadOnly();
 
-    /// <summary>
-    /// Replace all garbage filters.
-    /// </summary>
+    /// <summary>Replace all garbage filters.</summary>
     public void SetGarbageFilters(IEnumerable<string> filters)
     {
         _garbageFilters = filters.Where(f => !string.IsNullOrWhiteSpace(f)).ToList();
@@ -470,10 +424,7 @@ public partial class RadoubSettings : INotifyPropertyChanged
         SaveSettings();
     }
 
-    /// <summary>
-    /// Get the path to Radoub-level themes folder.
-    /// Location: ~/Radoub/Themes/
-    /// </summary>
+    /// <summary>Path to the Radoub-level themes folder (~/Radoub/Themes/); created if missing.</summary>
     public string GetSharedThemesPath()
     {
         var path = Path.Combine(SettingsDirectory, "Themes");
@@ -486,63 +437,49 @@ public partial class RadoubSettings : INotifyPropertyChanged
 
     // Tool path properties - auto-populated by tools for cross-tool discovery
 
-    /// <summary>
-    /// Path to Parley.exe. Auto-set when Parley runs.
-    /// </summary>
+    /// <summary>Path to Parley.exe. Auto-set when Parley runs.</summary>
     public string ParleyPath
     {
         get => _parleyPath;
         set { if (SetProperty(ref _parleyPath, value ?? "")) SaveSettings(); }
     }
 
-    /// <summary>
-    /// Path to Manifest.exe. Auto-set when Manifest runs.
-    /// </summary>
+    /// <summary>Path to Manifest.exe. Auto-set when Manifest runs.</summary>
     public string ManifestPath
     {
         get => _manifestPath;
         set { if (SetProperty(ref _manifestPath, value ?? "")) SaveSettings(); }
     }
 
-    /// <summary>
-    /// Path to Quartermaster.exe. Auto-set when Quartermaster runs.
-    /// </summary>
+    /// <summary>Path to Quartermaster.exe. Auto-set when Quartermaster runs.</summary>
     public string QuartermasterPath
     {
         get => _quartermasterPath;
         set { if (SetProperty(ref _quartermasterPath, value ?? "")) SaveSettings(); }
     }
 
-    /// <summary>
-    /// Path to Fence.exe. Auto-set when Fence runs.
-    /// </summary>
+    /// <summary>Path to Fence.exe. Auto-set when Fence runs.</summary>
     public string FencePath
     {
         get => _fencePath;
         set { if (SetProperty(ref _fencePath, value ?? "")) SaveSettings(); }
     }
 
-    /// <summary>
-    /// Path to Trebuchet.exe. Auto-set when Trebuchet runs.
-    /// </summary>
+    /// <summary>Path to Trebuchet.exe. Auto-set when Trebuchet runs.</summary>
     public string TrebuchetPath
     {
         get => _trebuchetPath;
         set { if (SetProperty(ref _trebuchetPath, value ?? "")) SaveSettings(); }
     }
 
-    /// <summary>
-    /// Path to Relique (ItemEditor) executable. Auto-set when Relique runs.
-    /// </summary>
+    /// <summary>Path to Relique (ItemEditor) executable. Auto-set when Relique runs.</summary>
     public string ReliquePath
     {
         get => _reliquePath;
         set { if (SetProperty(ref _reliquePath, value ?? "")) SaveSettings(); }
     }
 
-    /// <summary>
-    /// Path to Reliquary (PlaceableEditor) executable. Auto-set when Reliquary runs.
-    /// </summary>
+    /// <summary>Path to Reliquary (PlaceableEditor) executable. Auto-set when Reliquary runs.</summary>
     public string ReliquaryPath
     {
         get => _reliquaryPath;
@@ -559,9 +496,7 @@ public partial class RadoubSettings : INotifyPropertyChanged
         set { if (SetProperty(ref _codeEditorPath, value ?? "")) SaveSettings(); }
     }
 
-    /// <summary>
-    /// Check if game paths are configured.
-    /// </summary>
+    /// <summary>True when at least one of the two game paths is set.</summary>
     public bool HasGamePaths => !string.IsNullOrEmpty(_baseGameInstallPath) || !string.IsNullOrEmpty(_neverwinterNightsPath);
 
     /// <summary>
@@ -622,7 +557,6 @@ public partial class RadoubSettings : INotifyPropertyChanged
         if (string.IsNullOrEmpty(path))
             return false;
 
-        // .mod file
         if (File.Exists(path) && path.EndsWith(".mod", StringComparison.OrdinalIgnoreCase))
             return true;
 
@@ -679,9 +613,7 @@ public partial class RadoubSettings : INotifyPropertyChanged
         return null;
     }
 
-    /// <summary>
-    /// Find available TLK languages in the game installation.
-    /// </summary>
+    /// <summary>Find available TLK languages in the game installation.</summary>
     public IEnumerable<Language> GetAvailableTlkLanguages()
     {
         if (string.IsNullOrEmpty(_baseGameInstallPath))
@@ -705,9 +637,7 @@ public partial class RadoubSettings : INotifyPropertyChanged
         }
     }
 
-    /// <summary>
-    /// Get the TLK file path for a specific language.
-    /// </summary>
+    /// <summary>Get the TLK file path for a specific language.</summary>
     public string? GetTlkPath(Language language, Gender gender = Gender.Male)
     {
         if (string.IsNullOrEmpty(_baseGameInstallPath))

--- a/Radoub.Formats/Radoub.Formats/Settings/ResourcePathDetector.cs
+++ b/Radoub.Formats/Radoub.Formats/Settings/ResourcePathDetector.cs
@@ -64,9 +64,7 @@ public static class ResourcePathDetector
         return null;
     }
 
-    /// <summary>
-    /// Attempts to auto-detect the module directory path.
-    /// </summary>
+    /// <summary>Attempts to auto-detect the module directory path.</summary>
     public static string? AutoDetectModulePath(string? gamePath = null)
     {
         if (!string.IsNullOrEmpty(gamePath))
@@ -176,14 +174,10 @@ public static class ResourcePathDetector
         return false;
     }
 
-    /// <summary>
-    /// Validation result with message for UI display.
-    /// </summary>
+    /// <summary>Validation result with message for UI display.</summary>
     public record PathValidationResult(bool IsValid, string Message);
 
-    /// <summary>
-    /// Validate base game path with UI message.
-    /// </summary>
+    /// <summary>Validate base game path with UI message.</summary>
     public static PathValidationResult ValidateBaseGamePathWithMessage(string path)
     {
         if (string.IsNullOrEmpty(path))
@@ -195,9 +189,7 @@ public static class ResourcePathDetector
         return new PathValidationResult(false, "❌ Invalid path - missing data\\ folder");
     }
 
-    /// <summary>
-    /// Validate game documents path with UI message.
-    /// </summary>
+    /// <summary>Validate game documents path with UI message.</summary>
     public static PathValidationResult ValidateGamePathWithMessage(string path)
     {
         if (string.IsNullOrEmpty(path))
@@ -209,9 +201,7 @@ public static class ResourcePathDetector
         return new PathValidationResult(false, "❌ Invalid path - missing required directories (ambient, music)");
     }
 
-    /// <summary>
-    /// Validate module path with UI message.
-    /// </summary>
+    /// <summary>Validate module path with UI message.</summary>
     public static PathValidationResult ValidateModulePathWithMessage(string path)
     {
         if (string.IsNullOrEmpty(path))
@@ -223,9 +213,7 @@ public static class ResourcePathDetector
         return new PathValidationResult(false, "❌ Invalid path - no .mod files or module directories found");
     }
 
-    /// <summary>
-    /// Gets the sound directories relative to game path.
-    /// </summary>
+    /// <summary>Gets the sound directories relative to game path.</summary>
     public static List<string> GetSoundDirectories(string gamePath)
     {
         if (string.IsNullOrEmpty(gamePath))

--- a/Radoub.Formats/Radoub.Formats/Ssf/SsfEntry.cs
+++ b/Radoub.Formats/Radoub.Formats/Ssf/SsfEntry.cs
@@ -6,9 +6,7 @@ namespace Radoub.Formats.Ssf;
 /// </summary>
 public class SsfEntry
 {
-    /// <summary>
-    /// ResRef of the sound file to play (up to 16 characters, without .wav extension).
-    /// </summary>
+    /// <summary>ResRef of the sound file to play (up to 16 characters, without .wav extension).</summary>
     public string ResRef { get; set; } = string.Empty;
 
     /// <summary>
@@ -17,13 +15,8 @@ public class SsfEntry
     /// </summary>
     public uint StringRef { get; set; } = uint.MaxValue;
 
-    /// <summary>
-    /// Whether this entry has a valid sound file reference.
-    /// </summary>
+    /// <summary>Valid sound reference; "****" is the empty-slot sentinel.</summary>
     public bool HasSound => !string.IsNullOrEmpty(ResRef) && ResRef != "****";
 
-    /// <summary>
-    /// Whether this entry has text to display.
-    /// </summary>
     public bool HasText => StringRef != uint.MaxValue;
 }

--- a/Radoub.Formats/Radoub.Formats/Ssf/SsfFile.cs
+++ b/Radoub.Formats/Radoub.Formats/Ssf/SsfFile.cs
@@ -6,9 +6,7 @@ namespace Radoub.Formats.Ssf;
 /// </summary>
 public class SsfFile
 {
-    /// <summary>
-    /// File version (typically "V1.0").
-    /// </summary>
+    /// <summary>File version (typically "V1.0").</summary>
     public string Version { get; set; } = "V1.0";
 
     /// <summary>
@@ -17,14 +15,9 @@ public class SsfFile
     /// </summary>
     public List<SsfEntry> Entries { get; set; } = new();
 
-    /// <summary>
-    /// Get entry by index, or null if out of range.
-    /// </summary>
+    /// <summary>Get entry by index, or null if out of range.</summary>
     public SsfEntry? GetEntry(int index) => index >= 0 && index < Entries.Count ? Entries[index] : null;
 
-    /// <summary>
-    /// Get entry by sound type enum.
-    /// </summary>
     public SsfEntry? GetEntry(SsfSoundType soundType) => GetEntry((int)soundType);
 }
 

--- a/Radoub.Formats/Radoub.Formats/Ssf/SsfReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Ssf/SsfReader.cs
@@ -9,11 +9,7 @@ namespace Radoub.Formats.Ssf;
 /// </summary>
 public static class SsfReader
 {
-    /// <summary>
-    /// Reads an SSF file from binary data.
-    /// </summary>
-    /// <param name="data">Raw SSF file bytes.</param>
-    /// <returns>Parsed SsfFile, or null if parsing fails.</returns>
+    /// <summary>Reads an SSF file from binary data. Returns null if parsing fails.</summary>
     public static SsfFile? Read(byte[] data)
     {
         if (data == null || data.Length < 40)
@@ -27,7 +23,6 @@ public static class SsfReader
             using var stream = new MemoryStream(data);
             using var reader = new BinaryReader(stream, Encoding.ASCII);
 
-            // Read header
             var fileType = new string(reader.ReadChars(4));
             if (fileType != "SSF ")
             {
@@ -44,7 +39,6 @@ public static class SsfReader
 
             var ssf = new SsfFile { Version = version };
 
-            // Read entry offsets
             stream.Position = tableOffset;
             var entryOffsets = new uint[entryCount];
             for (int i = 0; i < entryCount; i++)
@@ -52,7 +46,6 @@ public static class SsfReader
                 entryOffsets[i] = reader.ReadUInt32();
             }
 
-            // Read each entry
             for (int i = 0; i < entryCount; i++)
             {
                 stream.Position = entryOffsets[i];

--- a/Radoub.Formats/Radoub.Formats/Ssf/SsfWriter.cs
+++ b/Radoub.Formats/Radoub.Formats/Ssf/SsfWriter.cs
@@ -57,9 +57,7 @@ public static class SsfWriter
         return stream.ToArray();
     }
 
-    /// <summary>
-    /// Write an SSF file to a stream.
-    /// </summary>
+    /// <summary>Write an SSF file to a stream.</summary>
     public static void Write(SsfFile ssf, Stream stream)
     {
         ArgumentNullException.ThrowIfNull(stream);
@@ -67,9 +65,7 @@ public static class SsfWriter
         stream.Write(bytes, 0, bytes.Length);
     }
 
-    /// <summary>
-    /// Write an SSF file to a file path.
-    /// </summary>
+    /// <summary>Write an SSF file to a file path.</summary>
     public static void Write(SsfFile ssf, string filePath)
     {
         var bytes = Write(ssf);

--- a/Radoub.Formats/Radoub.Formats/Tokens/ColorTokenEncoder.cs
+++ b/Radoub.Formats/Radoub.Formats/Tokens/ColorTokenEncoder.cs
@@ -29,9 +29,7 @@ public static class ColorTokenEncoder
         "\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF" + // 224-239
         "\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF";  // 240-255
 
-    /// <summary>
-    /// Encode RGB values to a NWN color tag.
-    /// </summary>
+    /// <summary>Encode RGB values to a NWN color tag.</summary>
     /// <param name="red">Red component (0-255)</param>
     /// <param name="green">Green component (0-255)</param>
     /// <param name="blue">Blue component (0-255)</param>
@@ -60,9 +58,7 @@ public static class ColorTokenEncoder
         return $"<c{EscapeColorByte(red)}{EscapeColorByte(green)}{EscapeColorByte(blue)}>";
     }
 
-    /// <summary>
-    /// Escape a color byte value for NWN:EE format.
-    /// </summary>
+    /// <summary>Escape a color byte value for NWN:EE format.</summary>
     private static string EscapeColorByte(byte value)
     {
         if (value < 32)
@@ -73,9 +69,7 @@ public static class ColorTokenEncoder
         return ((char)value).ToString();
     }
 
-    /// <summary>
-    /// Decode a 3-character RGB sequence from a color tag.
-    /// </summary>
+    /// <summary>Decode a 3-character RGB sequence from a color tag.</summary>
     /// <param name="rgbChars">The 3 characters after "&lt;c"</param>
     /// <param name="red">Decoded red component</param>
     /// <param name="green">Decoded green component</param>
@@ -146,14 +140,10 @@ public static class ColorTokenEncoder
         return false;
     }
 
-    /// <summary>
-    /// Get the close tag for color tokens.
-    /// </summary>
+    /// <summary>Get the close tag for color tokens.</summary>
     public static string GetCloseTag() => "</c>";
 
-    /// <summary>
-    /// Create a complete colored text string.
-    /// </summary>
+    /// <summary>Create a complete colored text string.</summary>
     /// <param name="text">Text to colorize</param>
     /// <param name="red">Red component (0-255)</param>
     /// <param name="green">Green component (0-255)</param>
@@ -164,9 +154,7 @@ public static class ColorTokenEncoder
         return $"{EncodeColorTag(red, green, blue)}{text}</c>";
     }
 
-    /// <summary>
-    /// Parse a hex color string to RGB components.
-    /// </summary>
+    /// <summary>Parse a hex color string to RGB components.</summary>
     /// <param name="hex">Hex color (e.g., "#FF0000" or "FF0000")</param>
     /// <param name="red">Parsed red component</param>
     /// <param name="green">Parsed green component</param>

--- a/Radoub.Formats/Radoub.Formats/Tokens/CustomTokenConfig.cs
+++ b/Radoub.Formats/Radoub.Formats/Tokens/CustomTokenConfig.cs
@@ -9,43 +9,27 @@ public class CustomTokenConfig
     public List<CustomTokenDefinition> Tokens { get; set; } = new();
 }
 
-/// <summary>
-/// A single custom token definition — standalone or paired.
-/// </summary>
+/// <summary>A single custom token definition — standalone or paired.</summary>
 public class CustomTokenDefinition
 {
-    /// <summary>
-    /// Display name shown in the token chooser UI.
-    /// </summary>
+    /// <summary>Display name shown in the token chooser UI.</summary>
     public string Name { get; set; } = "";
 
-    /// <summary>
-    /// Token type: "standalone" or "paired".
-    /// </summary>
+    /// <summary>Token type: "standalone" or "paired".</summary>
     public string Type { get; set; } = "standalone";
 
-    /// <summary>
-    /// The CUSTOM tag for standalone tokens (e.g., "&lt;CUSTOM500&gt;").
-    /// </summary>
+    /// <summary>The CUSTOM tag for standalone tokens (e.g., "&lt;CUSTOM500&gt;").</summary>
     public string? Tag { get; set; }
 
-    /// <summary>
-    /// The opening CUSTOM tag for paired tokens (e.g., "&lt;CUSTOM2001&gt;").
-    /// </summary>
+    /// <summary>The opening CUSTOM tag for paired tokens (e.g., "&lt;CUSTOM2001&gt;").</summary>
     public string? OpenTag { get; set; }
 
-    /// <summary>
-    /// The closing CUSTOM tag for paired tokens (e.g., "&lt;CUSTOM2000&gt;").
-    /// </summary>
+    /// <summary>The closing CUSTOM tag for paired tokens (e.g., "&lt;CUSTOM2000&gt;").</summary>
     public string? CloseTag { get; set; }
 
-    /// <summary>
-    /// Whether this is a standalone token (single tag insert).
-    /// </summary>
+    /// <summary>Whether this is a standalone token (single tag insert).</summary>
     public bool IsStandalone => Type?.Equals("standalone", StringComparison.OrdinalIgnoreCase) == true;
 
-    /// <summary>
-    /// Whether this is a paired token (open/close wrapping).
-    /// </summary>
+    /// <summary>Whether this is a paired token (open/close wrapping).</summary>
     public bool IsPaired => Type?.Equals("paired", StringComparison.OrdinalIgnoreCase) == true;
 }

--- a/Radoub.Formats/Radoub.Formats/Tokens/CustomTokenConfigLoader.cs
+++ b/Radoub.Formats/Radoub.Formats/Tokens/CustomTokenConfigLoader.cs
@@ -23,9 +23,7 @@ public static class CustomTokenConfigLoader
 
     private static readonly Regex CustomTagPattern = new(@"^<CUSTOM\d+>$", RegexOptions.Compiled);
 
-    /// <summary>
-    /// Get the default configuration file path.
-    /// </summary>
+    /// <summary>Get the default configuration file path.</summary>
     public static string GetDefaultConfigPath()
     {
         var homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
@@ -61,17 +59,13 @@ public static class CustomTokenConfigLoader
         }
     }
 
-    /// <summary>
-    /// Load configuration from the default path, creating empty default if not exists.
-    /// </summary>
+    /// <summary>Load configuration from the default path, creating empty default if not exists.</summary>
     public static CustomTokenConfig LoadOrCreateDefault()
     {
         return LoadOrCreateDefault(GetDefaultConfigPath());
     }
 
-    /// <summary>
-    /// Load configuration from a specific path, creating empty default if not exists.
-    /// </summary>
+    /// <summary>Load configuration from a specific path, creating empty default if not exists.</summary>
     public static CustomTokenConfig LoadOrCreateDefault(string path)
     {
         if (File.Exists(path))
@@ -82,9 +76,7 @@ public static class CustomTokenConfigLoader
         return config;
     }
 
-    /// <summary>
-    /// Save configuration to a specific path.
-    /// </summary>
+    /// <summary>Save configuration to a specific path.</summary>
     public static void Save(CustomTokenConfig config, string path)
     {
         var json = JsonSerializer.Serialize(config, JsonOptions);

--- a/Radoub.Formats/Radoub.Formats/Tokens/TokenDefinitions.cs
+++ b/Radoub.Formats/Radoub.Formats/Tokens/TokenDefinitions.cs
@@ -80,9 +80,7 @@ public static class TokenDefinitions
         "quarterday"
     };
 
-    /// <summary>
-    /// Standard tokens organized by category for UI display.
-    /// </summary>
+    /// <summary>Standard tokens organized by category for UI display.</summary>
     public static readonly Dictionary<string, string[]> TokensByCategory = new()
     {
         ["Name"] = new[]
@@ -117,9 +115,7 @@ public static class TokenDefinitions
         }
     };
 
-    /// <summary>
-    /// Hash set for O(1) lookup of standard tokens.
-    /// </summary>
+    /// <summary>Hash set for O(1) lookup of standard tokens.</summary>
     public static readonly HashSet<string> StandardTokenSet =
         new(StandardTokens, StringComparer.Ordinal);
 
@@ -172,17 +168,13 @@ public static class TokenDefinitions
         ["bitch/bastard"] = "wretch"
     };
 
-    /// <summary>
-    /// Check if a token name is a standard Aurora token.
-    /// </summary>
+    /// <summary>Check if a token name is a standard Aurora token.</summary>
     public static bool IsStandardToken(string tokenName)
     {
         return StandardTokenSet.Contains(tokenName);
     }
 
-    /// <summary>
-    /// Check if a token name is a CUSTOM token (CUSTOM0-CUSTOM9 or higher).
-    /// </summary>
+    /// <summary>Check if a token name is a CUSTOM token (CUSTOM0-CUSTOM9 or higher).</summary>
     public static bool IsCustomToken(string tokenName, out int tokenNumber)
     {
         tokenNumber = -1;
@@ -192,9 +184,7 @@ public static class TokenDefinitions
         return int.TryParse(tokenName.AsSpan(6), out tokenNumber) && tokenNumber >= 0;
     }
 
-    /// <summary>
-    /// Highlight token opening tags.
-    /// </summary>
+    /// <summary>Highlight token opening tags.</summary>
     public static readonly Dictionary<string, HighlightType> HighlightOpenTags = new(StringComparer.OrdinalIgnoreCase)
     {
         ["<StartAction>"] = HighlightType.Action,
@@ -202,24 +192,16 @@ public static class TokenDefinitions
         ["<StartHighlight>"] = HighlightType.Highlight
     };
 
-    /// <summary>
-    /// Closing tag for all highlight tokens.
-    /// </summary>
+    /// <summary>Closing tag for all highlight tokens.</summary>
     public const string HighlightCloseTag = "</Start>";
 
-    /// <summary>
-    /// Alternative closing tag (some content uses this).
-    /// </summary>
+    /// <summary>Alternative closing tag (some content uses this).</summary>
     public const string HighlightCloseTagAlt = "<End>";
 
-    /// <summary>
-    /// Color token close tag.
-    /// </summary>
+    /// <summary>Color token close tag.</summary>
     public const string ColorCloseTag = "</c>";
 
-    /// <summary>
-    /// Example text shown when selecting highlight tokens in the UI.
-    /// </summary>
+    /// <summary>Example text shown when selecting highlight tokens in the UI.</summary>
     public static readonly Dictionary<HighlightType, string> HighlightExamples = new()
     {
         [HighlightType.Action] = "[Character waves]",
@@ -227,9 +209,7 @@ public static class TokenDefinitions
         [HighlightType.Highlight] = "[Important text]"
     };
 
-    /// <summary>
-    /// Display colors for highlight tokens (Aurora Engine defaults).
-    /// </summary>
+    /// <summary>Display colors for highlight tokens (Aurora Engine defaults).</summary>
     public static readonly Dictionary<HighlightType, string> HighlightColors = new()
     {
         [HighlightType.Action] = "#00FF00",    // Green

--- a/Radoub.Formats/Radoub.Formats/Tokens/TokenParser.cs
+++ b/Radoub.Formats/Radoub.Formats/Tokens/TokenParser.cs
@@ -23,25 +23,19 @@ public class TokenParser
         @"<c(.{3,})>(.*?)</c>",
         RegexOptions.Compiled | RegexOptions.Singleline);
 
-    /// <summary>
-    /// Create a parser without user color configuration.
-    /// </summary>
+    /// <summary>Create a parser without user color configuration.</summary>
     public TokenParser()
     {
     }
 
-    /// <summary>
-    /// Create a parser with user color configuration for custom token support.
-    /// </summary>
+    /// <summary>Create a parser with user color configuration for custom token support.</summary>
     /// <param name="userColorConfig">User-defined color token mappings</param>
     public TokenParser(UserColorConfig userColorConfig)
     {
         _userColorConfig = userColorConfig;
     }
 
-    /// <summary>
-    /// Parse text into a list of token segments.
-    /// </summary>
+    /// <summary>Parse text into a list of token segments.</summary>
     /// <param name="text">Text to parse</param>
     /// <returns>List of token segments in order</returns>
     public List<TokenSegment> Parse(string text)
@@ -77,9 +71,7 @@ public class TokenParser
         return segments;
     }
 
-    /// <summary>
-    /// Parse text and return only the display text (tokens replaced with their content).
-    /// </summary>
+    /// <summary>Parse text and return only the display text (tokens replaced with their content).</summary>
     /// <param name="text">Text to parse</param>
     /// <returns>Display text with tokens expanded</returns>
     public string GetDisplayText(string text)
@@ -231,13 +223,11 @@ public class TokenParser
 
             var tokenName = match.Groups[1].Value;
 
-            // Check if it's a standard token
             if (TokenDefinitions.IsStandardToken(tokenName))
             {
                 segments.Add(new StandardToken(match.Value, tokenName, match.Index));
                 MarkProcessed(processed, match.Index, match.Length);
             }
-            // Check if it's a CUSTOM token
             else if (TokenDefinitions.IsCustomToken(tokenName, out int tokenNumber))
             {
                 segments.Add(new CustomToken(match.Value, tokenNumber, match.Index));
@@ -295,14 +285,10 @@ public class TokenParser
     }
 }
 
-/// <summary>
-/// Configuration for user-defined color tokens using CUSTOM token numbers.
-/// </summary>
+/// <summary>Configuration for user-defined color tokens using CUSTOM token numbers.</summary>
 public class UserColorConfig
 {
-    /// <summary>
-    /// The close token that ends all colored text (e.g., "&lt;CUSTOM1000&gt;").
-    /// </summary>
+    /// <summary>The close token that ends all colored text (e.g., "&lt;CUSTOM1000&gt;").</summary>
     public string CloseToken { get; set; } = "";
 
     /// <summary>
@@ -319,9 +305,7 @@ public class UserColorConfig
     /// </summary>
     public Dictionary<string, string> ColorHexValues { get; set; } = new();
 
-    /// <summary>
-    /// Get the hex color for a named color.
-    /// </summary>
+    /// <summary>Get the hex color for a named color.</summary>
     public string? GetHexColor(string colorName)
     {
         return ColorHexValues.TryGetValue(colorName, out var hex) ? hex : null;

--- a/Radoub.Formats/Radoub.Formats/Tokens/TokenSegment.cs
+++ b/Radoub.Formats/Radoub.Formats/Tokens/TokenSegment.cs
@@ -6,24 +6,14 @@ namespace Radoub.Formats.Tokens;
 /// </summary>
 public abstract class TokenSegment
 {
-    /// <summary>
-    /// The raw text of this segment (including token markers for tokens).
-    /// </summary>
+    /// <summary>The raw text of this segment (including token markers for tokens).</summary>
     public string RawText { get; }
 
-    /// <summary>
-    /// The display text (token content or plain text).
-    /// </summary>
+    /// <summary>The display text (token content or plain text).</summary>
     public abstract string DisplayText { get; }
 
-    /// <summary>
-    /// Starting index in the original string.
-    /// </summary>
     public int StartIndex { get; }
 
-    /// <summary>
-    /// Length in the original string.
-    /// </summary>
     public int Length => RawText.Length;
 
     protected TokenSegment(string rawText, int startIndex)
@@ -33,9 +23,7 @@ public abstract class TokenSegment
     }
 }
 
-/// <summary>
-/// Plain text segment with no token formatting.
-/// </summary>
+/// <summary>Plain text segment with no token formatting.</summary>
 public class PlainTextSegment : TokenSegment
 {
     public override string DisplayText => RawText;
@@ -52,9 +40,7 @@ public class PlainTextSegment : TokenSegment
 /// </summary>
 public class StandardToken : TokenSegment
 {
-    /// <summary>
-    /// The token name without angle brackets (e.g., "FirstName", "Boy/Girl").
-    /// </summary>
+    /// <summary>The token name without angle brackets (e.g., "FirstName", "Boy/Girl").</summary>
     public string TokenName { get; }
 
     public override string DisplayText => TokenName;
@@ -72,14 +58,10 @@ public class StandardToken : TokenSegment
 /// </summary>
 public class CustomToken : TokenSegment
 {
-    /// <summary>
-    /// The custom token number (0-9 for standard, higher for module-defined).
-    /// </summary>
+    /// <summary>The custom token number (0-9 for standard, higher for module-defined).</summary>
     public int TokenNumber { get; }
 
-    /// <summary>
-    /// The token name (e.g., "CUSTOM0", "CUSTOM1001").
-    /// </summary>
+    /// <summary>The token name (e.g., "CUSTOM0", "CUSTOM1001").</summary>
     public string TokenName { get; }
 
     public override string DisplayText => TokenName;
@@ -98,26 +80,17 @@ public class CustomToken : TokenSegment
 /// </summary>
 public class HighlightToken : TokenSegment
 {
-    /// <summary>
-    /// Type of highlight (Action, Check, Highlight).
-    /// </summary>
+    /// <summary>Type of highlight (Action, Check, Highlight).</summary>
     public HighlightType Type { get; }
 
-    /// <summary>
-    /// The text content inside the highlight tags.
-    /// </summary>
     public string Content { get; }
 
     public override string DisplayText => Content;
 
-    /// <summary>
-    /// The opening tag (e.g., "&lt;StartAction&gt;").
-    /// </summary>
+    /// <summary>The opening tag (e.g., "&lt;StartAction&gt;").</summary>
     public string OpenTag { get; }
 
-    /// <summary>
-    /// The closing tag ("&lt;/Start&gt;").
-    /// </summary>
+    /// <summary>The closing tag ("&lt;/Start&gt;").</summary>
     public string CloseTag { get; }
 
     public HighlightToken(string rawText, HighlightType type, string content,
@@ -131,9 +104,7 @@ public class HighlightToken : TokenSegment
     }
 }
 
-/// <summary>
-/// Types of highlight tokens in Aurora Engine.
-/// </summary>
+/// <summary>Types of highlight tokens in Aurora Engine.</summary>
 public enum HighlightType
 {
     /// <summary>
@@ -161,36 +132,23 @@ public enum HighlightType
 /// </summary>
 public class ColorToken : TokenSegment
 {
-    /// <summary>
-    /// Red component (0-255).
-    /// </summary>
+    /// <summary>Red component (0-255).</summary>
     public byte Red { get; }
 
-    /// <summary>
-    /// Green component (0-255).
-    /// </summary>
+    /// <summary>Green component (0-255).</summary>
     public byte Green { get; }
 
-    /// <summary>
-    /// Blue component (0-255).
-    /// </summary>
+    /// <summary>Blue component (0-255).</summary>
     public byte Blue { get; }
 
-    /// <summary>
-    /// The text content inside the color tags.
-    /// </summary>
     public string Content { get; }
 
     public override string DisplayText => Content;
 
-    /// <summary>
-    /// The opening tag (e.g., "&lt;cRGB&gt;").
-    /// </summary>
+    /// <summary>The opening tag (e.g., "&lt;cRGB&gt;").</summary>
     public string OpenTag { get; }
 
-    /// <summary>
-    /// The closing tag ("&lt;/c&gt;").
-    /// </summary>
+    /// <summary>The closing tag ("&lt;/c&gt;").</summary>
     public string CloseTag { get; }
 
     public ColorToken(string rawText, byte red, byte green, byte blue,
@@ -205,9 +163,7 @@ public class ColorToken : TokenSegment
         CloseTag = closeTag;
     }
 
-    /// <summary>
-    /// Get the color as a hex string (e.g., "#FF0000").
-    /// </summary>
+    /// <summary>Get the color as a hex string (e.g., "#FF0000").</summary>
     public string ToHexColor() => $"#{Red:X2}{Green:X2}{Blue:X2}";
 }
 
@@ -217,31 +173,20 @@ public class ColorToken : TokenSegment
 /// </summary>
 public class UserColorToken : TokenSegment
 {
-    /// <summary>
-    /// The color name from user configuration (e.g., "Red", "Gold").
-    /// </summary>
+    /// <summary>The color name from user configuration (e.g., "Red", "Gold").</summary>
     public string ColorName { get; }
 
-    /// <summary>
-    /// The text content between the color tokens.
-    /// </summary>
     public string Content { get; }
 
-    /// <summary>
-    /// The hex color value from configuration (e.g., "#FF0000").
-    /// </summary>
+    /// <summary>The hex color value from configuration (e.g., "#FF0000").</summary>
     public string HexColor { get; }
 
     public override string DisplayText => Content;
 
-    /// <summary>
-    /// The opening token (e.g., "&lt;CUSTOM1001&gt;").
-    /// </summary>
+    /// <summary>The opening token (e.g., "&lt;CUSTOM1001&gt;").</summary>
     public string OpenToken { get; }
 
-    /// <summary>
-    /// The closing token (e.g., "&lt;CUSTOM1000&gt;").
-    /// </summary>
+    /// <summary>The closing token (e.g., "&lt;CUSTOM1000&gt;").</summary>
     public string CloseToken { get; }
 
     public UserColorToken(string rawText, string colorName, string content,

--- a/Radoub.Formats/Radoub.Formats/Tokens/UserColorConfigLoader.cs
+++ b/Radoub.Formats/Radoub.Formats/Tokens/UserColorConfigLoader.cs
@@ -20,9 +20,7 @@ public static class UserColorConfigLoader
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
-    /// <summary>
-    /// Get the default configuration file path.
-    /// </summary>
+    /// <summary>Get the default configuration file path.</summary>
     public static string GetDefaultConfigPath()
     {
         var homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
@@ -64,9 +62,7 @@ public static class UserColorConfigLoader
         }
     }
 
-    /// <summary>
-    /// Load configuration, creating default if not exists.
-    /// </summary>
+    /// <summary>Load configuration, creating default if not exists.</summary>
     public static UserColorConfig LoadOrCreateDefault()
     {
         var config = Load();
@@ -78,17 +74,13 @@ public static class UserColorConfigLoader
         return config;
     }
 
-    /// <summary>
-    /// Save configuration to the default path.
-    /// </summary>
+    /// <summary>Save configuration to the default path.</summary>
     public static void Save(UserColorConfig config)
     {
         Save(config, GetDefaultConfigPath());
     }
 
-    /// <summary>
-    /// Save configuration to a specific path.
-    /// </summary>
+    /// <summary>Save configuration to a specific path.</summary>
     public static void Save(UserColorConfig config, string path)
     {
         var fileConfig = ConvertToFile(config);
@@ -103,9 +95,7 @@ public static class UserColorConfigLoader
         File.WriteAllText(path, json);
     }
 
-    /// <summary>
-    /// Check if a configuration file exists.
-    /// </summary>
+    /// <summary>Check if a configuration file exists.</summary>
     public static bool ConfigExists()
     {
         return File.Exists(GetDefaultConfigPath());
@@ -154,44 +144,28 @@ public static class UserColorConfigLoader
     }
 }
 
-/// <summary>
-/// JSON file format for user color configuration.
-/// </summary>
+/// <summary>JSON file format for user color configuration.</summary>
 internal class UserColorConfigFile
 {
-    /// <summary>
-    /// Human-readable description of the file purpose.
-    /// </summary>
+    /// <summary>Human-readable description of the file purpose.</summary>
     public string? Description { get; set; }
 
-    /// <summary>
-    /// The close token that ends colored text.
-    /// </summary>
+    /// <summary>The close token that ends colored text.</summary>
     public string? CloseToken { get; set; }
 
-    /// <summary>
-    /// List of color definitions.
-    /// </summary>
+    /// <summary>List of color definitions.</summary>
     public List<ColorDefinition>? Colors { get; set; }
 }
 
-/// <summary>
-/// A single color definition in the config file.
-/// </summary>
+/// <summary>A single color definition in the config file.</summary>
 internal class ColorDefinition
 {
-    /// <summary>
-    /// Display name for the color (e.g., "Red", "Gold").
-    /// </summary>
+    /// <summary>Display name for the color (e.g., "Red", "Gold").</summary>
     public string Name { get; set; } = "";
 
-    /// <summary>
-    /// The CUSTOM token to insert (e.g., "&lt;CUSTOM1001&gt;").
-    /// </summary>
+    /// <summary>The CUSTOM token to insert (e.g., "&lt;CUSTOM1001&gt;").</summary>
     public string Token { get; set; } = "";
 
-    /// <summary>
-    /// Hex color for display preview (e.g., "#FF0000").
-    /// </summary>
+    /// <summary>Hex color for display preview (e.g., "#FF0000").</summary>
     public string HexColor { get; set; } = "#FFFFFF";
 }

--- a/Radoub.Formats/Radoub.Formats/Utc/UtcFile.cs
+++ b/Radoub.Formats/Radoub.Formats/Utc/UtcFile.cs
@@ -14,87 +14,56 @@ namespace Radoub.Formats.Utc;
 /// </summary>
 public class UtcFile
 {
-    /// <summary>
-    /// File type signature - should be "UTC "
-    /// </summary>
+    /// <summary>File type signature - should be "UTC "</summary>
     public string FileType { get; set; } = "UTC ";
 
-    /// <summary>
-    /// File version - typically "V3.2"
-    /// </summary>
+    /// <summary>File version - typically "V3.2"</summary>
     public string FileVersion { get; set; } = "V3.2";
 
     // Blueprint-only fields (Table 2.2)
 
-    /// <summary>
-    /// Blueprint resource reference (should match filename)
-    /// </summary>
+    /// <summary>Blueprint resource reference (should match filename)</summary>
     public string TemplateResRef { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Module designer comment (blueprint only)
-    /// </summary>
+    /// <summary>Module designer comment (blueprint only)</summary>
     public string Comment { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Palette ID for toolset organization (blueprint only)
-    /// </summary>
+    /// <summary>Palette ID for toolset organization (blueprint only)</summary>
     public byte PaletteID { get; set; }
 
     // Identity fields (Table 2.1.1)
 
-    /// <summary>
-    /// First name (localized)
-    /// </summary>
+    /// <summary>First name (localized)</summary>
     public CExoLocString FirstName { get; set; } = new();
 
-    /// <summary>
-    /// Last name (localized)
-    /// </summary>
+    /// <summary>Last name (localized)</summary>
     public CExoLocString LastName { get; set; } = new();
 
-    /// <summary>
-    /// Tag of this creature
-    /// </summary>
     public string Tag { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Description of the creature (Examine action)
-    /// </summary>
+    /// <summary>Description of the creature (Examine action)</summary>
     public CExoLocString Description { get; set; } = new();
 
     // Basic info fields
 
-    /// <summary>
-    /// Index into racialtypes.2da
-    /// </summary>
+    /// <summary>Index into racialtypes.2da</summary>
     public byte Race { get; set; }
 
-    /// <summary>
-    /// Index into gender.2da (0 = male, 1 = female)
-    /// </summary>
+    /// <summary>Index into gender.2da (0 = male, 1 = female)</summary>
     public byte Gender { get; set; }
 
-    /// <summary>
-    /// Subrace string (not used by game, scripts can check)
-    /// </summary>
+    /// <summary>Subrace string (not used by game, scripts can check)</summary>
     public string Subrace { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Name of the creature's deity
-    /// </summary>
+    /// <summary>Name of the creature's deity</summary>
     public string Deity { get; set; } = string.Empty;
 
     // Appearance fields
 
-    /// <summary>
-    /// Index into appearance.2da
-    /// </summary>
+    /// <summary>Index into appearance.2da</summary>
     public ushort AppearanceType { get; set; }
 
-    /// <summary>
-    /// Phenotype (0 = normal, 1 = fat) - only for MODELTYPE "P" in appearance.2da
-    /// </summary>
+    /// <summary>Phenotype (0 = normal, 1 = fat) - only for MODELTYPE "P" in appearance.2da</summary>
     public int Phenotype { get; set; }
 
     /// <summary>
@@ -109,19 +78,13 @@ public class UtcFile
     /// </summary>
     public string Portrait { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Index into tailmodel.2da
-    /// </summary>
+    /// <summary>Index into tailmodel.2da</summary>
     public byte Tail { get; set; }
 
-    /// <summary>
-    /// Index into wingmodel.2da
-    /// </summary>
+    /// <summary>Index into wingmodel.2da</summary>
     public byte Wings { get; set; }
 
-    /// <summary>
-    /// Index into bodybag.2da
-    /// </summary>
+    /// <summary>Index into bodybag.2da</summary>
     public byte BodyBag { get; set; }
 
     // Body part fields (for dynamic/part-based appearances)
@@ -129,499 +92,219 @@ public class UtcFile
     // Values index into model_*.2da files (e.g., model_heads, model_torso, etc.)
     // CEP/PRC can add custom parts, so don't hardcode limits
 
-    /// <summary>
-    /// Head appearance index (Appearance_Head field)
-    /// </summary>
+    /// <summary>Head appearance index (Appearance_Head field)</summary>
     public byte AppearanceHead { get; set; }
 
-    /// <summary>
-    /// Body part: Belt
-    /// </summary>
     public byte BodyPart_Belt { get; set; }
-
-    /// <summary>
-    /// Body part: Left Bicep
-    /// </summary>
     public byte BodyPart_LBicep { get; set; }
-
-    /// <summary>
-    /// Body part: Right Bicep
-    /// </summary>
     public byte BodyPart_RBicep { get; set; }
-
-    /// <summary>
-    /// Body part: Left Forearm
-    /// </summary>
     public byte BodyPart_LFArm { get; set; }
-
-    /// <summary>
-    /// Body part: Right Forearm
-    /// </summary>
     public byte BodyPart_RFArm { get; set; }
-
-    /// <summary>
-    /// Body part: Left Foot
-    /// </summary>
     public byte BodyPart_LFoot { get; set; }
-
-    /// <summary>
-    /// Body part: Right Foot
-    /// </summary>
     public byte BodyPart_RFoot { get; set; }
-
-    /// <summary>
-    /// Body part: Left Hand
-    /// </summary>
     public byte BodyPart_LHand { get; set; }
-
-    /// <summary>
-    /// Body part: Right Hand
-    /// </summary>
     public byte BodyPart_RHand { get; set; }
-
-    /// <summary>
-    /// Body part: Left Shin
-    /// </summary>
     public byte BodyPart_LShin { get; set; }
-
-    /// <summary>
-    /// Body part: Right Shin
-    /// </summary>
     public byte BodyPart_RShin { get; set; }
-
-    /// <summary>
-    /// Body part: Left Shoulder
-    /// </summary>
     public byte BodyPart_LShoul { get; set; }
-
-    /// <summary>
-    /// Body part: Right Shoulder
-    /// </summary>
     public byte BodyPart_RShoul { get; set; }
-
-    /// <summary>
-    /// Body part: Left Thigh
-    /// </summary>
     public byte BodyPart_LThigh { get; set; }
-
-    /// <summary>
-    /// Body part: Right Thigh
-    /// </summary>
     public byte BodyPart_RThigh { get; set; }
-
-    /// <summary>
-    /// Body part: Neck
-    /// </summary>
     public byte BodyPart_Neck { get; set; }
-
-    /// <summary>
-    /// Body part: Pelvis
-    /// </summary>
     public byte BodyPart_Pelvis { get; set; }
-
-    /// <summary>
-    /// Body part: Torso
-    /// </summary>
     public byte BodyPart_Torso { get; set; }
 
     // Colors (for part-based appearances)
 
-    /// <summary>
-    /// Skin color index into pal_skin01.tga palette.
-    /// </summary>
+    /// <summary>Skin color index into pal_skin01.tga palette.</summary>
     public byte Color_Skin { get; set; }
 
-    /// <summary>
-    /// Hair color index into pal_hair01.tga palette.
-    /// </summary>
+    /// <summary>Hair color index into pal_hair01.tga palette.</summary>
     public byte Color_Hair { get; set; }
 
-    /// <summary>
-    /// Tattoo 1 color index into pal_tattoo01.tga palette.
-    /// </summary>
+    /// <summary>Tattoo 1 color index into pal_tattoo01.tga palette.</summary>
     public byte Color_Tattoo1 { get; set; }
 
-    /// <summary>
-    /// Tattoo 2 color index into pal_tattoo01.tga palette.
-    /// </summary>
+    /// <summary>Tattoo 2 color index into pal_tattoo01.tga palette.</summary>
     public byte Color_Tattoo2 { get; set; }
 
     // Armor Part Appearance (game instance fields - copied from equipped armor)
     // These override BodyPart fields when armor is equipped
 
-    /// <summary>
-    /// Armor appearance: Belt (from equipped armor)
-    /// </summary>
     public byte ArmorPart_Belt { get; set; }
-
-    /// <summary>
-    /// Armor appearance: Left Bicep (from equipped armor)
-    /// </summary>
     public byte ArmorPart_LBicep { get; set; }
-
-    /// <summary>
-    /// Armor appearance: Right Bicep (from equipped armor)
-    /// </summary>
     public byte ArmorPart_RBicep { get; set; }
-
-    /// <summary>
-    /// Armor appearance: Left Forearm (from equipped armor)
-    /// </summary>
     public byte ArmorPart_LFArm { get; set; }
-
-    /// <summary>
-    /// Armor appearance: Right Forearm (from equipped armor)
-    /// </summary>
     public byte ArmorPart_RFArm { get; set; }
-
-    /// <summary>
-    /// Armor appearance: Left Foot (from equipped armor)
-    /// </summary>
     public byte ArmorPart_LFoot { get; set; }
-
-    /// <summary>
-    /// Armor appearance: Right Foot (from equipped armor)
-    /// </summary>
     public byte ArmorPart_RFoot { get; set; }
-
-    /// <summary>
-    /// Armor appearance: Left Hand (from equipped armor)
-    /// </summary>
     public byte ArmorPart_LHand { get; set; }
-
-    /// <summary>
-    /// Armor appearance: Right Hand (from equipped armor)
-    /// </summary>
     public byte ArmorPart_RHand { get; set; }
-
-    /// <summary>
-    /// Armor appearance: Left Shin (from equipped armor)
-    /// </summary>
     public byte ArmorPart_LShin { get; set; }
-
-    /// <summary>
-    /// Armor appearance: Right Shin (from equipped armor)
-    /// </summary>
     public byte ArmorPart_RShin { get; set; }
-
-    /// <summary>
-    /// Armor appearance: Left Shoulder (from equipped armor)
-    /// </summary>
     public byte ArmorPart_LShoul { get; set; }
-
-    /// <summary>
-    /// Armor appearance: Right Shoulder (from equipped armor)
-    /// </summary>
     public byte ArmorPart_RShoul { get; set; }
-
-    /// <summary>
-    /// Armor appearance: Left Thigh (from equipped armor)
-    /// </summary>
     public byte ArmorPart_LThigh { get; set; }
-
-    /// <summary>
-    /// Armor appearance: Right Thigh (from equipped armor)
-    /// </summary>
     public byte ArmorPart_RThigh { get; set; }
-
-    /// <summary>
-    /// Armor appearance: Neck (from equipped armor)
-    /// </summary>
     public byte ArmorPart_Neck { get; set; }
-
-    /// <summary>
-    /// Armor appearance: Pelvis (from equipped armor)
-    /// </summary>
     public byte ArmorPart_Pelvis { get; set; }
-
-    /// <summary>
-    /// Armor appearance: Torso (from equipped armor)
-    /// </summary>
     public byte ArmorPart_Torso { get; set; }
-
-    /// <summary>
-    /// Armor appearance: Robe (from equipped armor)
-    /// </summary>
     public byte ArmorPart_Robe { get; set; }
 
-    // Ability scores
+    // Ability scores (before bonuses)
 
-    /// <summary>
-    /// Strength ability score (before bonuses)
-    /// </summary>
     public byte Str { get; set; } = 10;
-
-    /// <summary>
-    /// Dexterity ability score (before bonuses)
-    /// </summary>
     public byte Dex { get; set; } = 10;
-
-    /// <summary>
-    /// Constitution ability score (before bonuses)
-    /// </summary>
     public byte Con { get; set; } = 10;
-
-    /// <summary>
-    /// Intelligence ability score (before bonuses)
-    /// </summary>
     public byte Int { get; set; } = 10;
-
-    /// <summary>
-    /// Wisdom ability score (before bonuses)
-    /// </summary>
     public byte Wis { get; set; } = 10;
-
-    /// <summary>
-    /// Charisma ability score (before bonuses)
-    /// </summary>
     public byte Cha { get; set; } = 10;
 
     // Hit points
 
-    /// <summary>
-    /// Base maximum hit points (before bonuses)
-    /// </summary>
+    /// <summary>Base maximum hit points (before bonuses)</summary>
     public short HitPoints { get; set; }
 
-    /// <summary>
-    /// Current hit points
-    /// </summary>
     public short CurrentHitPoints { get; set; }
 
-    /// <summary>
-    /// Maximum hit points (after all bonuses)
-    /// </summary>
+    /// <summary>Maximum hit points (after all bonuses)</summary>
     public short MaxHitPoints { get; set; }
 
     // Combat
 
-    /// <summary>
-    /// Natural AC bonus
-    /// </summary>
+    /// <summary>Natural AC bonus</summary>
     public byte NaturalAC { get; set; }
 
-    /// <summary>
-    /// Calculated challenge rating (see Section 3.1)
-    /// </summary>
+    /// <summary>Calculated challenge rating (see Section 3.1)</summary>
     public float ChallengeRating { get; set; }
 
-    /// <summary>
-    /// Adjustment to challenge rating
-    /// </summary>
+    /// <summary>Adjustment to challenge rating</summary>
     public int CRAdjust { get; set; }
 
     // Saving throw bonuses
 
-    /// <summary>
-    /// Fortitude save bonus
-    /// </summary>
     public short FortBonus { get; set; }
-
-    /// <summary>
-    /// Reflex save bonus
-    /// </summary>
     public short RefBonus { get; set; }
-
-    /// <summary>
-    /// Will save bonus
-    /// </summary>
     public short WillBonus { get; set; }
 
     // Alignment
 
-    /// <summary>
-    /// Good-Evil axis (0 = most Evil, 100 = most Good)
-    /// </summary>
+    /// <summary>Good-Evil axis (0 = most Evil, 100 = most Good)</summary>
     public byte GoodEvil { get; set; } = 50;
 
-    /// <summary>
-    /// Law-Chaos axis (0 = most Chaotic, 100 = most Lawful)
-    /// </summary>
+    /// <summary>Law-Chaos axis (0 = most Chaotic, 100 = most Lawful)</summary>
     public byte LawfulChaotic { get; set; } = 50;
 
     // Flags
 
-    /// <summary>
-    /// True if creature is a plot creature
-    /// </summary>
     public bool Plot { get; set; }
 
-    /// <summary>
-    /// True if creature can never die
-    /// </summary>
+    /// <summary>True if creature can never die</summary>
     public bool IsImmortal { get; set; }
 
-    /// <summary>
-    /// True if creature cannot permanently die
-    /// </summary>
+    /// <summary>True if creature cannot permanently die</summary>
     public bool NoPermDeath { get; set; }
 
-    /// <summary>
-    /// True if creature is a player character
-    /// </summary>
+    /// <summary>True if creature is a player character</summary>
     public bool IsPC { get; set; }
 
-    /// <summary>
-    /// True if creature can be disarmed
-    /// </summary>
     public bool Disarmable { get; set; }
 
-    /// <summary>
-    /// True if creature leaves lootable corpse (vs bodybag)
-    /// </summary>
+    /// <summary>True if creature leaves lootable corpse (vs bodybag)</summary>
     public bool Lootable { get; set; }
 
-    /// <summary>
-    /// True if conversation can be interrupted
-    /// </summary>
+    /// <summary>True if conversation can be interrupted</summary>
     public bool Interruptable { get; set; } = true;
 
     // Behavior
 
-    /// <summary>
-    /// Faction ID (index into repute.fac FactionList)
-    /// </summary>
+    /// <summary>Faction ID (index into repute.fac FactionList)</summary>
     public ushort FactionID { get; set; }
 
-    /// <summary>
-    /// Index into ranges.2da (perception range, 9-13)
-    /// </summary>
+    /// <summary>Index into ranges.2da (perception range, 9-13)</summary>
     public byte PerceptionRange { get; set; } = 11;
 
-    /// <summary>
-    /// Index into creaturespeed.2da
-    /// </summary>
+    /// <summary>Index into creaturespeed.2da</summary>
     public int WalkRate { get; set; }
 
-    /// <summary>
-    /// Index into soundset.2da
-    /// </summary>
+    /// <summary>Index into soundset.2da</summary>
     public ushort SoundSetFile { get; set; }
 
-    /// <summary>
-    /// Milliseconds before corpse fades
-    /// </summary>
+    /// <summary>Milliseconds before corpse fades</summary>
     public uint DecayTime { get; set; } = 5000;
 
-    /// <summary>
-    /// Index into packages.2da (for LevelUpHenchman)
-    /// </summary>
+    /// <summary>Index into packages.2da (for LevelUpHenchman)</summary>
     public byte StartingPackage { get; set; }
 
-    /// <summary>
-    /// Index into hen_familiar.2da (familiar type for wizard/sorcerer)
-    /// </summary>
+    /// <summary>Index into hen_familiar.2da (familiar type for wizard/sorcerer)</summary>
     public int FamiliarType { get; set; }
 
-    /// <summary>
-    /// Custom name given to the familiar by the player.
-    /// </summary>
+    /// <summary>Custom name given to the familiar by the player.</summary>
     public string FamiliarName { get; set; } = string.Empty;
 
     // Conversation
 
-    /// <summary>
-    /// ResRef of conversation file (.dlg)
-    /// </summary>
+    /// <summary>ResRef of conversation file (.dlg)</summary>
     public string Conversation { get; set; } = string.Empty;
 
-    // Scripts
+    // Scripts — property name maps to the GFF field; comment gives the engine event
 
-    /// <summary>
-    /// OnPhysicalAttacked event script
-    /// </summary>
+    /// <summary>OnPhysicalAttacked</summary>
     public string ScriptAttacked { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnDamaged event script
-    /// </summary>
+    /// <summary>OnDamaged</summary>
     public string ScriptDamaged { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnDeath event script
-    /// </summary>
+    /// <summary>OnDeath</summary>
     public string ScriptDeath { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnConversation event script
-    /// </summary>
+    /// <summary>OnConversation</summary>
     public string ScriptDialogue { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnInventoryDisturbed event script
-    /// </summary>
+    /// <summary>OnInventoryDisturbed</summary>
     public string ScriptDisturbed { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnEndCombatRound event script
-    /// </summary>
+    /// <summary>OnEndCombatRound</summary>
     public string ScriptEndRound { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnHeartbeat event script
-    /// </summary>
+    /// <summary>OnHeartbeat</summary>
     public string ScriptHeartbeat { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnBlocked event script
-    /// </summary>
+    /// <summary>OnBlocked</summary>
     public string ScriptOnBlocked { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnPerception event script
-    /// </summary>
+    /// <summary>OnPerception</summary>
     public string ScriptOnNotice { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnRested event script
-    /// </summary>
+    /// <summary>OnRested</summary>
     public string ScriptRested { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnSpawnIn event script
-    /// </summary>
+    /// <summary>OnSpawnIn</summary>
     public string ScriptSpawn { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnSpellCastAt event script
-    /// </summary>
+    /// <summary>OnSpellCastAt</summary>
     public string ScriptSpellAt { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnUserDefined event script
-    /// </summary>
+    /// <summary>OnUserDefined</summary>
     public string ScriptUserDefine { get; set; } = string.Empty;
 
     // Lists
 
-    /// <summary>
-    /// List of creature classes (1-3 elements)
-    /// </summary>
+    /// <summary>List of creature classes (1-3 elements)</summary>
     public List<CreatureClass> ClassList { get; set; } = new();
 
-    /// <summary>
-    /// List of feats (indexes into feat.2da)
-    /// </summary>
+    /// <summary>List of feats (indexes into feat.2da)</summary>
     public List<ushort> FeatList { get; set; } = new();
 
-    /// <summary>
-    /// List of skill ranks (one per row in skills.2da)
-    /// </summary>
+    /// <summary>List of skill ranks (one per row in skills.2da)</summary>
     public List<byte> SkillList { get; set; } = new();
 
-    /// <summary>
-    /// List of special abilities
-    /// </summary>
     public List<SpecialAbility> SpecAbilityList { get; set; } = new();
 
-    /// <summary>
-    /// Inventory items (backpack contents)
-    /// </summary>
+    /// <summary>Inventory items (backpack contents)</summary>
     public List<InventoryItem> ItemList { get; set; } = new();
 
-    /// <summary>
-    /// Equipped items (mapped to equipment slots)
-    /// </summary>
+    /// <summary>Equipped items (mapped to equipment slots)</summary>
     public List<EquippedItem> EquipItemList { get; set; } = new();
 
     /// <summary>
@@ -822,14 +505,9 @@ public class UtcFile
 /// </summary>
 public class CreatureClass
 {
-    /// <summary>
-    /// Index into classes.2da
-    /// </summary>
+    /// <summary>Index into classes.2da</summary>
     public int Class { get; set; }
 
-    /// <summary>
-    /// Level in this class
-    /// </summary>
     public short ClassLevel { get; set; }
 
     /// <summary>
@@ -878,19 +556,13 @@ public class CreatureClass
 /// </summary>
 public class SpecialAbility
 {
-    /// <summary>
-    /// Index into spells.2da
-    /// </summary>
+    /// <summary>Index into spells.2da</summary>
     public ushort Spell { get; set; }
 
-    /// <summary>
-    /// Caster level to use this spell as
-    /// </summary>
+    /// <summary>Caster level to use this spell as</summary>
     public byte SpellCasterLevel { get; set; }
 
-    /// <summary>
-    /// Bit flags: 0x01=readied, 0x02=spontaneous, 0x04=unlimited
-    /// </summary>
+    /// <summary>Bit flags: 0x01=readied, 0x02=spontaneous, 0x04=unlimited</summary>
     public byte SpellFlags { get; set; } = 0x01;
 }
 
@@ -900,14 +572,10 @@ public class SpecialAbility
 /// </summary>
 public class KnownSpell
 {
-    /// <summary>
-    /// Index into spells.2da
-    /// </summary>
+    /// <summary>Index into spells.2da</summary>
     public ushort Spell { get; set; }
 
-    /// <summary>
-    /// Bit flags: 0x01=readied (always set), 0x02=spontaneous, 0x04=unlimited
-    /// </summary>
+    /// <summary>Bit flags: 0x01=readied (always set), 0x02=spontaneous, 0x04=unlimited</summary>
     public byte SpellFlags { get; set; } = 0x01;
 
     /// <summary>
@@ -923,14 +591,10 @@ public class KnownSpell
 /// </summary>
 public class MemorizedSpell
 {
-    /// <summary>
-    /// Index into spells.2da
-    /// </summary>
+    /// <summary>Index into spells.2da</summary>
     public ushort Spell { get; set; }
 
-    /// <summary>
-    /// Bit flags: 0x01=readied (always set), 0x02=spontaneous, 0x04=unlimited
-    /// </summary>
+    /// <summary>Bit flags: 0x01=readied (always set), 0x02=spontaneous, 0x04=unlimited</summary>
     public byte SpellFlags { get; set; } = 0x01;
 
     /// <summary>
@@ -952,29 +616,18 @@ public class MemorizedSpell
 /// </summary>
 public class InventoryItem
 {
-    /// <summary>
-    /// ResRef of the item blueprint (.uti)
-    /// </summary>
+    /// <summary>ResRef of the item blueprint (.uti)</summary>
     public string InventoryRes { get; set; } = string.Empty;
 
-    /// <summary>
-    /// X position in inventory grid (0-based)
-    /// </summary>
+    /// <summary>X position in inventory grid (0-based)</summary>
     public ushort Repos_PosX { get; set; }
 
-    /// <summary>
-    /// Y position in inventory grid (0-based)
-    /// </summary>
+    /// <summary>Y position in inventory grid (0-based)</summary>
     public ushort Repos_PosY { get; set; }
 
-    /// <summary>
-    /// If true, this is a dropable item (creature drops on death)
-    /// </summary>
+    /// <summary>If true, this is a dropable item (creature drops on death)</summary>
     public bool Dropable { get; set; } = true;
 
-    /// <summary>
-    /// If true, item can be pickpocketed
-    /// </summary>
     public bool Pickpocketable { get; set; }
 }
 
@@ -992,9 +645,7 @@ public class EquippedItem
     /// </summary>
     public int Slot { get; set; }
 
-    /// <summary>
-    /// ResRef of the equipped item blueprint (blueprint mode)
-    /// </summary>
+    /// <summary>ResRef of the equipped item blueprint (blueprint mode)</summary>
     public string EquipRes { get; set; } = string.Empty;
 }
 
@@ -1018,9 +669,7 @@ public static class EquipmentSlots
     public const int Bullets = 0x1000;
     public const int Bolts = 0x2000;
 
-    /// <summary>
-    /// Get human-readable name for equipment slot.
-    /// </summary>
+    /// <summary>Get human-readable name for equipment slot.</summary>
     public static string GetSlotName(int slot)
     {
         return slot switch

--- a/Radoub.Formats/Radoub.Formats/Utc/UtcReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Utc/UtcReader.cs
@@ -9,18 +9,12 @@ namespace Radoub.Formats.Utc;
 /// </summary>
 public static class UtcReader
 {
-    /// <summary>
-    /// Read a UTC file from a file path.
-    /// </summary>
     public static UtcFile Read(string filePath)
     {
         var buffer = File.ReadAllBytes(filePath);
         return Read(buffer);
     }
 
-    /// <summary>
-    /// Read a UTC file from a stream.
-    /// </summary>
     public static UtcFile Read(Stream stream)
     {
         using var ms = new MemoryStream();
@@ -28,15 +22,10 @@ public static class UtcReader
         return Read(ms.ToArray());
     }
 
-    /// <summary>
-    /// Read a UTC file from a byte buffer.
-    /// </summary>
     public static UtcFile Read(byte[] buffer)
     {
-        // Parse as GFF first
         var gff = GffReader.Read(buffer);
 
-        // Validate file type
         if (gff.FileType.TrimEnd() != "UTC")
         {
             throw new InvalidDataException(
@@ -239,13 +228,13 @@ public static class UtcReader
                 Domain2 = classStruct.GetFieldValue<byte>("Domain2", 0)
             };
 
-            // Parse known spells (KnownList0-9) - used by Bards, Sorcerers, PC Wizards
+            // KnownList0-9 - used by Bards, Sorcerers, PC Wizards
             for (int level = 0; level < 10; level++)
             {
                 ParseKnownSpellList(classStruct, creatureClass, level);
             }
 
-            // Parse memorized spells (MemorizedList0-9) - used by Wizards, Clerics, etc.
+            // MemorizedList0-9 - used by Wizards, Clerics, etc.
             for (int level = 0; level < 10; level++)
             {
                 ParseMemorizedSpellList(classStruct, creatureClass, level);

--- a/Radoub.Formats/Radoub.Formats/Utc/UtcWriter.cs
+++ b/Radoub.Formats/Radoub.Formats/Utc/UtcWriter.cs
@@ -10,27 +10,18 @@ namespace Radoub.Formats.Utc;
 /// </summary>
 public static class UtcWriter
 {
-    /// <summary>
-    /// Write a UTC file to a file path.
-    /// </summary>
     public static void Write(UtcFile utc, string filePath)
     {
         var buffer = Write(utc);
         File.WriteAllBytes(filePath, buffer);
     }
 
-    /// <summary>
-    /// Write a UTC file to a stream.
-    /// </summary>
     public static void Write(UtcFile utc, Stream stream)
     {
         var buffer = Write(utc);
         stream.Write(buffer, 0, buffer.Length);
     }
 
-    /// <summary>
-    /// Write a UTC file to a byte buffer.
-    /// </summary>
     public static byte[] Write(UtcFile utc)
     {
         var gff = BuildGffFile(utc);
@@ -233,20 +224,18 @@ public static class UtcWriter
             AddIntField(classStruct, "Class", cls.Class);
             AddShortField(classStruct, "ClassLevel", cls.ClassLevel);
 
-            // Write domains (Cleric)
+            // Domains (Cleric)
             if (cls.Domain1 != 0 || cls.Domain2 != 0)
             {
                 AddByteField(classStruct, "Domain1", cls.Domain1);
                 AddByteField(classStruct, "Domain2", cls.Domain2);
             }
 
-            // Write known spells (KnownList0-9)
             for (int level = 0; level < 10; level++)
             {
                 AddKnownSpellList(classStruct, cls.KnownSpells[level], level);
             }
 
-            // Write memorized spells (MemorizedList0-9)
             for (int level = 0; level < 10; level++)
             {
                 AddMemorizedSpellList(classStruct, cls.MemorizedSpells[level], level);

--- a/Radoub.Formats/Radoub.Formats/Utd/UtdFile.cs
+++ b/Radoub.Formats/Radoub.Formats/Utd/UtdFile.cs
@@ -9,292 +9,171 @@ namespace Radoub.Formats.Utd;
 /// </summary>
 public class UtdFile
 {
-    /// <summary>
-    /// File type signature - should be "UTD "
-    /// </summary>
+    /// <summary>File type signature - should be "UTD "</summary>
     public string FileType { get; set; } = "UTD ";
 
-    /// <summary>
-    /// File version - typically "V3.2"
-    /// </summary>
+    /// <summary>File version - typically "V3.2"</summary>
     public string FileVersion { get; set; } = "V3.2";
 
     // Identity fields
 
-    /// <summary>
-    /// Blueprint resource reference (should match filename)
-    /// </summary>
+    /// <summary>Blueprint resource reference (should match filename)</summary>
     public string TemplateResRef { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Door tag (max 32 characters)
-    /// </summary>
+    /// <summary>Door tag (max 32 characters)</summary>
     public string Tag { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Localized door name
-    /// </summary>
+    /// <summary>Localized door name</summary>
     public CExoLocString LocName { get; set; } = new();
 
-    /// <summary>
-    /// Localized description
-    /// </summary>
+    /// <summary>Localized description</summary>
     public CExoLocString Description { get; set; } = new();
 
     // Appearance
 
-    /// <summary>
-    /// Appearance ID - index into doortypes.2da (if >0, use this; if 0, use GenericType)
-    /// </summary>
+    /// <summary>Appearance ID - index into doortypes.2da (if >0, use this; if 0, use GenericType)</summary>
     public uint Appearance { get; set; }
 
-    /// <summary>
-    /// Generic door type - index into genericdoors.2da (used when Appearance=0)
-    /// </summary>
+    /// <summary>Generic door type - index into genericdoors.2da (used when Appearance=0)</summary>
     public byte GenericType { get; set; }
 
-    /// <summary>
-    /// Current animation state (0=closed, 1=opened1, 2=opened2)
-    /// </summary>
+    /// <summary>Current animation state (0=closed, 1=opened1, 2=opened2)</summary>
     public byte AnimationState { get; set; }
 
-    /// <summary>
-    /// Portrait ID - index into portraits.2da
-    /// </summary>
+    /// <summary>Portrait ID - index into portraits.2da</summary>
     public ushort PortraitId { get; set; }
 
     // Combat / Physical
 
-    /// <summary>
-    /// Maximum hit points
-    /// </summary>
+    /// <summary>Maximum hit points</summary>
     public short HP { get; set; }
 
-    /// <summary>
-    /// Current hit points
-    /// </summary>
+    /// <summary>Current hit points</summary>
     public short CurrentHP { get; set; }
 
-    /// <summary>
-    /// Damage reduction (slashing, piercing, bludgeoning)
-    /// </summary>
+    /// <summary>Damage reduction (slashing, piercing, bludgeoning)</summary>
     public byte Hardness { get; set; }
 
-    /// <summary>
-    /// Fortitude save bonus
-    /// </summary>
+    /// <summary>Fortitude save bonus</summary>
     public byte Fort { get; set; }
 
-    /// <summary>
-    /// Reflex save bonus
-    /// </summary>
+    /// <summary>Reflex save bonus</summary>
     public byte Ref { get; set; }
 
-    /// <summary>
-    /// Will save bonus
-    /// </summary>
+    /// <summary>Will save bonus</summary>
     public byte Will { get; set; }
 
-    /// <summary>
-    /// If true, door is a plot object (cannot be damaged/destroyed)
-    /// </summary>
+    /// <summary>If true, door is a plot object (cannot be damaged/destroyed)</summary>
     public bool Plot { get; set; }
 
-    /// <summary>
-    /// Faction ID from repute.fac
-    /// </summary>
+    /// <summary>Faction ID from repute.fac</summary>
     public uint Faction { get; set; }
 
-    /// <summary>
-    /// If true, conversation can be interrupted
-    /// </summary>
+    /// <summary>If true, conversation can be interrupted</summary>
     public bool Interruptable { get; set; } = true;
 
     // Lock fields
 
-    /// <summary>
-    /// If true, can be locked after unlock
-    /// </summary>
+    /// <summary>If true, can be locked after unlock</summary>
     public bool Lockable { get; set; }
 
-    /// <summary>
-    /// If true, currently locked
-    /// </summary>
+    /// <summary>If true, currently locked</summary>
     public bool Locked { get; set; }
 
-    /// <summary>
-    /// DC to unlock this door
-    /// </summary>
+    /// <summary>DC to unlock this door</summary>
     public byte OpenLockDC { get; set; }
 
-    /// <summary>
-    /// DC to lock the door
-    /// </summary>
+    /// <summary>DC to lock the door</summary>
     public byte CloseLockDC { get; set; }
 
-    /// <summary>
-    /// If true, destroy key from inventory when used
-    /// </summary>
+    /// <summary>If true, destroy key from inventory when used</summary>
     public bool AutoRemoveKey { get; set; }
 
-    /// <summary>
-    /// Tag of the key required to unlock
-    /// </summary>
+    /// <summary>Tag of the key required to unlock</summary>
     public string KeyName { get; set; } = string.Empty;
 
-    /// <summary>
-    /// If true, key is required to unlock (KeyName must be set)
-    /// </summary>
+    /// <summary>If true, key is required to unlock (KeyName must be set)</summary>
     public bool KeyRequired { get; set; }
 
     // Trap fields
 
-    /// <summary>
-    /// If true, door is trapped
-    /// </summary>
+    /// <summary>If true, door is trapped</summary>
     public bool TrapFlag { get; set; }
 
-    /// <summary>
-    /// Index into traps.2da
-    /// </summary>
+    /// <summary>Index into traps.2da</summary>
     public byte TrapType { get; set; }
 
-    /// <summary>
-    /// If true, trap can be detected
-    /// </summary>
+    /// <summary>If true, trap can be detected</summary>
     public bool TrapDetectable { get; set; } = true;
 
-    /// <summary>
-    /// DC to detect trap (1-250)
-    /// </summary>
+    /// <summary>DC to detect trap (1-250)</summary>
     public byte TrapDetectDC { get; set; }
 
-    /// <summary>
-    /// If true, trap can be disarmed
-    /// </summary>
+    /// <summary>If true, trap can be disarmed</summary>
     public bool TrapDisarmable { get; set; } = true;
 
-    /// <summary>
-    /// DC to disarm trap
-    /// </summary>
+    /// <summary>DC to disarm trap</summary>
     public byte DisarmDC { get; set; }
 
-    /// <summary>
-    /// If true, trap disappears after firing
-    /// </summary>
+    /// <summary>If true, trap disappears after firing</summary>
     public bool TrapOneShot { get; set; } = true;
 
     // Door-specific fields
 
-    /// <summary>
-    /// Tag of waypoint or door for area transition
-    /// </summary>
+    /// <summary>Tag of waypoint or door for area transition</summary>
     public string LinkedTo { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Link type: 0=no link, 1=links to door, 2=links to waypoint
-    /// </summary>
+    /// <summary>Link type: 0=no link, 1=links to door, 2=links to waypoint</summary>
     public byte LinkedToFlags { get; set; }
 
-    /// <summary>
-    /// Index into loadscreens.2da (0 = use destination default)
-    /// </summary>
+    /// <summary>Index into loadscreens.2da (0 = use destination default)</summary>
     public ushort LoadScreenID { get; set; }
 
     // Script fields
 
-    /// <summary>
-    /// OnAreaTransitionClick event script
-    /// </summary>
+    /// <summary>OnAreaTransitionClick event script</summary>
     public string OnClick { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnClosed event script
-    /// </summary>
     public string OnClosed { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnDamaged event script
-    /// </summary>
     public string OnDamaged { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnDeath event script
-    /// </summary>
     public string OnDeath { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnDisarm event script
-    /// </summary>
     public string OnDisarm { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnFailToOpen event script
-    /// </summary>
     public string OnFailToOpen { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnHeartbeat event script
-    /// </summary>
     public string OnHeartbeat { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnLock event script
-    /// </summary>
     public string OnLock { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnPhysicalAttacked event script
-    /// </summary>
+    /// <summary>OnPhysicalAttacked event script</summary>
     public string OnMeleeAttacked { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnOpen event script
-    /// </summary>
     public string OnOpen { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnSpellCastAt event script
-    /// </summary>
     public string OnSpellCastAt { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnTrapTriggered event script
-    /// </summary>
     public string OnTrapTriggered { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnUnlock event script
-    /// </summary>
     public string OnUnlock { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnUserDefined event script
-    /// </summary>
     public string OnUserDefined { get; set; } = string.Empty;
 
     // Metadata / Blueprint fields
 
-    /// <summary>
-    /// ResRef of .dlg file for conversations
-    /// </summary>
+    /// <summary>ResRef of .dlg file for conversations</summary>
     public string Conversation { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Module designer comment (blueprint only)
-    /// </summary>
+    /// <summary>Module designer comment (blueprint only)</summary>
     public string Comment { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Palette ID for toolset organization (0-255)
-    /// </summary>
+    /// <summary>Palette ID for toolset organization (0-255)</summary>
     public byte PaletteID { get; set; }
 
     // Local variables
 
-    /// <summary>
-    /// Local variables stored on this door.
-    /// Set via SetLocalInt/SetLocalFloat/SetLocalString script functions.
-    /// </summary>
+    /// <summary>Local variables stored on this door. Set via SetLocalInt/SetLocalFloat/SetLocalString script functions.</summary>
     public List<Variable> VarTable { get; set; } = new();
 }

--- a/Radoub.Formats/Radoub.Formats/Utd/UtdReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Utd/UtdReader.cs
@@ -9,18 +9,14 @@ namespace Radoub.Formats.Utd;
 /// </summary>
 public static class UtdReader
 {
-    /// <summary>
-    /// Read a UTD file from a file path.
-    /// </summary>
+    /// <summary>Read a UTD file from a file path.</summary>
     public static UtdFile Read(string filePath)
     {
         var buffer = File.ReadAllBytes(filePath);
         return Read(buffer);
     }
 
-    /// <summary>
-    /// Read a UTD file from a stream.
-    /// </summary>
+    /// <summary>Read a UTD file from a stream.</summary>
     public static UtdFile Read(Stream stream)
     {
         using var ms = new MemoryStream();
@@ -28,9 +24,7 @@ public static class UtdReader
         return Read(ms.ToArray());
     }
 
-    /// <summary>
-    /// Read a UTD file from a byte buffer.
-    /// </summary>
+    /// <summary>Read a UTD file from a byte buffer.</summary>
     public static UtdFile Read(byte[] buffer)
     {
         var gff = GffReader.Read(buffer);
@@ -119,11 +113,9 @@ public static class UtdReader
             PaletteID = root.GetFieldValue<byte>("PaletteID", 0)
         };
 
-        // Localized strings
         utd.LocName = ParseLocString(root, "LocName") ?? new CExoLocString();
         utd.Description = ParseLocString(root, "Description") ?? new CExoLocString();
 
-        // Local variables
         utd.VarTable = VarTableHelper.ReadVarTable(root);
 
         return utd;

--- a/Radoub.Formats/Radoub.Formats/Utd/UtdWriter.cs
+++ b/Radoub.Formats/Radoub.Formats/Utd/UtdWriter.cs
@@ -10,27 +10,21 @@ namespace Radoub.Formats.Utd;
 /// </summary>
 public static class UtdWriter
 {
-    /// <summary>
-    /// Write a UTD file to a file path.
-    /// </summary>
+    /// <summary>Write a UTD file to a file path.</summary>
     public static void Write(UtdFile utd, string filePath)
     {
         var buffer = Write(utd);
         File.WriteAllBytes(filePath, buffer);
     }
 
-    /// <summary>
-    /// Write a UTD file to a stream.
-    /// </summary>
+    /// <summary>Write a UTD file to a stream.</summary>
     public static void Write(UtdFile utd, Stream stream)
     {
         var buffer = Write(utd);
         stream.Write(buffer, 0, buffer.Length);
     }
 
-    /// <summary>
-    /// Write a UTD file to a byte buffer.
-    /// </summary>
+    /// <summary>Write a UTD file to a byte buffer.</summary>
     public static byte[] Write(UtdFile utd)
     {
         var gff = BuildGffFile(utd);
@@ -138,7 +132,6 @@ public static class UtdWriter
             AddCExoStringField(root, "Comment", utd.Comment);
         AddByteField(root, "PaletteID", utd.PaletteID);
 
-        // Local variables
         VarTableHelper.WriteVarTable(root, utd.VarTable);
 
         return root;

--- a/Radoub.Formats/Radoub.Formats/Uti/ItemPropertyResolver.cs
+++ b/Radoub.Formats/Radoub.Formats/Uti/ItemPropertyResolver.cs
@@ -31,9 +31,7 @@ public class ItemPropertyResolver : IDisposable
     private TwoDAFile? _costTable;
     private TwoDAFile? _paramTable;
 
-    /// <summary>
-    /// Create a resolver using a GameResourceResolver for 2DA access.
-    /// </summary>
+    /// <summary>Create a resolver using a GameResourceResolver for 2DA access.</summary>
     public ItemPropertyResolver(GameResourceResolver resolver, TlkFile? tlk = null, TlkFile? customTlk = null)
     {
         _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
@@ -49,31 +47,27 @@ public class ItemPropertyResolver : IDisposable
     {
         var result = new ResolvedItemProperty();
 
-        // Get property definition from itempropdef.2da
         var propDef = GetItemPropDef();
         if (propDef == null || property.PropertyName >= propDef.RowCount)
             return FormatUnknown(property);
 
-        // Get property name from TLK
+        // Property name from TLK
         var nameStrRef = propDef.GetValue(property.PropertyName, "Name");
         var gameStrRef = propDef.GetValue(property.PropertyName, "GameStrRef");
         result.PropertyName = GetTlkString(gameStrRef) ?? GetTlkString(nameStrRef) ?? $"Property {property.PropertyName}";
 
-        // Get subtype name if applicable
         var subtypeResRef = propDef.GetValue(property.PropertyName, "SubTypeResRef");
         if (!string.IsNullOrEmpty(subtypeResRef) && subtypeResRef != "****")
         {
             result.SubtypeName = ResolveSubtype(subtypeResRef, property.Subtype);
         }
 
-        // Get cost value name if applicable
         var costTableIdx = propDef.GetValue(property.PropertyName, "CostTableResRef");
         if (!string.IsNullOrEmpty(costTableIdx) && costTableIdx != "****" && int.TryParse(costTableIdx, out int costIdx))
         {
             result.CostValueName = ResolveCostValue(costIdx, property.CostValue);
         }
 
-        // Get param value name if applicable
         var paramIdx = property.Param1;
         if (paramIdx != 0xFF)
         {
@@ -92,9 +86,7 @@ public class ItemPropertyResolver : IDisposable
         return result.Format();
     }
 
-    /// <summary>
-    /// Resolve multiple item properties.
-    /// </summary>
+    /// <summary>Resolve multiple item properties.</summary>
     public IEnumerable<string> Resolve(IEnumerable<ItemProperty> properties)
     {
         return properties.Select(Resolve);
@@ -297,9 +289,7 @@ public class ItemPropertyResolver : IDisposable
     }
 }
 
-/// <summary>
-/// Detailed resolution result for an item property.
-/// </summary>
+/// <summary>Detailed resolution result for an item property.</summary>
 public class ResolvedItemProperty
 {
     public int PropertyIndex { get; set; }
@@ -329,15 +319,14 @@ public class ResolvedItemProperty
         var propName = PropertyName.TrimEnd(':');
         parts.Add(propName);
 
-        // Add subtype if present
         if (!string.IsNullOrEmpty(SubtypeName))
             parts.Add(SubtypeName);
 
-        // Add cost value if present (often the "amount" like +1, +2, etc.)
+        // Cost value is often the "amount" like +1, +2, etc.
         if (!string.IsNullOrEmpty(CostValueName))
             parts.Add(CostValueName);
 
-        // Add param value if present (often a target like damage type, skill, etc.)
+        // Param value is often a target like damage type, skill, etc.
         if (!string.IsNullOrEmpty(ParamValueName))
             parts.Add(ParamValueName);
 

--- a/Radoub.Formats/Radoub.Formats/Uti/UtiFile.cs
+++ b/Radoub.Formats/Radoub.Formats/Uti/UtiFile.cs
@@ -9,143 +9,87 @@ namespace Radoub.Formats.Uti;
 /// </summary>
 public class UtiFile
 {
-    /// <summary>
-    /// File type signature - should be "UTI "
-    /// </summary>
+    /// <summary>File type signature - should be "UTI "</summary>
     public string FileType { get; set; } = "UTI ";
 
-    /// <summary>
-    /// File version - typically "V3.2"
-    /// </summary>
+    /// <summary>File version - typically "V3.2"</summary>
     public string FileVersion { get; set; } = "V3.2";
 
-    /// <summary>
-    /// Blueprint resource reference (should match filename)
-    /// </summary>
+    /// <summary>Blueprint resource reference (should match filename)</summary>
     public string TemplateResRef { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Item tag (max 32 characters)
-    /// </summary>
+    /// <summary>Item tag (max 32 characters)</summary>
     public string Tag { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Localized item name (appears in game when identified)
-    /// </summary>
+    /// <summary>Localized item name (appears in game when identified)</summary>
     public CExoLocString LocalizedName { get; set; } = new();
 
-    /// <summary>
-    /// Unidentified description
-    /// </summary>
+    /// <summary>Unidentified description</summary>
     public CExoLocString Description { get; set; } = new();
 
-    /// <summary>
-    /// Identified description
-    /// </summary>
+    /// <summary>Identified description</summary>
     public CExoLocString DescIdentified { get; set; } = new();
 
-    /// <summary>
-    /// Index into baseitems.2da - determines item type
-    /// </summary>
+    /// <summary>Index into baseitems.2da - determines item type</summary>
     public int BaseItem { get; set; }
 
-    /// <summary>
-    /// Stack size (1 for unstackable items)
-    /// </summary>
+    /// <summary>Stack size (1 for unstackable items)</summary>
     public ushort StackSize { get; set; } = 1;
 
-    /// <summary>
-    /// Number of charges remaining
-    /// </summary>
     public byte Charges { get; set; }
 
-    /// <summary>
-    /// Base cost of item
-    /// </summary>
+    /// <summary>Base cost of item</summary>
     public uint Cost { get; set; }
 
-    /// <summary>
-    /// Additional cost added to calculated cost
-    /// </summary>
+    /// <summary>Additional cost added to calculated cost</summary>
     public uint AddCost { get; set; }
 
-    /// <summary>
-    /// True if item cannot be removed from inventory (undroppable, unsellable)
-    /// </summary>
+    /// <summary>True if item cannot be removed from inventory (undroppable, unsellable)</summary>
     public bool Cursed { get; set; }
 
-    /// <summary>
-    /// True if item is a plot item (cannot be sold)
-    /// </summary>
+    /// <summary>True if item is a plot item (cannot be sold)</summary>
     public bool Plot { get; set; }
 
-    /// <summary>
-    /// True if item was stolen
-    /// </summary>
     public bool Stolen { get; set; }
 
-    /// <summary>
-    /// True if item has been identified (no lore check needed)
-    /// </summary>
+    /// <summary>True if item has been identified (no lore check needed)</summary>
     public bool Identified { get; set; }
 
-    /// <summary>
-    /// True if item can be dropped (default true). Note: BioWare misspells as "Dropable".
-    /// </summary>
+    /// <summary>True if item can be dropped (default true). Note: BioWare misspells as "Dropable".</summary>
     public bool Dropable { get; set; } = true;
 
-    /// <summary>
-    /// List of item properties (enchantments, abilities)
-    /// </summary>
+    /// <summary>List of item properties (enchantments, abilities)</summary>
     public List<ItemProperty> Properties { get; set; } = new();
 
     // Model fields - present depending on ModelType in baseitems.2da
 
-    /// <summary>
-    /// Part number for Simple (ModelType 0) and Layered (ModelType 1) items
-    /// </summary>
+    /// <summary>Part number for Simple (ModelType 0) and Layered (ModelType 1) items</summary>
     public byte ModelPart1 { get; set; }
 
-    /// <summary>
-    /// Part number 2 for Composite (ModelType 2) items
-    /// </summary>
+    /// <summary>Part number 2 for Composite (ModelType 2) items</summary>
     public byte ModelPart2 { get; set; }
 
-    /// <summary>
-    /// Part number 3 for Composite (ModelType 2) items
-    /// </summary>
+    /// <summary>Part number 3 for Composite (ModelType 2) items</summary>
     public byte ModelPart3 { get; set; }
 
     // Color fields - present for Layered (ModelType 1) and Armor (ModelType 3)
 
-    /// <summary>
-    /// Cloth color 1 (PLT layer index)
-    /// </summary>
+    /// <summary>Cloth color 1 (PLT layer index)</summary>
     public byte Cloth1Color { get; set; }
 
-    /// <summary>
-    /// Cloth color 2 (PLT layer index)
-    /// </summary>
+    /// <summary>Cloth color 2 (PLT layer index)</summary>
     public byte Cloth2Color { get; set; }
 
-    /// <summary>
-    /// Leather color 1 (PLT layer index)
-    /// </summary>
+    /// <summary>Leather color 1 (PLT layer index)</summary>
     public byte Leather1Color { get; set; }
 
-    /// <summary>
-    /// Leather color 2 (PLT layer index)
-    /// </summary>
+    /// <summary>Leather color 2 (PLT layer index)</summary>
     public byte Leather2Color { get; set; }
 
-    /// <summary>
-    /// Metal color 1 (PLT layer index)
-    /// </summary>
+    /// <summary>Metal color 1 (PLT layer index)</summary>
     public byte Metal1Color { get; set; }
 
-    /// <summary>
-    /// Metal color 2 (PLT layer index)
-    /// </summary>
+    /// <summary>Metal color 2 (PLT layer index)</summary>
     public byte Metal2Color { get; set; }
 
     // Armor part fields - present for Armor (ModelType 3) only
@@ -160,22 +104,15 @@ public class UtiFile
 
     // Local variables (used by scripting)
 
-    /// <summary>
-    /// Local variables attached to the item blueprint.
-    /// Used for scripting and module-specific data.
-    /// </summary>
+    /// <summary>Local variables attached to the item blueprint; used for scripting and module-specific data.</summary>
     public List<Variable> VarTable { get; set; } = new();
 
     // Blueprint-only fields
 
-    /// <summary>
-    /// Module designer comment (blueprint only)
-    /// </summary>
+    /// <summary>Module designer comment (blueprint only)</summary>
     public string Comment { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Palette ID for toolset organization (blueprint only)
-    /// </summary>
+    /// <summary>Palette ID for toolset organization (blueprint only)</summary>
     public byte PaletteID { get; set; }
 }
 
@@ -185,48 +122,30 @@ public class UtiFile
 /// </summary>
 public class ItemProperty
 {
-    /// <summary>
-    /// Index into itempropdef.2da - identifies the property type
-    /// </summary>
+    /// <summary>Index into itempropdef.2da - identifies the property type</summary>
     public ushort PropertyName { get; set; }
 
-    /// <summary>
-    /// Index into subtype table (determined by PropertyName)
-    /// </summary>
+    /// <summary>Index into subtype table (determined by PropertyName)</summary>
     public ushort Subtype { get; set; }
 
-    /// <summary>
-    /// Index into iprp_costtable.2da
-    /// </summary>
+    /// <summary>Index into iprp_costtable.2da</summary>
     public byte CostTable { get; set; }
 
-    /// <summary>
-    /// Index into cost table (determined by CostTable)
-    /// </summary>
+    /// <summary>Index into cost table (determined by CostTable)</summary>
     public ushort CostValue { get; set; }
 
-    /// <summary>
-    /// Index into iprp_paramtable.2da (-1 if no params)
-    /// </summary>
+    /// <summary>Index into iprp_paramtable.2da (-1 if no params)</summary>
     public byte Param1 { get; set; } = 0xFF;
 
-    /// <summary>
-    /// Index into param table (determined by Param1)
-    /// </summary>
+    /// <summary>Index into param table (determined by Param1)</summary>
     public byte Param1Value { get; set; }
 
-    /// <summary>
-    /// Obsolete - always 100
-    /// </summary>
+    /// <summary>Obsolete - always 100</summary>
     public byte ChanceAppear { get; set; } = 100;
 
-    /// <summary>
-    /// Obsolete param2
-    /// </summary>
+    /// <summary>Obsolete param2</summary>
     public byte Param2 { get; set; } = 0xFF;
 
-    /// <summary>
-    /// Obsolete param2 value
-    /// </summary>
+    /// <summary>Obsolete param2 value</summary>
     public byte Param2Value { get; set; }
 }

--- a/Radoub.Formats/Radoub.Formats/Uti/UtiReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Uti/UtiReader.cs
@@ -9,18 +9,14 @@ namespace Radoub.Formats.Uti;
 /// </summary>
 public static class UtiReader
 {
-    /// <summary>
-    /// Read a UTI file from a file path.
-    /// </summary>
+    /// <summary>Read a UTI file from a file path.</summary>
     public static UtiFile Read(string filePath)
     {
         var buffer = File.ReadAllBytes(filePath);
         return Read(buffer);
     }
 
-    /// <summary>
-    /// Read a UTI file from a stream.
-    /// </summary>
+    /// <summary>Read a UTI file from a stream.</summary>
     public static UtiFile Read(Stream stream)
     {
         using var ms = new MemoryStream();
@@ -28,15 +24,11 @@ public static class UtiReader
         return Read(ms.ToArray());
     }
 
-    /// <summary>
-    /// Read a UTI file from a byte buffer.
-    /// </summary>
+    /// <summary>Read a UTI file from a byte buffer.</summary>
     public static UtiFile Read(byte[] buffer)
     {
-        // Parse as GFF first
         var gff = GffReader.Read(buffer);
 
-        // Validate file type
         if (gff.FileType.TrimEnd() != "UTI")
         {
             throw new InvalidDataException(
@@ -87,7 +79,6 @@ public static class UtiReader
             Metal2Color = root.GetFieldValue<byte>("Metal2Color", 0)
         };
 
-        // Localized strings
         uti.LocalizedName = ParseLocString(root, "LocalizedName") ?? ParseLocString(root, "LocName") ?? new CExoLocString();
         uti.Description = ParseLocString(root, "Description") ?? new CExoLocString();
         uti.DescIdentified = ParseLocString(root, "DescIdentified") ?? new CExoLocString();
@@ -98,7 +89,6 @@ public static class UtiReader
         // Properties list (Table 2.1.3)
         ParsePropertiesList(root, uti);
 
-        // Local variables
         uti.VarTable = VarTableHelper.ReadVarTable(root);
 
         return uti;

--- a/Radoub.Formats/Radoub.Formats/Uti/UtiWriter.cs
+++ b/Radoub.Formats/Radoub.Formats/Uti/UtiWriter.cs
@@ -10,27 +10,21 @@ namespace Radoub.Formats.Uti;
 /// </summary>
 public static class UtiWriter
 {
-    /// <summary>
-    /// Write a UTI file to a file path.
-    /// </summary>
+    /// <summary>Write a UTI file to a file path.</summary>
     public static void Write(UtiFile uti, string filePath)
     {
         var buffer = Write(uti);
         File.WriteAllBytes(filePath, buffer);
     }
 
-    /// <summary>
-    /// Write a UTI file to a stream.
-    /// </summary>
+    /// <summary>Write a UTI file to a stream.</summary>
     public static void Write(UtiFile uti, Stream stream)
     {
         var buffer = Write(uti);
         stream.Write(buffer, 0, buffer.Length);
     }
 
-    /// <summary>
-    /// Write a UTI file to a byte buffer.
-    /// </summary>
+    /// <summary>Write a UTI file to a byte buffer.</summary>
     public static byte[] Write(UtiFile uti)
     {
         var gff = BuildGffFile(uti);
@@ -67,7 +61,6 @@ public static class UtiWriter
         AddByteField(root, "Identified", (byte)(uti.Identified ? 1 : 0));
         AddByteField(root, "Dropable", (byte)(uti.Dropable ? 1 : 0));
 
-        // Localized strings
         AddLocStringField(root, "LocalizedName", uti.LocalizedName);
         AddLocStringField(root, "Description", uti.Description);
         AddLocStringField(root, "DescIdentified", uti.DescIdentified);
@@ -99,16 +92,13 @@ public static class UtiWriter
         if (uti.Metal2Color != 0)
             AddByteField(root, "Metal2Color", uti.Metal2Color);
 
-        // Armor parts
         foreach (var kvp in uti.ArmorParts)
         {
             AddByteField(root, $"ArmorPart_{kvp.Key}", kvp.Value);
         }
 
-        // Properties list
         AddPropertiesList(root, uti.Properties);
 
-        // Local variables
         VarTableHelper.WriteVarTable(root, uti.VarTable);
 
         return root;

--- a/Radoub.Formats/Radoub.Formats/Utm/UtmFile.cs
+++ b/Radoub.Formats/Radoub.Formats/Utm/UtmFile.cs
@@ -9,31 +9,21 @@ namespace Radoub.Formats.Utm;
 /// </summary>
 public class UtmFile
 {
-    /// <summary>
-    /// File type signature - should be "UTM "
-    /// </summary>
+    /// <summary>File type signature - should be "UTM "</summary>
     public string FileType { get; set; } = "UTM ";
 
-    /// <summary>
-    /// File version - typically "V3.2"
-    /// </summary>
+    /// <summary>File version - typically "V3.2"</summary>
     public string FileVersion { get; set; } = "V3.2";
 
     // Identity fields
 
-    /// <summary>
-    /// Blueprint resource reference (should match filename)
-    /// </summary>
+    /// <summary>Blueprint resource reference (should match filename)</summary>
     public string ResRef { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Store tag (max 32 characters)
-    /// </summary>
+    /// <summary>Store tag (max 32 characters)</summary>
     public string Tag { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Localized store name
-    /// </summary>
+    /// <summary>Localized store name</summary>
     public CExoLocString LocName { get; set; } = new();
 
     // Pricing fields
@@ -52,26 +42,18 @@ public class UtmFile
     /// </summary>
     public int MarkUp { get; set; } = 150;
 
-    /// <summary>
-    /// Store's gold reserves. -1 = infinite gold.
-    /// </summary>
+    /// <summary>Store's gold reserves. -1 = infinite gold.</summary>
     public int StoreGold { get; set; } = -1;
 
-    /// <summary>
-    /// Maximum price the store will pay for an item. -1 = no limit.
-    /// </summary>
+    /// <summary>Maximum price the store will pay for an item. -1 = no limit.</summary>
     public int MaxBuyPrice { get; set; } = -1;
 
-    /// <summary>
-    /// Cost to identify an item. -1 = identification service not available.
-    /// </summary>
+    /// <summary>Cost to identify an item. -1 = identification service not available.</summary>
     public int IdentifyPrice { get; set; } = 100;
 
     // Black market fields
 
-    /// <summary>
-    /// If true, store will buy stolen items.
-    /// </summary>
+    /// <summary>If true, store will buy stolen items.</summary>
     public bool BlackMarket { get; set; }
 
     /// <summary>
@@ -82,26 +64,18 @@ public class UtmFile
 
     // Blueprint-only fields
 
-    /// <summary>
-    /// Module designer comment (blueprint only)
-    /// </summary>
+    /// <summary>Module designer comment (blueprint only)</summary>
     public string Comment { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Palette ID for toolset organization (0-255)
-    /// </summary>
+    /// <summary>Palette ID for toolset organization (0-255)</summary>
     public byte PaletteID { get; set; }
 
     // Script fields
 
-    /// <summary>
-    /// Script to run when store is opened
-    /// </summary>
+    /// <summary>Script to run when store is opened</summary>
     public string OnOpenStore { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Script to run when store is closed
-    /// </summary>
+    /// <summary>Script to run when store is closed</summary>
     public string OnStoreClosed { get; set; } = string.Empty;
 
     // Store inventory (5 panels)
@@ -128,16 +102,11 @@ public class UtmFile
 
     // Local variables
 
-    /// <summary>
-    /// Local variables stored on this store.
-    /// Set via SetLocalInt/SetLocalFloat/SetLocalString script functions.
-    /// </summary>
+    /// <summary>Local variables stored on this store. Set via SetLocalInt/SetLocalFloat/SetLocalString script functions.</summary>
     public List<Variable> VarTable { get; set; } = new();
 }
 
-/// <summary>
-/// Represents a store inventory panel (one of 5 categories).
-/// </summary>
+/// <summary>Represents a store inventory panel (one of 5 categories).</summary>
 public class StorePanel
 {
     /// <summary>
@@ -146,35 +115,22 @@ public class StorePanel
     /// </summary>
     public int PanelId { get; set; }
 
-    /// <summary>
-    /// Items in this panel.
-    /// </summary>
     public List<StoreItem> Items { get; set; } = new();
 }
 
-/// <summary>
-/// Represents an item for sale in a store.
-/// </summary>
+/// <summary>Represents an item for sale in a store.</summary>
 public class StoreItem
 {
-    /// <summary>
-    /// ResRef of the item blueprint (.uti)
-    /// </summary>
+    /// <summary>ResRef of the item blueprint (.uti)</summary>
     public string InventoryRes { get; set; } = string.Empty;
 
-    /// <summary>
-    /// If true, item has infinite stock (never runs out).
-    /// </summary>
+    /// <summary>If true, item has infinite stock (never runs out).</summary>
     public bool Infinite { get; set; }
 
-    /// <summary>
-    /// X position in inventory grid (used by toolset, usually 0xFFFF).
-    /// </summary>
+    /// <summary>X position in inventory grid (used by toolset, usually 0xFFFF).</summary>
     public ushort Repos_PosX { get; set; } = 0xFFFF;
 
-    /// <summary>
-    /// Y position in inventory grid (used by toolset, usually 0xFFFF).
-    /// </summary>
+    /// <summary>Y position in inventory grid (used by toolset, usually 0xFFFF).</summary>
     public ushort Repos_PosY { get; set; } = 0xFFFF;
 }
 
@@ -190,9 +146,7 @@ public static class StorePanels
     public const int RingsAmulets = 3;
     public const int Weapons = 4;
 
-    /// <summary>
-    /// Get human-readable name for a store panel.
-    /// </summary>
+    /// <summary>Get human-readable name for a store panel.</summary>
     public static string GetPanelName(int panelId)
     {
         return panelId switch

--- a/Radoub.Formats/Radoub.Formats/Utm/UtmReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Utm/UtmReader.cs
@@ -9,18 +9,14 @@ namespace Radoub.Formats.Utm;
 /// </summary>
 public static class UtmReader
 {
-    /// <summary>
-    /// Read a UTM file from a file path.
-    /// </summary>
+    /// <summary>Read a UTM file from a file path.</summary>
     public static UtmFile Read(string filePath)
     {
         var buffer = File.ReadAllBytes(filePath);
         return Read(buffer);
     }
 
-    /// <summary>
-    /// Read a UTM file from a stream.
-    /// </summary>
+    /// <summary>Read a UTM file from a stream.</summary>
     public static UtmFile Read(Stream stream)
     {
         using var ms = new MemoryStream();
@@ -28,15 +24,11 @@ public static class UtmReader
         return Read(ms.ToArray());
     }
 
-    /// <summary>
-    /// Read a UTM file from a byte buffer.
-    /// </summary>
+    /// <summary>Read a UTM file from a byte buffer.</summary>
     public static UtmFile Read(byte[] buffer)
     {
-        // Parse as GFF first
         var gff = GffReader.Read(buffer);
 
-        // Validate file type
         if (gff.FileType.TrimEnd() != "UTM")
         {
             throw new InvalidDataException(
@@ -79,17 +71,13 @@ public static class UtmReader
             OnStoreClosed = root.GetFieldValue<string>("OnStoreClosed", string.Empty)
         };
 
-        // Localized name
         utm.LocName = ParseLocString(root, "LocName") ?? new CExoLocString();
 
-        // Store inventory panels
         ParseStoreList(root, utm);
 
-        // Buy restrictions
         ParseWillOnlyBuy(root, utm);
         ParseWillNotBuy(root, utm);
 
-        // Local variables
         utm.VarTable = VarTableHelper.ReadVarTable(root);
 
         return utm;
@@ -117,7 +105,6 @@ public static class UtmReader
                 PanelId = (int)panelStruct.Type
             };
 
-            // Parse ItemList within each panel
             ParsePanelItems(panelStruct, panel);
 
             utm.StoreList.Add(panel);

--- a/Radoub.Formats/Radoub.Formats/Utm/UtmWriter.cs
+++ b/Radoub.Formats/Radoub.Formats/Utm/UtmWriter.cs
@@ -10,27 +10,21 @@ namespace Radoub.Formats.Utm;
 /// </summary>
 public static class UtmWriter
 {
-    /// <summary>
-    /// Write a UTM file to a file path.
-    /// </summary>
+    /// <summary>Write a UTM file to a file path.</summary>
     public static void Write(UtmFile utm, string filePath)
     {
         var buffer = Write(utm);
         File.WriteAllBytes(filePath, buffer);
     }
 
-    /// <summary>
-    /// Write a UTM file to a stream.
-    /// </summary>
+    /// <summary>Write a UTM file to a stream.</summary>
     public static void Write(UtmFile utm, Stream stream)
     {
         var buffer = Write(utm);
         stream.Write(buffer, 0, buffer.Length);
     }
 
-    /// <summary>
-    /// Write a UTM file to a byte buffer.
-    /// </summary>
+    /// <summary>Write a UTM file to a byte buffer.</summary>
     public static byte[] Write(UtmFile utm)
     {
         var gff = BuildGffFile(utm);
@@ -80,16 +74,13 @@ public static class UtmWriter
         if (!string.IsNullOrEmpty(utm.OnStoreClosed))
             AddCResRefField(root, "OnStoreClosed", utm.OnStoreClosed);
 
-        // Store inventory panels
         AddStoreList(root, utm.StoreList);
 
-        // Buy restrictions
         if (utm.WillOnlyBuy.Count > 0)
             AddBaseItemList(root, "WillOnlyBuy", utm.WillOnlyBuy);
         if (utm.WillNotBuy.Count > 0)
             AddBaseItemList(root, "WillNotBuy", utm.WillNotBuy);
 
-        // Local variables
         VarTableHelper.WriteVarTable(root, utm.VarTable);
 
         return root;

--- a/Radoub.Formats/Radoub.Formats/Utp/UtpFile.cs
+++ b/Radoub.Formats/Radoub.Formats/Utp/UtpFile.cs
@@ -9,323 +9,190 @@ namespace Radoub.Formats.Utp;
 /// </summary>
 public class UtpFile
 {
-    /// <summary>
-    /// File type signature - should be "UTP "
-    /// </summary>
+    /// <summary>File type signature - should be "UTP "</summary>
     public string FileType { get; set; } = "UTP ";
 
-    /// <summary>
-    /// File version - typically "V3.2"
-    /// </summary>
+    /// <summary>File version - typically "V3.2"</summary>
     public string FileVersion { get; set; } = "V3.2";
 
     // Identity fields
 
-    /// <summary>
-    /// Blueprint resource reference (should match filename)
-    /// </summary>
+    /// <summary>Blueprint resource reference (should match filename)</summary>
     public string TemplateResRef { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Placeable tag (max 32 characters)
-    /// </summary>
+    /// <summary>Placeable tag (max 32 characters)</summary>
     public string Tag { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Localized placeable name
-    /// </summary>
+    /// <summary>Localized placeable name</summary>
     public CExoLocString LocName { get; set; } = new();
 
-    /// <summary>
-    /// Localized description
-    /// </summary>
+    /// <summary>Localized description</summary>
     public CExoLocString Description { get; set; } = new();
 
     // Appearance
 
-    /// <summary>
-    /// Appearance ID - index into placeables.2da
-    /// </summary>
+    /// <summary>Appearance ID - index into placeables.2da</summary>
     public uint Appearance { get; set; }
 
-    /// <summary>
-    /// Current animation state (0=default, 1=open, 2=closed, 3=destroyed, 4=activated, 5=deactivated)
-    /// </summary>
+    /// <summary>Current animation state (0=default, 1=open, 2=closed, 3=destroyed, 4=activated, 5=deactivated)</summary>
     public byte AnimationState { get; set; }
 
-    /// <summary>
-    /// Portrait ID - index into portraits.2da
-    /// </summary>
+    /// <summary>Portrait ID - index into portraits.2da</summary>
     public ushort PortraitId { get; set; }
 
     // Combat / Physical
 
-    /// <summary>
-    /// Maximum hit points
-    /// </summary>
+    /// <summary>Maximum hit points</summary>
     public short HP { get; set; }
 
-    /// <summary>
-    /// Current hit points
-    /// </summary>
+    /// <summary>Current hit points</summary>
     public short CurrentHP { get; set; }
 
-    /// <summary>
-    /// Damage reduction (slashing, piercing, bludgeoning)
-    /// </summary>
+    /// <summary>Damage reduction (slashing, piercing, bludgeoning)</summary>
     public byte Hardness { get; set; }
 
-    /// <summary>
-    /// Fortitude save bonus
-    /// </summary>
+    /// <summary>Fortitude save bonus</summary>
     public byte Fort { get; set; }
 
-    /// <summary>
-    /// Reflex save bonus
-    /// </summary>
+    /// <summary>Reflex save bonus</summary>
     public byte Ref { get; set; }
 
-    /// <summary>
-    /// Will save bonus
-    /// </summary>
+    /// <summary>Will save bonus</summary>
     public byte Will { get; set; }
 
-    /// <summary>
-    /// If true, placeable is a plot object (cannot be damaged/destroyed)
-    /// </summary>
+    /// <summary>If true, placeable is a plot object (cannot be damaged/destroyed)</summary>
     public bool Plot { get; set; }
 
-    /// <summary>
-    /// Faction ID from repute.fac
-    /// </summary>
+    /// <summary>Faction ID from repute.fac</summary>
     public uint Faction { get; set; }
 
-    /// <summary>
-    /// If true, conversation can be interrupted
-    /// </summary>
+    /// <summary>If true, conversation can be interrupted</summary>
     public bool Interruptable { get; set; } = true;
 
     // Lock fields
 
-    /// <summary>
-    /// If true, can be locked after unlock
-    /// </summary>
+    /// <summary>If true, can be locked after unlock</summary>
     public bool Lockable { get; set; }
 
-    /// <summary>
-    /// If true, currently locked
-    /// </summary>
+    /// <summary>If true, currently locked</summary>
     public bool Locked { get; set; }
 
-    /// <summary>
-    /// DC to unlock this object
-    /// </summary>
+    /// <summary>DC to unlock this object</summary>
     public byte OpenLockDC { get; set; }
 
-    /// <summary>
-    /// DC to lock the object
-    /// </summary>
+    /// <summary>DC to lock the object</summary>
     public byte CloseLockDC { get; set; }
 
-    /// <summary>
-    /// If true, destroy key from inventory when used
-    /// </summary>
+    /// <summary>If true, destroy key from inventory when used</summary>
     public bool AutoRemoveKey { get; set; }
 
-    /// <summary>
-    /// Tag of the key required to unlock
-    /// </summary>
+    /// <summary>Tag of the key required to unlock</summary>
     public string KeyName { get; set; } = string.Empty;
 
-    /// <summary>
-    /// If true, key is required to unlock (KeyName must be set)
-    /// </summary>
+    /// <summary>If true, key is required to unlock (KeyName must be set)</summary>
     public bool KeyRequired { get; set; }
 
     // Trap fields
 
-    /// <summary>
-    /// If true, object is trapped
-    /// </summary>
+    /// <summary>If true, object is trapped</summary>
     public bool TrapFlag { get; set; }
 
-    /// <summary>
-    /// Index into traps.2da
-    /// </summary>
+    /// <summary>Index into traps.2da</summary>
     public byte TrapType { get; set; }
 
-    /// <summary>
-    /// If true, trap can be detected
-    /// </summary>
+    /// <summary>If true, trap can be detected</summary>
     public bool TrapDetectable { get; set; } = true;
 
-    /// <summary>
-    /// DC to detect trap (1-250)
-    /// </summary>
+    /// <summary>DC to detect trap (1-250)</summary>
     public byte TrapDetectDC { get; set; }
 
-    /// <summary>
-    /// If true, trap can be disarmed
-    /// </summary>
+    /// <summary>If true, trap can be disarmed</summary>
     public bool TrapDisarmable { get; set; } = true;
 
-    /// <summary>
-    /// DC to disarm trap
-    /// </summary>
+    /// <summary>DC to disarm trap</summary>
     public byte DisarmDC { get; set; }
 
-    /// <summary>
-    /// If true, trap disappears after firing
-    /// </summary>
+    /// <summary>If true, trap disappears after firing</summary>
     public bool TrapOneShot { get; set; } = true;
 
     // Placeable-specific fields
 
-    /// <summary>
-    /// If true, placeable has inventory
-    /// </summary>
+    /// <summary>If true, placeable has inventory</summary>
     public bool HasInventory { get; set; }
 
-    /// <summary>
-    /// If true, can be used by player
-    /// </summary>
+    /// <summary>If true, can be used by player</summary>
     public bool Useable { get; set; } = true;
 
-    /// <summary>
-    /// If true, static (client-side only, no scripting)
-    /// </summary>
+    /// <summary>If true, static (client-side only, no scripting)</summary>
     public bool Static { get; set; }
 
-    /// <summary>
-    /// Obsolete type field, always 0
-    /// </summary>
+    /// <summary>Obsolete type field, always 0</summary>
     public byte Type { get; set; }
 
-    /// <summary>
-    /// Index into bodybag.2da (body bag left when destroyed with inventory)
-    /// </summary>
+    /// <summary>Index into bodybag.2da (body bag left when destroyed with inventory)</summary>
     public byte BodyBag { get; set; }
 
-    /// <summary>
-    /// Items in placeable (only if HasInventory)
-    /// </summary>
+    /// <summary>Items in placeable (only if HasInventory)</summary>
     public List<PlaceableItem> ItemList { get; set; } = new();
 
     // Script fields
 
-    /// <summary>
-    /// OnClosed event script
-    /// </summary>
     public string OnClosed { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnDamaged event script
-    /// </summary>
     public string OnDamaged { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnDeath event script
-    /// </summary>
     public string OnDeath { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnDisarm event script
-    /// </summary>
     public string OnDisarm { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnHeartbeat event script
-    /// </summary>
     public string OnHeartbeat { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnInventoryDisturbed event script
-    /// </summary>
+    /// <summary>OnInventoryDisturbed event script</summary>
     public string OnInvDisturbed { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnLock event script
-    /// </summary>
     public string OnLock { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnPhysicalAttacked event script
-    /// </summary>
+    /// <summary>OnPhysicalAttacked event script</summary>
     public string OnMeleeAttacked { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnOpen event script
-    /// </summary>
     public string OnOpen { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnSpellCastAt event script
-    /// </summary>
     public string OnSpellCastAt { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnTrapTriggered event script
-    /// </summary>
     public string OnTrapTriggered { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnUnlock event script
-    /// </summary>
     public string OnUnlock { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnUserDefined event script
-    /// </summary>
     public string OnUserDefined { get; set; } = string.Empty;
 
-    /// <summary>
-    /// OnUsed event script
-    /// </summary>
     public string OnUsed { get; set; } = string.Empty;
 
     // Metadata / Blueprint fields
 
-    /// <summary>
-    /// ResRef of .dlg file for conversations
-    /// </summary>
+    /// <summary>ResRef of .dlg file for conversations</summary>
     public string Conversation { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Module designer comment (blueprint only)
-    /// </summary>
+    /// <summary>Module designer comment (blueprint only)</summary>
     public string Comment { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Palette ID for toolset organization (0-255)
-    /// </summary>
+    /// <summary>Palette ID for toolset organization (0-255)</summary>
     public byte PaletteID { get; set; }
 
     // Local variables
 
-    /// <summary>
-    /// Local variables stored on this placeable.
-    /// Set via SetLocalInt/SetLocalFloat/SetLocalString script functions.
-    /// </summary>
+    /// <summary>Local variables stored on this placeable. Set via SetLocalInt/SetLocalFloat/SetLocalString script functions.</summary>
     public List<Variable> VarTable { get; set; } = new();
 }
 
-/// <summary>
-/// Represents an item in a placeable's inventory.
-/// </summary>
+/// <summary>Represents an item in a placeable's inventory.</summary>
 public class PlaceableItem
 {
-    /// <summary>
-    /// ResRef of the item blueprint (.uti)
-    /// </summary>
+    /// <summary>ResRef of the item blueprint (.uti)</summary>
     public string InventoryRes { get; set; } = string.Empty;
 
-    /// <summary>
-    /// X position in inventory grid
-    /// </summary>
+    /// <summary>X position in inventory grid</summary>
     public ushort Repos_PosX { get; set; }
 
-    /// <summary>
-    /// Y position in inventory grid
-    /// </summary>
+    /// <summary>Y position in inventory grid</summary>
     public ushort Repos_PosY { get; set; }
 }

--- a/Radoub.Formats/Radoub.Formats/Utp/UtpReader.cs
+++ b/Radoub.Formats/Radoub.Formats/Utp/UtpReader.cs
@@ -9,18 +9,14 @@ namespace Radoub.Formats.Utp;
 /// </summary>
 public static class UtpReader
 {
-    /// <summary>
-    /// Read a UTP file from a file path.
-    /// </summary>
+    /// <summary>Read a UTP file from a file path.</summary>
     public static UtpFile Read(string filePath)
     {
         var buffer = File.ReadAllBytes(filePath);
         return Read(buffer);
     }
 
-    /// <summary>
-    /// Read a UTP file from a stream.
-    /// </summary>
+    /// <summary>Read a UTP file from a stream.</summary>
     public static UtpFile Read(Stream stream)
     {
         using var ms = new MemoryStream();
@@ -28,9 +24,7 @@ public static class UtpReader
         return Read(ms.ToArray());
     }
 
-    /// <summary>
-    /// Read a UTP file from a byte buffer.
-    /// </summary>
+    /// <summary>Read a UTP file from a byte buffer.</summary>
     public static UtpFile Read(byte[] buffer)
     {
         var gff = GffReader.Read(buffer);
@@ -120,14 +114,11 @@ public static class UtpReader
             PaletteID = root.GetFieldValue<byte>("PaletteID", 0)
         };
 
-        // Localized strings
         utp.LocName = ParseLocString(root, "LocName") ?? new CExoLocString();
         utp.Description = ParseLocString(root, "Description") ?? new CExoLocString();
 
-        // Item list
         ParseItemList(root, utp);
 
-        // Local variables
         utp.VarTable = VarTableHelper.ReadVarTable(root);
 
         return utp;

--- a/Radoub.Formats/Radoub.Formats/Utp/UtpWriter.cs
+++ b/Radoub.Formats/Radoub.Formats/Utp/UtpWriter.cs
@@ -10,27 +10,21 @@ namespace Radoub.Formats.Utp;
 /// </summary>
 public static class UtpWriter
 {
-    /// <summary>
-    /// Write a UTP file to a file path.
-    /// </summary>
+    /// <summary>Write a UTP file to a file path.</summary>
     public static void Write(UtpFile utp, string filePath)
     {
         var buffer = Write(utp);
         File.WriteAllBytes(filePath, buffer);
     }
 
-    /// <summary>
-    /// Write a UTP file to a stream.
-    /// </summary>
+    /// <summary>Write a UTP file to a stream.</summary>
     public static void Write(UtpFile utp, Stream stream)
     {
         var buffer = Write(utp);
         stream.Write(buffer, 0, buffer.Length);
     }
 
-    /// <summary>
-    /// Write a UTP file to a byte buffer.
-    /// </summary>
+    /// <summary>Write a UTP file to a byte buffer.</summary>
     public static byte[] Write(UtpFile utp)
     {
         var gff = BuildGffFile(utp);
@@ -138,11 +132,9 @@ public static class UtpWriter
             AddCExoStringField(root, "Comment", utp.Comment);
         AddByteField(root, "PaletteID", utp.PaletteID);
 
-        // Item list
         if (utp.ItemList.Count > 0)
             AddItemList(root, utp.ItemList);
 
-        // Local variables
         VarTableHelper.WriteVarTable(root, utp.VarTable);
 
         return root;

--- a/Radoub.UI/Radoub.UI/Controls/EquipmentSlotsPanel.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Controls/EquipmentSlotsPanel.axaml.cs
@@ -9,64 +9,39 @@ using Radoub.UI.ViewModels;
 namespace Radoub.UI.Controls;
 
 /// <summary>
-/// Visual equipment slot display showing creature's equipped items.
-/// Displays a grid of slots with item icons and validation warnings.
+/// Visual equipment slot display showing creature's equipped items, with item
+/// icons and validation warnings.
 /// </summary>
 public partial class EquipmentSlotsPanel : UserControl
 {
-    /// <summary>
-    /// All equipment slots (standard + natural).
-    /// </summary>
+    /// <summary>All equipment slots (standard + natural).</summary>
     public static readonly StyledProperty<ObservableCollection<EquipmentSlotViewModel>> SlotsProperty =
         AvaloniaProperty.Register<EquipmentSlotsPanel, ObservableCollection<EquipmentSlotViewModel>>(
             nameof(Slots),
             defaultValue: new ObservableCollection<EquipmentSlotViewModel>());
 
-    /// <summary>
-    /// Currently selected slot.
-    /// </summary>
     public static readonly StyledProperty<EquipmentSlotViewModel?> SelectedSlotProperty =
         AvaloniaProperty.Register<EquipmentSlotsPanel, EquipmentSlotViewModel?>(nameof(SelectedSlot));
 
-    /// <summary>
-    /// Whether to show natural equipment slots (creature-only).
-    /// </summary>
+    /// <summary>Whether to show natural equipment slots (creature-only).</summary>
     public static readonly StyledProperty<bool> ShowNaturalSlotsProperty =
         AvaloniaProperty.Register<EquipmentSlotsPanel, bool>(nameof(ShowNaturalSlots), defaultValue: false);
 
-    /// <summary>
-    /// Event raised when a slot is clicked.
-    /// </summary>
     public event EventHandler<EquipmentSlotViewModel>? SlotClicked;
 
-    /// <summary>
-    /// Event raised when a slot is double-clicked.
-    /// </summary>
     public event EventHandler<EquipmentSlotViewModel>? SlotDoubleClicked;
 
-    /// <summary>
-    /// Event raised when drag operation starts from a slot.
-    /// </summary>
     public event EventHandler<EquipmentSlotDragEventArgs>? DragStarting;
 
-    /// <summary>
-    /// Event raised when an item is dropped on a slot.
-    /// </summary>
     public event EventHandler<EquipmentSlotDropEventArgs>? ItemDropped;
 
-    /// <summary>
-    /// Event raised when "Unequip to Backpack" is requested from context menu.
-    /// </summary>
+    /// <summary>Raised when "Unequip to Backpack" is chosen from the context menu.</summary>
     public event EventHandler<EquipmentSlotViewModel>? UnequipRequested;
 
-    /// <summary>
-    /// Event raised when "Remove" (delete) is requested from context menu.
-    /// </summary>
+    /// <summary>Raised when "Remove" (delete) is chosen from the context menu.</summary>
     public event EventHandler<EquipmentSlotViewModel>? RemoveRequested;
 
-    /// <summary>
-    /// Event raised when "Copy ResRef" is requested from context menu.
-    /// </summary>
+    /// <summary>Raised when "Copy ResRef" is chosen from the context menu.</summary>
     public event EventHandler<EquipmentSlotViewModel>? CopyResRefRequested;
 
     // Slot controls mapped by slot ID
@@ -76,34 +51,25 @@ public partial class EquipmentSlotsPanel : UserControl
     {
         InitializeComponent();
 
-        // Wire up tab switching
         StandardTab.IsCheckedChanged += OnTabChanged;
         NaturalTab.IsCheckedChanged += OnTabChanged;
 
         Loaded += OnLoaded;
     }
 
-    /// <summary>
-    /// All equipment slots.
-    /// </summary>
     public ObservableCollection<EquipmentSlotViewModel> Slots
     {
         get => GetValue(SlotsProperty);
         set => SetValue(SlotsProperty, value);
     }
 
-    /// <summary>
-    /// Currently selected slot.
-    /// </summary>
     public EquipmentSlotViewModel? SelectedSlot
     {
         get => GetValue(SelectedSlotProperty);
         set => SetValue(SelectedSlotProperty, value);
     }
 
-    /// <summary>
-    /// Whether to show the natural slots tab.
-    /// </summary>
+    /// <summary>Whether to show the natural slots tab.</summary>
     public bool ShowNaturalSlots
     {
         get => GetValue(ShowNaturalSlotsProperty);
@@ -112,7 +78,6 @@ public partial class EquipmentSlotsPanel : UserControl
 
     private void OnLoaded(object? sender, RoutedEventArgs e)
     {
-        // Create slot controls if not yet created
         if (_slotControls.Count == 0)
         {
             CreateSlotControls();
@@ -163,9 +128,7 @@ public partial class EquipmentSlotsPanel : UserControl
         }
     }
 
-    /// <summary>
-    /// Apply slot size dimensions after slots are bound.
-    /// </summary>
+    /// <summary>Apply slot size dimensions after slots are bound.</summary>
     private void ApplySlotSizes()
     {
         foreach (var slot in Slots)
@@ -276,9 +239,7 @@ public partial class EquipmentSlotsPanel : UserControl
         CopyResRefRequested?.Invoke(this, slot);
     }
 
-    /// <summary>
-    /// Clears all equipped items from slots.
-    /// </summary>
+    /// <summary>Clears all equipped items from slots.</summary>
     public void ClearAllSlots()
     {
         foreach (var slot in Slots)
@@ -288,79 +249,48 @@ public partial class EquipmentSlotsPanel : UserControl
         }
     }
 
-    /// <summary>
-    /// Gets a slot by its bit flag.
-    /// </summary>
+    /// <summary>Gets a slot by its bit flag.</summary>
     public EquipmentSlotViewModel? GetSlotByFlag(int flag)
     {
         return Slots.FirstOrDefault(s => s.SlotFlag == flag);
     }
 
-    /// <summary>
-    /// Gets a slot by its ID.
-    /// </summary>
+    /// <summary>Gets a slot by its ID.</summary>
     public EquipmentSlotViewModel? GetSlotById(int slotId)
     {
         return Slots.FirstOrDefault(s => s.SlotId == slotId);
     }
 }
 
-/// <summary>
-/// Individual equipment slot control.
-/// </summary>
+/// <summary>Individual equipment slot control.</summary>
 public class EquipmentSlotControl : TemplatedControl
 {
-    /// <summary>
-    /// The slot view model.
-    /// </summary>
     public static readonly StyledProperty<EquipmentSlotViewModel?> SlotProperty =
         AvaloniaProperty.Register<EquipmentSlotControl, EquipmentSlotViewModel?>(nameof(Slot));
 
-    /// <summary>
-    /// Width of the slot icon area (varies by SlotSize).
-    /// </summary>
+    /// <summary>Width of the slot icon area (varies by SlotSize).</summary>
     public static readonly StyledProperty<double> SlotWidthProperty =
         AvaloniaProperty.Register<EquipmentSlotControl, double>(nameof(SlotWidth), defaultValue: 64);
 
-    /// <summary>
-    /// Height of the slot icon area (varies by SlotSize).
-    /// </summary>
+    /// <summary>Height of the slot icon area (varies by SlotSize).</summary>
     public static readonly StyledProperty<double> SlotHeightProperty =
         AvaloniaProperty.Register<EquipmentSlotControl, double>(nameof(SlotHeight), defaultValue: 64);
 
-    /// <summary>
-    /// Event raised when slot is clicked.
-    /// </summary>
     public event EventHandler<EquipmentSlotViewModel>? SlotClicked;
 
-    /// <summary>
-    /// Event raised when slot is double-clicked.
-    /// </summary>
     public event EventHandler<EquipmentSlotViewModel>? SlotDoubleClicked;
 
-    /// <summary>
-    /// Event raised when drag starts.
-    /// </summary>
     public event EventHandler<EquipmentSlotDragEventArgs>? DragStarting;
 
-    /// <summary>
-    /// Event raised when item is dropped.
-    /// </summary>
     public event EventHandler<EquipmentSlotDropEventArgs>? ItemDropped;
 
-    /// <summary>
-    /// Event raised when "Unequip to Backpack" is selected from context menu.
-    /// </summary>
+    /// <summary>Raised when "Unequip to Backpack" is chosen from the context menu.</summary>
     public event EventHandler<EquipmentSlotViewModel>? UnequipRequested;
 
-    /// <summary>
-    /// Event raised when "Remove" is selected from context menu.
-    /// </summary>
+    /// <summary>Raised when "Remove" is chosen from the context menu.</summary>
     public event EventHandler<EquipmentSlotViewModel>? RemoveRequested;
 
-    /// <summary>
-    /// Event raised when "Copy ResRef" is selected from context menu.
-    /// </summary>
+    /// <summary>Raised when "Copy ResRef" is chosen from the context menu.</summary>
     public event EventHandler<EquipmentSlotViewModel>? CopyResRefRequested;
 
     // Drag state

--- a/Radoub.UI/Radoub.UI/Controls/EquipmentSlotsPanel.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Controls/EquipmentSlotsPanel.axaml.cs
@@ -300,15 +300,12 @@ public class EquipmentSlotControl : TemplatedControl
 
     public EquipmentSlotControl()
     {
-        // Enable drag-drop
         DragDrop.SetAllowDrop(this, true);
         AddHandler(DragDrop.DropEvent, OnDrop);
         AddHandler(DragDrop.DragOverEvent, OnDragOver);
 
-        // Handle double-tap via event
         DoubleTapped += OnDoubleTapped;
 
-        // Build context menu
         BuildContextMenu();
     }
 
@@ -373,27 +370,18 @@ public class EquipmentSlotControl : TemplatedControl
         ContextMenu = menu;
     }
 
-    /// <summary>
-    /// The slot view model.
-    /// </summary>
     public EquipmentSlotViewModel? Slot
     {
         get => GetValue(SlotProperty);
         set => SetValue(SlotProperty, value);
     }
 
-    /// <summary>
-    /// Width of the slot icon area.
-    /// </summary>
     public double SlotWidth
     {
         get => GetValue(SlotWidthProperty);
         set => SetValue(SlotWidthProperty, value);
     }
 
-    /// <summary>
-    /// Height of the slot icon area.
-    /// </summary>
     public double SlotHeight
     {
         get => GetValue(SlotHeightProperty);
@@ -481,24 +469,15 @@ public class EquipmentSlotControl : TemplatedControl
     }
 }
 
-/// <summary>
-/// Event args for drag operations from equipment slots.
-/// </summary>
+/// <summary>Event args for drag operations from equipment slots.</summary>
 public class EquipmentSlotDragEventArgs : EventArgs
 {
-    /// <summary>
-    /// The slot being dragged from.
-    /// </summary>
+    /// <summary>The slot being dragged from.</summary>
     public EquipmentSlotViewModel Slot { get; }
 
-    /// <summary>
-    /// Data to include in drag operation. Set by event handler.
-    /// </summary>
+    /// <summary>Data to include in the drag operation. Set by the event handler.</summary>
     public object? Data { get; set; }
 
-    /// <summary>
-    /// Data format string.
-    /// </summary>
     public string? DataFormat { get; set; }
 
     public EquipmentSlotDragEventArgs(EquipmentSlotViewModel slot)
@@ -507,14 +486,10 @@ public class EquipmentSlotDragEventArgs : EventArgs
     }
 }
 
-/// <summary>
-/// Event args for drop operations on equipment slots.
-/// </summary>
+/// <summary>Event args for drop operations on equipment slots.</summary>
 public class EquipmentSlotDropEventArgs : EventArgs
 {
-    /// <summary>
-    /// The slot receiving the drop.
-    /// </summary>
+    /// <summary>The slot receiving the drop.</summary>
     public EquipmentSlotViewModel TargetSlot { get; }
 
     /// <summary>

--- a/Radoub.UI/Radoub.UI/Controls/FileBrowserPanelBase.UI.cs
+++ b/Radoub.UI/Radoub.UI/Controls/FileBrowserPanelBase.UI.cs
@@ -39,9 +39,6 @@ public partial class FileBrowserPanelBase
         CountLabel.Foreground = BrushManager.GetErrorBrush(this);
     }
 
-    /// <summary>
-    /// Update the status text during loading operations.
-    /// </summary>
     protected void UpdateLoadingStatus(string message)
     {
         StatusText.Text = message;

--- a/Radoub.UI/Radoub.UI/Controls/IFileBrowserPanel.cs
+++ b/Radoub.UI/Radoub.UI/Controls/IFileBrowserPanel.cs
@@ -3,20 +3,11 @@ using System.Threading.Tasks;
 
 namespace Radoub.UI.Controls;
 
-/// <summary>
-/// Event args for when a file is selected in the browser panel.
-/// </summary>
 public class FileSelectedEventArgs : EventArgs
 {
-    /// <summary>
-    /// The selected file entry.
-    /// </summary>
     public FileBrowserEntry Entry { get; }
 
-    /// <summary>
-    /// Whether this was a double-click (or Enter key) indicating immediate action.
-    /// Single-click sets selection; double-click triggers load.
-    /// </summary>
+    /// <summary>Single-click sets selection; double-click (or Enter) triggers load.</summary>
     public bool IsDoubleClick { get; }
 
     public FileSelectedEventArgs(FileBrowserEntry entry, bool isDoubleClick = false)
@@ -26,35 +17,22 @@ public class FileSelectedEventArgs : EventArgs
     }
 }
 
-/// <summary>
-/// Base entry class for file browser panels.
-/// Tool-specific panels can extend this with additional properties.
-/// </summary>
+/// <summary>Base entry for file browser panels; tool-specific panels extend it.</summary>
 public class FileBrowserEntry
 {
-    /// <summary>
-    /// Resource name without extension (e.g., "merchant_01").
-    /// </summary>
+    /// <summary>Resource name without extension (e.g., "merchant_01").</summary>
     public string Name { get; set; } = "";
 
-    /// <summary>
-    /// Full file path for filesystem files. Null for HAK/BIF resources.
-    /// </summary>
+    /// <summary>Full file path for filesystem files. Null for HAK/BIF resources.</summary>
     public string? FilePath { get; set; }
 
-    /// <summary>
-    /// Source description: "Module", "HAK: filename", "LocalVault", etc.
-    /// </summary>
+    /// <summary>Source description: "Module", "HAK: filename", "LocalVault", etc.</summary>
     public string Source { get; set; } = "Module";
 
-    /// <summary>
-    /// True if this resource is from a HAK file (not directly on filesystem).
-    /// </summary>
+    /// <summary>True if from a HAK file (not directly on filesystem).</summary>
     public bool IsFromHak { get; set; }
 
-    /// <summary>
-    /// Path to the HAK file containing this resource. Only set if IsFromHak is true.
-    /// </summary>
+    /// <summary>Path to the containing HAK. Only set if IsFromHak is true.</summary>
     public string? HakPath { get; set; }
 
     /// <summary>
@@ -71,14 +49,12 @@ public class FileBrowserEntry
     public string? Tag { get; set; }
 
     /// <summary>
-    /// True once DisplayLabel/Tag have been populated (or attempted) for this entry.
-    /// Lets the panel skip re-indexing entries that already have metadata.
+    /// True once DisplayLabel/Tag have been populated (or attempted). Lets the
+    /// panel skip re-indexing entries that already have metadata.
     /// </summary>
     public bool MetadataLoaded { get; set; }
 
-    /// <summary>
-    /// Display name shown in the list. Override for custom formatting.
-    /// </summary>
+    /// <summary>Display name shown in the list. Override for custom formatting.</summary>
     public virtual string DisplayName => IsFromHak ? $"{Name} ({Source})" : Name;
 
     public override string ToString() => DisplayName;

--- a/Radoub.UI/Radoub.UI/Controls/ItemFilterPanel.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ItemFilterPanel.axaml.cs
@@ -169,72 +169,52 @@ public partial class ItemFilterPanel : UserControl
         set => SetValue(ShowCreatureItemsProperty, value);
     }
 
-    /// <summary>
-    /// Available item types from baseitems.2da.
-    /// </summary>
+    /// <summary>Available item types from baseitems.2da.</summary>
     public ObservableCollection<ItemTypeInfo> ItemTypes
     {
         get => GetValue(ItemTypesProperty);
         set => SetValue(ItemTypesProperty, value);
     }
 
-    /// <summary>
-    /// Currently selected item type filter. Null means "All Types".
-    /// </summary>
+    /// <summary>Currently selected item type filter. Null means "All Types".</summary>
     public ItemTypeInfo? SelectedItemType
     {
         get => GetValue(SelectedItemTypeProperty);
         set => SetValue(SelectedItemTypeProperty, value);
     }
 
-    /// <summary>
-    /// Game data service for loading item types.
-    /// </summary>
     public IGameDataService? GameDataService
     {
         get => GetValue(GameDataServiceProperty);
         set => SetValue(GameDataServiceProperty, value);
     }
 
-    /// <summary>
-    /// Filter settings provider for persistence.
-    /// </summary>
     public IFilterSettings? FilterSettings
     {
         get => GetValue(FilterSettingsProperty);
         set => SetValue(FilterSettingsProperty, value);
     }
 
-    /// <summary>
-    /// Context key for filter settings (e.g., "Backpack", "Palette").
-    /// </summary>
+    /// <summary>Context key for filter settings (e.g., "Backpack", "Palette").</summary>
     public string ContextKey
     {
         get => GetValue(ContextKeyProperty);
         set => SetValue(ContextKeyProperty, value);
     }
 
-    /// <summary>
-    /// Property search text for filtering by item properties.
-    /// </summary>
     public string PropertySearchText
     {
         get => GetValue(PropertySearchTextProperty);
         set => SetValue(PropertySearchTextProperty, value);
     }
 
-    /// <summary>
-    /// Available slot filters.
-    /// </summary>
     public ObservableCollection<SlotFilterInfo> SlotFilters
     {
         get => GetValue(SlotFiltersProperty);
         set => SetValue(SlotFiltersProperty, value);
     }
 
-    /// <summary>
-    /// Currently selected slot filter. Null or AllSlots means no filter.
-    /// </summary>
+    /// <summary>Currently selected slot filter. Null or AllSlots means no filter.</summary>
     public SlotFilterInfo? SelectedSlotFilter
     {
         get => GetValue(SelectedSlotFilterProperty);
@@ -260,7 +240,6 @@ public partial class ItemFilterPanel : UserControl
         _debounceTimer.Stop();
         _debounceTimer.Dispose();
 
-        // Unsubscribe from collection changes
         if (Items != null)
         {
             Items.CollectionChanged -= OnItemsCollectionChanged;
@@ -277,13 +256,11 @@ public partial class ItemFilterPanel : UserControl
 
         if (change.Property == ItemsProperty)
         {
-            // Unsubscribe from old collection
             if (change.OldValue is ObservableCollection<ItemViewModel> oldItems)
             {
                 oldItems.CollectionChanged -= OnItemsCollectionChanged;
             }
 
-            // Subscribe to new collection
             if (change.NewValue is ObservableCollection<ItemViewModel> newItems)
             {
                 newItems.CollectionChanged += OnItemsCollectionChanged;
@@ -322,7 +299,6 @@ public partial class ItemFilterPanel : UserControl
 
     private void OnItemsCollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
     {
-        // Re-apply filter when source items change
         ApplyFilter();
     }
 
@@ -334,7 +310,6 @@ public partial class ItemFilterPanel : UserControl
     {
         ItemTypes.Clear();
 
-        // Always add "All Types" option
         ItemTypes.Add(ItemTypeInfo.AllTypes);
 
         if (GameDataService == null || !GameDataService.IsConfigured)
@@ -344,10 +319,8 @@ public partial class ItemFilterPanel : UserControl
         if (baseItems == null)
             return;
 
-        // Load valid base item types
         for (int i = 0; i < baseItems.Rows.Count; i++)
         {
-            // Skip invalid/unused entries
             var label = baseItems.GetValue(i, "label");
             if (string.IsNullOrEmpty(label) || label == "****")
                 continue;

--- a/Radoub.UI/Radoub.UI/Controls/ItemFilterPanel.axaml.cs
+++ b/Radoub.UI/Radoub.UI/Controls/ItemFilterPanel.axaml.cs
@@ -20,29 +20,18 @@ public partial class ItemFilterPanel : UserControl
 {
     #region Styled Properties
 
-    /// <summary>
-    /// Source items to filter.
-    /// </summary>
     public static readonly StyledProperty<ObservableCollection<ItemViewModel>?> ItemsProperty =
         AvaloniaProperty.Register<ItemFilterPanel, ObservableCollection<ItemViewModel>?>(nameof(Items));
 
-    /// <summary>
-    /// Filtered items output.
-    /// </summary>
     public static readonly StyledProperty<ObservableCollection<ItemViewModel>> FilteredItemsProperty =
         AvaloniaProperty.Register<ItemFilterPanel, ObservableCollection<ItemViewModel>>(
             nameof(FilteredItems),
             defaultValue: new ObservableCollection<ItemViewModel>());
 
-    /// <summary>
-    /// Search text for filtering.
-    /// </summary>
     public static readonly StyledProperty<string> SearchTextProperty =
         AvaloniaProperty.Register<ItemFilterPanel, string>(nameof(SearchText), defaultValue: string.Empty);
 
-    /// <summary>
-    /// Show items from base game (Standard).
-    /// </summary>
+    /// <summary>Show items from base game (Standard).</summary>
     public static readonly StyledProperty<bool> ShowStandardProperty =
         AvaloniaProperty.Register<ItemFilterPanel, bool>(nameof(ShowStandard), defaultValue: true);
 
@@ -53,15 +42,11 @@ public partial class ItemFilterPanel : UserControl
     public static readonly StyledProperty<bool> ShowOverrideProperty =
         AvaloniaProperty.Register<ItemFilterPanel, bool>(nameof(ShowOverride), defaultValue: false);
 
-    /// <summary>
-    /// Show items from module-referenced HAK packs. Default true.
-    /// </summary>
+    /// <summary>Show items from module-referenced HAK packs. Default true.</summary>
     public static readonly StyledProperty<bool> ShowHakProperty =
         AvaloniaProperty.Register<ItemFilterPanel, bool>(nameof(ShowHak), defaultValue: true);
 
-    /// <summary>
-    /// Show loose UTI files from the module directory. Default true.
-    /// </summary>
+    /// <summary>Show loose UTI files from the module directory. Default true.</summary>
     public static readonly StyledProperty<bool> ShowModuleProperty =
         AvaloniaProperty.Register<ItemFilterPanel, bool>(nameof(ShowModule), defaultValue: true);
 
@@ -73,55 +58,35 @@ public partial class ItemFilterPanel : UserControl
     public static readonly StyledProperty<bool> ShowCreatureItemsProperty =
         AvaloniaProperty.Register<ItemFilterPanel, bool>(nameof(ShowCreatureItems), defaultValue: false);
 
-    /// <summary>
-    /// Available item types for filtering.
-    /// </summary>
     public static readonly StyledProperty<ObservableCollection<ItemTypeInfo>> ItemTypesProperty =
         AvaloniaProperty.Register<ItemFilterPanel, ObservableCollection<ItemTypeInfo>>(
             nameof(ItemTypes),
             defaultValue: new ObservableCollection<ItemTypeInfo>());
 
-    /// <summary>
-    /// Currently selected item type filter.
-    /// </summary>
     public static readonly StyledProperty<ItemTypeInfo?> SelectedItemTypeProperty =
         AvaloniaProperty.Register<ItemFilterPanel, ItemTypeInfo?>(nameof(SelectedItemType));
 
-    /// <summary>
-    /// Game data service for loading item types from baseitems.2da.
-    /// </summary>
+    /// <summary>Game data service for loading item types from baseitems.2da.</summary>
     public static readonly StyledProperty<IGameDataService?> GameDataServiceProperty =
         AvaloniaProperty.Register<ItemFilterPanel, IGameDataService?>(nameof(GameDataService));
 
-    /// <summary>
-    /// Filter settings provider for state persistence.
-    /// </summary>
+    /// <summary>Filter settings provider for state persistence.</summary>
     public static readonly StyledProperty<IFilterSettings?> FilterSettingsProperty =
         AvaloniaProperty.Register<ItemFilterPanel, IFilterSettings?>(nameof(FilterSettings));
 
-    /// <summary>
-    /// Context key for filter state persistence.
-    /// </summary>
+    /// <summary>Context key for filter state persistence.</summary>
     public static readonly StyledProperty<string> ContextKeyProperty =
         AvaloniaProperty.Register<ItemFilterPanel, string>(nameof(ContextKey), defaultValue: "Default");
 
-    /// <summary>
-    /// Property search text for filtering by item properties.
-    /// </summary>
+    /// <summary>Property search text for filtering by item properties.</summary>
     public static readonly StyledProperty<string> PropertySearchTextProperty =
         AvaloniaProperty.Register<ItemFilterPanel, string>(nameof(PropertySearchText), defaultValue: string.Empty);
 
-    /// <summary>
-    /// Available slot filters for the dropdown.
-    /// </summary>
     public static readonly StyledProperty<ObservableCollection<SlotFilterInfo>> SlotFiltersProperty =
         AvaloniaProperty.Register<ItemFilterPanel, ObservableCollection<SlotFilterInfo>>(
             nameof(SlotFilters),
             defaultValue: new ObservableCollection<SlotFilterInfo>());
 
-    /// <summary>
-    /// Currently selected slot filter.
-    /// </summary>
     public static readonly StyledProperty<SlotFilterInfo?> SelectedSlotFilterProperty =
         AvaloniaProperty.Register<ItemFilterPanel, SlotFilterInfo?>(nameof(SelectedSlotFilter));
 
@@ -129,9 +94,6 @@ public partial class ItemFilterPanel : UserControl
 
     #region Events
 
-    /// <summary>
-    /// Raised when filter criteria change.
-    /// </summary>
     public event EventHandler? FilterChanged;
 
     #endregion
@@ -148,7 +110,6 @@ public partial class ItemFilterPanel : UserControl
     {
         InitializeComponent();
 
-        // Setup debounce timer for search
         _debounceTimer = new System.Timers.Timer(DebounceDelayMs);
         _debounceTimer.AutoReset = false;
         _debounceTimer.Elapsed += OnDebounceTimerElapsed;
@@ -159,63 +120,43 @@ public partial class ItemFilterPanel : UserControl
 
     #region Public Properties
 
-    /// <summary>
-    /// Source items to filter.
-    /// </summary>
     public ObservableCollection<ItemViewModel>? Items
     {
         get => GetValue(ItemsProperty);
         set => SetValue(ItemsProperty, value);
     }
 
-    /// <summary>
-    /// Filtered items output. Bind ItemListView.Items to this.
-    /// </summary>
+    /// <summary>Filtered items output. Bind ItemListView.Items to this.</summary>
     public ObservableCollection<ItemViewModel> FilteredItems
     {
         get => GetValue(FilteredItemsProperty);
         set => SetValue(FilteredItemsProperty, value);
     }
 
-    /// <summary>
-    /// Current search text.
-    /// </summary>
     public string SearchText
     {
         get => GetValue(SearchTextProperty);
         set => SetValue(SearchTextProperty, value);
     }
 
-    /// <summary>
-    /// Show base game items.
-    /// </summary>
     public bool ShowStandard
     {
         get => GetValue(ShowStandardProperty);
         set => SetValue(ShowStandardProperty, value);
     }
 
-    /// <summary>
-    /// Show Override-folder items.
-    /// </summary>
     public bool ShowOverride
     {
         get => GetValue(ShowOverrideProperty);
         set => SetValue(ShowOverrideProperty, value);
     }
 
-    /// <summary>
-    /// Show module-referenced HAK items.
-    /// </summary>
     public bool ShowHak
     {
         get => GetValue(ShowHakProperty);
         set => SetValue(ShowHakProperty, value);
     }
 
-    /// <summary>
-    /// Show loose module-directory items.
-    /// </summary>
     public bool ShowModule
     {
         get => GetValue(ShowModuleProperty);

--- a/Radoub.UI/Radoub.UI/Controls/MeshVisibility.cs
+++ b/Radoub.UI/Radoub.UI/Controls/MeshVisibility.cs
@@ -9,9 +9,7 @@ namespace Radoub.UI.Controls;
 /// </summary>
 public static class MeshVisibility
 {
-    /// <summary>
-    /// Whether a mesh should be rendered. True iff Render is set and the mesh has geometry.
-    /// </summary>
+    /// <summary>True iff Render is set and the mesh has geometry.</summary>
     public static bool ShouldRender(bool render, int vertexCount, int faceCount)
         => render && vertexCount > 0 && faceCount > 0;
 }

--- a/Radoub.UI/Radoub.UI/Models/FilterState.cs
+++ b/Radoub.UI/Radoub.UI/Models/FilterState.cs
@@ -2,14 +2,10 @@ using System.Text.Json.Serialization;
 
 namespace Radoub.UI.Models;
 
-/// <summary>
-/// Persisted filter state for ItemFilterPanel.
-/// </summary>
+/// <summary>Persisted filter state for ItemFilterPanel.</summary>
 public class FilterState
 {
-    /// <summary>
-    /// Show base game (Standard / BIF) items.
-    /// </summary>
+    /// <summary>Show base game (Standard / BIF) items.</summary>
     public bool ShowStandard { get; set; } = true;
 
     /// <summary>
@@ -36,24 +32,16 @@ public class FilterState
     [JsonPropertyName("ShowCustom")]
     public bool? LegacyShowCustom { get; set; }
 
-    /// <summary>
-    /// Text search string.
-    /// </summary>
+    /// <summary>Text search string.</summary>
     public string? SearchText { get; set; }
 
-    /// <summary>
-    /// Selected base item type index, or null for "All Types".
-    /// </summary>
+    /// <summary>Selected base item type index, or null for "All Types".</summary>
     public int? SelectedBaseItemIndex { get; set; }
 
-    /// <summary>
-    /// Property search string (searches item properties).
-    /// </summary>
+    /// <summary>Property search string (searches item properties).</summary>
     public string? PropertySearchText { get; set; }
 
-    /// <summary>
-    /// Selected slot filter flag, or null for "All Slots".
-    /// </summary>
+    /// <summary>Selected slot filter flag, or null for "All Slots".</summary>
     public int? SelectedSlotFlag { get; set; }
 
     /// <summary>

--- a/Radoub.UI/Radoub.UI/Models/ItemTypeInfo.cs
+++ b/Radoub.UI/Radoub.UI/Models/ItemTypeInfo.cs
@@ -1,33 +1,21 @@
 namespace Radoub.UI.Models;
 
-/// <summary>
-/// Represents an item type from baseitems.2da for filtering.
-/// </summary>
+/// <summary>Represents an item type from baseitems.2da for filtering.</summary>
 public class ItemTypeInfo
 {
-    /// <summary>
-    /// Special instance representing "All Types" (no filter).
-    /// </summary>
+    /// <summary>Special instance representing "All Types" (no filter).</summary>
     public static readonly ItemTypeInfo AllTypes = new(-1, "All Types", "*");
 
-    /// <summary>
-    /// Row index in baseitems.2da.
-    /// </summary>
+    /// <summary>Row index in baseitems.2da.</summary>
     public int BaseItemIndex { get; }
 
-    /// <summary>
-    /// Display name (resolved from TLK or label).
-    /// </summary>
+    /// <summary>Display name (resolved from TLK or label).</summary>
     public string Name { get; }
 
-    /// <summary>
-    /// Label from baseitems.2da.
-    /// </summary>
+    /// <summary>Label from baseitems.2da.</summary>
     public string Label { get; }
 
-    /// <summary>
-    /// True if this is the "All Types" option.
-    /// </summary>
+    /// <summary>True if this is the "All Types" option.</summary>
     public bool IsAllTypes => BaseItemIndex == -1;
 
     public ItemTypeInfo(int baseItemIndex, string name, string label)

--- a/Radoub.UI/Radoub.UI/Models/SearchBarCriteriaFactory.cs
+++ b/Radoub.UI/Radoub.UI/Models/SearchBarCriteriaFactory.cs
@@ -10,9 +10,7 @@ namespace Radoub.UI.Models;
 /// </summary>
 public static class SearchBarCriteriaFactory
 {
-    /// <summary>
-    /// Builds search criteria from the raw SearchBar control values.
-    /// </summary>
+    /// <summary>Builds search criteria from the raw SearchBar control values.</summary>
     /// <param name="pattern">The search pattern text.</param>
     /// <param name="isRegex">Whether the pattern is a regular expression.</param>
     /// <param name="caseSensitive">Whether matching is case-sensitive.</param>

--- a/Radoub.UI/Radoub.UI/Models/SlotFilterInfo.cs
+++ b/Radoub.UI/Radoub.UI/Models/SlotFilterInfo.cs
@@ -1,18 +1,12 @@
 namespace Radoub.UI.Models;
 
-/// <summary>
-/// Represents an equipment slot filter option for the item palette filter.
-/// </summary>
+/// <summary>Represents an equipment slot filter option for the item palette filter.</summary>
 public class SlotFilterInfo
 {
-    /// <summary>
-    /// Special instance representing "All Slots" (no slot filter).
-    /// </summary>
+    /// <summary>Special instance representing "All Slots" (no slot filter).</summary>
     public static readonly SlotFilterInfo AllSlots = new(0, "All Slots");
 
-    /// <summary>
-    /// Special instance for showing only non-equipable items.
-    /// </summary>
+    /// <summary>Special instance for showing only non-equipable items.</summary>
     public static readonly SlotFilterInfo NonEquipable = new(-1, "Non-Equipable");
 
     /// <summary>
@@ -21,19 +15,13 @@ public class SlotFilterInfo
     /// </summary>
     public int SlotFlag { get; }
 
-    /// <summary>
-    /// Display name for the filter dropdown.
-    /// </summary>
+    /// <summary>Display name for the filter dropdown.</summary>
     public string Name { get; }
 
-    /// <summary>
-    /// True if this is the "All Slots" option.
-    /// </summary>
+    /// <summary>True if this is the "All Slots" option.</summary>
     public bool IsAllSlots => SlotFlag == 0;
 
-    /// <summary>
-    /// True if this filters to non-equipable items only.
-    /// </summary>
+    /// <summary>True if this filters to non-equipable items only.</summary>
     public bool IsNonEquipable => SlotFlag == -1;
 
     public SlotFilterInfo(int slotFlag, string name)

--- a/Radoub.UI/Radoub.UI/Models/ThemeManifest.cs
+++ b/Radoub.UI/Radoub.UI/Models/ThemeManifest.cs
@@ -30,16 +30,12 @@ public class ThemeManifest
     [JsonPropertyName("spacing")]
     public ThemeSpacing? Spacing { get; set; }
 
-    /// <summary>
-    /// Path to the theme file (set at runtime, not in JSON)
-    /// </summary>
+    /// <summary>Path to the theme file (set at runtime, not in JSON)</summary>
     [JsonIgnore]
     public string? SourcePath { get; set; }
 }
 
-/// <summary>
-/// Theme plugin metadata
-/// </summary>
+/// <summary>Theme plugin metadata</summary>
 public class ThemePluginInfo
 {
     [JsonPropertyName("id")]
@@ -64,9 +60,7 @@ public class ThemePluginInfo
     public string[] Tags { get; set; } = Array.Empty<string>();
 }
 
-/// <summary>
-/// Theme accessibility metadata
-/// </summary>
+/// <summary>Theme accessibility metadata</summary>
 public class ThemeAccessibility
 {
     [JsonPropertyName("type")]
@@ -196,9 +190,7 @@ public class ThemeColors
     public string? Speaker6 { get; set; }
 }
 
-/// <summary>
-/// Theme font configuration
-/// </summary>
+/// <summary>Theme font configuration</summary>
 public class ThemeFonts
 {
     [JsonPropertyName("primary")]
@@ -214,9 +206,7 @@ public class ThemeFonts
     public string? Weight { get; set; } // "Normal", "Bold", etc.
 }
 
-/// <summary>
-/// Theme spacing/layout configuration
-/// </summary>
+/// <summary>Theme spacing/layout configuration</summary>
 public class ThemeSpacing
 {
     [JsonPropertyName("control_padding")]

--- a/Radoub.UI/Radoub.UI/Services/AudioService.cs
+++ b/Radoub.UI/Radoub.UI/Services/AudioService.cs
@@ -20,9 +20,7 @@ public class AudioService : IDisposable
     public bool IsPlaying => _isPlaying;
     public string? CurrentFile => _currentFile;
 
-    /// <summary>
-    /// Event raised when playback stops (either naturally or via Stop()).
-    /// </summary>
+    /// <summary>Event raised when playback stops (either naturally or via Stop()).</summary>
     public event EventHandler? PlaybackStopped;
 
     public AudioService()
@@ -58,9 +56,7 @@ public class AudioService : IDisposable
         PlaybackStopped?.Invoke(this, EventArgs.Empty);
     }
 
-    /// <summary>
-    /// Play a sound file.
-    /// </summary>
+    /// <summary>Play a sound file.</summary>
     public void Play(string filePath)
     {
         if (!File.Exists(filePath))
@@ -88,9 +84,7 @@ public class AudioService : IDisposable
         }
     }
 
-    /// <summary>
-    /// Stop current playback.
-    /// </summary>
+    /// <summary>Stop current playback.</summary>
     public void Stop()
     {
         if (_isPlaying)
@@ -120,9 +114,7 @@ public class AudioService : IDisposable
     }
 }
 
-/// <summary>
-/// Platform-agnostic audio player interface.
-/// </summary>
+/// <summary>Platform-agnostic audio player interface.</summary>
 internal interface IAudioPlayer : IDisposable
 {
     void Play(string filePath);
@@ -140,9 +132,7 @@ internal class WindowsAudioPlayer : IAudioPlayer
     private NAudio.Wave.WaveOutEvent? _outputDevice;
     private NAudio.Wave.WaveStream? _waveStream;
 
-    /// <summary>
-    /// Event raised when playback stops (either naturally or via Stop()).
-    /// </summary>
+    /// <summary>Event raised when playback stops (either naturally or via Stop()).</summary>
     public event EventHandler? PlaybackStopped;
 
     public void Play(string filePath)
@@ -486,9 +476,7 @@ internal class LinuxAudioPlayer : IAudioPlayer
     }
 }
 
-/// <summary>
-/// macOS audio player using afplay command.
-/// </summary>
+/// <summary>macOS audio player using afplay command.</summary>
 internal class MacOSAudioPlayer : IAudioPlayer
 {
     private System.Diagnostics.Process? _process;

--- a/Radoub.UI/Radoub.UI/Services/AuroraFilenameValidator.cs
+++ b/Radoub.UI/Radoub.UI/Services/AuroraFilenameValidator.cs
@@ -7,14 +7,10 @@ namespace Radoub.UI.Services;
 /// </summary>
 public static class AuroraFilenameValidator
 {
-    /// <summary>
-    /// Maximum filename length for Aurora Engine (excluding extension).
-    /// </summary>
+    /// <summary>Maximum filename length for Aurora Engine (excluding extension).</summary>
     public const int MaxFilenameLength = 16;
 
-    /// <summary>
-    /// Validates a filename for Aurora Engine compatibility.
-    /// </summary>
+    /// <summary>Validates a filename for Aurora Engine compatibility.</summary>
     /// <param name="filename">Filename without extension</param>
     /// <returns>Validation result with any errors</returns>
     public static ValidationResult Validate(string filename)
@@ -50,9 +46,7 @@ public static class AuroraFilenameValidator
         return new ValidationResult(errors.Count == 0, errors);
     }
 
-    /// <summary>
-    /// Suggests a valid filename based on the input.
-    /// </summary>
+    /// <summary>Suggests a valid filename based on the input.</summary>
     /// <param name="filename">Original filename</param>
     /// <returns>Sanitized filename that passes validation (may be truncated)</returns>
     public static string Sanitize(string filename)
@@ -85,9 +79,7 @@ public static class AuroraFilenameValidator
     }
 }
 
-/// <summary>
-/// Result of filename validation.
-/// </summary>
+/// <summary>Result of filename validation.</summary>
 public class ValidationResult
 {
     public bool IsValid { get; }
@@ -99,8 +91,6 @@ public class ValidationResult
         Errors = errors.ToList().AsReadOnly();
     }
 
-    /// <summary>
-    /// Gets all errors as a single string, one per line.
-    /// </summary>
+    /// <summary>Gets all errors as a single string, one per line.</summary>
     public string GetErrorMessage() => string.Join("\n", Errors);
 }

--- a/Radoub.UI/Radoub.UI/Services/BackupCleanupService.cs
+++ b/Radoub.UI/Radoub.UI/Services/BackupCleanupService.cs
@@ -29,9 +29,7 @@ public static class BackupCleanupService
     private static readonly HashSet<string> FlatFileBuckets =
         new(StringComparer.OrdinalIgnoreCase) { "SearchReplace", ArchivesBucket };
 
-    /// <summary>
-    /// Delete backup directories/files older than retentionDays.
-    /// </summary>
+    /// <summary>Delete backup directories/files older than retentionDays.</summary>
     public static void CleanupExpiredBackups(int retentionDays, string? backupRoot = null)
     {
         var root = backupRoot ?? DefaultBackupRoot;
@@ -69,9 +67,7 @@ public static class BackupCleanupService
         }
     }
 
-    /// <summary>
-    /// Delete all contents of the backup directory.
-    /// </summary>
+    /// <summary>Delete all contents of the backup directory.</summary>
     public static void DeleteAllBackups(string? backupRoot = null)
     {
         var root = backupRoot ?? DefaultBackupRoot;
@@ -104,9 +100,7 @@ public static class BackupCleanupService
         }
     }
 
-    /// <summary>
-    /// Returns (fileCount, totalBytes) for all backup content.
-    /// </summary>
+    /// <summary>Returns (fileCount, totalBytes) for all backup content.</summary>
     public static (int fileCount, long totalBytes) GetBackupSummary(string? backupRoot = null)
     {
         var root = backupRoot ?? DefaultBackupRoot;
@@ -203,9 +197,7 @@ public static class BackupCleanupService
         return deleted;
     }
 
-    /// <summary>
-    /// Parse timestamp from batch backup directory name (yyyyMMdd_HHmmss).
-    /// </summary>
+    /// <summary>Parse timestamp from batch backup directory name (yyyyMMdd_HHmmss).</summary>
     private static bool TryParseTimestamp(string dirName, out DateTime timestamp)
     {
         return DateTime.TryParseExact(dirName, "yyyyMMdd_HHmmss",

--- a/Radoub.UI/Radoub.UI/Services/BaseToolSettingsService.cs
+++ b/Radoub.UI/Radoub.UI/Services/BaseToolSettingsService.cs
@@ -56,66 +56,38 @@ public abstract class BaseToolSettingsService<TSettings> : INotifyPropertyChange
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
-    /// <summary>
-    /// Tool name used for directory and logging (e.g., "Quartermaster", "Fence").
-    /// </summary>
+    /// <summary>Tool name used for directory and logging (e.g., "Quartermaster", "Fence").</summary>
     protected abstract string ToolName { get; }
 
-    /// <summary>
-    /// Environment variable name for settings directory override (e.g., "QUARTERMASTER_SETTINGS_DIR").
-    /// </summary>
+    /// <summary>Environment variable name for settings directory override (e.g., "QUARTERMASTER_SETTINGS_DIR").</summary>
     protected abstract string SettingsEnvironmentVariable { get; }
 
-    /// <summary>
-    /// Settings JSON filename (e.g., "QuartermasterSettings.json").
-    /// </summary>
+    /// <summary>Settings JSON filename (e.g., "QuartermasterSettings.json").</summary>
     protected abstract string SettingsFileName { get; }
 
-    /// <summary>
-    /// Default window width for this tool.
-    /// </summary>
     protected virtual double DefaultWindowWidth => 1200;
 
-    /// <summary>
-    /// Default window height for this tool.
-    /// </summary>
     protected virtual double DefaultWindowHeight => 800;
 
-    /// <summary>
-    /// Minimum window width constraint.
-    /// </summary>
     protected virtual double MinWindowWidth => 600;
 
-    /// <summary>
-    /// Minimum window height constraint.
-    /// </summary>
     protected virtual double MinWindowHeight => 400;
 
-    /// <summary>
-    /// Default width of the resizable browser/side-panel (#2356).
-    /// </summary>
+    /// <summary>Default width of the resizable browser/side-panel (#2356).</summary>
     protected virtual double DefaultBrowserPanelWidth => 250;
 
-    /// <summary>
-    /// Minimum browser-panel width constraint (#2356).
-    /// </summary>
+    /// <summary>Minimum browser-panel width constraint (#2356).</summary>
     protected virtual double MinBrowserPanelWidth => 150;
 
-    /// <summary>
-    /// Maximum browser-panel width constraint (#2356).
-    /// </summary>
+    /// <summary>Maximum browser-panel width constraint (#2356).</summary>
     protected virtual double MaxBrowserPanelWidth => 500;
 
-    /// <summary>
-    /// Shared settings for game paths and TLK configuration.
-    /// </summary>
+    /// <summary>Shared settings for game paths and TLK configuration.</summary>
     public static RadoubSettings SharedSettings => RadoubSettings.Instance;
 
     private string? _settingsDirectory;
 
-    /// <summary>
-    /// Gets the settings directory, supporting environment variable override for testing.
-    /// </summary>
+    /// <summary>Gets the settings directory, supporting environment variable override for testing.</summary>
     protected string SettingsDirectory
     {
         get
@@ -229,16 +201,10 @@ public abstract class BaseToolSettingsService<TSettings> : INotifyPropertyChange
         }
     }
 
-    /// <summary>
-    /// Override to perform additional actions when log retention changes.
-    /// Trebuchet uses this to sync to RadoubSettings.
-    /// </summary>
+    /// <summary>Override for extra actions on retention change. Trebuchet syncs to RadoubSettings.</summary>
     protected virtual void OnLoggingRetentionChanged(int sessions) { }
 
-    /// <summary>
-    /// Override to perform additional actions when log level changes.
-    /// Trebuchet uses this to sync to RadoubSettings.
-    /// </summary>
+    /// <summary>Override for extra actions on log-level change. Trebuchet syncs to RadoubSettings.</summary>
     protected virtual void OnLoggingLevelChanged(LogLevel level) { }
 
     #endregion
@@ -375,7 +341,6 @@ public abstract class BaseToolSettingsService<TSettings> : INotifyPropertyChange
 
                 if (settings != null)
                 {
-                    // Load common properties
                     _windowLeft = settings.WindowLeft;
                     _windowTop = settings.WindowTop;
                     _windowWidth = Math.Max(MinWindowWidth, settings.WindowWidth);
@@ -397,7 +362,6 @@ public abstract class BaseToolSettingsService<TSettings> : INotifyPropertyChange
                         UnifiedLogger.SetLogLevel(shared.SharedLogLevel);
                     }
 
-                    // Load recent files
                     _recentFiles = PathHelper.ExpandPaths(settings.RecentFiles ?? new List<string>()).ToList();
                     _maxRecentFiles = settings.MaxRecentFiles > 0 && settings.MaxRecentFiles <= 20
                         ? settings.MaxRecentFiles
@@ -411,7 +375,6 @@ public abstract class BaseToolSettingsService<TSettings> : INotifyPropertyChange
 
                     ValidateRecentFilesOnLoad();
 
-                    // Load tool-specific properties
                     LoadToolSettings(settings);
 
                     UnifiedLogger.LogApplication(LogLevel.INFO,
@@ -440,7 +403,6 @@ public abstract class BaseToolSettingsService<TSettings> : INotifyPropertyChange
         {
             var settings = new TSettings();
 
-            // Save common properties
             settings.WindowLeft = WindowLeft;
             settings.WindowTop = WindowTop;
             settings.WindowWidth = WindowWidth;
@@ -455,7 +417,6 @@ public abstract class BaseToolSettingsService<TSettings> : INotifyPropertyChange
             settings.BrowserPanelWidth = BrowserPanelWidth;
             settings.BrowserPanelVisible = BrowserPanelVisible;
 
-            // Save tool-specific properties
             SaveToolSettings(settings);
 
             var json = JsonSerializer.Serialize(settings, new JsonSerializerOptions
@@ -473,16 +434,10 @@ public abstract class BaseToolSettingsService<TSettings> : INotifyPropertyChange
         }
     }
 
-    /// <summary>
-    /// Load tool-specific properties from the deserialized settings data.
-    /// Called during LoadSettings() after common properties are loaded.
-    /// </summary>
+    /// <summary>Load tool-specific properties. Called by LoadSettings() after common properties.</summary>
     protected abstract void LoadToolSettings(TSettings settings);
 
-    /// <summary>
-    /// Save tool-specific properties to the settings data object.
-    /// Called during SaveSettings() after common properties are saved.
-    /// </summary>
+    /// <summary>Save tool-specific properties. Called by SaveSettings() after common properties.</summary>
     protected abstract void SaveToolSettings(TSettings settings);
 
     #endregion
@@ -509,9 +464,8 @@ public abstract class BaseToolSettingsService<TSettings> : INotifyPropertyChange
     #region Base Settings Data
 
     /// <summary>
-    /// Base class for the JSON-serializable settings data.
-    /// Contains all common properties. Tool-specific data classes
-    /// should inherit from this and add their own properties.
+    /// Base for the JSON-serializable settings data. Tool-specific data classes inherit
+    /// from this and add their own properties.
     /// </summary>
     public class BaseSettingsData
     {

--- a/Radoub.UI/Radoub.UI/Services/BlueprintNamingService.cs
+++ b/Radoub.UI/Radoub.UI/Services/BlueprintNamingService.cs
@@ -54,9 +54,7 @@ public static partial class BlueprintNamingService
         return TruncateAndTrim(resref, MaxResRefLength);
     }
 
-    /// <summary>
-    /// Returns true if the resRef is valid: [a-z0-9_], 1–16 chars.
-    /// </summary>
+    /// <summary>Returns true if the resRef is valid: [a-z0-9_], 1–16 chars.</summary>
     public static bool IsValidResRef(string resRef)
     {
         if (string.IsNullOrEmpty(resRef) || resRef.Length > MaxResRefLength)
@@ -64,9 +62,7 @@ public static partial class BlueprintNamingService
         return ValidResRefRegex().IsMatch(resRef);
     }
 
-    /// <summary>
-    /// Returns true if the tag is valid: [a-zA-Z0-9_], 1–32 chars.
-    /// </summary>
+    /// <summary>Returns true if the tag is valid: [a-zA-Z0-9_], 1–32 chars.</summary>
     public static bool IsValidTag(string tag)
     {
         if (string.IsNullOrEmpty(tag) || tag.Length > MaxTagLength)

--- a/Radoub.UI/Radoub.UI/Services/CopyToModuleValidator.cs
+++ b/Radoub.UI/Radoub.UI/Services/CopyToModuleValidator.cs
@@ -9,9 +9,7 @@ namespace Radoub.UI.Services;
 /// </summary>
 public sealed record CopyToModuleResult(string NewResRef, string? NewTag, string? NewName);
 
-/// <summary>
-/// Validation state for the Copy-to-Module dialog's editable fields.
-/// </summary>
+/// <summary>Validation state for the Copy-to-Module dialog's editable fields.</summary>
 public enum CopyToModuleValidationState
 {
     Valid,
@@ -39,9 +37,7 @@ public static class CopyToModuleValidator
     /// <summary>NWN Tag field maximum length.</summary>
     public const int MaxTagLength = 32;
 
-    /// <summary>
-    /// Validate the dialog's current state against target module directory and extension.
-    /// </summary>
+    /// <summary>Validate the dialog's current state against target module directory and extension.</summary>
     /// <param name="resRef">New ResRef (filename stem)</param>
     /// <param name="tag">New Tag (ignored when showTagAndName is false)</param>
     /// <param name="originalResRef">Original ResRef — used to detect "unchanged"</param>

--- a/Radoub.UI/Radoub.UI/Services/DialogHelper.cs
+++ b/Radoub.UI/Radoub.UI/Services/DialogHelper.cs
@@ -55,12 +55,7 @@ public static class DialogHelper
 
     #region Confirmation Dialogs (Modal)
 
-    /// <summary>
-    /// Shows a Yes/No confirmation dialog.
-    /// </summary>
-    /// <param name="parent">Parent window for centering</param>
-    /// <param name="title">Dialog title</param>
-    /// <param name="message">Message to display</param>
+    /// <summary>Shows a Yes/No confirmation dialog.</summary>
     /// <param name="showDontAskAgain">If true, shows "Don't show this again" checkbox</param>
     /// <param name="onDontAskAgain">Callback when user checks "Don't ask again" and clicks Yes</param>
     /// <returns>True if user clicked Yes, false if No</returns>
@@ -136,12 +131,7 @@ public static class DialogHelper
         return result;
     }
 
-    /// <summary>
-    /// Shows an OK/Cancel confirmation dialog.
-    /// </summary>
-    /// <param name="parent">Parent window for centering</param>
-    /// <param name="title">Dialog title</param>
-    /// <param name="message">Message to display</param>
+    /// <summary>Shows an OK/Cancel confirmation dialog.</summary>
     /// <returns>True if user clicked OK, false if Cancel</returns>
     public static async Task<bool> ShowOkCancelAsync(Window parent, string title, string message)
     {
@@ -189,11 +179,7 @@ public static class DialogHelper
         return result;
     }
 
-    /// <summary>
-    /// Shows an OK/Cancel confirmation dialog with a warning icon.
-    /// </summary>
-    /// <param name="parent">Parent window for centering</param>
-    /// <param name="title">Dialog title</param>
+    /// <summary>Shows an OK/Cancel confirmation dialog with a warning icon.</summary>
     /// <param name="message">Message to display (supports longer text with scrolling)</param>
     /// <returns>True if user clicked OK, false if Cancel</returns>
     public static async Task<bool> ShowWarningConfirmAsync(Window parent, string title, string message)
@@ -270,10 +256,7 @@ public static class DialogHelper
         return result;
     }
 
-    /// <summary>
-    /// Shows a Save/Discard/Cancel dialog for unsaved changes.
-    /// </summary>
-    /// <param name="parent">Parent window for centering</param>
+    /// <summary>Shows a Save/Discard/Cancel dialog for unsaved changes.</summary>
     /// <returns>"Save", "Discard", or "Cancel"</returns>
     public static async Task<string> ShowUnsavedChangesAsync(Window parent)
     {
@@ -319,12 +302,7 @@ public static class DialogHelper
         return result;
     }
 
-    /// <summary>
-    /// Shows an error dialog with Save As option.
-    /// Used when save operation fails.
-    /// </summary>
-    /// <param name="parent">Parent window for centering</param>
-    /// <param name="errorMessage">Error message to display</param>
+    /// <summary>Shows an error dialog with Save As option. Used when a save fails.</summary>
     /// <returns>True if user wants to Save As, false to cancel</returns>
     public static async Task<bool> ShowSaveErrorAsync(Window parent, string errorMessage)
     {
@@ -377,12 +355,7 @@ public static class DialogHelper
 
     #region Message Dialogs (Non-Modal)
 
-    /// <summary>
-    /// Shows an informational message dialog (non-modal).
-    /// </summary>
-    /// <param name="parent">Parent window for positioning</param>
-    /// <param name="title">Dialog title</param>
-    /// <param name="message">Message to display</param>
+    /// <summary>Shows an informational message dialog (non-modal).</summary>
     public static void ShowMessage(Window parent, string title, string message)
     {
         var dialog = new Window
@@ -414,12 +387,7 @@ public static class DialogHelper
         dialog.Show(parent);
     }
 
-    /// <summary>
-    /// Shows an error message dialog (non-modal).
-    /// </summary>
-    /// <param name="parent">Parent window for positioning</param>
-    /// <param name="title">Dialog title</param>
-    /// <param name="message">Error message to display</param>
+    /// <summary>Shows an error message dialog (non-modal).</summary>
     public static void ShowError(Window parent, string title, string message)
     {
         var dialog = new Window

--- a/Radoub.UI/Radoub.UI/Services/EasterEggService.cs
+++ b/Radoub.UI/Radoub.UI/Services/EasterEggService.cs
@@ -68,9 +68,7 @@ namespace Radoub.UI.Services
                    _state.ToolsLaunched.Contains("quartermaster");
         }
 
-        /// <summary>
-        /// Gets a list of tools that still need to be launched to unlock Sea-Sick.
-        /// </summary>
+        /// <summary>Gets a list of tools that still need to be launched to unlock Sea-Sick.</summary>
         public List<string> GetMissingTools()
         {
             var missing = new List<string>();

--- a/Radoub.UI/Radoub.UI/Services/EquipmentSlotValidator.cs
+++ b/Radoub.UI/Radoub.UI/Services/EquipmentSlotValidator.cs
@@ -4,25 +4,19 @@ using Radoub.UI.ViewModels;
 
 namespace Radoub.UI.Services;
 
-/// <summary>
-/// Validates equipment slot assignments using baseitems.2da.
-/// </summary>
+/// <summary>Validates equipment slot assignments using baseitems.2da.</summary>
 public class EquipmentSlotValidator
 {
     private readonly IGameDataService _gameData;
 
-    /// <summary>
-    /// Creates a new equipment slot validator.
-    /// </summary>
+    /// <summary>Creates a new equipment slot validator.</summary>
     /// <param name="gameData">Game data service for 2DA access.</param>
     public EquipmentSlotValidator(IGameDataService gameData)
     {
         _gameData = gameData;
     }
 
-    /// <summary>
-    /// Validates an item in a slot and returns a warning message if invalid.
-    /// </summary>
+    /// <summary>Validates an item in a slot and returns a warning message if invalid.</summary>
     /// <param name="slot">The equipment slot.</param>
     /// <returns>Warning message if invalid, null if valid or no item equipped.</returns>
     public string? ValidateSlot(EquipmentSlotViewModel slot)
@@ -46,9 +40,7 @@ public class EquipmentSlotValidator
         return null;
     }
 
-    /// <summary>
-    /// Validates all slots and sets their warning messages.
-    /// </summary>
+    /// <summary>Validates all slots and sets their warning messages.</summary>
     /// <param name="slots">Equipment slots to validate.</param>
     public void ValidateAllSlots(IEnumerable<EquipmentSlotViewModel> slots)
     {
@@ -58,9 +50,7 @@ public class EquipmentSlotValidator
         }
     }
 
-    /// <summary>
-    /// Checks if an item can be equipped in a specific slot.
-    /// </summary>
+    /// <summary>Checks if an item can be equipped in a specific slot.</summary>
     /// <param name="baseItem">Base item index from UTI.</param>
     /// <param name="slotFlag">Slot bit flag to check.</param>
     /// <returns>True if item can be equipped in the slot.</returns>
@@ -73,9 +63,7 @@ public class EquipmentSlotValidator
         return (equipableSlots.Value & slotFlag) != 0;
     }
 
-    /// <summary>
-    /// Gets the valid slot flags for a base item type.
-    /// </summary>
+    /// <summary>Gets the valid slot flags for a base item type.</summary>
     /// <param name="baseItem">Base item index from UTI.</param>
     /// <returns>Bit flags of valid equipment slots, or null if not found.</returns>
     public int? GetEquipableSlots(int baseItem)
@@ -127,9 +115,7 @@ public class EquipmentSlotValidator
         return null;
     }
 
-    /// <summary>
-    /// Validates all slots for creature compatibility and sets their warning messages.
-    /// </summary>
+    /// <summary>Validates all slots for creature compatibility and sets their warning messages.</summary>
     /// <param name="slots">Equipment slots to validate.</param>
     /// <param name="creatureSize">Creature size category.</param>
     public void ValidateAllCreatureCompatibility(IEnumerable<EquipmentSlotViewModel> slots, int creatureSize)
@@ -140,9 +126,7 @@ public class EquipmentSlotValidator
         }
     }
 
-    /// <summary>
-    /// Gets the weapon size for a base item type from baseitems.2da WeaponSize column.
-    /// </summary>
+    /// <summary>Gets the weapon size for a base item type from baseitems.2da WeaponSize column.</summary>
     /// <param name="baseItem">Base item index from UTI.</param>
     /// <returns>Weapon size (1-5), or null if not a weapon or data unavailable.</returns>
     public int? GetWeaponSize(int baseItem)
@@ -157,9 +141,7 @@ public class EquipmentSlotValidator
         return null;
     }
 
-    /// <summary>
-    /// Gets a human-readable name for a creature/weapon size category.
-    /// </summary>
+    /// <summary>Gets a human-readable name for a creature/weapon size category.</summary>
     private static string GetSizeName(int size) => size switch
     {
         1 => "Tiny",
@@ -172,9 +154,7 @@ public class EquipmentSlotValidator
 
     #region Feat Requirement Validation
 
-    /// <summary>
-    /// Gets the required feats for a base item type from baseitems.2da ReqFeat0-ReqFeat4 columns.
-    /// </summary>
+    /// <summary>Gets the required feats for a base item type from baseitems.2da ReqFeat0-ReqFeat4 columns.</summary>
     /// <param name="baseItem">Base item index from UTI.</param>
     /// <returns>List of (FeatId, FeatName) tuples for required feats.</returns>
     public IReadOnlyList<(int FeatId, string FeatName)> GetRequiredFeats(int baseItem)
@@ -347,9 +327,7 @@ public class EquipmentSlotValidator
         return null;
     }
 
-    /// <summary>
-    /// Validates all slots for feat requirements and sets their warning messages.
-    /// </summary>
+    /// <summary>Validates all slots for feat requirements and sets their warning messages.</summary>
     /// <param name="slots">Equipment slots to validate.</param>
     /// <param name="creatureFeats">Set of feat IDs the creature possesses.</param>
     public void ValidateAllFeatRequirements(IEnumerable<EquipmentSlotViewModel> slots, IReadOnlySet<int> creatureFeats)
@@ -385,9 +363,7 @@ public class EquipmentSlotValidator
 
     #endregion
 
-    /// <summary>
-    /// Gets the list of valid slot names for a base item type.
-    /// </summary>
+    /// <summary>Gets the list of valid slot names for a base item type.</summary>
     /// <param name="baseItem">Base item index from UTI.</param>
     /// <returns>List of valid slot names.</returns>
     public IReadOnlyList<string> GetValidSlotNames(int baseItem)

--- a/Radoub.UI/Radoub.UI/Services/FileOperationsHelper.cs
+++ b/Radoub.UI/Radoub.UI/Services/FileOperationsHelper.cs
@@ -4,9 +4,7 @@ using Avalonia.Controls;
 
 namespace Radoub.UI.Services;
 
-/// <summary>
-/// Result of a dirty-check prompt.
-/// </summary>
+/// <summary>Result of a dirty-check prompt.</summary>
 public enum DirtyCheckResult
 {
     /// <summary>User chose to save first (caller should save, then proceed).</summary>
@@ -54,9 +52,7 @@ public static class FileOperationsHelper
         };
     }
 
-    /// <summary>
-    /// Checks if the document is dirty using an IDocumentState instance.
-    /// </summary>
+    /// <summary>Checks if the document is dirty using an IDocumentState instance.</summary>
     /// <param name="parent">Parent window for dialog centering</param>
     /// <param name="documentState">The document state tracker</param>
     /// <returns>The result indicating what the caller should do</returns>

--- a/Radoub.UI/Radoub.UI/Services/FileSessionLockService.cs
+++ b/Radoub.UI/Radoub.UI/Services/FileSessionLockService.cs
@@ -101,9 +101,7 @@ public static class FileSessionLockService
         }
     }
 
-    /// <summary>
-    /// Release the lock for the given file.
-    /// </summary>
+    /// <summary>Release the lock for the given file.</summary>
     public static void ReleaseLock(string? filePath)
     {
         if (string.IsNullOrEmpty(filePath)) return;
@@ -123,9 +121,7 @@ public static class FileSessionLockService
         UnifiedLogger.LogApplication(LogLevel.DEBUG, $"Released lock: {UnifiedLogger.SanitizePath(filePath)}");
     }
 
-    /// <summary>
-    /// Release all locks owned by this process (call on app exit).
-    /// </summary>
+    /// <summary>Release all locks owned by this process (call on app exit).</summary>
     public static void ReleaseAllLocks()
     {
         foreach (var path in _ownedLocks.Keys)

--- a/Radoub.UI/Radoub.UI/Services/GameDataCacheService.cs
+++ b/Radoub.UI/Radoub.UI/Services/GameDataCacheService.cs
@@ -29,9 +29,7 @@ public class GameDataCacheService<T> where T : class
         WriteIndented = false // Compact for faster read/write
     };
 
-    /// <summary>
-    /// Create a cache service for a specific tool and cache type.
-    /// </summary>
+    /// <summary>Create a cache service for a specific tool and cache type.</summary>
     /// <param name="toolName">Tool name (e.g., "Quartermaster", "Fence")</param>
     /// <param name="cacheName">Cache identifier (e.g., "palette", "feats")</param>
     /// <param name="version">Cache version - bump to invalidate existing caches</param>
@@ -45,9 +43,7 @@ public class GameDataCacheService<T> where T : class
         _cacheFilePath = Path.Combine(_cacheDirectory, $"{cacheName}_cache.json");
     }
 
-    /// <summary>
-    /// Check if a valid cache exists for the current game paths.
-    /// </summary>
+    /// <summary>Check if a valid cache exists for the current game paths.</summary>
     public bool HasValidCache()
     {
         if (!File.Exists(_cacheFilePath))
@@ -87,9 +83,7 @@ public class GameDataCacheService<T> where T : class
         }
     }
 
-    /// <summary>
-    /// Load cached items.
-    /// </summary>
+    /// <summary>Load cached items.</summary>
     public List<T>? LoadCache()
     {
         try
@@ -111,9 +105,7 @@ public class GameDataCacheService<T> where T : class
         return null;
     }
 
-    /// <summary>
-    /// Save items to cache.
-    /// </summary>
+    /// <summary>Save items to cache.</summary>
     public async Task SaveCacheAsync(List<T> items)
     {
         try
@@ -145,9 +137,7 @@ public class GameDataCacheService<T> where T : class
         }
     }
 
-    /// <summary>
-    /// Delete the cache file.
-    /// </summary>
+    /// <summary>Delete the cache file.</summary>
     public void ClearCache()
     {
         try
@@ -164,9 +154,7 @@ public class GameDataCacheService<T> where T : class
         }
     }
 
-    /// <summary>
-    /// Get cache file info for display.
-    /// </summary>
+    /// <summary>Get cache file info for display.</summary>
     public CacheInfo? GetCacheInfo()
     {
         if (!File.Exists(_cacheFilePath))
@@ -197,15 +185,11 @@ public class GameDataCacheService<T> where T : class
         return null;
     }
 
-    /// <summary>
-    /// Get the cache file path (for debugging/display).
-    /// </summary>
+    /// <summary>Get the cache file path (for debugging/display).</summary>
     public string CacheFilePath => _cacheFilePath;
 }
 
-/// <summary>
-/// Generic cache wrapper that stores metadata alongside items.
-/// </summary>
+/// <summary>Generic cache wrapper that stores metadata alongside items.</summary>
 /// <typeparam name="T">The type of items being cached</typeparam>
 public class CacheWrapper<T>
 {
@@ -216,9 +200,7 @@ public class CacheWrapper<T>
     public List<T> Items { get; set; } = new();
 }
 
-/// <summary>
-/// Cache metadata for display in settings UI.
-/// </summary>
+/// <summary>Cache metadata for display in settings UI.</summary>
 public class CacheInfo
 {
     public string CacheName { get; set; } = string.Empty;

--- a/Radoub.UI/Radoub.UI/Services/HakPaletteScannerService.cs
+++ b/Radoub.UI/Radoub.UI/Services/HakPaletteScannerService.cs
@@ -167,9 +167,7 @@ public class HakPaletteScannerService
 
 }
 
-/// <summary>
-/// Result of scanning module HAK files.
-/// </summary>
+/// <summary>Result of scanning module HAK files.</summary>
 public class HakScanResult
 {
     /// <summary>Number of HAK files that were actually scanned (cache was stale/missing).</summary>

--- a/Radoub.UI/Radoub.UI/Services/HakScriptScanner.cs
+++ b/Radoub.UI/Radoub.UI/Services/HakScriptScanner.cs
@@ -10,9 +10,7 @@ using Radoub.Formats.Logging;
 
 namespace Radoub.UI.Services;
 
-/// <summary>
-/// Cached HAK file script data to avoid re-scanning on each browser open.
-/// </summary>
+/// <summary>Cached HAK file script data to avoid re-scanning on each browser open.</summary>
 internal class ScriptHakCacheEntry
 {
     public string HakPath { get; set; } = "";
@@ -35,9 +33,7 @@ public class HakScriptScanner
     private static readonly ConcurrentDictionary<string, ScriptHakCacheEntry> _hakCache = new();
     private const int MaxCacheEntries = 64;
 
-    /// <summary>
-    /// Scans multiple HAK files for scripts, respecting module override priority.
-    /// </summary>
+    /// <summary>Scans multiple HAK files for scripts, respecting module override priority.</summary>
     /// <param name="hakPaths">List of HAK file paths to scan</param>
     /// <param name="moduleScripts">Module scripts (highest priority - these override HAK scripts)</param>
     /// <param name="progressCallback">Optional callback for progress updates (hakIndex, totalHaks, hakName)</param>
@@ -73,9 +69,7 @@ public class HakScriptScanner
         return hakScripts;
     }
 
-    /// <summary>
-    /// Scans a single HAK file for scripts, using cache when available.
-    /// </summary>
+    /// <summary>Scans a single HAK file for scripts, using cache when available.</summary>
     private void ScanHakForScripts(
         string hakPath,
         IReadOnlyList<ScriptEntry> moduleScripts,
@@ -158,9 +152,7 @@ public class HakScriptScanner
         }
     }
 
-    /// <summary>
-    /// Checks if a script name already exists in module scripts or HAK scripts.
-    /// </summary>
+    /// <summary>Checks if a script name already exists in module scripts or HAK scripts.</summary>
     private static bool IsDuplicate(
         string scriptName,
         IReadOnlyList<ScriptEntry> moduleScripts,
@@ -175,9 +167,7 @@ public class HakScriptScanner
         return false;
     }
 
-    /// <summary>
-    /// Creates a copy of a script entry for use outside the cache.
-    /// </summary>
+    /// <summary>Creates a copy of a script entry for use outside the cache.</summary>
     private static ScriptEntry CloneScriptEntry(ScriptEntry source)
     {
         return new ScriptEntry
@@ -191,9 +181,7 @@ public class HakScriptScanner
         };
     }
 
-    /// <summary>
-    /// Extracts script content from a HAK file.
-    /// </summary>
+    /// <summary>Extracts script content from a HAK file.</summary>
     /// <param name="scriptEntry">Script entry with HAK path and ERF entry</param>
     /// <returns>Script content with source header, or null if extraction fails</returns>
     public async Task<string?> ExtractScriptFromHakAsync(ScriptEntry scriptEntry)
@@ -235,9 +223,7 @@ public class HakScriptScanner
         }
     }
 
-    /// <summary>
-    /// Gets HAK file paths from a directory.
-    /// </summary>
+    /// <summary>Gets HAK file paths from a directory.</summary>
     public static IEnumerable<string> GetHakFilesFromPath(string path)
     {
         try
@@ -255,9 +241,7 @@ public class HakScriptScanner
         return Enumerable.Empty<string>();
     }
 
-    /// <summary>
-    /// Collects HAK paths from multiple locations with deduplication.
-    /// </summary>
+    /// <summary>Collects HAK paths from multiple locations with deduplication.</summary>
     /// <param name="currentDir">Current file directory (highest priority)</param>
     /// <param name="overridePath">Override path if set</param>
     /// <param name="userPath">NWN user documents path (for hak folder)</param>

--- a/Radoub.UI/Radoub.UI/Services/IDocumentState.cs
+++ b/Radoub.UI/Radoub.UI/Services/IDocumentState.cs
@@ -13,19 +13,13 @@ namespace Radoub.UI.Services;
 /// </summary>
 public interface IDocumentState
 {
-    /// <summary>
-    /// Whether the document has unsaved changes.
-    /// </summary>
+    /// <summary>Whether the document has unsaved changes.</summary>
     bool IsDirty { get; }
 
-    /// <summary>
-    /// Whether the document is currently loading (suppresses dirty marking).
-    /// </summary>
+    /// <summary>Whether the document is currently loading (suppresses dirty marking).</summary>
     bool IsLoading { get; set; }
 
-    /// <summary>
-    /// Current file path, or null if no file is loaded.
-    /// </summary>
+    /// <summary>Current file path, or null if no file is loaded.</summary>
     string? CurrentFilePath { get; set; }
 
     /// <summary>
@@ -40,9 +34,7 @@ public interface IDocumentState
     /// </summary>
     void ForceDirty();
 
-    /// <summary>
-    /// Clear the dirty flag (after save or load).
-    /// </summary>
+    /// <summary>Clear the dirty flag (after save or load).</summary>
     void ClearDirty();
 
     /// <summary>
@@ -71,9 +63,7 @@ public class DocumentState : IDocumentState
     private readonly string? _titleSuffix;
     private bool _isDirty;
 
-    /// <summary>
-    /// Creates a new DocumentState tracker.
-    /// </summary>
+    /// <summary>Creates a new DocumentState tracker.</summary>
     /// <param name="toolName">Tool name for title bar (e.g., "Quartermaster")</param>
     /// <param name="titleSuffix">Optional suffix for the tool name (e.g., " - Merchant Editor")</param>
     public DocumentState(string toolName, string? titleSuffix = null)

--- a/Radoub.UI/Radoub.UI/Services/IPortraitBrowserContext.cs
+++ b/Radoub.UI/Radoub.UI/Services/IPortraitBrowserContext.cs
@@ -2,34 +2,22 @@ using Avalonia.Media.Imaging;
 
 namespace Radoub.UI.Services;
 
-/// <summary>
-/// Represents a portrait entry in the browser with metadata.
-/// </summary>
+/// <summary>Represents a portrait entry in the browser with metadata.</summary>
 public class PortraitEntry
 {
-    /// <summary>
-    /// Portrait ID from portraits.2da.
-    /// </summary>
+    /// <summary>Portrait ID from portraits.2da.</summary>
     public ushort Id { get; set; }
 
-    /// <summary>
-    /// Base resource reference (e.g., "po_elf_m_").
-    /// </summary>
+    /// <summary>Base resource reference (e.g., "po_elf_m_").</summary>
     public string ResRef { get; set; } = "";
 
-    /// <summary>
-    /// Race ID from portraits.2da (or -1 if unknown).
-    /// </summary>
+    /// <summary>Race ID from portraits.2da (or -1 if unknown).</summary>
     public int Race { get; set; } = -1;
 
-    /// <summary>
-    /// Sex/Gender ID from portraits.2da (0=Male, 1=Female, -1=unknown).
-    /// </summary>
+    /// <summary>Sex/Gender ID from portraits.2da (0=Male, 1=Female, -1=unknown).</summary>
     public int Sex { get; set; } = -1;
 
-    /// <summary>
-    /// Display-friendly name (resolved from TLK or fallback).
-    /// </summary>
+    /// <summary>Display-friendly name (resolved from TLK or fallback).</summary>
     public string DisplayName => string.IsNullOrEmpty(ResRef) ? $"Portrait {Id}" : ResRef;
 }
 
@@ -40,9 +28,7 @@ public class PortraitEntry
 /// </summary>
 public interface IPortraitBrowserContext
 {
-    /// <summary>
-    /// The current file's directory (for local portrait lookup).
-    /// </summary>
+    /// <summary>The current file's directory (for local portrait lookup).</summary>
     string? CurrentFileDirectory { get; }
 
     /// <summary>
@@ -51,27 +37,19 @@ public interface IPortraitBrowserContext
     /// </summary>
     string? NeverwinterNightsPath { get; }
 
-    /// <summary>
-    /// Whether game resources (BIF files) are available for portrait lookup.
-    /// </summary>
+    /// <summary>Whether game resources (BIF files) are available for portrait lookup.</summary>
     bool GameResourcesAvailable { get; }
 
-    /// <summary>
-    /// Lists all portraits from portraits.2da.
-    /// </summary>
+    /// <summary>Lists all portraits from portraits.2da.</summary>
     /// <returns>List of portrait entries with metadata</returns>
     IEnumerable<PortraitEntry> ListPortraits();
 
-    /// <summary>
-    /// Gets a portrait bitmap by ResRef.
-    /// </summary>
+    /// <summary>Gets a portrait bitmap by ResRef.</summary>
     /// <param name="resRef">Portrait resource reference</param>
     /// <returns>Portrait bitmap, or null if not found</returns>
     Bitmap? GetPortraitBitmap(string resRef);
 
-    /// <summary>
-    /// Gets the display name for a race ID.
-    /// </summary>
+    /// <summary>Gets the display name for a race ID.</summary>
     /// <param name="raceId">Race ID from racialtypes.2da</param>
     /// <returns>Localized race name</returns>
     string GetRaceName(int raceId);

--- a/Radoub.UI/Radoub.UI/Services/IScriptBrowserContext.cs
+++ b/Radoub.UI/Radoub.UI/Services/IScriptBrowserContext.cs
@@ -3,33 +3,23 @@ using Radoub.Formats.Erf;
 
 namespace Radoub.UI.Services;
 
-/// <summary>
-/// Represents a script entry in the browser with source information.
-/// </summary>
+/// <summary>Represents a script entry in the browser with source information.</summary>
 public class ScriptEntry
 {
     public string Name { get; set; } = "";
     public bool IsBuiltIn { get; set; }
     public string Source { get; set; } = ""; // "Module", "Override", "BIF: filename", "HAK: filename"
 
-    /// <summary>
-    /// If from HAK, the path to the HAK file.
-    /// </summary>
+    /// <summary>If from HAK, the path to the HAK file.</summary>
     public string? HakPath { get; set; }
 
-    /// <summary>
-    /// If from HAK, the ERF resource entry for extraction.
-    /// </summary>
+    /// <summary>If from HAK, the ERF resource entry for extraction.</summary>
     public ErfResourceEntry? ErfEntry { get; set; }
 
-    /// <summary>
-    /// True if this script comes from a HAK file (requires extraction for preview).
-    /// </summary>
+    /// <summary>True if this script comes from a HAK file (requires extraction for preview).</summary>
     public bool IsFromHak => HakPath != null && ErfEntry != null;
 
-    /// <summary>
-    /// Full file path for filesystem scripts.
-    /// </summary>
+    /// <summary>Full file path for filesystem scripts.</summary>
     public string? FilePath { get; set; }
 
     public string DisplayName => IsBuiltIn ? $"○ {Name}" : IsFromHak ? $"☐ {Name}" : Name;
@@ -55,24 +45,16 @@ public interface IScriptBrowserContext
     /// </summary>
     string? NeverwinterNightsPath { get; }
 
-    /// <summary>
-    /// Path to external script editor (optional).
-    /// </summary>
+    /// <summary>Path to external script editor (optional).</summary>
     string? ExternalEditorPath { get; }
 
-    /// <summary>
-    /// Whether game resources (BIF files) are available for built-in script lookup.
-    /// </summary>
+    /// <summary>Whether game resources (BIF files) are available for built-in script lookup.</summary>
     bool GameResourcesAvailable { get; }
 
-    /// <summary>
-    /// Lists all built-in scripts from game BIF files.
-    /// </summary>
+    /// <summary>Lists all built-in scripts from game BIF files.</summary>
     IEnumerable<(string ResRef, string SourcePath)> ListBuiltInScripts();
 
-    /// <summary>
-    /// Finds a resource from game BIF files.
-    /// </summary>
+    /// <summary>Finds a resource from game BIF files.</summary>
     /// <param name="resRef">Resource reference name</param>
     /// <param name="resourceType">Resource type (use ResourceTypes.Nss for scripts)</param>
     byte[]? FindBuiltInResource(string resRef, ushort resourceType);

--- a/Radoub.UI/Radoub.UI/Services/ISharedPaletteCacheService.cs
+++ b/Radoub.UI/Radoub.UI/Services/ISharedPaletteCacheService.cs
@@ -24,9 +24,7 @@ public interface ISharedPaletteCacheService
     /// </summary>
     List<SharedPaletteCacheItem>? LoadSourceCache(string source, string? sourcePath = null);
 
-    /// <summary>
-    /// Save items to a source-specific cache file.
-    /// </summary>
+    /// <summary>Save items to a source-specific cache file.</summary>
     Task SaveSourceCacheAsync(
         string source,
         List<SharedPaletteCacheItem> items,
@@ -68,29 +66,19 @@ public interface ISharedPaletteCacheService
         int categoryId,
         IEnumerable<string>? activeHakPaths = null);
 
-    /// <summary>
-    /// Clear the in-memory aggregated cache (forces reload from disk).
-    /// </summary>
+    /// <summary>Clear the in-memory aggregated cache (forces reload from disk).</summary>
     void InvalidateAggregatedCache();
 
-    /// <summary>
-    /// Clear a specific source cache file.
-    /// </summary>
+    /// <summary>Clear a specific source cache file.</summary>
     void ClearSourceCache(string source, string? sourcePath = null);
 
-    /// <summary>
-    /// Clear all cache files.
-    /// </summary>
+    /// <summary>Clear all cache files.</summary>
     void ClearAllCaches();
 
-    /// <summary>
-    /// Get cache statistics for display.
-    /// </summary>
+    /// <summary>Get cache statistics for display.</summary>
     SharedPaletteCacheStatistics GetCacheStatistics();
 
-    /// <summary>
-    /// Get the cache directory path.
-    /// </summary>
+    /// <summary>Get the cache directory path.</summary>
     string CacheDirectory { get; }
 
     /// <summary>

--- a/Radoub.UI/Radoub.UI/Services/ISoundBrowserContext.cs
+++ b/Radoub.UI/Radoub.UI/Services/ISoundBrowserContext.cs
@@ -1,48 +1,30 @@
 namespace Radoub.UI.Services;
 
-/// <summary>
-/// Represents a sound entry in the browser with metadata.
-/// </summary>
+/// <summary>Represents a sound entry in the browser with metadata.</summary>
 public class SoundEntry
 {
-    /// <summary>
-    /// Sound filename without extension (e.g., "vs_femelf_att1").
-    /// </summary>
+    /// <summary>Sound filename without extension (e.g., "vs_femelf_att1").</summary>
     public string ResRef { get; set; } = "";
 
-    /// <summary>
-    /// Source of the sound file (e.g., "Override", "BIF: sounds", "HAK: custom.hak").
-    /// </summary>
+    /// <summary>Source of the sound file (e.g., "Override", "BIF: sounds", "HAK: custom.hak").</summary>
     public string Source { get; set; } = "";
 
-    /// <summary>
-    /// Full path to the file (for loose files) or null (for archived).
-    /// </summary>
+    /// <summary>Full path to the file (for loose files) or null (for archived).</summary>
     public string? FilePath { get; set; }
 
-    /// <summary>
-    /// Whether this is a mono sound (required for NWN voice/sfx).
-    /// </summary>
+    /// <summary>Whether this is a mono sound (required for NWN voice/sfx).</summary>
     public bool IsMono { get; set; }
 
-    /// <summary>
-    /// Whether this is a valid WAV file format.
-    /// </summary>
+    /// <summary>Whether this is a valid WAV file format.</summary>
     public bool IsValidWav { get; set; } = true;
 
-    /// <summary>
-    /// Whether this sound comes from a HAK archive.
-    /// </summary>
+    /// <summary>Whether this sound comes from a HAK archive.</summary>
     public bool IsFromHak { get; set; }
 
-    /// <summary>
-    /// Whether this sound comes from a BIF archive.
-    /// </summary>
+    /// <summary>Whether this sound comes from a BIF archive.</summary>
     public bool IsFromBif { get; set; }
 
-    /// <summary>
-    /// Display name for the sound.
-    /// </summary>
+    /// <summary>Display name for the sound.</summary>
     public string DisplayName => ResRef;
 }
 
@@ -53,9 +35,7 @@ public class SoundEntry
 /// </summary>
 public interface ISoundBrowserContext
 {
-    /// <summary>
-    /// The current file's directory (for local sound lookup).
-    /// </summary>
+    /// <summary>The current file's directory (for local sound lookup).</summary>
     string? CurrentFileDirectory { get; }
 
     /// <summary>
@@ -70,35 +50,25 @@ public interface ISoundBrowserContext
     /// </summary>
     string? BaseGameInstallPath { get; }
 
-    /// <summary>
-    /// Whether game resources (BIF files) are available for sound lookup.
-    /// </summary>
+    /// <summary>Whether game resources (BIF files) are available for sound lookup.</summary>
     bool GameResourcesAvailable { get; }
 
-    /// <summary>
-    /// Lists sounds from the specified sources.
-    /// </summary>
+    /// <summary>Lists sounds from the specified sources.</summary>
     /// <param name="includeOverride">Include override folder sounds</param>
     /// <param name="includeHak">Include HAK file sounds</param>
     /// <param name="includeBif">Include BIF archive sounds</param>
     /// <returns>List of sound entries</returns>
     IEnumerable<SoundEntry> ListSounds(bool includeOverride = true, bool includeHak = true, bool includeBif = true);
 
-    /// <summary>
-    /// Extracts a sound to a temporary file for playback.
-    /// </summary>
+    /// <summary>Extracts a sound to a temporary file for playback.</summary>
     /// <param name="entry">Sound entry to extract</param>
     /// <returns>Path to temporary file, or null if extraction failed</returns>
     string? ExtractToTemp(SoundEntry entry);
 
-    /// <summary>
-    /// Plays a sound by path.
-    /// </summary>
+    /// <summary>Plays a sound by path.</summary>
     /// <param name="path">Path to sound file</param>
     void Play(string path);
 
-    /// <summary>
-    /// Stops any currently playing sound.
-    /// </summary>
+    /// <summary>Stops any currently playing sound.</summary>
     void Stop();
 }

--- a/Radoub.UI/Radoub.UI/Services/ITlkService.cs
+++ b/Radoub.UI/Radoub.UI/Services/ITlkService.cs
@@ -12,9 +12,7 @@ public interface ITlkService : IDisposable
 {
     #region TLK Loading
 
-    /// <summary>
-    /// Loads the primary TLK file (dialog.tlk or language-specific).
-    /// </summary>
+    /// <summary>Loads the primary TLK file (dialog.tlk or language-specific).</summary>
     /// <param name="path">Path to the TLK file</param>
     /// <returns>True if loaded successfully</returns>
     bool LoadPrimaryTlk(string path);
@@ -27,9 +25,7 @@ public interface ITlkService : IDisposable
     /// <returns>True if loaded successfully</returns>
     bool LoadCustomTlk(string path);
 
-    /// <summary>
-    /// Clears all loaded TLK files and cache.
-    /// </summary>
+    /// <summary>Clears all loaded TLK files and cache.</summary>
     void ClearTlk();
 
     #endregion
@@ -44,9 +40,7 @@ public interface ITlkService : IDisposable
     /// <returns>Resolved string, or null if not found</returns>
     string? GetString(uint strRef);
 
-    /// <summary>
-    /// Resolves a StrRef from a specific source.
-    /// </summary>
+    /// <summary>Resolves a StrRef from a specific source.</summary>
     /// <param name="strRef">String reference number</param>
     /// <param name="source">Which TLK to use</param>
     /// <returns>Resolved string, or null if not found</returns>
@@ -65,55 +59,37 @@ public interface ITlkService : IDisposable
 
     #region Status
 
-    /// <summary>
-    /// Whether a primary TLK file is loaded.
-    /// </summary>
+    /// <summary>Whether a primary TLK file is loaded.</summary>
     bool IsPrimaryLoaded { get; }
 
-    /// <summary>
-    /// Whether a custom TLK file is loaded.
-    /// </summary>
+    /// <summary>Whether a custom TLK file is loaded.</summary>
     bool IsCustomLoaded { get; }
 
-    /// <summary>
-    /// Number of entries in the primary TLK.
-    /// </summary>
+    /// <summary>Number of entries in the primary TLK.</summary>
     int PrimaryEntryCount { get; }
 
-    /// <summary>
-    /// Number of entries in the custom TLK.
-    /// </summary>
+    /// <summary>Number of entries in the custom TLK.</summary>
     int CustomEntryCount { get; }
 
     #endregion
 
     #region Language Support
 
-    /// <summary>
-    /// Current language for string resolution.
-    /// </summary>
+    /// <summary>Current language for string resolution.</summary>
     Language CurrentLanguage { get; set; }
 
-    /// <summary>
-    /// Current gender preference for gendered strings.
-    /// </summary>
+    /// <summary>Current gender preference for gendered strings.</summary>
     Gender CurrentGender { get; set; }
 
-    /// <summary>
-    /// List of available languages (detected from game installation).
-    /// </summary>
+    /// <summary>List of available languages (detected from game installation).</summary>
     IReadOnlyList<Language> AvailableLanguages { get; }
 
-    /// <summary>
-    /// Detect and return available languages in the game installation.
-    /// </summary>
+    /// <summary>Detect and return available languages in the game installation.</summary>
     /// <param name="gameInstallPath">Path to game installation</param>
     /// <returns>List of available languages</returns>
     IReadOnlyList<Language> DetectAvailableLanguages(string gameInstallPath);
 
-    /// <summary>
-    /// Gets the TLK file path for a specific language.
-    /// </summary>
+    /// <summary>Gets the TLK file path for a specific language.</summary>
     /// <param name="gameInstallPath">Path to game installation</param>
     /// <param name="language">Target language</param>
     /// <param name="gender">Gender variant (default Male)</param>
@@ -123,19 +99,13 @@ public interface ITlkService : IDisposable
     #endregion
 }
 
-/// <summary>
-/// Source for TLK string resolution.
-/// </summary>
+/// <summary>Source for TLK string resolution.</summary>
 public enum TlkSource
 {
-    /// <summary>
-    /// Primary TLK (dialog.tlk) - base game strings.
-    /// </summary>
+    /// <summary>Primary TLK (dialog.tlk) - base game strings.</summary>
     Primary,
 
-    /// <summary>
-    /// Custom TLK - module or server-specific strings.
-    /// </summary>
+    /// <summary>Custom TLK - module or server-specific strings.</summary>
     Custom,
 
     /// <summary>

--- a/Radoub.UI/Radoub.UI/Services/ImageHelper.cs
+++ b/Radoub.UI/Radoub.UI/Services/ImageHelper.cs
@@ -16,29 +16,19 @@ public static class ImageHelper
 {
     #region Standard Portrait Sizes
 
-    /// <summary>
-    /// Tiny portrait size (32x40) - Used for inventory icons.
-    /// </summary>
+    /// <summary>Tiny portrait size (32x40) - Used for inventory icons.</summary>
     public static readonly Size PortraitTiny = new(32, 40);
 
-    /// <summary>
-    /// Small portrait size (64x100) - Used for party bar, dialog speaker.
-    /// </summary>
+    /// <summary>Small portrait size (64x100) - Used for party bar, dialog speaker.</summary>
     public static readonly Size PortraitSmall = new(64, 100);
 
-    /// <summary>
-    /// Medium portrait size (128x200) - Used for character sheet.
-    /// </summary>
+    /// <summary>Medium portrait size (128x200) - Used for character sheet.</summary>
     public static readonly Size PortraitMedium = new(128, 200);
 
-    /// <summary>
-    /// Large portrait size (256x400) - Used for full portrait view.
-    /// </summary>
+    /// <summary>Large portrait size (256x400) - Used for full portrait view.</summary>
     public static readonly Size PortraitLarge = new(256, 400);
 
-    /// <summary>
-    /// Huge portrait size (512x800) - Used for HD portrait mods.
-    /// </summary>
+    /// <summary>Huge portrait size (512x800) - Used for HD portrait mods.</summary>
     public static readonly Size PortraitHuge = new(512, 800);
 
     /// <summary>
@@ -51,9 +41,7 @@ public static class ImageHelper
 
     #region Size Calculation
 
-    /// <summary>
-    /// Calculates the target size that fits within bounds while preserving aspect ratio.
-    /// </summary>
+    /// <summary>Calculates the target size that fits within bounds while preserving aspect ratio.</summary>
     /// <param name="sourceSize">Original image size</param>
     /// <param name="targetBounds">Maximum bounds to fit within</param>
     /// <param name="preserveAspect">If true, preserve aspect ratio (default). If false, stretch to fill.</param>
@@ -87,9 +75,7 @@ public static class ImageHelper
         return new Size(Math.Round(newWidth), Math.Round(newHeight));
     }
 
-    /// <summary>
-    /// Calculates portrait size for a given panel width, maintaining standard aspect ratio.
-    /// </summary>
+    /// <summary>Calculates portrait size for a given panel width, maintaining standard aspect ratio.</summary>
     /// <param name="availableWidth">Available width in pixels</param>
     /// <returns>Size with correct portrait aspect ratio</returns>
     public static Size CalculatePortraitSize(double availableWidth)
@@ -98,9 +84,7 @@ public static class ImageHelper
         return new Size(Math.Round(availableWidth), Math.Round(height));
     }
 
-    /// <summary>
-    /// Gets the nearest standard portrait size for a given dimension.
-    /// </summary>
+    /// <summary>Gets the nearest standard portrait size for a given dimension.</summary>
     /// <param name="width">Target width</param>
     /// <returns>Nearest standard portrait size</returns>
     public static Size GetNearestPortraitSize(double width)
@@ -116,9 +100,7 @@ public static class ImageHelper
 
     #region Bitmap Resizing
 
-    /// <summary>
-    /// Resizes a bitmap to the target size with high quality filtering.
-    /// </summary>
+    /// <summary>Resizes a bitmap to the target size with high quality filtering.</summary>
     /// <param name="source">Source bitmap</param>
     /// <param name="targetSize">Target size</param>
     /// <param name="preserveAspect">If true, maintain aspect ratio within target bounds</param>
@@ -159,9 +141,7 @@ public static class ImageHelper
         return new Bitmap(resultStream);
     }
 
-    /// <summary>
-    /// Resizes a portrait to a standard size with high quality filtering.
-    /// </summary>
+    /// <summary>Resizes a portrait to a standard size with high quality filtering.</summary>
     /// <param name="source">Source portrait bitmap</param>
     /// <param name="targetSize">Target portrait size (use PortraitSmall, PortraitMedium, etc.)</param>
     /// <returns>Resized portrait bitmap</returns>
@@ -285,9 +265,7 @@ public static class ImageHelper
 
     #region Utility Methods
 
-    /// <summary>
-    /// Validates that an image has valid dimensions.
-    /// </summary>
+    /// <summary>Validates that an image has valid dimensions.</summary>
     /// <param name="bitmap">Bitmap to validate</param>
     /// <returns>True if bitmap has valid non-zero dimensions</returns>
     public static bool IsValidBitmap(Bitmap? bitmap)
@@ -297,9 +275,7 @@ public static class ImageHelper
                bitmap.PixelSize.Height > 0;
     }
 
-    /// <summary>
-    /// Gets the aspect ratio of a bitmap.
-    /// </summary>
+    /// <summary>Gets the aspect ratio of a bitmap.</summary>
     /// <param name="bitmap">Bitmap to measure</param>
     /// <returns>Width/Height ratio, or 1.0 if bitmap is null/invalid</returns>
     public static double GetAspectRatio(Bitmap? bitmap)
@@ -310,9 +286,7 @@ public static class ImageHelper
         return (double)bitmap!.PixelSize.Width / bitmap.PixelSize.Height;
     }
 
-    /// <summary>
-    /// Checks if a bitmap appears to be a portrait (roughly 5:8 aspect ratio).
-    /// </summary>
+    /// <summary>Checks if a bitmap appears to be a portrait (roughly 5:8 aspect ratio).</summary>
     /// <param name="bitmap">Bitmap to check</param>
     /// <param name="tolerance">Aspect ratio tolerance (default 0.1)</param>
     /// <returns>True if bitmap has portrait-like aspect ratio</returns>

--- a/Radoub.UI/Radoub.UI/Services/ItemIconHelper.cs
+++ b/Radoub.UI/Radoub.UI/Services/ItemIconHelper.cs
@@ -10,9 +10,7 @@ public static class ItemIconHelper
     // See: https://nwn.wiki/display/NWN1/baseitems.2da
     private const string IconsPath = "avares://Radoub.UI/Assets/Icons/";
 
-    /// <summary>
-    /// Gets the icon path for a base item type.
-    /// </summary>
+    /// <summary>Gets the icon path for a base item type.</summary>
     public static string GetIconPath(int baseItem)
     {
         return baseItem switch
@@ -154,9 +152,7 @@ public static class ItemIconHelper
         };
     }
 
-    /// <summary>
-    /// Gets the icon path for an equipment slot flag.
-    /// </summary>
+    /// <summary>Gets the icon path for an equipment slot flag.</summary>
     public static string GetSlotIconPath(int slotFlag)
     {
         return slotFlag switch

--- a/Radoub.UI/Radoub.UI/Services/ItemIconService.cs
+++ b/Radoub.UI/Radoub.UI/Services/ItemIconService.cs
@@ -34,9 +34,7 @@ public class ItemIconService
     public int CacheCount => _bitmapCache.Count;
     public int CacheCapacity => _bitmapCache.Capacity;
 
-    /// <summary>
-    /// Get the icon for an item.
-    /// </summary>
+    /// <summary>Get the icon for an item.</summary>
     public Bitmap? GetItemIcon(UtiFile item)
     {
         if (item == null)
@@ -45,9 +43,7 @@ public class ItemIconService
         return GetItemIcon(item.BaseItem, item.ModelPart1);
     }
 
-    /// <summary>
-    /// Get the icon for a base item type.
-    /// </summary>
+    /// <summary>Get the icon for a base item type.</summary>
     /// <param name="baseItemType">Base item type ID from baseitems.2da</param>
     /// <param name="modelNumber">Model variation number (default 0 uses minimum from 2DA)</param>
     public Bitmap? GetItemIcon(int baseItemType, int modelNumber = 0)
@@ -75,9 +71,7 @@ public class ItemIconService
         return bitmap;
     }
 
-    /// <summary>
-    /// Get a portrait image.
-    /// </summary>
+    /// <summary>Get a portrait image.</summary>
     public Bitmap? GetPortrait(string resRef)
     {
         if (string.IsNullOrWhiteSpace(resRef))
@@ -100,41 +94,31 @@ public class ItemIconService
         return bitmap;
     }
 
-    /// <summary>
-    /// Get a spell icon.
-    /// </summary>
+    /// <summary>Get a spell icon.</summary>
     public Bitmap? GetSpellIcon(int spellId)
     {
         return GetCachedIcon($"spell:{spellId}", () => _imageService.GetSpellIcon(spellId));
     }
 
-    /// <summary>
-    /// Get a feat icon.
-    /// </summary>
+    /// <summary>Get a feat icon.</summary>
     public Bitmap? GetFeatIcon(int featId)
     {
         return GetCachedIcon($"feat:{featId}", () => _imageService.GetFeatIcon(featId));
     }
 
-    /// <summary>
-    /// Get a skill icon.
-    /// </summary>
+    /// <summary>Get a skill icon.</summary>
     public Bitmap? GetSkillIcon(int skillId)
     {
         return GetCachedIcon($"skill:{skillId}", () => _imageService.GetSkillIcon(skillId));
     }
 
-    /// <summary>
-    /// Get a class icon.
-    /// </summary>
+    /// <summary>Get a class icon.</summary>
     public Bitmap? GetClassIcon(int classId)
     {
         return GetCachedIcon($"class:{classId}", () => _imageService.GetClassIcon(classId));
     }
 
-    /// <summary>
-    /// Helper to get cached icon with lazy loading.
-    /// </summary>
+    /// <summary>Helper to get cached icon with lazy loading.</summary>
     private Bitmap? GetCachedIcon(string cacheKey, Func<ImageData?> loader)
     {
         if (_bitmapCache.TryGetValue(cacheKey, out var cached))
@@ -161,14 +145,10 @@ public class ItemIconService
         }
     }
 
-    /// <summary>
-    /// Check if game data is available for loading real icons.
-    /// </summary>
+    /// <summary>Check if game data is available for loading real icons.</summary>
     public bool IsGameDataAvailable => _gameDataService.IsConfigured;
 
-    /// <summary>
-    /// Clear the bitmap cache.
-    /// </summary>
+    /// <summary>Clear the bitmap cache.</summary>
     public void ClearCache()
     {
         // NOTE: Do NOT dispose bitmaps here - they may still be bound to UI Image controls.
@@ -178,9 +158,7 @@ public class ItemIconService
         _imageService.ClearCache();
     }
 
-    /// <summary>
-    /// Convert ImageData (RGBA bytes) to Avalonia Bitmap.
-    /// </summary>
+    /// <summary>Convert ImageData (RGBA bytes) to Avalonia Bitmap.</summary>
     private static Bitmap? ImageDataToBitmap(ImageData imageData)
     {
         try

--- a/Radoub.UI/Radoub.UI/Services/ItemResolutionService.cs
+++ b/Radoub.UI/Radoub.UI/Services/ItemResolutionService.cs
@@ -53,9 +53,7 @@ public class ItemResolutionService
         UnifiedLogger.LogApplication(LogLevel.DEBUG, $"ItemResolutionService: Module directory set to: {_moduleDirectory ?? "(none)"}");
     }
 
-    /// <summary>
-    /// Sets the module directory directly for item resolution.
-    /// </summary>
+    /// <summary>Sets the module directory directly for item resolution.</summary>
     public void SetModuleDirectory(string? directory)
     {
         _moduleDirectory = directory;
@@ -63,9 +61,7 @@ public class ItemResolutionService
         UnifiedLogger.LogApplication(LogLevel.DEBUG, $"ItemResolutionService: Module directory set to: {_moduleDirectory ?? "(none)"}");
     }
 
-    /// <summary>
-    /// Resolve item data from a ResRef.
-    /// </summary>
+    /// <summary>Resolve item data from a ResRef.</summary>
     /// <param name="resRef">Item blueprint ResRef</param>
     /// <returns>Resolved item data, or null if not found</returns>
     public ResolvedItemData? ResolveItem(string resRef)
@@ -85,9 +81,7 @@ public class ItemResolutionService
         return data;
     }
 
-    /// <summary>
-    /// Resolve multiple items efficiently.
-    /// </summary>
+    /// <summary>Resolve multiple items efficiently.</summary>
     public Dictionary<string, ResolvedItemData> ResolveItems(IEnumerable<string> resRefs)
     {
         var results = new Dictionary<string, ResolvedItemData>(StringComparer.OrdinalIgnoreCase);
@@ -104,9 +98,7 @@ public class ItemResolutionService
         return results;
     }
 
-    /// <summary>
-    /// Clear the item cache.
-    /// </summary>
+    /// <summary>Clear the item cache.</summary>
     public void ClearCache()
     {
         _cache.Clear();
@@ -260,9 +252,7 @@ public class ItemResolutionService
     }
 }
 
-/// <summary>
-/// Resolved item data from a UTI file.
-/// </summary>
+/// <summary>Resolved item data from a UTI file.</summary>
 public class ResolvedItemData
 {
     public required string ResRef { get; init; }
@@ -277,18 +267,14 @@ public class ResolvedItemData
     public string PropertiesDisplay { get; init; } = string.Empty;
     public string SourceLocation { get; init; } = string.Empty;
 
-    /// <summary>
-    /// Calculate sell price (what player pays to buy from store).
-    /// </summary>
+    /// <summary>Calculate sell price (what player pays to buy from store).</summary>
     /// <param name="markUp">Store markup percentage (100 = base price)</param>
     public int CalculateSellPrice(int markUp)
     {
         return (int)Math.Ceiling(BaseCost * markUp / 100.0);
     }
 
-    /// <summary>
-    /// Calculate buy price (what store pays to buy from player).
-    /// </summary>
+    /// <summary>Calculate buy price (what store pays to buy from player).</summary>
     /// <param name="markDown">Store markdown percentage (100 = full price)</param>
     public int CalculateBuyPrice(int markDown)
     {

--- a/Radoub.UI/Radoub.UI/Services/MdlPartBoneMap.cs
+++ b/Radoub.UI/Radoub.UI/Services/MdlPartBoneMap.cs
@@ -43,9 +43,7 @@ public static class MdlPartBoneMap
     };
 }
 
-/// <summary>
-/// String-formatting helpers for NWN body-part MDL ResRefs.
-/// </summary>
+/// <summary>String-formatting helpers for NWN body-part MDL ResRefs.</summary>
 public static class MdlPartNaming
 {
     /// <summary>

--- a/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
+++ b/Radoub.UI/Radoub.UI/Services/MdlPartComposer.cs
@@ -808,9 +808,7 @@ public sealed class MdlPartComposer
         }
     }
 
-    /// <summary>
-    /// Aggregate the bounding box across all attached meshes, using each mesh's local S*R*T transform.
-    /// </summary>
+    /// <summary>Aggregate the bounding box across all attached meshes, using each mesh's local S*R*T transform.</summary>
     public static void UpdateCompositeBounds(MdlModel model)
     {
         var minX = float.MaxValue;

--- a/Radoub.UI/Radoub.UI/Services/ModelViewController.cs
+++ b/Radoub.UI/Radoub.UI/Services/ModelViewController.cs
@@ -57,9 +57,7 @@ public class ModelViewController
     public float ModelRadius => _modelRadius;
     public bool HasVertexBounds => _hasVertexBounds;
 
-    /// <summary>
-    /// Rotate the model incrementally.
-    /// </summary>
+    /// <summary>Rotate the model incrementally.</summary>
     public void Rotate(float deltaY, float deltaX = 0)
     {
         _rotationY += deltaY;
@@ -133,9 +131,7 @@ public class ModelViewController
         _cameraTarget = Vector3.Zero;
     }
 
-    /// <summary>
-    /// Reset the view to default (facing front).
-    /// </summary>
+    /// <summary>Reset the view to default (facing front).</summary>
     public void ResetView()
     {
         _rotationY = MathF.PI;
@@ -234,17 +230,13 @@ public class ModelViewController
         bool HasOrientation, Quaternion Orientation,
         bool HasScale, float Scale);
 
-    /// <summary>
-    /// Transform a position vector by a matrix.
-    /// </summary>
+    /// <summary>Transform a position vector by a matrix.</summary>
     public static Vector3 TransformPosition(Vector3 position, Matrix4x4 matrix)
     {
         return Vector3.Transform(position, matrix);
     }
 
-    /// <summary>
-    /// Transform a normal vector by a matrix (ignores translation, handles non-uniform scale).
-    /// </summary>
+    /// <summary>Transform a normal vector by a matrix (ignores translation, handles non-uniform scale).</summary>
     public static Vector3 TransformNormal(Vector3 normal, Matrix4x4 matrix)
     {
         var transformed = Vector3.TransformNormal(normal, matrix);

--- a/Radoub.UI/Radoub.UI/Services/Palette/IBlueprintPaletteStore.cs
+++ b/Radoub.UI/Radoub.UI/Services/Palette/IBlueprintPaletteStore.cs
@@ -31,9 +31,7 @@ public interface IBlueprintPaletteStore
     /// </summary>
     bool SetPaletteId(string resRef, byte paletteId);
 
-    /// <summary>
-    /// True if the pool contains a blueprint with this ResRef.
-    /// </summary>
+    /// <summary>True if the pool contains a blueprint with this ResRef.</summary>
     bool Contains(string resRef);
 
     /// <summary>

--- a/Radoub.UI/Radoub.UI/Services/PaletteColorService.cs
+++ b/Radoub.UI/Radoub.UI/Services/PaletteColorService.cs
@@ -48,9 +48,7 @@ public class PaletteColorService
         _gameDataService = gameDataService;
     }
 
-    /// <summary>
-    /// Get the color for a palette index.
-    /// </summary>
+    /// <summary>Get the color for a palette index.</summary>
     /// <param name="paletteName">Palette file name (e.g., "pal_skin01")</param>
     /// <param name="colorIndex">Color index (0-175)</param>
     /// <returns>Avalonia Color, or gray if palette not found</returns>
@@ -64,19 +62,13 @@ public class PaletteColorService
         return Color.FromArgb(a, r, g, b);
     }
 
-    /// <summary>
-    /// Get the skin color for a palette index.
-    /// </summary>
+    /// <summary>Get the skin color for a palette index.</summary>
     public Color GetSkinColor(byte colorIndex) => GetPaletteColor(Palettes.Skin, colorIndex);
 
-    /// <summary>
-    /// Get the hair color for a palette index.
-    /// </summary>
+    /// <summary>Get the hair color for a palette index.</summary>
     public Color GetHairColor(byte colorIndex) => GetPaletteColor(Palettes.Hair, colorIndex);
 
-    /// <summary>
-    /// Get the tattoo color for a palette index (both tattoos use same palette).
-    /// </summary>
+    /// <summary>Get the tattoo color for a palette index (both tattoos use same palette).</summary>
     public Color GetTattooColor(byte colorIndex) => GetPaletteColor(Palettes.Tattoo1, colorIndex);
 
     /// <summary>
@@ -107,9 +99,7 @@ public class PaletteColorService
         return stops;
     }
 
-    /// <summary>
-    /// Create a LinearGradientBrush for a palette row.
-    /// </summary>
+    /// <summary>Create a LinearGradientBrush for a palette row.</summary>
     public LinearGradientBrush CreateGradientBrush(string paletteName, byte colorIndex)
     {
         var stops = GetPaletteGradient(paletteName, colorIndex);

--- a/Radoub.UI/Radoub.UI/Services/ProjectPathResolver.cs
+++ b/Radoub.UI/Radoub.UI/Services/ProjectPathResolver.cs
@@ -11,9 +11,7 @@ namespace Radoub.UI.Services;
 /// </summary>
 public static class ProjectPathResolver
 {
-    /// <summary>
-    /// Resolve a module name and optional file path to an absolute file path.
-    /// </summary>
+    /// <summary>Resolve a module name and optional file path to an absolute file path.</summary>
     /// <param name="moduleName">Module name (e.g., "LNS")</param>
     /// <param name="filePath">File path — if absolute, returned as-is. If relative, resolved under module.</param>
     /// <param name="modulesDirectory">Base modules directory. If null, uses RadoubSettings.</param>
@@ -39,9 +37,7 @@ public static class ProjectPathResolver
         return Path.Combine(modulesDir, moduleName, filePath);
     }
 
-    /// <summary>
-    /// Resolve a module name to a module directory path.
-    /// </summary>
+    /// <summary>Resolve a module name to a module directory path.</summary>
     /// <param name="moduleName">Module name (e.g., "LNS")</param>
     /// <param name="modulesDirectory">Base modules directory. If null, uses RadoubSettings.</param>
     /// <returns>Absolute path to the module directory, or null.</returns>
@@ -57,9 +53,7 @@ public static class ProjectPathResolver
         return Path.Combine(modulesDir, moduleName);
     }
 
-    /// <summary>
-    /// Get the NWN modules directory from RadoubSettings.
-    /// </summary>
+    /// <summary>Get the NWN modules directory from RadoubSettings.</summary>
     private static string? GetModulesDirectory()
     {
         var nwnPath = RadoubSettings.Instance.NeverwinterNightsPath;

--- a/Radoub.UI/Radoub.UI/Services/RecentFilesMenuHelper.cs
+++ b/Radoub.UI/Radoub.UI/Services/RecentFilesMenuHelper.cs
@@ -21,9 +21,7 @@ namespace Radoub.UI.Services;
 /// </summary>
 public static class RecentFilesMenuHelper
 {
-    /// <summary>
-    /// Populates a MenuItem with recent file entries.
-    /// </summary>
+    /// <summary>Populates a MenuItem with recent file entries.</summary>
     /// <param name="menuItem">The parent MenuItem to populate (e.g., "Open Recent")</param>
     /// <param name="recentFiles">List of file paths from the settings service</param>
     /// <param name="onFileClick">Callback when a file is clicked. Receives the file path.

--- a/Radoub.UI/Radoub.UI/Services/ScriptListManager.cs
+++ b/Radoub.UI/Radoub.UI/Services/ScriptListManager.cs
@@ -4,9 +4,7 @@ using System.Linq;
 
 namespace Radoub.UI.Services;
 
-/// <summary>
-/// Result of filtering and merging script lists for display.
-/// </summary>
+/// <summary>Result of filtering and merging script lists for display.</summary>
 public class ScriptListResult
 {
     public List<ScriptEntry> Scripts { get; set; } = new();
@@ -93,9 +91,7 @@ public static class ScriptListManager
         };
     }
 
-    /// <summary>
-    /// Formats the script count for display in the UI.
-    /// </summary>
+    /// <summary>Formats the script count for display in the UI.</summary>
     public static string FormatCountText(ScriptListResult result)
     {
         var countText = $"{result.ModuleCount} module";

--- a/Radoub.UI/Radoub.UI/Services/ScriptPreviewLoader.cs
+++ b/Radoub.UI/Radoub.UI/Services/ScriptPreviewLoader.cs
@@ -22,9 +22,7 @@ public class ScriptPreviewLoader
         _hakScanner = hakScanner;
     }
 
-    /// <summary>
-    /// Loads script content based on script source (module, HAK, or built-in).
-    /// </summary>
+    /// <summary>Loads script content based on script source (module, HAK, or built-in).</summary>
     /// <param name="scriptEntry">The script to load</param>
     /// <param name="overridePath">Optional override path for module scripts</param>
     /// <returns>Script content with source header, or error message if not found</returns>

--- a/Radoub.UI/Radoub.UI/Services/Search/BackupService.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/BackupService.cs
@@ -54,9 +54,7 @@ public class BackupService
         return manifest;
     }
 
-    /// <summary>
-    /// Back up a single archive file (.mod, .erf).
-    /// </summary>
+    /// <summary>Back up a single archive file (.mod, .erf).</summary>
     public async Task<BackupManifest> BackupArchiveAsync(string archivePath, string moduleName)
     {
         return await BackupFilesAsync(new[] { archivePath }, moduleName);

--- a/Radoub.UI/Radoub.UI/Services/Search/Models/BackupManifest.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/Models/BackupManifest.cs
@@ -1,8 +1,6 @@
 namespace Radoub.UI.Services.Search;
 
-/// <summary>
-/// Tracks all files backed up during a batch replace operation.
-/// </summary>
+/// <summary>Tracks all files backed up during a batch replace operation.</summary>
 public class BackupManifest
 {
     /// <summary>Directory containing all backup copies</summary>
@@ -18,9 +16,7 @@ public class BackupManifest
     public List<BackupEntry> Entries { get; init; } = new();
 }
 
-/// <summary>
-/// A single file's backup record with hash for integrity verification.
-/// </summary>
+/// <summary>A single file's backup record with hash for integrity verification.</summary>
 public class BackupEntry
 {
     /// <summary>Original file path that was backed up</summary>

--- a/Radoub.UI/Radoub.UI/Services/Search/Models/BatchReplaceModels.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/Models/BatchReplaceModels.cs
@@ -2,9 +2,7 @@ using Radoub.Formats.Search;
 
 namespace Radoub.UI.Services.Search;
 
-/// <summary>
-/// A single pending change with selection state for the UI.
-/// </summary>
+/// <summary>A single pending change with selection state for the UI.</summary>
 public class PendingChange
 {
     /// <summary>The original search match</summary>
@@ -57,9 +55,7 @@ public class PendingChange
     }
 }
 
-/// <summary>
-/// Groups pending changes by file for preview display.
-/// </summary>
+/// <summary>Groups pending changes by file for preview display.</summary>
 public class FileChangeGroup
 {
     public required string FilePath { get; init; }
@@ -67,9 +63,7 @@ public class FileChangeGroup
     public List<PendingChange> Changes { get; init; } = new();
 }
 
-/// <summary>
-/// Preview of all changes before execution, with per-match selectability.
-/// </summary>
+/// <summary>Preview of all changes before execution, with per-match selectability.</summary>
 public class BatchReplacePreview
 {
     /// <summary>All individual pending changes (flat list)</summary>
@@ -107,9 +101,7 @@ public class BatchReplacePreview
     public int SkippedNssContentMatches { get; set; }
 }
 
-/// <summary>
-/// Result of a batch replace execution.
-/// </summary>
+/// <summary>Result of a batch replace execution.</summary>
 public class BatchReplaceResult
 {
     /// <summary>Whether the entire operation succeeded</summary>

--- a/Radoub.UI/Radoub.UI/Services/Search/Models/FileSearchResult.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/Models/FileSearchResult.cs
@@ -2,9 +2,7 @@ using Radoub.Formats.Search;
 
 namespace Radoub.UI.Services.Search;
 
-/// <summary>
-/// Search results for a single file within a module scan.
-/// </summary>
+/// <summary>Search results for a single file within a module scan.</summary>
 public class FileSearchResult
 {
     /// <summary>Full path to the file that was searched</summary>

--- a/Radoub.UI/Radoub.UI/Services/Search/Models/ModuleSearchResults.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/Models/ModuleSearchResults.cs
@@ -1,8 +1,6 @@
 namespace Radoub.UI.Services.Search;
 
-/// <summary>
-/// Aggregated search results from a module-wide scan.
-/// </summary>
+/// <summary>Aggregated search results from a module-wide scan.</summary>
 public class ModuleSearchResults
 {
     /// <summary>Per-file results (only files with matches or errors)</summary>

--- a/Radoub.UI/Radoub.UI/Services/Search/Models/ResRefRenameResult.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/Models/ResRefRenameResult.cs
@@ -1,8 +1,6 @@
 namespace Radoub.UI.Services.Search;
 
-/// <summary>
-/// Outcome of a ResRefRenameOrchestrator.ExecuteAsync call.
-/// </summary>
+/// <summary>Outcome of a ResRefRenameOrchestrator.ExecuteAsync call.</summary>
 public class ResRefRenameResult
 {
     public required bool Success { get; init; }

--- a/Radoub.UI/Radoub.UI/Services/Search/Models/ScanProgress.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/Models/ScanProgress.cs
@@ -1,8 +1,6 @@
 namespace Radoub.UI.Services.Search;
 
-/// <summary>
-/// Progress reporting for module-wide search operations.
-/// </summary>
+/// <summary>Progress reporting for module-wide search operations.</summary>
 public class ScanProgress
 {
     /// <summary>Current phase of the scan (e.g., "Discovering files", "Searching")</summary>

--- a/Radoub.UI/Radoub.UI/Services/Search/ModuleSearchService.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/ModuleSearchService.cs
@@ -62,9 +62,7 @@ public class ModuleSearchService
         _factory = factory ?? throw new ArgumentNullException(nameof(factory));
     }
 
-    /// <summary>
-    /// Search all matching files in a module directory.
-    /// </summary>
+    /// <summary>Search all matching files in a module directory.</summary>
     /// <param name="modulePath">Path to the unpacked module directory</param>
     /// <param name="criteria">Search criteria including pattern and filters</param>
     /// <param name="progress">Optional progress reporter</param>
@@ -175,9 +173,7 @@ public class ModuleSearchService
         };
     }
 
-    /// <summary>
-    /// Search a single file and return results.
-    /// </summary>
+    /// <summary>Search a single file and return results.</summary>
     public FileSearchResult SearchSingleFile(string filePath, SearchCriteria criteria)
     {
         if (string.IsNullOrEmpty(filePath))
@@ -248,9 +244,7 @@ public class ModuleSearchService
         }
     }
 
-    /// <summary>
-    /// Search NWScript (.nss) source as plain text, one match per regex hit, with line numbers.
-    /// </summary>
+    /// <summary>Search NWScript (.nss) source as plain text, one match per regex hit, with line numbers.</summary>
     private FileSearchResult? SearchNssFileInternal(
         string filePath, ushort resourceType, string toolId, SearchCriteria criteria)
     {

--- a/Radoub.UI/Radoub.UI/Services/Search/ToolDispatchService.cs
+++ b/Radoub.UI/Radoub.UI/Services/Search/ToolDispatchService.cs
@@ -5,9 +5,7 @@ using Radoub.Formats.Logging;
 
 namespace Radoub.UI.Services.Search;
 
-/// <summary>
-/// Information about a Radoub tool for dispatch.
-/// </summary>
+/// <summary>Information about a Radoub tool for dispatch.</summary>
 public class DispatchableToolInfo
 {
     /// <summary>Display name (e.g., "Parley")</summary>
@@ -48,9 +46,7 @@ public class ToolDispatchService
         return ToolMap.TryGetValue(resourceType, out var info) ? info : null;
     }
 
-    /// <summary>
-    /// Returns true if a tool can handle this resource type.
-    /// </summary>
+    /// <summary>Returns true if a tool can handle this resource type.</summary>
     public bool CanDispatch(ushort resourceType)
     {
         return ToolMap.ContainsKey(resourceType);

--- a/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheItem.cs
+++ b/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheItem.cs
@@ -41,9 +41,7 @@ public class SharedPaletteCacheItem
     public bool IsStandard => Source == GameResourceSource.Bif;
 }
 
-/// <summary>
-/// Wrapper for per-source cache files with validation metadata.
-/// </summary>
+/// <summary>Wrapper for per-source cache files with validation metadata.</summary>
 public class SourcePaletteCacheWrapper
 {
     public int Version { get; set; }
@@ -54,9 +52,7 @@ public class SourcePaletteCacheWrapper
     public List<SharedPaletteCacheItem> Items { get; set; } = new();
 }
 
-/// <summary>
-/// Cache statistics for display in settings or diagnostics.
-/// </summary>
+/// <summary>Cache statistics for display in settings or diagnostics.</summary>
 public class SharedPaletteCacheStatistics
 {
     public int TotalItems { get; set; }

--- a/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheService.cs
+++ b/Radoub.UI/Radoub.UI/Services/SharedPaletteCacheService.cs
@@ -24,9 +24,7 @@ public class SharedPaletteCacheService : ISharedPaletteCacheService, IDisposable
     private List<SharedPaletteCacheItem>? _aggregatedCache;
     private bool _disposed;
 
-    /// <summary>
-    /// Create a shared palette cache service using the default shared location.
-    /// </summary>
+    /// <summary>Create a shared palette cache service using the default shared location.</summary>
     public SharedPaletteCacheService()
         : this(Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
@@ -34,9 +32,7 @@ public class SharedPaletteCacheService : ISharedPaletteCacheService, IDisposable
     {
     }
 
-    /// <summary>
-    /// Create a shared palette cache service with a custom cache directory (for testing).
-    /// </summary>
+    /// <summary>Create a shared palette cache service with a custom cache directory (for testing).</summary>
     public SharedPaletteCacheService(string cacheDirectory)
     {
         _cacheDirectory = cacheDirectory;

--- a/Radoub.UI/Radoub.UI/Services/SpellCheckService.cs
+++ b/Radoub.UI/Radoub.UI/Services/SpellCheckService.cs
@@ -48,35 +48,21 @@ public class SpellCheckService : IDisposable
     private volatile bool _isReloading;
     private readonly SemaphoreSlim _initLock = new(1, 1);
 
-    /// <summary>
-    /// Path to the Radoub-wide custom dictionary file.
-    /// Located at ~/Radoub/Dictionaries/custom.dic
-    /// </summary>
+    /// <summary>Radoub-wide custom dictionary file (~/Radoub/Dictionaries/custom.dic).</summary>
     /// <remarks>
     /// Retained for diagnostics/logging only. As of #2263, <see cref="UserDictionaryService"/>
     /// is the single owner of reads and writes to this file; SpellCheckService is a consumer.
     /// </remarks>
     private readonly string _customDictionaryPath;
 
-    /// <summary>
-    /// Whether spell-checking is available and loaded.
-    /// Also checks if spell-check is enabled in settings.
-    /// </summary>
+    /// <summary>Available and loaded, and enabled in settings.</summary>
     public bool IsReady => _isInitialized && _spellChecker != null && DictionarySettingsService.Instance.SpellCheckEnabled && !_isReloading;
 
-    /// <summary>
-    /// Event raised when spell-check is ready for use.
-    /// </summary>
     public event EventHandler? Ready;
 
-    /// <summary>
-    /// Event raised when dictionaries are reloaded (for UI refresh).
-    /// </summary>
+    /// <summary>Raised when dictionaries are reloaded (for UI refresh).</summary>
     public event EventHandler? DictionariesReloaded;
 
-    /// <summary>
-    /// Event raised when spell-check enabled state changes.
-    /// </summary>
     public event EventHandler<bool>? EnabledChanged;
 
     private SpellCheckService()
@@ -126,9 +112,7 @@ public class SpellCheckService : IDisposable
         }
     }
 
-    /// <summary>
-    /// Load all dictionaries based on current settings.
-    /// </summary>
+    /// <summary>Load all dictionaries based on current settings.</summary>
     private async Task LoadDictionariesAsync()
     {
         var settings = DictionarySettingsService.Instance;
@@ -137,15 +121,12 @@ public class SpellCheckService : IDisposable
         // Clear discovery cache to pick up any new dictionaries
         _discovery?.ClearCache();
 
-        // Create fresh dictionary manager and spell checker
         _dictionaryManager = new DictionaryManager();
         _spellChecker?.Dispose();
         _spellChecker = new SpellChecker(_dictionaryManager);
 
-        // Load primary language (Hunspell)
         await LoadPrimaryLanguageAsync(primaryLanguage);
 
-        // Load enabled custom dictionaries
         await LoadEnabledCustomDictionariesAsync();
 
         // Load user's custom dictionary (words they've added)
@@ -156,9 +137,7 @@ public class SpellCheckService : IDisposable
             $"Spell-check loaded: {primaryLanguage} + {_dictionaryManager.DictionaryCount} custom dictionaries ({totalWordCount} words)");
     }
 
-    /// <summary>
-    /// Load the primary Hunspell language dictionary.
-    /// </summary>
+    /// <summary>Load the primary Hunspell language dictionary.</summary>
     private async Task LoadPrimaryLanguageAsync(string languageCode)
     {
         if (_spellChecker == null || _discovery == null) return;
@@ -187,9 +166,7 @@ public class SpellCheckService : IDisposable
         }
     }
 
-    /// <summary>
-    /// Load all enabled custom dictionaries.
-    /// </summary>
+    /// <summary>Load all enabled custom dictionaries.</summary>
     private async Task LoadEnabledCustomDictionariesAsync()
     {
         if (_discovery == null) return;
@@ -267,9 +244,7 @@ public class SpellCheckService : IDisposable
         EnabledChanged?.Invoke(this, isEnabled);
     }
 
-    /// <summary>
-    /// Check if a word is spelled correctly.
-    /// </summary>
+    /// <summary>Check if a word is spelled correctly.</summary>
     public bool IsCorrect(string word)
     {
         if (!IsReady || string.IsNullOrWhiteSpace(word))
@@ -278,9 +253,7 @@ public class SpellCheckService : IDisposable
         return _spellChecker!.IsCorrect(word);
     }
 
-    /// <summary>
-    /// Get all spelling errors in text.
-    /// </summary>
+    /// <summary>Get all spelling errors in text.</summary>
     public IEnumerable<SpellingError> CheckText(string text)
     {
         if (!IsReady || string.IsNullOrWhiteSpace(text))
@@ -289,9 +262,7 @@ public class SpellCheckService : IDisposable
         return _spellChecker!.CheckText(text);
     }
 
-    /// <summary>
-    /// Get spelling suggestions for a misspelled word.
-    /// </summary>
+    /// <summary>Get spelling suggestions for a misspelled word.</summary>
     public IEnumerable<string> GetSuggestions(string word, int maxSuggestions = 5)
     {
         if (!IsReady || string.IsNullOrWhiteSpace(word))
@@ -300,18 +271,13 @@ public class SpellCheckService : IDisposable
         return _spellChecker!.GetSuggestions(word, maxSuggestions);
     }
 
-    /// <summary>
-    /// Ignore a word for the current session only.
-    /// </summary>
+    /// <summary>Ignore a word for the current session only.</summary>
     public void IgnoreForSession(string word)
     {
         _spellChecker?.IgnoreForSession(word);
     }
 
-    /// <summary>
-    /// Add a word to the custom dictionary permanently.
-    /// Automatically saves to disk.
-    /// </summary>
+    /// <summary>Add a word to the custom dictionary permanently. Saves to disk.</summary>
     public void AddToCustomDictionary(string word)
     {
         if (!string.IsNullOrWhiteSpace(word))
@@ -329,19 +295,11 @@ public class SpellCheckService : IDisposable
         }
     }
 
-    /// <summary>
-    /// Get the number of session-ignored words.
-    /// </summary>
     public int SessionIgnoredCount => _spellChecker?.SessionIgnoredCount ?? 0;
 
-    /// <summary>
-    /// Get the number of custom words.
-    /// </summary>
     public int GetCustomWordCount() => _dictionaryManager.WordCount;
 
-    /// <summary>
-    /// Clear all session-ignored words.
-    /// </summary>
+    /// <summary>Clear all session-ignored words.</summary>
     public void ClearSessionIgnored()
     {
         _spellChecker?.ClearSessionIgnored();
@@ -366,9 +324,7 @@ public class SpellCheckService : IDisposable
         };
     }
 
-    /// <summary>
-    /// Get the theme-aware brush for spelling errors.
-    /// </summary>
+    /// <summary>Get the theme-aware brush for spelling errors.</summary>
     public IBrush GetSpellingErrorBrush()
     {
         // Try to get from theme resources

--- a/Radoub.UI/Radoub.UI/Services/StartupCleanupCoordinator.cs
+++ b/Radoub.UI/Radoub.UI/Services/StartupCleanupCoordinator.cs
@@ -53,8 +53,6 @@ public static class StartupCleanupCoordinator
         });
     }
 
-    /// <summary>
-    /// Test hook: allow a fresh run within the same process.
-    /// </summary>
+    /// <summary>Test hook: allow a fresh run within the same process.</summary>
     internal static void ResetForTests() => Interlocked.Exchange(ref _started, 0);
 }

--- a/Radoub.UI/Radoub.UI/Services/StatusIndicatorHelper.cs
+++ b/Radoub.UI/Radoub.UI/Services/StatusIndicatorHelper.cs
@@ -24,9 +24,7 @@ public static class StatusIndicatorHelper
     /// <summary>Info indicator (information) - U+2139</summary>
     public const string Info = "\u2139";
 
-    /// <summary>
-    /// Formats a validation message with the appropriate status icon.
-    /// </summary>
+    /// <summary>Formats a validation message with the appropriate status icon.</summary>
     /// <param name="message">The validation message text</param>
     /// <param name="isValid">True for success icon, false for error icon</param>
     /// <returns>Message prefixed with status icon and space</returns>
@@ -39,9 +37,7 @@ public static class StatusIndicatorHelper
         return $"{icon} {message}";
     }
 
-    /// <summary>
-    /// Formats a message with a warning icon.
-    /// </summary>
+    /// <summary>Formats a message with a warning icon.</summary>
     /// <param name="message">The warning message text</param>
     /// <returns>Message prefixed with warning icon and space</returns>
     public static string FormatWarning(string message)
@@ -52,9 +48,7 @@ public static class StatusIndicatorHelper
         return $"{Warning} {message}";
     }
 
-    /// <summary>
-    /// Formats a message with an info icon.
-    /// </summary>
+    /// <summary>Formats a message with an info icon.</summary>
     /// <param name="message">The info message text</param>
     /// <returns>Message prefixed with info icon and space</returns>
     public static string FormatInfo(string message)

--- a/Radoub.UI/Radoub.UI/Services/TextureService.cs
+++ b/Radoub.UI/Radoub.UI/Services/TextureService.cs
@@ -33,9 +33,7 @@ public class TextureService
         _gameDataService = gameDataService;
     }
 
-    /// <summary>
-    /// Load and render a PLT texture with the specified colors.
-    /// </summary>
+    /// <summary>Load and render a PLT texture with the specified colors.</summary>
     /// <param name="pltResRef">PLT texture resource reference (without extension)</param>
     /// <param name="colorIndices">Color indices for all PLT layers (optional, uses defaults if null)</param>
     /// <returns>RGBA texture data (width, height, pixels), or null if not found</returns>
@@ -48,7 +46,6 @@ public class TextureService
 
         colorIndices ??= new PltColorIndices();
 
-        // Try to load PLT file
         var pltData = _gameDataService.FindResource(pltResRef.ToLowerInvariant(), ResourceTypes.Plt);
         if (pltData == null || pltData.Length == 0)
         {
@@ -62,7 +59,6 @@ public class TextureService
         {
             var pltFile = PltReader.Read(pltData);
 
-            // Load all required palettes
             var palettes = new Dictionary<int, PaletteData>();
             for (int layerId = 0; layerId <= 9; layerId++)
             {
@@ -92,9 +88,7 @@ public class TextureService
         }
     }
 
-    /// <summary>
-    /// Legacy overload for backward compatibility.
-    /// </summary>
+    /// <summary>Legacy overload for backward compatibility.</summary>
     public (int width, int height, byte[] pixels)? RenderPltTexture(
         string pltResRef,
         int skinColor,
@@ -111,9 +105,7 @@ public class TextureService
         });
     }
 
-    /// <summary>
-    /// Load a regular TGA texture.
-    /// </summary>
+    /// <summary>Load a regular TGA texture.</summary>
     /// <param name="tgaResRef">TGA resource reference (without extension)</param>
     /// <returns>RGBA texture data (width, height, pixels), or null if not found</returns>
     public (int width, int height, byte[] pixels)? LoadTgaTexture(string tgaResRef)
@@ -530,9 +522,7 @@ public class TextureService
         _ => $"layer{layerId}",
     };
 
-    /// <summary>
-    /// Build layer color mapping from PltColorIndices.
-    /// </summary>
+    /// <summary>Build layer color mapping from PltColorIndices.</summary>
     internal static Dictionary<int, int> BuildLayerColors(PltColorIndices colorIndices)
     {
         return new Dictionary<int, int>
@@ -550,9 +540,7 @@ public class TextureService
         };
     }
 
-    /// <summary>
-    /// Load a texture (tries PLT first, then TGA, then DDS, with human fallback).
-    /// </summary>
+    /// <summary>Load a texture (tries PLT first, then TGA, then DDS, with human fallback).</summary>
     public (int width, int height, byte[] pixels)? LoadTexture(
         string resRef,
         PltColorIndices? colorIndices = null)
@@ -561,11 +549,6 @@ public class TextureService
         return result.HasValue ? (result.Value.width, result.Value.height, result.Value.pixels) : null;
     }
 
-    /// <summary>
-    /// Same as <see cref="LoadTexture"/> but also reports whether the texture came from
-    /// a PLT (color-index-dependent) source. Callers can use this to cache non-PLT
-    /// textures across color changes.
-    /// </summary>
     /// <summary>
     /// Reports whether the texture <paramref name="resRef"/> resolves from base-game
     /// BIF rather than a HAK/Module/Override. Used by the preview to warn when a CEP
@@ -653,9 +636,7 @@ public class TextureService
         return LoadTextureWithKind(resRef, colorIndices);
     }
 
-    /// <summary>
-    /// Diagnostic helper: list the non-empty MTR sampler slots as <c>texN=name</c> for logging.
-    /// </summary>
+    /// <summary>Diagnostic helper: list the non-empty MTR sampler slots as <c>texN=name</c> for logging.</summary>
     private static IEnumerable<string> DescribeMtrTextures(MtrFile mtr)
     {
         for (int i = 0; i < mtr.Textures.Length; i++)
@@ -771,9 +752,7 @@ public class TextureService
         return tga ?? dds;
     }
 
-    /// <summary>
-    /// Legacy overload for backward compatibility.
-    /// </summary>
+    /// <summary>Legacy overload for backward compatibility.</summary>
     public (int width, int height, byte[] pixels)? LoadTexture(
         string resRef,
         int skinColor,
@@ -817,9 +796,7 @@ public class TextureService
         }
     }
 
-    /// <summary>
-    /// Clear all cached textures and palettes.
-    /// </summary>
+    /// <summary>Clear all cached textures and palettes.</summary>
     public void ClearCache()
     {
         _paletteCache.Clear();
@@ -952,14 +929,10 @@ public class PltColorIndices
     /// <summary>Tattoo2 color (0-175)</summary>
     public int Tattoo2 { get; set; }
 
-    /// <summary>
-    /// Create default color indices (all 0).
-    /// </summary>
+    /// <summary>Create default color indices (all 0).</summary>
     public PltColorIndices() { }
 
-    /// <summary>
-    /// Create color indices from creature body colors and armor colors.
-    /// </summary>
+    /// <summary>Create color indices from creature body colors and armor colors.</summary>
     public static PltColorIndices FromCreatureAndArmor(
         byte skinColor, byte hairColor, byte tattoo1, byte tattoo2,
         byte metal1 = 0, byte metal2 = 0,

--- a/Radoub.UI/Radoub.UI/Services/ThemeCatalogCache.cs
+++ b/Radoub.UI/Radoub.UI/Services/ThemeCatalogCache.cs
@@ -24,9 +24,7 @@ public class ThemeCatalogCache
         _cachePath = cachePath;
     }
 
-    /// <summary>
-    /// Creates a cache using the shared theme catalog path ~/Radoub/Themes/ThemeCatalog.json.
-    /// </summary>
+    /// <summary>Creates a cache using the shared theme catalog path ~/Radoub/Themes/ThemeCatalog.json.</summary>
     public static ThemeCatalogCache ForShared()
     {
         var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
@@ -91,9 +89,7 @@ public class ThemeCatalogCache
         return true;
     }
 
-    /// <summary>
-    /// Get the last write timestamp for a directory, or null if it doesn't exist.
-    /// </summary>
+    /// <summary>Get the last write timestamp for a directory, or null if it doesn't exist.</summary>
     public static string? GetDirectoryTimestamp(string directory)
     {
         if (!Directory.Exists(directory))
@@ -102,9 +98,7 @@ public class ThemeCatalogCache
         return Directory.GetLastWriteTimeUtc(directory).ToString("O");
     }
 
-    /// <summary>
-    /// Build the current timestamps dictionary for the given directories.
-    /// </summary>
+    /// <summary>Build the current timestamps dictionary for the given directories.</summary>
     public static Dictionary<string, string?> BuildTimestamps(IReadOnlyList<string> directories)
     {
         var timestamps = new Dictionary<string, string?>();
@@ -136,9 +130,7 @@ public class ThemeCatalogCache
         }
     }
 
-    /// <summary>
-    /// Save catalog data to cache file.
-    /// </summary>
+    /// <summary>Save catalog data to cache file.</summary>
     public void Save(ThemeCatalogData data)
     {
         try
@@ -164,9 +156,7 @@ public class ThemeCatalogCache
     };
 }
 
-/// <summary>
-/// Serializable cache data for discovered themes.
-/// </summary>
+/// <summary>Serializable cache data for discovered themes.</summary>
 public class ThemeCatalogData
 {
     [JsonPropertyName("cacheVersion")]

--- a/Radoub.UI/Radoub.UI/Services/ThemeManager.Resources.cs
+++ b/Radoub.UI/Radoub.UI/Services/ThemeManager.Resources.cs
@@ -8,14 +8,10 @@ using Radoub.UI.Models;
 
 namespace Radoub.UI.Services;
 
-/// <summary>
-/// Theme resource application: colors, fonts, and spacing.
-/// </summary>
+/// <summary>Theme resource application: colors, fonts, and spacing.</summary>
 public partial class ThemeManager
 {
-    /// <summary>
-    /// Apply theme resources (colors, fonts, spacing) after variant change.
-    /// </summary>
+    /// <summary>Apply theme resources (colors, fonts, spacing) after variant change.</summary>
     private void ApplyThemeResources(Application app, ThemeManifest theme)
     {
         try
@@ -325,9 +321,7 @@ public partial class ThemeManager
         }
     }
 
-    /// <summary>
-    /// Apply font values to resource dictionary
-    /// </summary>
+    /// <summary>Apply font values to resource dictionary</summary>
     /// <summary>
     /// Resolves the effective global font size (#2152). The Trebuchet slider
     /// (<paramref name="sharedFontSize"/>) is the single authority; a theme's own
@@ -452,9 +446,7 @@ public partial class ThemeManager
         resources["FontSizeTitle"] = baseSize + 10;                 // 24 @ base 14
     }
 
-    /// <summary>
-    /// Apply spacing values to resource dictionary
-    /// </summary>
+    /// <summary>Apply spacing values to resource dictionary</summary>
     private void ApplySpacing(IResourceDictionary resources, ThemeSpacing spacing)
     {
         if (spacing.ControlPadding.HasValue)

--- a/Radoub.UI/Radoub.UI/Services/ThemeManager.cs
+++ b/Radoub.UI/Radoub.UI/Services/ThemeManager.cs
@@ -27,30 +27,17 @@ public partial class ThemeManager
     private readonly string? _cachePathOverride;
     private const string DefaultThemeId = "org.radoub.theme.light";
 
-    /// <summary>
-    /// Event raised when a theme is successfully applied.
-    /// UI components can subscribe to refresh their visuals.
-    /// </summary>
+    /// <summary>Raised when a theme is applied. UI components subscribe to refresh their visuals.</summary>
     public event EventHandler? ThemeApplied;
 
-    /// <summary>
-    /// Theme directories (official and user)
-    /// </summary>
+    /// <summary>Theme directories (official and user)</summary>
     private readonly List<string> _themeDirectories = new();
 
-    /// <summary>
-    /// Available themes discovered from theme directories
-    /// </summary>
     public IReadOnlyList<ThemeManifest> AvailableThemes { get { lock (_lock) { return _themes.Values.ToList(); } } }
 
-    /// <summary>
-    /// Currently active theme
-    /// </summary>
     public ThemeManifest? CurrentTheme => _currentTheme;
 
-    /// <summary>
-    /// Gets the singleton instance. Must call Initialize() first.
-    /// </summary>
+    /// <summary>Gets the singleton instance. Must call Initialize() first.</summary>
     /// <exception cref="InvalidOperationException">Thrown if Initialize() has not been called.</exception>
     public static ThemeManager Instance
     {
@@ -240,9 +227,7 @@ public partial class ThemeManager
         UnifiedLogger.LogApplication(LogLevel.INFO, $"[{_toolName}] Discovered {_themes.Count} themes (rescanned)");
     }
 
-    /// <summary>
-    /// Try to load themes from cached file paths. Returns false if any file is missing or corrupt.
-    /// </summary>
+    /// <summary>Try to load themes from cached file paths. Returns false if any file is missing or corrupt.</summary>
     private bool TryLoadFromCache(ThemeCatalogData cached)
     {
         var discovered = new Dictionary<string, ThemeManifest>();
@@ -281,9 +266,7 @@ public partial class ThemeManager
         return true;
     }
 
-    /// <summary>
-    /// Load theme manifest from JSON file
-    /// </summary>
+    /// <summary>Load theme manifest from JSON file</summary>
     private ThemeManifest? LoadThemeManifest(string filePath)
     {
         var json = File.ReadAllText(filePath);
@@ -303,9 +286,7 @@ public partial class ThemeManager
         return manifest;
     }
 
-    /// <summary>
-    /// Apply a theme by ID
-    /// </summary>
+    /// <summary>Apply a theme by ID</summary>
     public bool ApplyTheme(string themeId)
     {
         ThemeManifest? theme;
@@ -389,9 +370,7 @@ public partial class ThemeManager
         }
     }
 
-    /// <summary>
-    /// Get theme by ID
-    /// </summary>
+    /// <summary>Get theme by ID</summary>
     public ThemeManifest? GetTheme(string themeId)
     {
         lock (_lock)
@@ -400,9 +379,7 @@ public partial class ThemeManager
         }
     }
 
-    /// <summary>
-    /// Reload themes from disk
-    /// </summary>
+    /// <summary>Reload themes from disk</summary>
     public void RefreshThemes()
     {
         DiscoverThemes();
@@ -437,9 +414,7 @@ public partial class ThemeManager
         return DefaultThemeId;
     }
 
-    /// <summary>
-    /// Apply the shared theme from RadoubSettings.
-    /// </summary>
+    /// <summary>Apply the shared theme from RadoubSettings.</summary>
     /// <returns>True if a theme was applied successfully</returns>
     public bool ApplySharedTheme()
     {

--- a/Radoub.UI/Radoub.UI/Services/TlkService.cs
+++ b/Radoub.UI/Radoub.UI/Services/TlkService.cs
@@ -6,9 +6,7 @@ using Radoub.Formats.Tlk;
 
 namespace Radoub.UI.Services;
 
-/// <summary>
-/// Information about a LocString's source and available translations.
-/// </summary>
+/// <summary>Information about a LocString's source and available translations.</summary>
 public class LocStringInfo
 {
     public bool HasEmbeddedStrings { get; init; }
@@ -335,9 +333,7 @@ public class TlkService : ITlkService
         }
     }
 
-    /// <summary>
-    /// Invalidate all cached TLK files.
-    /// </summary>
+    /// <summary>Invalidate all cached TLK files.</summary>
     public void InvalidateCache()
     {
         lock (_lock)
@@ -349,14 +345,10 @@ public class TlkService : ITlkService
         }
     }
 
-    /// <summary>
-    /// Check if TLK resources are available (game paths configured).
-    /// </summary>
+    /// <summary>Check if TLK resources are available (game paths configured).</summary>
     public bool IsAvailable => RadoubSettings.Instance.HasGamePaths;
 
-    /// <summary>
-    /// Get available languages from RadoubSettings.
-    /// </summary>
+    /// <summary>Get available languages from RadoubSettings.</summary>
     public IReadOnlyList<Language> GetAvailableLanguages()
     {
         return RadoubSettings.Instance.GetAvailableTlkLanguages().ToList();
@@ -371,9 +363,7 @@ public class TlkService : ITlkService
         return ResolveStrRef(strRef, RadoubSettings.Instance.EffectiveLanguage);
     }
 
-    /// <summary>
-    /// Resolve a StrRef in a specific language with settings-driven TLK auto-loading.
-    /// </summary>
+    /// <summary>Resolve a StrRef in a specific language with settings-driven TLK auto-loading.</summary>
     public string? ResolveStrRef(uint strRef, Language language)
     {
         if (!LanguageHelper.IsValidStrRef(strRef))
@@ -420,9 +410,7 @@ public class TlkService : ITlkService
         return null;
     }
 
-    /// <summary>
-    /// Resolve a CExoLocString using settings-driven language/gender preferences.
-    /// </summary>
+    /// <summary>Resolve a CExoLocString using settings-driven language/gender preferences.</summary>
     public string ResolveLocStringFromSettings(CExoLocString locString, Language? preferredLanguage = null)
     {
         var language = preferredLanguage ?? RadoubSettings.Instance.EffectiveLanguage;
@@ -461,9 +449,7 @@ public class TlkService : ITlkService
         return string.Empty;
     }
 
-    /// <summary>
-    /// Get information about a LocString's source.
-    /// </summary>
+    /// <summary>Get information about a LocString's source.</summary>
     public LocStringInfo GetLocStringInfo(CExoLocString locString)
     {
         var hasEmbedded = locString.LocalizedStrings.Count > 0;
@@ -515,9 +501,7 @@ public class TlkService : ITlkService
         return "Empty";
     }
 
-    /// <summary>
-    /// Get all available translations for a LocString.
-    /// </summary>
+    /// <summary>Get all available translations for a LocString.</summary>
     public Dictionary<Language, string> GetAllTranslations(CExoLocString locString)
     {
         var translations = new Dictionary<Language, string>();
@@ -551,9 +535,7 @@ public class TlkService : ITlkService
         return translations;
     }
 
-    /// <summary>
-    /// Get the TLK file path for the effective language from settings.
-    /// </summary>
+    /// <summary>Get the TLK file path for the effective language from settings.</summary>
     public string? GetCurrentTlkPath()
     {
         return RadoubSettings.Instance.GetTlkPath(
@@ -561,9 +543,7 @@ public class TlkService : ITlkService
             RadoubSettings.Instance.PreferredGender);
     }
 
-    /// <summary>
-    /// Get a summary of TLK status for display.
-    /// </summary>
+    /// <summary>Get a summary of TLK status for display.</summary>
     public string GetTlkStatusSummary()
     {
         if (!IsAvailable)
@@ -579,9 +559,7 @@ public class TlkService : ITlkService
         return $"TLK: {langName} - {displayPath}";
     }
 
-    /// <summary>
-    /// Load a TLK from cache or disk for the given language (settings-driven).
-    /// </summary>
+    /// <summary>Load a TLK from cache or disk for the given language (settings-driven).</summary>
     private TlkFile? GetCachedTlk(Language language)
     {
         lock (_lock)
@@ -614,9 +592,7 @@ public class TlkService : ITlkService
         }
     }
 
-    /// <summary>
-    /// Load custom TLK from cache or disk (settings-driven).
-    /// </summary>
+    /// <summary>Load custom TLK from cache or disk (settings-driven).</summary>
     private TlkFile? GetCachedCustomTlk()
     {
         lock (_lock)

--- a/Radoub.UI/Radoub.UI/Services/TokenContextMenu.cs
+++ b/Radoub.UI/Radoub.UI/Services/TokenContextMenu.cs
@@ -63,9 +63,7 @@ public static class TokenContextMenu
         return items;
     }
 
-    /// <summary>
-    /// Build the full "Insert Token" submenu with standard tokens, quick slots, and "All Tokens...".
-    /// </summary>
+    /// <summary>Build the full "Insert Token" submenu with standard tokens, quick slots, and "All Tokens...".</summary>
     public static MenuItem BuildInsertTokenMenu(
         TextBox targetTextBox,
         Action openTokenWindow,
@@ -119,9 +117,7 @@ public static class TokenContextMenu
         return insertMenu;
     }
 
-    /// <summary>
-    /// Append token menu items to an existing ContextMenu (for SpellCheckTextBox).
-    /// </summary>
+    /// <summary>Append token menu items to an existing ContextMenu (for SpellCheckTextBox).</summary>
     public static void AppendTokenMenu(
         ContextMenu menu,
         TextBox targetTextBox,
@@ -131,9 +127,7 @@ public static class TokenContextMenu
         menu.Items.Add(BuildInsertTokenMenu(targetTextBox, openTokenWindow, quickTokenService));
     }
 
-    /// <summary>
-    /// Attach a token-enabled context menu to a plain TextBox.
-    /// </summary>
+    /// <summary>Attach a token-enabled context menu to a plain TextBox.</summary>
     public static void Attach(
         TextBox textBox,
         Action openTokenWindow,

--- a/Radoub.UI/Radoub.UI/Services/WindowLifecycleManager.cs
+++ b/Radoub.UI/Radoub.UI/Services/WindowLifecycleManager.cs
@@ -93,9 +93,7 @@ namespace Radoub.UI.Services
             return window;
         }
 
-        /// <summary>
-        /// Gets an existing window by key without creating a new one.
-        /// </summary>
+        /// <summary>Gets an existing window by key without creating a new one.</summary>
         /// <typeparam name="T">Window type</typeparam>
         /// <param name="key">Unique key for this window type</param>
         /// <returns>The window instance, or null if not exists or not visible</returns>
@@ -108,17 +106,13 @@ namespace Radoub.UI.Services
             return null;
         }
 
-        /// <summary>
-        /// Checks if a window exists and is visible.
-        /// </summary>
+        /// <summary>Checks if a window exists and is visible.</summary>
         public bool IsOpen(string key)
         {
             return _windows.TryGetValue(key, out var window) && window?.IsVisible == true;
         }
 
-        /// <summary>
-        /// Closes a specific window if it exists.
-        /// </summary>
+        /// <summary>Closes a specific window if it exists.</summary>
         /// <param name="key">Unique key for the window</param>
         /// <returns>True if window was closed, false if it didn't exist</returns>
         public bool Close(string key)
@@ -155,9 +149,7 @@ namespace Radoub.UI.Services
             _closedCallbacks.Clear();
         }
 
-        /// <summary>
-        /// Performs an action on a window if it exists and is visible.
-        /// </summary>
+        /// <summary>Performs an action on a window if it exists and is visible.</summary>
         /// <typeparam name="T">Window type</typeparam>
         /// <param name="key">Unique key for this window type</param>
         /// <param name="action">Action to perform on the window</param>

--- a/Radoub.UI/Radoub.UI/Settings/IColumnSettings.cs
+++ b/Radoub.UI/Radoub.UI/Settings/IColumnSettings.cs
@@ -6,24 +6,18 @@ namespace Radoub.UI.Settings;
 /// </summary>
 public interface IColumnSettings
 {
-    /// <summary>
-    /// Get the stored width for a column.
-    /// </summary>
+    /// <summary>Get the stored width for a column.</summary>
     /// <param name="contextKey">Context identifier (e.g., "Backpack", "Palette")</param>
     /// <param name="columnKey">Column identifier (e.g., "Name", "ResRef")</param>
     /// <returns>Stored width, or null if not set</returns>
     double? GetColumnWidth(string contextKey, string columnKey);
 
-    /// <summary>
-    /// Store the width for a column.
-    /// </summary>
+    /// <summary>Store the width for a column.</summary>
     /// <param name="contextKey">Context identifier</param>
     /// <param name="columnKey">Column identifier</param>
     /// <param name="width">Width to store</param>
     void SetColumnWidth(string contextKey, string columnKey, double width);
 
-    /// <summary>
-    /// Save all pending changes.
-    /// </summary>
+    /// <summary>Save all pending changes.</summary>
     void Save();
 }

--- a/Radoub.UI/Radoub.UI/Settings/IFilterSettings.cs
+++ b/Radoub.UI/Radoub.UI/Settings/IFilterSettings.cs
@@ -8,22 +8,16 @@ namespace Radoub.UI.Settings;
 /// </summary>
 public interface IFilterSettings
 {
-    /// <summary>
-    /// Get saved filter state for a context.
-    /// </summary>
+    /// <summary>Get saved filter state for a context.</summary>
     /// <param name="contextKey">Context identifier (e.g., "Backpack", "Palette").</param>
     /// <returns>Saved filter state, or null if none saved.</returns>
     FilterState? GetFilterState(string contextKey);
 
-    /// <summary>
-    /// Save filter state for a context.
-    /// </summary>
+    /// <summary>Save filter state for a context.</summary>
     /// <param name="contextKey">Context identifier.</param>
     /// <param name="state">Filter state to save.</param>
     void SetFilterState(string contextKey, FilterState state);
 
-    /// <summary>
-    /// Persist changes to storage.
-    /// </summary>
+    /// <summary>Persist changes to storage.</summary>
     void Save();
 }

--- a/Radoub.UI/Radoub.UI/Utils/ComboBoxHelper.cs
+++ b/Radoub.UI/Radoub.UI/Utils/ComboBoxHelper.cs
@@ -39,9 +39,7 @@ public static class ComboBoxHelper
         combo.SelectedIndex = combo.Items.Count - 1;
     }
 
-    /// <summary>
-    /// Get the selected item's Tag value, cast to specified type.
-    /// </summary>
+    /// <summary>Get the selected item's Tag value, cast to specified type.</summary>
     /// <typeparam name="T">Expected type of the Tag</typeparam>
     /// <returns>Tag value or null if no selection or wrong type</returns>
     public static T? GetSelectedTag<T>(ComboBox? combo) where T : struct
@@ -51,9 +49,7 @@ public static class ComboBoxHelper
         return null;
     }
 
-    /// <summary>
-    /// Get the selected item's Tag value as the specified type, with default fallback.
-    /// </summary>
+    /// <summary>Get the selected item's Tag value as the specified type, with default fallback.</summary>
     public static T GetSelectedTagOrDefault<T>(ComboBox? combo, T defaultValue) where T : struct
     {
         return GetSelectedTag<T>(combo) ?? defaultValue;

--- a/Radoub.UI/Radoub.UI/Utils/PaletteCategoryComboBinder.cs
+++ b/Radoub.UI/Radoub.UI/Utils/PaletteCategoryComboBinder.cs
@@ -117,9 +117,7 @@ public static class PaletteCategoryComboBinder
             combo.SelectedIndex = 0;
     }
 
-    /// <summary>
-    /// The PaletteID of the currently selected item, or null if nothing selected / wrong Tag type.
-    /// </summary>
+    /// <summary>The PaletteID of the currently selected item, or null if nothing selected / wrong Tag type.</summary>
     public static byte? GetSelectedId(ComboBox? combo)
         => ComboBoxHelper.GetSelectedTag<byte>(combo);
 }

--- a/Radoub.UI/Radoub.UI/Utils/VersionHelper.cs
+++ b/Radoub.UI/Radoub.UI/Utils/VersionHelper.cs
@@ -49,9 +49,7 @@ public static class VersionHelper
         return "1.0.0";
     }
 
-    /// <summary>
-    /// Gets the semantic version string for the entry assembly (main application).
-    /// </summary>
+    /// <summary>Gets the semantic version string for the entry assembly (main application).</summary>
     /// <returns>Version string (e.g., "0.1.0-alpha")</returns>
     public static string GetEntryAssemblyVersion()
     {

--- a/Radoub.UI/Radoub.UI/Utils/WikiHelper.cs
+++ b/Radoub.UI/Radoub.UI/Utils/WikiHelper.cs
@@ -47,9 +47,7 @@ public static class WikiHelper
             : WikiRoot;
     }
 
-    /// <summary>
-    /// Opens the tool's wiki documentation in the default browser.
-    /// </summary>
+    /// <summary>Opens the tool's wiki documentation in the default browser.</summary>
     /// <returns>True if the browser was launched; false if it failed (already logged).</returns>
     public static bool OpenToolDocumentation(string? toolName)
     {

--- a/Radoub.UI/Radoub.UI/ViewModels/EquipmentSlotViewModel.cs
+++ b/Radoub.UI/Radoub.UI/ViewModels/EquipmentSlotViewModel.cs
@@ -23,14 +23,10 @@ public enum SlotSize
     ExtraTall
 }
 
-/// <summary>
-/// ViewModel for a single equipment slot in the EquipmentSlotsPanel.
-/// </summary>
+/// <summary>ViewModel for a single equipment slot in the EquipmentSlotsPanel.</summary>
 public partial class EquipmentSlotViewModel : ObservableObject
 {
-    /// <summary>
-    /// Creates an equipment slot view model.
-    /// </summary>
+    /// <summary>Creates an equipment slot view model.</summary>
     /// <param name="slotId">Slot ID (0-17).</param>
     /// <param name="slotFlag">Bit flag for GFF struct ID.</param>
     /// <param name="name">Display name.</param>
@@ -43,77 +39,49 @@ public partial class EquipmentSlotViewModel : ObservableObject
         IsNatural = isNatural;
     }
 
-    /// <summary>
-    /// Slot ID (0-17 per issue spec).
-    /// </summary>
+    /// <summary>Slot ID (0-17 per issue spec).</summary>
     public int SlotId { get; }
 
-    /// <summary>
-    /// Bit flag value used in GFF Equip_ItemList struct ID.
-    /// </summary>
+    /// <summary>Bit flag value used in GFF Equip_ItemList struct ID.</summary>
     public int SlotFlag { get; }
 
-    /// <summary>
-    /// Display name (e.g., "Head", "Chest", "Claw 1").
-    /// </summary>
+    /// <summary>Display name (e.g., "Head", "Chest", "Claw 1").</summary>
     public string Name { get; }
 
-    /// <summary>
-    /// True if this is a natural equipment slot (creature-only: Claws, Skin).
-    /// </summary>
+    /// <summary>True if this is a natural equipment slot (creature-only: Claws, Skin).</summary>
     public bool IsNatural { get; }
 
-    /// <summary>
-    /// Path to the slot's placeholder icon resource.
-    /// </summary>
+    /// <summary>Path to the slot's placeholder icon resource.</summary>
     public string IconPath => ItemIconHelper.GetSlotIconPath(SlotFlag);
 
-    /// <summary>
-    /// Visual size category for paperdoll layout.
-    /// </summary>
+    /// <summary>Visual size category for paperdoll layout.</summary>
     public SlotSize Size { get; init; } = SlotSize.Medium;
 
-    /// <summary>
-    /// True if this is a standard equipment slot (Head, Chest, etc.).
-    /// </summary>
+    /// <summary>True if this is a standard equipment slot (Head, Chest, etc.).</summary>
     public bool IsStandard => !IsNatural;
 
-    /// <summary>
-    /// The item currently equipped in this slot, if any.
-    /// </summary>
+    /// <summary>The item currently equipped in this slot, if any.</summary>
     [ObservableProperty]
     private ItemViewModel? _equippedItem;
 
-    /// <summary>
-    /// True if no item is equipped in this slot.
-    /// </summary>
+    /// <summary>True if no item is equipped in this slot.</summary>
     public bool IsEmpty => EquippedItem == null;
 
-    /// <summary>
-    /// True if an item is equipped in this slot.
-    /// </summary>
+    /// <summary>True if an item is equipped in this slot.</summary>
     public bool HasItem => EquippedItem != null;
 
-    /// <summary>
-    /// True if slot is selected (for context operations).
-    /// </summary>
+    /// <summary>True if slot is selected (for context operations).</summary>
     [ObservableProperty]
     private bool _isSelected;
 
-    /// <summary>
-    /// Validation warning message, if any.
-    /// </summary>
+    /// <summary>Validation warning message, if any.</summary>
     [ObservableProperty]
     private string? _validationWarning;
 
-    /// <summary>
-    /// True if there's a validation warning for this slot.
-    /// </summary>
+    /// <summary>True if there's a validation warning for this slot.</summary>
     public bool HasWarning => !string.IsNullOrEmpty(ValidationWarning);
 
-    /// <summary>
-    /// Tooltip text combining item info and any warnings.
-    /// </summary>
+    /// <summary>Tooltip text combining item info and any warnings.</summary>
     public string Tooltip
     {
         get
@@ -143,9 +111,7 @@ public partial class EquipmentSlotViewModel : ObservableObject
     }
 }
 
-/// <summary>
-/// Factory for creating equipment slot view models with correct metadata.
-/// </summary>
+/// <summary>Factory for creating equipment slot view models with correct metadata.</summary>
 public static class EquipmentSlotFactory
 {
     // Slot flags matching EquipmentSlots constants
@@ -168,9 +134,7 @@ public static class EquipmentSlotFactory
     private const int FlagClaw3 = 0x10000;
     private const int FlagSkin = 0x20000;
 
-    /// <summary>
-    /// Creates all standard equipment slots (14 slots) with paperdoll sizes.
-    /// </summary>
+    /// <summary>Creates all standard equipment slots (14 slots) with paperdoll sizes.</summary>
     public static IReadOnlyList<EquipmentSlotViewModel> CreateStandardSlots()
     {
         return new List<EquipmentSlotViewModel>
@@ -192,9 +156,7 @@ public static class EquipmentSlotFactory
         };
     }
 
-    /// <summary>
-    /// Creates all natural equipment slots (4 creature-only slots).
-    /// </summary>
+    /// <summary>Creates all natural equipment slots (4 creature-only slots).</summary>
     public static IReadOnlyList<EquipmentSlotViewModel> CreateNaturalSlots()
     {
         return new List<EquipmentSlotViewModel>
@@ -206,9 +168,7 @@ public static class EquipmentSlotFactory
         };
     }
 
-    /// <summary>
-    /// Creates all equipment slots (standard + natural).
-    /// </summary>
+    /// <summary>Creates all equipment slots (standard + natural).</summary>
     public static IReadOnlyList<EquipmentSlotViewModel> CreateAllSlots()
     {
         var all = new List<EquipmentSlotViewModel>();
@@ -217,9 +177,7 @@ public static class EquipmentSlotFactory
         return all;
     }
 
-    /// <summary>
-    /// Gets a slot by its bit flag value.
-    /// </summary>
+    /// <summary>Gets a slot by its bit flag value.</summary>
     public static EquipmentSlotViewModel? GetSlotByFlag(IEnumerable<EquipmentSlotViewModel> slots, int flag)
     {
         return slots.FirstOrDefault(s => s.SlotFlag == flag);

--- a/Radoub.UI/Radoub.UI/ViewModels/ItemViewModel.cs
+++ b/Radoub.UI/Radoub.UI/ViewModels/ItemViewModel.cs
@@ -21,9 +21,7 @@ public partial class ItemViewModel : ObservableObject
     private readonly int _cachedBaseItem;
     private readonly uint _cachedValue;
 
-    /// <summary>
-    /// Creates a new ItemViewModel wrapping a UtiFile.
-    /// </summary>
+    /// <summary>Creates a new ItemViewModel wrapping a UtiFile.</summary>
     /// <param name="item">The underlying item data.</param>
     /// <param name="resolvedName">Display name (from TLK or LocalizedName).</param>
     /// <param name="baseItemName">Name of base item type (from baseitems.2da).</param>
@@ -55,9 +53,7 @@ public partial class ItemViewModel : ObservableObject
         Source = GameResourceSource.Bif;
     }
 
-    /// <summary>
-    /// Creates a new ItemViewModel for a backpack item with inventory metadata.
-    /// </summary>
+    /// <summary>Creates a new ItemViewModel for a backpack item with inventory metadata.</summary>
     public ItemViewModel(
         UtiFile item,
         string resolvedName,
@@ -81,101 +77,69 @@ public partial class ItemViewModel : ObservableObject
     /// </summary>
     public UtiFile? Item => _item;
 
-    /// <summary>
-    /// Display name resolved from TLK or LocalizedName.
-    /// </summary>
+    /// <summary>Display name resolved from TLK or LocalizedName.</summary>
     public string Name { get; set; }
 
-    /// <summary>
-    /// Blueprint resource reference (filename without extension).
-    /// </summary>
+    /// <summary>Blueprint resource reference (filename without extension).</summary>
     public string ResRef
     {
         get => _item?.TemplateResRef ?? _cachedResRef ?? string.Empty;
         init => _cachedResRef = value;
     }
 
-    /// <summary>
-    /// Item tag for scripting reference.
-    /// </summary>
+    /// <summary>Item tag for scripting reference.</summary>
     public string Tag
     {
         get => _item?.Tag ?? _cachedTag ?? string.Empty;
         init => _cachedTag = value;
     }
 
-    /// <summary>
-    /// Base item type name (e.g., "Longsword", "Ring", "Amulet").
-    /// </summary>
+    /// <summary>Base item type name (e.g., "Longsword", "Ring", "Amulet").</summary>
     public string BaseItemName { get; set; }
 
-    /// <summary>
-    /// Base item type index into baseitems.2da.
-    /// </summary>
+    /// <summary>Base item type index into baseitems.2da.</summary>
     public int BaseItem
     {
         get => _item?.BaseItem ?? _cachedBaseItem;
         init => _cachedBaseItem = value;
     }
 
-    /// <summary>
-    /// Item value (Cost + AddCost).
-    /// </summary>
+    /// <summary>Item value (Cost + AddCost).</summary>
     public uint Value
     {
         get => _item != null ? _item.Cost + _item.AddCost : _cachedValue;
         init => _cachedValue = value;
     }
 
-    /// <summary>
-    /// Formatted display of item properties.
-    /// </summary>
+    /// <summary>Formatted display of item properties.</summary>
     public string PropertiesDisplay { get; set; }
 
-    /// <summary>
-    /// Number of item properties.
-    /// </summary>
+    /// <summary>Number of item properties.</summary>
     public int PropertyCount => _item?.Properties.Count ?? 0;
 
-    /// <summary>
-    /// Selection state for checkbox column.
-    /// </summary>
+    /// <summary>Selection state for checkbox column.</summary>
     [ObservableProperty]
     private bool _isSelected;
 
-    /// <summary>
-    /// Stack size for stackable items.
-    /// </summary>
+    /// <summary>Stack size for stackable items.</summary>
     public ushort StackSize => _item?.StackSize ?? 1;
 
-    /// <summary>
-    /// True if item is a plot item.
-    /// </summary>
+    /// <summary>True if item is a plot item.</summary>
     public bool IsPlot => _item?.Plot ?? false;
 
-    /// <summary>
-    /// True if item is cursed (undroppable).
-    /// </summary>
+    /// <summary>True if item is cursed (undroppable).</summary>
     public bool IsCursed => _item?.Cursed ?? false;
 
-    /// <summary>
-    /// Source of the item resource.
-    /// </summary>
+    /// <summary>Source of the item resource.</summary>
     public GameResourceSource Source { get; init; }
 
-    /// <summary>
-    /// True if item is from base game (BIF).
-    /// </summary>
+    /// <summary>True if item is from base game (BIF).</summary>
     public bool IsStandard => Source == GameResourceSource.Bif;
 
-    /// <summary>
-    /// True if item is from custom content (Override, HAK, or Module).
-    /// </summary>
+    /// <summary>True if item is from custom content (Override, HAK, or Module).</summary>
     public bool IsCustom => Source != GameResourceSource.Bif;
 
-    /// <summary>
-    /// Specific source file or archive name (e.g., "templates.bif", "cep2_add_wpn.hak").
-    /// </summary>
+    /// <summary>Specific source file or archive name (e.g., "templates.bif", "cep2_add_wpn.hak").</summary>
     public string SourceLocation { get; set; } = string.Empty;
 
     /// <summary>
@@ -184,9 +148,7 @@ public partial class ItemViewModel : ObservableObject
     /// </summary>
     public string IconPath => ItemIconHelper.GetIconPath(BaseItem);
 
-    /// <summary>
-    /// Delegate for lazy loading icon bitmaps.
-    /// </summary>
+    /// <summary>Delegate for lazy loading icon bitmaps.</summary>
     public delegate Bitmap? IconLoader(UtiFile item);
 
     private Bitmap? _iconBitmap;
@@ -261,9 +223,7 @@ public partial class ItemViewModel : ObservableObject
     [ObservableProperty]
     private int _equipableSlotFlags;
 
-    /// <summary>
-    /// True if this item can be equipped in at least one slot.
-    /// </summary>
+    /// <summary>True if this item can be equipped in at least one slot.</summary>
     public bool IsEquipable => EquipableSlotFlags != 0;
 
     #endregion
@@ -288,9 +248,7 @@ public partial class ItemViewModel : ObservableObject
     [ObservableProperty]
     private bool _isDropable;
 
-    /// <summary>
-    /// If true, item can be pickpocketed from creature.
-    /// </summary>
+    /// <summary>If true, item can be pickpocketed from creature.</summary>
     [ObservableProperty]
     private bool _isPickpocketable;
 

--- a/Radoub.UI/Radoub.UI/ViewModels/ItemViewModelFactory.cs
+++ b/Radoub.UI/Radoub.UI/ViewModels/ItemViewModelFactory.cs
@@ -15,9 +15,7 @@ public class ItemViewModelFactory
 {
     private readonly IGameDataService _gameData;
 
-    /// <summary>
-    /// Creates a new factory using the specified game data service.
-    /// </summary>
+    /// <summary>Creates a new factory using the specified game data service.</summary>
     public ItemViewModelFactory(IGameDataService gameData)
     {
         _gameData = gameData ?? throw new ArgumentNullException(nameof(gameData));
@@ -40,9 +38,7 @@ public class ItemViewModelFactory
         return vm;
     }
 
-    /// <summary>
-    /// Create an ItemViewModel for a backpack item with inventory metadata.
-    /// </summary>
+    /// <summary>Create an ItemViewModel for a backpack item with inventory metadata.</summary>
     /// <param name="item">The item to wrap.</param>
     /// <param name="gridPositionX">X position in inventory grid.</param>
     /// <param name="gridPositionY">Y position in inventory grid.</param>
@@ -68,9 +64,7 @@ public class ItemViewModelFactory
         return vm;
     }
 
-    /// <summary>
-    /// Create ItemViewModels for a collection of items (all assumed to be from same source).
-    /// </summary>
+    /// <summary>Create ItemViewModels for a collection of items (all assumed to be from same source).</summary>
     /// <param name="items">Items to wrap.</param>
     /// <param name="source">Source of all items (default: Bif for standard items).</param>
     public IEnumerable<ItemViewModel> Create(IEnumerable<UtiFile> items, GameResourceSource source = GameResourceSource.Bif)
@@ -78,27 +72,19 @@ public class ItemViewModelFactory
         return items.Select(i => Create(i, source));
     }
 
-    /// <summary>
-    /// Create ItemViewModels from items with their source information.
-    /// </summary>
+    /// <summary>Create ItemViewModels from items with their source information.</summary>
     public IEnumerable<ItemViewModel> Create(IEnumerable<(UtiFile item, GameResourceSource source)> itemsWithSource)
     {
         return itemsWithSource.Select(x => Create(x.item, x.source));
     }
 
-    /// <summary>
-    /// Get the display name for an item (for caching).
-    /// </summary>
+    /// <summary>Get the display name for an item (for caching).</summary>
     public string GetItemDisplayName(UtiFile item) => ResolveDisplayName(item);
 
-    /// <summary>
-    /// Get the base item type name (for caching).
-    /// </summary>
+    /// <summary>Get the base item type name (for caching).</summary>
     public string GetBaseItemTypeName(int baseItem) => ResolveBaseItemName(baseItem);
 
-    /// <summary>
-    /// Get the properties display string for caching.
-    /// </summary>
+    /// <summary>Get the properties display string for caching.</summary>
     public string GetPropertiesDisplay(List<ItemProperty> properties) => ResolvePropertiesDisplay(properties);
 
     /// <summary>

--- a/Radoub.UI/Radoub.UI/Views/NewBlueprintValidation.cs
+++ b/Radoub.UI/Radoub.UI/Views/NewBlueprintValidation.cs
@@ -10,9 +10,7 @@ namespace Radoub.UI.Views;
 /// </summary>
 public static class NewBlueprintValidation
 {
-    /// <summary>
-    /// Returns the first validation error for the given field values, or null if all are valid.
-    /// </summary>
+    /// <summary>First validation error for the given field values, or null if all valid.</summary>
     public static string? Validate(string? name, string? tag, string? resRef)
     {
         var trimmedName = (name ?? string.Empty).Trim();


### PR DESCRIPTION
## Summary

Two related tech-debt items, both driven by the `writing-clearly-and-concisely` skill.

- **#2671** — Added a mandatory concision pass to CLAUDE.md's Commit & PR Standards and wired it into the five commands that author prose (`create-issue`, `init-item`, `pre-merge`, `documentation`). The four load-bearing rules are named inline so short text skips the skill's 12k-token reference.
- **#2672** — Swept `Radoub.Formats` and `Radoub.UI` comments: 174 files, **net 3,357 comment lines removed**. Collapsed verbose XML doc blocks, deleted summaries that only restated the identifier, cut step narration above self-evident code.

Kept throughout: 2DA and Table provenance, BioWare spec references, issue markers, TODOs, capacity math, and domain rationale. All 175 unique issue references in the shared libraries survive.

The six rendering files (`ModelPreviewGLControl`, `MeshTransparency`, `SmoothGroupNormals`, `VertexWelder`, `MeshNormalSource`, `OpenGLShaderManager`) were **excluded** — sampling showed 15-17% of their comments carry issue refs or domain markers, versus ~0% in boilerplate code-behind. Per-tool sweeps follow in #2689-#2695.

## Pre-Merge Checklist

**Branch**: `radoub/issue-2671` | **Tool**: Radoub (shared)

### Tests
| Check | Status |
|-------|--------|
| Privacy scan | ✅ No hardcoded paths |
| Tech debt | ✅ No file over 1000 lines (two in the 800-1000 warn band, both shrank in this PR) |
| Unit tests (local, Windows) | ✅ 3032 passed, 0 failed |
| UI tests | ⏭️ Skipped — diff is comment-only, binaries identical |
| CI checks (incl. Linux) | ✅ All 5 pass on `80edb730` |

**UI Test Reason**: Auto-detection flagged 6 files under `Controls/`/`Views/`, but the branch diff contains 0 non-comment lines and no `.axaml` markup. Compiled output is unchanged, so FlaUI would exercise identical binaries. Skipped with user confirmation.

### Validation
| Check | Status |
|-------|--------|
| init-item | ✅ Branch follows convention, PR links both issues |
| Code review | ➖ Skipped — docs-only diff (comments + markdown) |
| CHANGELOG | ✅ Versioned section, PR number filled, dated today |
| [Unreleased] section | ✅ Empty |
| Wiki | ✅ Unaffected — no architecture change |

### Verification method

Every commit was checked comment-only by filtering the diff to non-comment lines — zero across all 174 files. Builds match baseline exactly (Formats 0 warnings; UI 2 pre-existing CS0067, untouched).

### Status
**Ready**: ✅

## Related Issues

- Closes #2671
- Closes #2672

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
