### PR TITLE
[Quartermaster] Sprint: Level-Up Wizard Data Integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.Formats 0.2.79-alpha] - 2026-07-20
+**Branch**: `quartermaster/issue-2676` | **PR**: #TBD
+
+### Added
+
+- `UtcFile.CopyFrom` copies every field from another creature while preserving instance identity, letting editors commit a working copy back without invalidating existing references (#2676).
+
+---
+
 ## [Prose-Concision] - 2026-07-20
 **Branch**: `radoub/issue-2671` | **PR**: #2675
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 ## [Radoub.Formats 0.2.79-alpha] - 2026-07-20
-**Branch**: `quartermaster/issue-2676` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2676` | **PR**: #2697
 
 ### Added
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -12,6 +12,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 - The Level-Up wizard now edits a private copy of the creature and commits only on success, so cancelling, closing, or a mid-apply error leaves the creature untouched (#2572, #2573).
 - Multi-level apply no longer drops extra ability increases selected in CE mode (#2696).
+- The character sheet's Final ability column now adds the racial modifier instead of repeating the base score.
 
 ---
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.140-alpha] - 2026-07-20
+**Branch**: `quartermaster/issue-2676` | **PR**: #TBD
+
+### Sprint: Level-Up Wizard Data Integrity (#2676)
+
+- The Level-Up wizard now edits a private copy of the creature and commits only on success, so cancelling, closing, or a mid-apply error leaves the creature untouched (#2572, #2573).
+- Multi-level apply no longer drops extra ability increases selected in CE mode (#2696).
+
+---
+
 ## [0.2.139-alpha] - 2026-07-08
 **Branch**: `radoub/sprint/save-integrity` | **PR**: #2656
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.140-alpha] - 2026-07-20
-**Branch**: `quartermaster/issue-2676` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2676` | **PR**: #2697
 
 ### Sprint: Level-Up Wizard Data Integrity (#2676)
 

--- a/Quartermaster/Quartermaster.Tests/CharacterSheetServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/CharacterSheetServiceTests.cs
@@ -132,6 +132,44 @@ public class CharacterSheetServiceTests
     }
 
     [Fact]
+    public void GenerateTextSheet_AbilityRow_FinalIsBasePlusRacial()
+    {
+        // UTC stores base scores (BioWare Creature Format 3.2), so the Final column
+        // must be base + racial. The row previously printed the stored score in both
+        // the Base and Final columns while still showing a racial modifier between
+        // them, so the arithmetic on screen did not add up.
+        _mockGameData.Set2DAValue("racialtypes", 0, "ConAdjust", "2");
+        var creature = CreateTestCreature();
+        creature.Race = 0;
+        creature.Con = 14;
+
+        var text = _sheetService.GenerateTextSheet(creature);
+
+        var conRow = text.Split('\n').First(l => l.TrimStart().StartsWith("CON"));
+        var numbers = conRow.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+        // Layout: CON <base> <racial> <final> <modifier>
+        Assert.Equal("14", numbers[1]);
+        Assert.Equal("16", numbers[3]);
+    }
+
+    [Fact]
+    public void GenerateTextSheet_AbilityRow_NoRacialModifier_FinalMatchesBase()
+    {
+        var creature = CreateTestCreature();
+        creature.Race = 6; // Human: no racial ability modifiers
+        creature.Con = 14;
+
+        var text = _sheetService.GenerateTextSheet(creature);
+
+        var conRow = text.Split('\n').First(l => l.TrimStart().StartsWith("CON"));
+        var numbers = conRow.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Equal("14", numbers[1]);
+        Assert.Equal("14", numbers[3]);
+    }
+
+    [Fact]
     public void GenerateTextSheet_ContainsCombatStats()
     {
         var creature = CreateTestCreature();

--- a/Quartermaster/Quartermaster.Tests/LevelHistoryServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/LevelHistoryServiceTests.cs
@@ -206,6 +206,52 @@ public class LevelHistoryServiceTests
         };
     }
 
+    [Fact]
+    public void Encode_RecordWithUnencodableData_ReturnsEmptyRatherThanThrowing()
+    {
+        // Level history is cosmetic metadata. An encode failure must not abort an
+        // otherwise-valid level-up, so Encode swallows and logs like Decode does.
+        // A cyclic Skills dictionary is not reachable through the UI, but it stands
+        // in for any serializer failure (#2676 code review).
+        var records = new List<LevelRecord>
+        {
+            new()
+            {
+                TotalLevel = 1,
+                ClassId = 0,
+                ClassLevel = 1,
+                Feats = null!,   // Serializer and the readable encoder both dereference this
+                Skills = null!,
+                AbilityIncrease = -1
+            }
+        };
+
+        // Readable and binary dereference the lists directly and throw; both must be
+        // swallowed. JSON tolerates nulls and still produces output, which is fine —
+        // the guarantee is "never throws", not "always returns empty".
+        var readable = LevelHistoryService.Encode(records, LevelHistoryEncoding.Readable);
+        var binary = LevelHistoryService.Encode(records, LevelHistoryEncoding.Binary);
+        var json = Record.Exception(() =>
+            LevelHistoryService.Encode(records, LevelHistoryEncoding.JsonCompressed));
+
+        Assert.Equal("", readable);
+        Assert.Equal("", binary);
+        Assert.Null(json);
+    }
+
+    [Fact]
+    public void AppendToComment_EncodeFails_PreservesExistingComment()
+    {
+        var records = new List<LevelRecord>
+        {
+            new() { TotalLevel = 1, ClassId = 0, ClassLevel = 1, Feats = null!, Skills = null!, AbilityIncrease = -1 }
+        };
+
+        var result = LevelHistoryService.AppendToComment("designer note", records, LevelHistoryEncoding.Readable);
+
+        Assert.Equal("designer note", result);
+    }
+
     private static void AssertRecordsEqual(LevelRecord expected, LevelRecord actual)
     {
         Assert.Equal(expected.TotalLevel, actual.TotalLevel);

--- a/Quartermaster/Quartermaster.Tests/LevelUpApplicationServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/LevelUpApplicationServiceTests.cs
@@ -1072,6 +1072,79 @@ public class LevelUpApplicationServiceTests
         Assert.Equal(36, result);
     }
 
+    [Fact]
+    public void ApplyOverflowAbilityIncreases_AppliesIncrementsBeyondLegitimateSlots()
+    {
+        // CE mode lets the user take more increases than the every-fourth-level
+        // slots allow. The consolidated path applies the slotted ones itself; the
+        // overflow beyond them was silently dropped before #2696.
+        var creature = new CreatureBuilder()
+            .WithClass(CommonClass.Fighter, 3)
+            .WithAbilities(14, 12, 14, 10, 10, 8)
+            .Build();
+
+        // Two increments requested (STR, DEX) but only one legitimate slot.
+        var allIncreases = new List<int> { 0, 1 };
+        var applied = new Dictionary<int, int> { [4] = 0 }; // STR used the slot at char level 4
+
+        LevelUpApplicationService.ApplyOverflowAbilityIncreases(creature, allIncreases, applied);
+
+        Assert.Equal(14, creature.Str); // Untouched — the slot already applied it
+        Assert.Equal(13, creature.Dex); // 12 + 1 overflow
+    }
+
+    [Fact]
+    public void ApplyOverflowAbilityIncreases_NoOverflow_LeavesCreatureUnchanged()
+    {
+        var creature = new CreatureBuilder()
+            .WithClass(CommonClass.Fighter, 3)
+            .WithAbilities(14, 12, 14, 10, 10, 8)
+            .Build();
+
+        var allIncreases = new List<int> { 0 };
+        var applied = new Dictionary<int, int> { [4] = 0 };
+
+        LevelUpApplicationService.ApplyOverflowAbilityIncreases(creature, allIncreases, applied);
+
+        Assert.Equal(14, creature.Str);
+        Assert.Equal(12, creature.Dex);
+    }
+
+    [Fact]
+    public void ApplyOverflowAbilityIncreases_SameAbilityOverflowsTwice_Stacks()
+    {
+        var creature = new CreatureBuilder()
+            .WithClass(CommonClass.Fighter, 3)
+            .WithAbilities(14, 12, 14, 10, 10, 8)
+            .Build();
+
+        // STR three times, one slot available.
+        var allIncreases = new List<int> { 0, 0, 0 };
+        var applied = new Dictionary<int, int> { [4] = 0 };
+
+        LevelUpApplicationService.ApplyOverflowAbilityIncreases(creature, allIncreases, applied);
+
+        Assert.Equal(16, creature.Str); // 14 + 2 overflow (third one used the slot)
+    }
+
+    [Fact]
+    public void ApplyOverflowAbilityIncreases_NoSlotsUsed_AppliesEverything()
+    {
+        var creature = new CreatureBuilder()
+            .WithClass(CommonClass.Fighter, 3)
+            .WithAbilities(14, 12, 14, 10, 10, 8)
+            .Build();
+
+        var allIncreases = new List<int> { 0, 1, 2 };
+        var applied = new Dictionary<int, int>();
+
+        LevelUpApplicationService.ApplyOverflowAbilityIncreases(creature, allIncreases, applied);
+
+        Assert.Equal(15, creature.Str);
+        Assert.Equal(13, creature.Dex);
+        Assert.Equal(15, creature.Con);
+    }
+
     #endregion
 
     #region Saving Throw Updates (#1740)

--- a/Quartermaster/Quartermaster.Tests/LevelUpCloneAndCommitTests.cs
+++ b/Quartermaster/Quartermaster.Tests/LevelUpCloneAndCommitTests.cs
@@ -1,0 +1,200 @@
+using Quartermaster.Services;
+using Radoub.Formats.Bic;
+using Radoub.Formats.Utc;
+using Xunit;
+
+namespace Quartermaster.Tests;
+
+/// <summary>
+/// Pins the clone-and-commit contract the Level Up wizard depends on (#2572, #2573).
+///
+/// The wizard edits a clone and writes the caller's creature only when the apply
+/// succeeds. These tests exercise that lifecycle against the real level-up service
+/// without instantiating the Avalonia window: clone, mutate, then either discard
+/// (cancel, close, error) or commit (finish).
+/// </summary>
+public class LevelUpCloneAndCommitTests
+{
+    [Fact]
+    public void DiscardedClone_LeavesLiveCreatureUntouched()
+    {
+        // Models cancelling or closing the wizard after edits.
+        var live = CreateCreature();
+        var working = CreatureCloning.Clone(live);
+
+        working.Str = 18;
+        working.HitPoints = 99;
+        LevelUpApplicationService.ApplyClassLevel(working, 0);
+
+        Assert.Equal(14, live.Str);
+        Assert.Equal(8, live.HitPoints);
+        Assert.Equal(1, live.ClassList[0].ClassLevel);
+    }
+
+    [Fact]
+    public void DiscardedClone_AfterAbilityIncrements_LeavesLiveCreatureUntouched()
+    {
+        // #2573: tentative increments are projected onto the working copy so feat
+        // prereqs see them. Closing without finishing must not leak them.
+        var live = CreateCreature();
+        var working = CreatureCloning.Clone(live);
+
+        working.Str = (byte)(working.Str + 2);
+        working.Con = (byte)(working.Con + 1);
+
+        Assert.Equal(14, live.Str);
+        Assert.Equal(14, live.Con);
+    }
+
+    [Fact]
+    public void CommittedClone_PublishesEveryChangedField()
+    {
+        var live = CreateCreature();
+        var working = CreatureCloning.Clone(live);
+
+        working.Str = 18;
+        working.HitPoints = 42;
+        working.FortBonus = 7;
+        LevelUpApplicationService.ApplyClassLevel(working, 0);
+
+        live.CopyFrom(working);
+
+        Assert.Equal(18, live.Str);
+        Assert.Equal(42, live.HitPoints);
+        Assert.Equal(7, live.FortBonus);
+        Assert.Equal(2, live.ClassList[0].ClassLevel);
+    }
+
+    [Fact]
+    public void CommittedClone_PublishesHpAndSaves()
+    {
+        // #2572: the old rollback restored neither, so a partial commit left them
+        // inflated. They must round-trip through the commit intact.
+        var live = CreateCreature();
+        var working = CreatureCloning.Clone(live);
+
+        working.HitPoints = 55;
+        working.MaxHitPoints = 55;
+        working.CurrentHitPoints = 55;
+        working.FortBonus = 4;
+        working.RefBonus = 3;
+        working.WillBonus = 2;
+
+        live.CopyFrom(working);
+
+        Assert.Equal(55, live.HitPoints);
+        Assert.Equal(55, live.MaxHitPoints);
+        Assert.Equal(55, live.CurrentHitPoints);
+        Assert.Equal(4, live.FortBonus);
+        Assert.Equal(3, live.RefBonus);
+        Assert.Equal(2, live.WillBonus);
+    }
+
+    [Fact]
+    public void FailedApply_LeavesLiveCreatureUntouched()
+    {
+        // Models a throw partway through apply: HP and saves are already written to
+        // the clone, then a later step fails and the clone is discarded uncommitted.
+        var live = CreateCreature();
+        var working = CreatureCloning.Clone(live);
+
+        try
+        {
+            LevelUpApplicationService.ApplyHitPoints(working, 20);
+            working.FortBonus = 9;
+            throw new InvalidOperationException("simulated failure after HP/saves");
+        }
+        catch (InvalidOperationException)
+        {
+            // Wizard discards the clone; no rollback call.
+        }
+
+        Assert.Equal(8, live.HitPoints);
+        Assert.Equal(0, live.FortBonus);
+    }
+
+    [Fact]
+    public void Commit_PreservesLiveCreatureInstance()
+    {
+        // Panels hold the live creature by reference, so the commit must mutate in
+        // place rather than swap the object.
+        var live = CreateCreature();
+        var heldByPanel = live;
+        var working = CreatureCloning.Clone(live);
+        working.Str = 18;
+
+        live.CopyFrom(working);
+
+        Assert.Same(heldByPanel, live);
+        Assert.Equal(18, heldByPanel.Str);
+    }
+
+    [Fact]
+    public void BicCreature_SurvivesCloneAndCommitWithPlayerFields()
+    {
+        // The wizard levels BIC files too. DeepCopy would downcast and drop these
+        // (#2698); CreatureCloning.Clone preserves the runtime type.
+        var live = CreateBic();
+        live.Gold = 5000u;
+        live.Experience = 15000u;
+        live.Age = 30;
+
+        var working = CreatureCloning.Clone(live);
+        Assert.IsType<BicFile>(working);
+
+        working.Str = 18;
+        live.CopyFrom(working);
+
+        Assert.Equal(18, live.Str);
+        Assert.Equal(5000u, live.Gold);
+        Assert.Equal(15000u, live.Experience);
+        Assert.Equal(30, live.Age);
+    }
+
+    [Fact]
+    public void BicCreature_DiscardedClone_LeavesPlayerFieldsUntouched()
+    {
+        var live = CreateBic();
+        live.Gold = 5000u;
+
+        var working = (BicFile)CreatureCloning.Clone(live);
+        working.Gold = 1u;
+        working.Str = 18;
+
+        Assert.Equal(5000u, live.Gold);
+        Assert.Equal(14, live.Str);
+    }
+
+    private static UtcFile CreateCreature()
+    {
+        var creature = new UtcFile
+        {
+            Str = 14, Dex = 14, Con = 14, Int = 14, Wis = 14, Cha = 14,
+            Race = 6,
+            HitPoints = 8,
+            MaxHitPoints = 8,
+            CurrentHitPoints = 8
+        };
+        creature.FirstName.SetString(0, "TestCreature");
+        creature.ClassList.Add(new CreatureClass { Class = 0, ClassLevel = 1 });
+        for (int i = 0; i < 28; i++) creature.SkillList.Add(0);
+        return creature;
+    }
+
+    private static BicFile CreateBic()
+    {
+        var bic = new BicFile
+        {
+            Str = 14, Dex = 14, Con = 14, Int = 14, Wis = 14, Cha = 14,
+            Race = 6,
+            HitPoints = 8,
+            MaxHitPoints = 8,
+            CurrentHitPoints = 8,
+            Age = 25
+        };
+        bic.FirstName.SetString(0, "TestPC");
+        bic.ClassList.Add(new CreatureClass { Class = 0, ClassLevel = 1 });
+        for (int i = 0; i < 28; i++) bic.SkillList.Add(0);
+        return bic;
+    }
+}

--- a/Quartermaster/Quartermaster/Services/CharacterSheetService.cs
+++ b/Quartermaster/Quartermaster/Services/CharacterSheetService.cs
@@ -204,12 +204,15 @@ public class CharacterSheetService
 
     private static void AppendAbilityRow(StringBuilder sb, string name, byte score, int racialMod)
     {
-        var baseScore = score; // Note: UTC stores final scores, not base
-        var modifier = CreatureDisplayService.CalculateAbilityBonus(score);
+        // UTC stores base scores; the racial modifier is applied at display time.
+        // BioWare Creature Format 3.2: "Only the base values themselves are saved
+        // in a Creature Struct."
+        var totalScore = score + racialMod;
+        var modifier = CreatureDisplayService.CalculateAbilityBonus(totalScore);
         var modStr = CreatureDisplayService.FormatBonus(modifier);
         var racialStr = racialMod != 0 ? CreatureDisplayService.FormatBonus(racialMod) : "  -";
 
-        sb.AppendLine($"  {name,-8}  {baseScore,4}    {racialStr,6}    {score,5}    {modStr,8}");
+        sb.AppendLine($"  {name,-8}  {score,4}    {racialStr,6}    {totalScore,5}    {modStr,8}");
     }
 
     private void AppendCombatSection(StringBuilder sb, UtcFile creature)

--- a/Quartermaster/Quartermaster/Services/CharacterSheetService.cs
+++ b/Quartermaster/Quartermaster/Services/CharacterSheetService.cs
@@ -493,21 +493,26 @@ public class CharacterSheetService
         sb.AppendLine("| Ability | Score | Modifier |");
         sb.AppendLine("|---------|-------|----------|");
 
-        AppendAbilityRowMd(sb, "STR", creature.Str);
-        AppendAbilityRowMd(sb, "DEX", creature.Dex);
-        AppendAbilityRowMd(sb, "CON", creature.Con);
-        AppendAbilityRowMd(sb, "INT", creature.Int);
-        AppendAbilityRowMd(sb, "WIS", creature.Wis);
-        AppendAbilityRowMd(sb, "CHA", creature.Cha);
+        var racialMods = _displayService.GetRacialModifiers(creature.Race);
+
+        AppendAbilityRowMd(sb, "STR", creature.Str, racialMods.Str);
+        AppendAbilityRowMd(sb, "DEX", creature.Dex, racialMods.Dex);
+        AppendAbilityRowMd(sb, "CON", creature.Con, racialMods.Con);
+        AppendAbilityRowMd(sb, "INT", creature.Int, racialMods.Int);
+        AppendAbilityRowMd(sb, "WIS", creature.Wis, racialMods.Wis);
+        AppendAbilityRowMd(sb, "CHA", creature.Cha, racialMods.Cha);
 
         sb.AppendLine();
     }
 
-    private static void AppendAbilityRowMd(StringBuilder sb, string name, byte score)
+    private static void AppendAbilityRowMd(StringBuilder sb, string name, byte score, int racialMod)
     {
-        var modifier = CreatureDisplayService.CalculateAbilityBonus(score);
+        // Single Score column, so it shows the effective score — otherwise the
+        // modifier beside it would not match. UTC stores base; racial is applied here.
+        var totalScore = score + racialMod;
+        var modifier = CreatureDisplayService.CalculateAbilityBonus(totalScore);
         var modStr = CreatureDisplayService.FormatBonus(modifier);
-        sb.AppendLine($"| {name} | {score} | {modStr} |");
+        sb.AppendLine($"| {name} | {totalScore} | {modStr} |");
     }
 
     private void AppendCombatSectionMd(StringBuilder sb, UtcFile creature)

--- a/Quartermaster/Quartermaster/Services/LevelHistoryService.cs
+++ b/Quartermaster/Quartermaster/Services/LevelHistoryService.cs
@@ -54,13 +54,24 @@ public static class LevelHistoryService
         if (records == null || records.Count == 0)
             return "";
 
-        return encoding switch
+        // History is cosmetic metadata appended to the creature's comment. Failing
+        // to encode it must not abort an otherwise-valid level-up, so this swallows
+        // and logs exactly as Decode does — the caller gets "" and skips the append.
+        try
         {
-            LevelHistoryEncoding.Readable => EncodeReadable(records),
-            LevelHistoryEncoding.Binary => EncodeBinary(records),
-            LevelHistoryEncoding.JsonCompressed => EncodeJsonCompressed(records),
-            _ => EncodeReadable(records)
-        };
+            return encoding switch
+            {
+                LevelHistoryEncoding.Readable => EncodeReadable(records),
+                LevelHistoryEncoding.Binary => EncodeBinary(records),
+                LevelHistoryEncoding.JsonCompressed => EncodeJsonCompressed(records),
+                _ => EncodeReadable(records)
+            };
+        }
+        catch (Exception ex)
+        {
+            UnifiedLogger.LogApplication(LogLevel.WARN, $"Failed to encode level history: {ex.Message}");
+            return "";
+        }
     }
 
     /// <summary>

--- a/Quartermaster/Quartermaster/Services/LevelUpApplicationService.cs
+++ b/Quartermaster/Quartermaster/Services/LevelUpApplicationService.cs
@@ -291,6 +291,37 @@ public class LevelUpApplicationService
     }
 
     /// <summary>
+    /// Applies ability increases that exceed the available every-fourth-level slots.
+    /// CE mode lets the user take more increases than the slots allow; the consolidated
+    /// path applies the slotted ones per level and this applies the remainder (#2696).
+    /// </summary>
+    /// <param name="allIncreases">Every requested increase, one entry per increment.</param>
+    /// <param name="appliedByLevel">Increases already applied, keyed by character level.</param>
+    public static void ApplyOverflowAbilityIncreases(
+        UtcFile creature,
+        IEnumerable<int> allIncreases,
+        Dictionary<int, int> appliedByLevel)
+    {
+        // Counting rather than set-subtracting: the same ability can be raised
+        // several times, so identity of each increment matters, not membership.
+        var remaining = new Dictionary<int, int>();
+        foreach (int abilityIndex in allIncreases)
+            remaining[abilityIndex] = remaining.GetValueOrDefault(abilityIndex) + 1;
+
+        foreach (int abilityIndex in appliedByLevel.Values)
+        {
+            if (remaining.TryGetValue(abilityIndex, out int count) && count > 0)
+                remaining[abilityIndex] = count - 1;
+        }
+
+        foreach (var (abilityIndex, count) in remaining)
+        {
+            for (int i = 0; i < count; i++)
+                ApplyAbilityIncrease(creature, abilityIndex);
+        }
+    }
+
+    /// <summary>
     /// Calculates total HP gain for multiple levels, accounting for CON increases and retroactive HP.
     /// conIncreaseLevels: character levels where CON was increased (within the range).
     /// </summary>

--- a/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.AbilityScore.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.AbilityScore.cs
@@ -197,8 +197,11 @@ public partial class LevelUpWizardWindow
     private void UpdateAbilityToggle(int index, bool selected) { }
 
     /// <summary>
-    /// Temporarily applies ability increments to creature so feat prereqs see projected scores.
+    /// Temporarily applies ability increments so feat prereqs see projected scores.
     /// Called when entering Step 3 (feats). Safe to call multiple times — tracks applied state.
+    ///
+    /// Writes to the wizard's working copy, never the caller's creature, so an
+    /// increment left applied at close cannot reach the live creature (#2573).
     /// </summary>
     private bool _abilityIncrementsApplied;
 

--- a/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.SummaryAndApply.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.SummaryAndApply.cs
@@ -254,6 +254,12 @@ public partial class LevelUpWizardWindow
             }
         }
 
+        // 1.5. Apply CE increases beyond the every-fourth-level slots (#2696).
+        // _abilityIncreasesByLevel holds only what fit into those slots; the rest
+        // would otherwise be dropped on a multi-level apply.
+        LevelUpApplicationService.ApplyOverflowAbilityIncreases(
+            _creature, _ceAbilityIncreases, _abilityIncreasesByLevel);
+
         // 2. Apply pooled HP
         LevelUpApplicationService.ApplyHitPoints(_creature, _hpIncrease);
 

--- a/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.axaml.cs
@@ -21,8 +21,11 @@ namespace Quartermaster.Views.Dialogs;
 public partial class LevelUpWizardWindow : Window
 {
     private readonly CreatureDisplayService _displayService;
+    /// <summary>Working copy. Every step edits this, never the caller's creature.</summary>
     private readonly UtcFile _creature;
-    private readonly UtcFile _originalCreature; // For cancellation
+
+    /// <summary>The caller's creature. Written only on a successful apply.</summary>
+    private readonly UtcFile _liveCreature;
 
     // Wizard state
     private int _currentStep = 1;
@@ -181,9 +184,16 @@ public partial class LevelUpWizardWindow : Window
         InitializeComponent();
 
         _displayService = displayService;
-        _creature = creature;
         _isBicFile = isBicFile;
-        _originalCreature = creature.DeepCopy(); // Deep copy for cancel/undo rollback
+
+        // Clone-and-commit (#2571): every step edits the clone, and the live
+        // creature is written only when the apply succeeds. Cancelling, closing,
+        // or an error simply discards the clone, so no rollback path can drift
+        // out of sync with what apply mutates.
+        // CreatureCloning.Clone preserves the runtime type — DeepCopy would
+        // downcast a BicFile and drop its player-only fields (#2698).
+        _liveCreature = creature;
+        _creature = CreatureCloning.Clone(creature);
 
         // Find all controls
         _characterNameLabel = this.FindControl<TextBlock>("CharacterNameLabel")!;
@@ -700,45 +710,34 @@ public partial class LevelUpWizardWindow : Window
         try
         {
             ApplyLevelUp();
+            CommitToLiveCreature();
             Confirmed = true;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (
+            ex is InvalidOperationException or ArgumentException or KeyNotFoundException
+               or FormatException or OverflowException)
         {
-            // Rollback: restore creature from deep copy
-            RestoreFromOriginal();
+            // The clone absorbed the failed apply, so the live creature is
+            // untouched and there is nothing to roll back.
             Confirmed = false;
             Radoub.Formats.Logging.UnifiedLogger.LogApplication(
                 Radoub.Formats.Logging.LogLevel.ERROR,
-                $"Level-up failed, rolled back changes: {ex.Message}");
+                $"Level-up failed; creature left unchanged: {ex.Message}");
         }
-        Close();
-    }
-
-    private void OnCancelClick(object? sender, RoutedEventArgs e)
-    {
-        // Restore creature state in case tentative ability increments were applied (#1737)
-        UnapplyAbilityIncrementsFromCreature();
-        Confirmed = false;
         Close();
     }
 
     /// <summary>
-    /// Restores the creature to its pre-wizard state from the deep copy.
-    /// Used for rollback on error during ApplyLevelUp.
+    /// Publishes the working copy to the caller's creature. Copies field by field
+    /// rather than swapping the reference, so panels holding the live creature
+    /// stay valid.
     /// </summary>
-    private void RestoreFromOriginal()
+    private void CommitToLiveCreature() => _liveCreature.CopyFrom(_creature);
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e)
     {
-        _creature.ClassList = _originalCreature.ClassList;
-        _creature.FeatList = _originalCreature.FeatList;
-        _creature.SkillList = _originalCreature.SkillList;
-        _creature.SpecAbilityList = _originalCreature.SpecAbilityList;
-        _creature.Comment = _originalCreature.Comment;
-        _creature.Str = _originalCreature.Str;
-        _creature.Dex = _originalCreature.Dex;
-        _creature.Con = _originalCreature.Con;
-        _creature.Int = _originalCreature.Int;
-        _creature.Wis = _originalCreature.Wis;
-        _creature.Cha = _originalCreature.Cha;
+        Confirmed = false;
+        Close();
     }
 
     #endregion

--- a/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -715,7 +716,8 @@ public partial class LevelUpWizardWindow : Window
         }
         catch (Exception ex) when (
             ex is InvalidOperationException or ArgumentException or KeyNotFoundException
-               or FormatException or OverflowException)
+               or FormatException or OverflowException or IOException
+               or System.Text.Json.JsonException)
         {
             // The clone absorbed the failed apply, so the live creature is
             // untouched and there is nothing to roll back.

--- a/Quartermaster/Quartermaster/Views/MainWindow.FileOps.cs
+++ b/Quartermaster/Quartermaster/Views/MainWindow.FileOps.cs
@@ -224,13 +224,13 @@ public partial class MainWindow
                 LoadAllPanels(_currentCreature);
                 UpdateCharacterHeader();
                 UpdateStatus($"Character created at level {targetLevel}");
+                MarkDirty();
             }
             else
             {
+                // Cancelling leaves the creature untouched, so nothing is dirty.
                 UpdateStatus("Multi-level creation cancelled");
             }
-
-            MarkDirty();
         }
 
         // Save to path chosen in wizard Step 1, or prompt if not chosen (#1476)

--- a/Radoub.Formats/Radoub.Formats.Tests/CreatureCopyFromTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/CreatureCopyFromTests.cs
@@ -1,0 +1,370 @@
+using System.Reflection;
+using Radoub.Formats.Bic;
+using Radoub.Formats.Utc;
+using Xunit;
+
+namespace Radoub.Formats.Tests;
+
+/// <summary>
+/// Tests for UtcFile.CopyFrom, which commits a working copy back into an existing
+/// creature instance without breaking references held by editor panels.
+///
+/// CopyFrom round-trips through the type's own writer/reader, so copy fidelity
+/// equals save fidelity and no hand-maintained field list can drift. Cross-type
+/// copies are rejected — converting UTC to BIC is BicFile.FromUtcFile's job.
+///
+/// Supports the Level Up wizard's clone-and-commit refactor (#2676, epic #2571).
+/// </summary>
+public class CreatureCopyFromTests
+{
+    [Fact]
+    public void CopyFrom_PreservesTargetInstanceIdentity()
+    {
+        // The whole point: panels hold a reference to the live creature, so the
+        // commit must mutate in place rather than swap the object.
+        var target = CreateTestUtc();
+        var reference = target;
+        var source = CreateTestUtc();
+        source.Str = 18;
+
+        target.CopyFrom(source);
+
+        Assert.Same(reference, target);
+        Assert.Equal(18, target.Str);
+    }
+
+    [Fact]
+    public void CopyFrom_CopiesScalarFields()
+    {
+        var target = CreateTestUtc();
+        var source = CreateTestUtc();
+        source.Str = 18;
+        source.HitPoints = 42;
+        source.FortBonus = 7;
+        source.WillBonus = 3;
+
+        target.CopyFrom(source);
+
+        Assert.Equal(18, target.Str);
+        Assert.Equal(42, target.HitPoints);
+        Assert.Equal(7, target.FortBonus);
+        Assert.Equal(3, target.WillBonus);
+    }
+
+    [Fact]
+    public void CopyFrom_CopiesClassList()
+    {
+        var target = CreateTestUtc();
+        var source = CreateTestUtc();
+        source.ClassList[0].ClassLevel = 5;
+        source.ClassList.Add(new CreatureClass { Class = 3, ClassLevel = 2 });
+
+        target.CopyFrom(source);
+
+        Assert.Equal(2, target.ClassList.Count);
+        Assert.Equal(5, target.ClassList[0].ClassLevel);
+        Assert.Equal(3, target.ClassList[1].Class);
+    }
+
+    [Fact]
+    public void CopyFrom_IsDeepCopy_MutatingSourceDoesNotAffectTarget()
+    {
+        var target = CreateTestUtc();
+        var source = CreateTestUtc();
+        source.ClassList[0].ClassLevel = 5;
+
+        target.CopyFrom(source);
+        source.ClassList[0].ClassLevel = 99;
+        source.Str = 99;
+
+        Assert.Equal(5, target.ClassList[0].ClassLevel);
+        Assert.NotEqual(99, target.Str);
+    }
+
+    [Fact]
+    public void CopyFrom_ReplacesTargetListsRatherThanAppending()
+    {
+        var target = CreateTestUtc();
+        target.FeatList.Add(100);
+        target.FeatList.Add(101);
+        var source = CreateTestUtc();
+        source.FeatList.Add(200);
+
+        target.CopyFrom(source);
+
+        Assert.Single(target.FeatList);
+        Assert.Equal(200, target.FeatList[0]);
+    }
+
+    [Fact]
+    public void CopyFrom_ClearsFieldsAbsentFromSource()
+    {
+        // A field set on the target but not the source must end up cleared, not
+        // left behind as stale data.
+        var target = CreateTestUtc();
+        target.Comment = "stale comment";
+        var source = CreateTestUtc();
+        source.Comment = "";
+
+        target.CopyFrom(source);
+
+        Assert.Equal("", target.Comment);
+    }
+
+    [Fact]
+    public void CopyFrom_BicToBic_PreservesPlayerOnlyFields()
+    {
+        // BIC carries fields UTC does not officially support. A BIC-to-BIC copy
+        // must keep them.
+        var target = CreateTestBic();
+        var source = CreateTestBic();
+        source.Age = 37;
+        source.Gold = 12345u;
+        source.Experience = 90000u;
+        source.ReputationList.Add(50);
+
+        target.CopyFrom(source);
+
+        Assert.Equal(37, target.Age);
+        Assert.Equal(12345u, target.Gold);
+        Assert.Equal(90000u, target.Experience);
+        Assert.Single(target.ReputationList);
+        Assert.Equal(50, target.ReputationList[0]);
+    }
+
+    [Fact]
+    public void CopyFrom_BicToBic_PreservesQuickBar()
+    {
+        var target = CreateTestBic();
+        var source = CreateTestBic();
+        source.QBList.Add(new QuickBarSlot { ObjectType = QuickBarObjectType.Empty });
+        source.QBList.Add(new QuickBarSlot { ObjectType = QuickBarObjectType.Empty });
+
+        target.CopyFrom(source);
+
+        Assert.Equal(2, target.QBList.Count);
+    }
+
+    [Fact]
+    public void CopyFrom_UtcSourceIntoBicTarget_Throws()
+    {
+        // Converting UTC to BIC is BicFile.FromUtcFile's job — it synthesizes
+        // Experience and the QuickBar. A silent copy would leave the target's
+        // player fields stale instead.
+        var target = CreateTestBic();
+        var source = CreateTestUtc();
+
+        Assert.Throws<InvalidOperationException>(() => target.CopyFrom(source));
+    }
+
+    [Fact]
+    public void CopyFrom_BicSourceIntoUtcTarget_Throws()
+    {
+        var target = CreateTestUtc();
+        var source = CreateTestBic();
+
+        Assert.Throws<InvalidOperationException>(() => target.CopyFrom(source));
+    }
+
+    [Fact]
+    public void CopyFrom_NullSource_Throws()
+    {
+        var target = CreateTestUtc();
+
+        Assert.Throws<ArgumentNullException>(() => target.CopyFrom(null!));
+    }
+
+    /// <summary>
+    /// Format metadata written by the writer itself, not user data.
+    /// A test value here produces an invalid GFF header.
+    /// </summary>
+    private static readonly HashSet<string> FormatMetadata = new()
+    {
+        nameof(UtcFile.FileType),
+        nameof(UtcFile.FileVersion)
+    };
+
+    /// <summary>
+    /// Blueprint-only fields the BIC format does not carry (BioWare Table 2.6.2,
+    /// see the exclusions in BicWriter). They do not survive a BIC save, so they
+    /// do not survive a BIC copy either — copy fidelity equals save fidelity.
+    /// </summary>
+    private static readonly HashSet<string> BlueprintOnlyFields = new()
+    {
+        nameof(UtcFile.TemplateResRef),
+        nameof(UtcFile.Comment),
+        nameof(UtcFile.ChallengeRating),
+        nameof(UtcFile.Conversation)
+    };
+
+    [Theory]
+    [MemberData(nameof(UtcPropertyNames))]
+    public void CopyFrom_CopiesEveryUtcProperty(string propertyName)
+    {
+        // Drift guard: every public read-write property on UtcFile must survive
+        // a CopyFrom. Adding a field to UtcFile without the writer/reader
+        // handling it fails here rather than silently dropping on commit.
+        AssertPropertyCopied(propertyName, CreateTestUtc, () => CreateTestUtc());
+    }
+
+    [Theory]
+    [MemberData(nameof(BicPropertyNames))]
+    public void CopyFrom_CopiesEveryBicProperty(string propertyName)
+    {
+        AssertPropertyCopied(propertyName, CreateTestBic, () => CreateTestBic());
+    }
+
+    [Theory]
+    [InlineData(nameof(UtcFile.TemplateResRef))]
+    [InlineData(nameof(UtcFile.Comment))]
+    [InlineData(nameof(UtcFile.Conversation))]
+    public void CopyFrom_BicToBic_DropsBlueprintOnlyStringFields(string propertyName)
+    {
+        // Pins the documented consequence of round-tripping: BIC does not persist
+        // these, so a BIC-to-BIC copy clears them rather than carrying stale values.
+        var target = CreateTestBic();
+        var source = CreateTestBic();
+        var prop = typeof(BicFile).GetProperty(propertyName)!;
+        prop.SetValue(source, "blueprint-only");
+
+        target.CopyFrom(source);
+
+        Assert.Equal("", prop.GetValue(target));
+    }
+
+    [Fact]
+    public void CopyFrom_BicToBic_DropsChallengeRating()
+    {
+        var target = CreateTestBic();
+        var source = CreateTestBic();
+        source.ChallengeRating = 7.5f;
+
+        target.CopyFrom(source);
+
+        Assert.Equal(0f, target.ChallengeRating);
+    }
+
+    [Fact]
+    public void CopyFrom_UtcToUtc_KeepsBlueprintOnlyFields()
+    {
+        // The same fields DO survive a UTC-to-UTC copy — the exclusion is a
+        // property of the BIC format, not of CopyFrom.
+        var target = CreateTestUtc();
+        var source = CreateTestUtc();
+        source.Comment = "designer note";
+        source.ChallengeRating = 7.5f;
+        source.Conversation = "convo";
+
+        target.CopyFrom(source);
+
+        Assert.Equal("designer note", target.Comment);
+        Assert.Equal(7.5f, target.ChallengeRating);
+        Assert.Equal("convo", target.Conversation);
+    }
+
+    public static TheoryData<string> UtcPropertyNames => BuildPropertyNames(typeof(UtcFile), false);
+
+    public static TheoryData<string> BicPropertyNames => BuildPropertyNames(typeof(BicFile), true);
+
+    private static TheoryData<string> BuildPropertyNames(Type type, bool isBic)
+    {
+        var data = new TheoryData<string>();
+        foreach (var prop in GetCopyableProperties(type, isBic))
+            data.Add(prop.Name);
+        return data;
+    }
+
+    private static IEnumerable<PropertyInfo> GetCopyableProperties(Type type, bool isBic)
+    {
+        return type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead && p.CanWrite)
+            .Where(p => !FormatMetadata.Contains(p.Name))
+            // Covered by the explicit blueprint-only tests above.
+            .Where(p => !isBic || !BlueprintOnlyFields.Contains(p.Name))
+            .OrderBy(p => p.Name);
+    }
+
+    /// <summary>
+    /// Sets a distinct non-default value on the named property of a fresh source,
+    /// copies into a fresh target, and asserts the value arrived.
+    /// </summary>
+    private static void AssertPropertyCopied<T>(
+        string propertyName,
+        Func<T> createSource,
+        Func<T> createTarget) where T : UtcFile
+    {
+        var source = createSource();
+        var target = createTarget();
+        var prop = typeof(T).GetProperty(propertyName)!;
+
+        if (!TrySetDistinctValue(prop, source, out var expected))
+            return; // Property type has no simple distinct value; covered by explicit tests above.
+
+        target.CopyFrom(source);
+
+        var actual = prop.GetValue(target);
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    /// Assigns a recognisably non-default value for the simple property types the
+    /// creature formats use. Returns false for collection and object types, which
+    /// the explicit tests cover instead.
+    /// </summary>
+    private static bool TrySetDistinctValue(PropertyInfo prop, object target, out object? assigned)
+    {
+        assigned = null;
+        var t = prop.PropertyType;
+
+        if (t == typeof(string)) assigned = "zz";
+        else if (t == typeof(byte)) assigned = (byte)7;
+        else if (t == typeof(sbyte)) assigned = (sbyte)7;
+        else if (t == typeof(short)) assigned = (short)77;
+        else if (t == typeof(ushort)) assigned = (ushort)77;
+        else if (t == typeof(int)) assigned = 77;
+        else if (t == typeof(uint)) assigned = 77u;
+        else if (t == typeof(float)) assigned = 7.5f;
+        else if (t == typeof(bool)) assigned = true;
+        else return false;
+
+        prop.SetValue(target, assigned);
+        return true;
+    }
+
+    private static BicFile CreateTestBic()
+    {
+        var bic = new BicFile
+        {
+            Str = 10, Dex = 10, Con = 10, Int = 10, Wis = 10, Cha = 10,
+            Race = 6,
+            Gender = 0,
+            HitPoints = 8,
+            MaxHitPoints = 8,
+            CurrentHitPoints = 8,
+            Age = 25,
+            Experience = 0,
+            Gold = 0
+        };
+        bic.FirstName.SetString(0, "TestPC");
+        bic.ClassList.Add(new CreatureClass { Class = 0, ClassLevel = 1 });
+        for (int i = 0; i < 28; i++) bic.SkillList.Add(0);
+        return bic;
+    }
+
+    private static UtcFile CreateTestUtc()
+    {
+        var utc = new UtcFile
+        {
+            Str = 10, Dex = 10, Con = 10, Int = 10, Wis = 10, Cha = 10,
+            Race = 6,
+            Gender = 0,
+            HitPoints = 8,
+            MaxHitPoints = 8,
+            CurrentHitPoints = 8
+        };
+        utc.FirstName.SetString(0, "TestCreature");
+        utc.ClassList.Add(new CreatureClass { Class = 0, ClassLevel = 1 });
+        for (int i = 0; i < 28; i++) utc.SkillList.Add(0);
+        return utc;
+    }
+}

--- a/Radoub.Formats/Radoub.Formats.Tests/CreatureCopyFromTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/CreatureCopyFromTests.cs
@@ -167,6 +167,37 @@ public class CreatureCopyFromTests
     }
 
     [Fact]
+    public void CopyFrom_DoesNotAliasSourceLists()
+    {
+        // The commit takes ownership of a private round-tripped copy, so mutating
+        // the source afterwards must not reach the target. This pins the property
+        // the clone-and-commit design depends on.
+        var target = CreateTestUtc();
+        var source = CreateTestUtc();
+        source.FeatList.Add(200);
+
+        target.CopyFrom(source);
+        source.FeatList.Add(201);
+        source.ClassList[0].ClassLevel = 99;
+
+        Assert.Single(target.FeatList);
+        Assert.Equal(1, target.ClassList[0].ClassLevel);
+    }
+
+    [Fact]
+    public void CopyFrom_BicToBic_DoesNotAliasPlayerLists()
+    {
+        var target = CreateTestBic();
+        var source = CreateTestBic();
+        source.ReputationList.Add(50);
+
+        target.CopyFrom(source);
+        source.ReputationList.Add(75);
+
+        Assert.Single(target.ReputationList);
+    }
+
+    [Fact]
     public void CopyFrom_NullSource_Throws()
     {
         var target = CreateTestUtc();

--- a/Radoub.Formats/Radoub.Formats/Bic/BicFile.cs
+++ b/Radoub.Formats/Radoub.Formats/Bic/BicFile.cs
@@ -600,6 +600,25 @@ public class BicFile : UtcFile
     /// Not documented in BioWare specs but present in all valid BIC files.
     /// </summary>
     public List<LevelStatEntry> LvlStatList { get; set; } = new();
+
+    /// <summary>
+    /// Round-trips through the BIC writer/reader so the player-only fields UTC
+    /// does not carry — Age, Experience, Gold, QuickBar, reputations, level
+    /// history — survive a BIC-to-BIC copy.
+    /// </summary>
+    protected override void CopyFromCore(UtcFile source)
+    {
+        var roundTripped = BicReader.Read(BicWriter.Write((BicFile)source));
+
+        AssignUtcFields(roundTripped);
+
+        Age = roundTripped.Age;
+        Experience = roundTripped.Experience;
+        Gold = roundTripped.Gold;
+        QBList = roundTripped.QBList;
+        ReputationList = roundTripped.ReputationList;
+        LvlStatList = roundTripped.LvlStatList;
+    }
 }
 
 /// <summary>

--- a/Radoub.Formats/Radoub.Formats/Utc/UtcFile.cs
+++ b/Radoub.Formats/Radoub.Formats/Utc/UtcFile.cs
@@ -314,6 +314,166 @@ public class UtcFile
     public List<Variable> VarTable { get; set; } = new();
 
     /// <summary>
+    /// Replaces every field of this creature with the source's, preserving this
+    /// instance so existing references stay valid. Editors clone a creature, edit
+    /// the copy, and commit it back here only on success.
+    ///
+    /// Copies by round-tripping through the format's own writer and reader, so
+    /// copy fidelity equals save fidelity and no hand-maintained field list can
+    /// drift. Source and target must be the same runtime type — converting a UTC
+    /// to a BIC is <see cref="Bic.BicFile.FromUtcFile"/>'s job, since that
+    /// synthesizes Experience and the QuickBar rather than leaving them stale.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">Source is null.</exception>
+    /// <exception cref="InvalidOperationException">Source is a different runtime type.</exception>
+    public void CopyFrom(UtcFile source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        if (source.GetType() != GetType())
+        {
+            throw new InvalidOperationException(
+                $"Cannot copy {source.GetType().Name} into {GetType().Name}. " +
+                "Use BicFile.FromUtcFile to convert a creature between formats.");
+        }
+
+        CopyFromCore(source);
+    }
+
+    /// <summary>
+    /// Round-trips the source through the UTC writer/reader and assigns the result
+    /// field by field. BicFile overrides this to use the BIC writer/reader, which
+    /// carries the player-only fields UTC does not support.
+    /// </summary>
+    protected virtual void CopyFromCore(UtcFile source)
+    {
+        var roundTripped = UtcReader.Read(UtcWriter.Write(source));
+        AssignUtcFields(roundTripped);
+    }
+
+    /// <summary>
+    /// Assigns every UTC field from an already-round-tripped creature.
+    /// </summary>
+    protected void AssignUtcFields(UtcFile source)
+    {
+        FileType = source.FileType;
+        FileVersion = source.FileVersion;
+        TemplateResRef = source.TemplateResRef;
+        Comment = source.Comment;
+        PaletteID = source.PaletteID;
+        FirstName = source.FirstName;
+        LastName = source.LastName;
+        Tag = source.Tag;
+        Description = source.Description;
+        Race = source.Race;
+        Gender = source.Gender;
+        Subrace = source.Subrace;
+        Deity = source.Deity;
+        AppearanceType = source.AppearanceType;
+        Phenotype = source.Phenotype;
+        PortraitId = source.PortraitId;
+        Portrait = source.Portrait;
+        Tail = source.Tail;
+        Wings = source.Wings;
+        BodyBag = source.BodyBag;
+        AppearanceHead = source.AppearanceHead;
+        BodyPart_Belt = source.BodyPart_Belt;
+        BodyPart_LBicep = source.BodyPart_LBicep;
+        BodyPart_RBicep = source.BodyPart_RBicep;
+        BodyPart_LFArm = source.BodyPart_LFArm;
+        BodyPart_RFArm = source.BodyPart_RFArm;
+        BodyPart_LFoot = source.BodyPart_LFoot;
+        BodyPart_RFoot = source.BodyPart_RFoot;
+        BodyPart_LHand = source.BodyPart_LHand;
+        BodyPart_RHand = source.BodyPart_RHand;
+        BodyPart_LShin = source.BodyPart_LShin;
+        BodyPart_RShin = source.BodyPart_RShin;
+        BodyPart_LShoul = source.BodyPart_LShoul;
+        BodyPart_RShoul = source.BodyPart_RShoul;
+        BodyPart_LThigh = source.BodyPart_LThigh;
+        BodyPart_RThigh = source.BodyPart_RThigh;
+        BodyPart_Neck = source.BodyPart_Neck;
+        BodyPart_Pelvis = source.BodyPart_Pelvis;
+        BodyPart_Torso = source.BodyPart_Torso;
+        Color_Skin = source.Color_Skin;
+        Color_Hair = source.Color_Hair;
+        Color_Tattoo1 = source.Color_Tattoo1;
+        Color_Tattoo2 = source.Color_Tattoo2;
+        ArmorPart_Belt = source.ArmorPart_Belt;
+        ArmorPart_LBicep = source.ArmorPart_LBicep;
+        ArmorPart_RBicep = source.ArmorPart_RBicep;
+        ArmorPart_LFArm = source.ArmorPart_LFArm;
+        ArmorPart_RFArm = source.ArmorPart_RFArm;
+        ArmorPart_LFoot = source.ArmorPart_LFoot;
+        ArmorPart_RFoot = source.ArmorPart_RFoot;
+        ArmorPart_LHand = source.ArmorPart_LHand;
+        ArmorPart_RHand = source.ArmorPart_RHand;
+        ArmorPart_LShin = source.ArmorPart_LShin;
+        ArmorPart_RShin = source.ArmorPart_RShin;
+        ArmorPart_LShoul = source.ArmorPart_LShoul;
+        ArmorPart_RShoul = source.ArmorPart_RShoul;
+        ArmorPart_LThigh = source.ArmorPart_LThigh;
+        ArmorPart_RThigh = source.ArmorPart_RThigh;
+        ArmorPart_Neck = source.ArmorPart_Neck;
+        ArmorPart_Pelvis = source.ArmorPart_Pelvis;
+        ArmorPart_Torso = source.ArmorPart_Torso;
+        ArmorPart_Robe = source.ArmorPart_Robe;
+        Str = source.Str;
+        Dex = source.Dex;
+        Con = source.Con;
+        Int = source.Int;
+        Wis = source.Wis;
+        Cha = source.Cha;
+        HitPoints = source.HitPoints;
+        CurrentHitPoints = source.CurrentHitPoints;
+        MaxHitPoints = source.MaxHitPoints;
+        NaturalAC = source.NaturalAC;
+        ChallengeRating = source.ChallengeRating;
+        CRAdjust = source.CRAdjust;
+        FortBonus = source.FortBonus;
+        RefBonus = source.RefBonus;
+        WillBonus = source.WillBonus;
+        GoodEvil = source.GoodEvil;
+        LawfulChaotic = source.LawfulChaotic;
+        Plot = source.Plot;
+        IsImmortal = source.IsImmortal;
+        NoPermDeath = source.NoPermDeath;
+        IsPC = source.IsPC;
+        Disarmable = source.Disarmable;
+        Lootable = source.Lootable;
+        Interruptable = source.Interruptable;
+        FactionID = source.FactionID;
+        PerceptionRange = source.PerceptionRange;
+        WalkRate = source.WalkRate;
+        SoundSetFile = source.SoundSetFile;
+        DecayTime = source.DecayTime;
+        StartingPackage = source.StartingPackage;
+        FamiliarType = source.FamiliarType;
+        FamiliarName = source.FamiliarName;
+        Conversation = source.Conversation;
+        ScriptAttacked = source.ScriptAttacked;
+        ScriptDamaged = source.ScriptDamaged;
+        ScriptDeath = source.ScriptDeath;
+        ScriptDialogue = source.ScriptDialogue;
+        ScriptDisturbed = source.ScriptDisturbed;
+        ScriptEndRound = source.ScriptEndRound;
+        ScriptHeartbeat = source.ScriptHeartbeat;
+        ScriptOnBlocked = source.ScriptOnBlocked;
+        ScriptOnNotice = source.ScriptOnNotice;
+        ScriptRested = source.ScriptRested;
+        ScriptSpawn = source.ScriptSpawn;
+        ScriptSpellAt = source.ScriptSpellAt;
+        ScriptUserDefine = source.ScriptUserDefine;
+        ClassList = source.ClassList;
+        FeatList = source.FeatList;
+        SkillList = source.SkillList;
+        SpecAbilityList = source.SpecAbilityList;
+        ItemList = source.ItemList;
+        EquipItemList = source.EquipItemList;
+        VarTable = source.VarTable;
+    }
+
+    /// <summary>
     /// Creates a deep copy of this UtcFile, including all list contents.
     /// Used by Level Up Wizard for cancel/undo safety.
     /// </summary>


### PR DESCRIPTION
## Summary

Makes the Level-Up apply path transactional. The wizard currently mutates the live creature as the user navigates, then hand-rolls partial rollback on cancel or error. That rollback omits HP and saving throws, so a mid-apply failure silently persists a corrupted creature.

The fix inverts the relationship: the wizard edits a private clone and commits only on success. Cancel, close, and error all become "discard the clone," which deletes the bookkeeping both bugs live in.

Adds `UtcFile.CopyFrom` to commit the clone back while preserving instance identity, so existing references stay valid.

## Related Issues

- Closes #2572 — rollback omits HP/save fields
- Closes #2573 — closing via X leaves phantom ability points
- Closes #2696 — consolidated apply drops CE extra ability increases
- Relates to #2571 — parent epic

Sprint #2676 was filed with five items. Verification closed #2574, #2577, and #2579 as wrong-premise and surfaced #2696; #2575 was rewritten and deferred. Reasoning is on each issue.

## Checklist

- [ ] Implementation complete
- [ ] Tests added/updated
- [ ] CHANGELOG updated with date
- [ ] Manual spot-checks passed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
