### PR TITLE
[Quartermaster] Fix: Multi-level apply offers no general feats (#2701)

### DIFF
--- a/.claude/commands/init-item.md
+++ b/.claude/commands/init-item.md
@@ -86,6 +86,33 @@ ls NonPublic/Plans/*-[number]-plan.md 2>/dev/null
 If one exists, tell the user it was prepared in an earlier session and should be reviewed
 before implementation. Otherwise continue silently.
 
+### 1.5 Challenge AI-generated issues
+
+**Skip this entirely if Phase 1.4 found a plan containing a Verification Summary.** `/pre-warm`
+already challenged the claims; re-running it wastes tokens and time. Say so in the report:
+"Claims verified during pre-warm [date] — skipping re-verification."
+
+Otherwise, challenge before writing code — but only for **AI-generated tech debt or
+`/code-review` output**, identified by a `## Source` line citing `/code-review`, a
+`🤖 Generated with Claude Code` footer, or `tech-debt`/`performance` labels on a body dense with
+`file.cs:123` citations. AI-filed issues carry fabricated line numbers, invented magnitudes, and
+premises that have since gone stale.
+
+Skip it for human-written enhancements and features. A feature describes what should exist, so
+there is no premise to falsify.
+
+**How.** Dispatch `Explore` agents (one per issue, concurrently) instructed to **refute** rather
+than confirm. Require quoted code with real current line numbers, a per-claim verdict of
+CONFIRMED / WRONG / STALE / UNREACHABLE, and `git log` on cited files since the filing date. Be
+suspicious of perf claims over already-cached data, round row counts lifted from `?? fallback`
+constants, and "these two have drifted" assertions — verify those character by character.
+
+**Then act.** A materially wrong premise stops the branch: report it and ask whether to rescope,
+proceed anyway, or cancel and re-triage. Wrong details get the issue body corrected
+(`gh issue edit N --body-file NonPublic/_scratch/N-body.md`) with a dated correction note before
+implementation begins. Confirm the active identity is `LordOfMyatar` (`gh api user --jq .login`)
+before any issue edit.
+
 ## Phase 2 — Classify
 
 ### 2.1 Item type
@@ -262,6 +289,7 @@ the item in hand are still expected. Prompt before FlaUI — it takes over the m
 | Dirty working directory | Ask the user to commit or stash |
 | Branch already exists | Ask whether to check it out or create a new one |
 | Tool ambiguous | Ask the user |
+| Issue premise refuted (1.5) | Report the failed claims; ask whether to rescope, proceed, or cancel |
 | PR creation fails | Print the manual command |
 
 ## Notes

--- a/.claude/commands/pre-warm.md
+++ b/.claude/commands/pre-warm.md
@@ -55,6 +55,53 @@ dependencies between items. Use the Explore agent for open-ended sweeps.
 **Verify each item's premise.** An issue written weeks ago may describe a problem already
 fixed, or partly delivered by other work. A plan built on a stale premise wastes the sprint.
 
+### 1.4 Challenge AI-generated issues (MANDATORY)
+
+AI-filed issues carry fabricated line numbers, invented magnitudes, and premises that no
+longer hold. Challenge them before planning, not after. This step is the reason `/init-item`
+can skip its own challenge pass — record the results in the plan so the work is not repeated.
+
+**When this applies.** Challenge any issue that is AI-generated tech debt or came from a
+`/code-review` sweep — check the body for a `## Source` line citing `/code-review`, a
+`🤖 Generated with Claude Code` footer, or `tech-debt`/`performance` labels on a body full of
+`file.cs:123` citations.
+
+Skip it for human-written enhancements and feature requests. A feature describes what should
+exist, so there is no premise to falsify.
+
+**How.** Dispatch one `Explore` agent per issue, in a single message so they run concurrently.
+Instruct each to **refute**, not confirm — an agreeable verifier finds nothing. Give it the
+issue's claims as a numbered list and require:
+
+- The actual file, quoted code, and actual current line number for every claim
+- A per-claim verdict: CONFIRMED / WRONG / STALE / UNREACHABLE
+- `git log` on the cited files since the issue's filing date, since another sprint may have
+  already fixed it
+- An explicit flag when a cited line number is off by more than ~20 lines or the file does not
+  exist — that signals a fabricated citation
+
+Aim each agent at the claim most likely to be wrong. Common failure modes worth naming
+directly in the prompt:
+
+| Smell | What to check |
+|---|---|
+| A big-O or "N calls" perf claim | Whether the data is already cached — a cached lookup collapses the severity |
+| A round row count (`~2000`, `~300`) | Whether it came from a `?? fallback` constant rather than a real table |
+| "These two have drifted" | Compare character by character; the drift is often bigger or smaller than filed |
+| "X is unreachable / theoretical" | Hunt for a real guard; absence of one upgrades severity |
+| Duplicated code that "should be unified" | Whether the variants are different-by-design |
+
+**Then act on the results.** Do not plan around a claim that failed verification:
+
+- Materially wrong premise -> ask the user whether to rescope, keep, or defer the item
+- Wrong or understated details -> correct the GitHub issue body via
+  `gh issue edit N --body-file NonPublic/_scratch/N-body.md`, keeping a dated correction note
+  in the body so the next reader knows it was re-verified
+- Record every verdict in the plan's Verification Summary table
+
+Verify the active GitHub identity is `LordOfMyatar` (`gh api user --jq .login`) before editing
+any issue.
+
 ## Phase 2 — Design
 
 Invoke the `superpowers:brainstorming` skill and work through scope (in and out), approach
@@ -70,6 +117,23 @@ mkdir -p NonPublic/Plans
 Save the approved spec to `NonPublic/Plans/{YYYY-MM-DD}-{issue-number}-plan.md`, dated the day
 it was written — for example `NonPublic/Plans/2026-03-23-1901-plan.md`.
 
+The plan must open with a Verification Summary recording the Phase 1.4 results, so
+`/init-item` can confirm the challenge was done and skip its own pass:
+
+```markdown
+## Verification Summary
+
+Challenged [date] per `/pre-warm` Phase 1.4.
+
+| Issue | Verdict | Action taken |
+|---|---|---|
+| #N | CONFIRMED — all claims hold | None needed |
+| #N | Headline REFUTED | Body corrected: [what] |
+| #N | CONFIRMED but understated | Body corrected: [what] |
+```
+
+Then report:
+
 ```markdown
 ## Pre-Warm Complete
 
@@ -77,11 +141,12 @@ it was written — for example `NonPublic/Plans/2026-03-23-1901-plan.md`.
 **Plan**: `NonPublic/Plans/{date}-{number}-plan.md`
 
 ### What's Ready
-- [N] work items planned
+- [N] work items planned, [N] challenged and verified
 - Dependencies mapped
 - Implementation order defined
 - [Any item whose premise no longer holds, and why]
+- [Any GitHub issue bodies corrected]
 
 ### To Start Work
-Run `/init-item #[number]` — it detects the plan automatically.
+Run `/init-item #[number]` — it detects the plan and skips re-verification.
 ```

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.141-alpha] - 2026-07-20
+**Branch**: `quartermaster/issue-2701` | **PR**: #TBD
+
+### Fix: Multi-level apply offers no general feats (#2701)
+
+- Multi-level level-up now offers the general feats earned across the whole range; previously it counted every level as the creature's current level plus one and offered none.
+
+---
+
 ## [0.2.140-alpha] - 2026-07-20
 **Branch**: `quartermaster/issue-2676` | **PR**: #2697
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.141-alpha] - 2026-07-20
-**Branch**: `quartermaster/issue-2701` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2701` | **PR**: #2703
 
 ### Fix: Multi-level apply offers no general feats (#2701)
 

--- a/Quartermaster/Quartermaster.Tests/FeatServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/FeatServiceTests.cs
@@ -725,6 +725,101 @@ public class FeatServiceTests
 
     #endregion
 
+    #region Level Up Feat Count - Multi-Level Range (#2701)
+
+    /// <summary>
+    /// The requested class level drives the answer, not the creature's current state.
+    /// A level-1 creature asked about level 3 must report the level-3 general feat,
+    /// even though its current level plus one is 2.
+    /// </summary>
+    /// <remarks>
+    /// Class level 1 is excluded: against a level-1 creature it projects to character
+    /// level 1, which correctly grants a feat under the level-1 rule.
+    /// <see cref="GetLevelUpFeatCount_Level1Human_Gets3Feats"/> covers that case.
+    /// </remarks>
+    [Theory]
+    [InlineData(2, false)]
+    [InlineData(3, true)]
+    [InlineData(4, false)]
+    [InlineData(5, false)]
+    [InlineData(6, true)]
+    [InlineData(9, true)]
+    public void GetLevelUpFeatCount_QueriedLevelDrivesGeneralFeat_NotCurrentState(
+        int queriedLevel, bool expectsGeneralFeat)
+    {
+        var creature = new CreatureBuilder()
+            .WithRace(6)
+            .WithClass(4, 1) // Fighter 1 — current state stays fixed across every case
+            .Build();
+
+        var result = _featService.GetLevelUpFeatCount(creature, 4, queriedLevel);
+
+        Assert.Equal(expectsGeneralFeat ? 1 : 0, result.GeneralFeats);
+    }
+
+    /// <summary>
+    /// Acceptance: multi-level apply pools the same count as levelling one at a time.
+    /// 1 to 5 earns one general feat (level 3); 1 to 8 earns two (levels 3 and 6).
+    /// </summary>
+    [Theory]
+    [InlineData(5, 1)]  // levels 2,3,4,5 -> feat at 3
+    [InlineData(8, 2)]  // levels 2..8 -> feats at 3 and 6
+    [InlineData(10, 3)] // levels 2..10 -> feats at 3, 6, 9
+    public void GetLevelUpFeatCount_PooledOverRange_MatchesSingleLevelTotal(
+        int targetLevel, int expectedGeneralFeats)
+    {
+        var creature = new CreatureBuilder()
+            .WithRace(6)
+            .WithClass(4, 1) // Fighter 1
+            .Build();
+
+        int pooled = 0;
+        for (int lvl = 2; lvl <= targetLevel; lvl++)
+            pooled += _featService.GetLevelUpFeatCount(creature, 4, lvl).GeneralFeats;
+
+        Assert.Equal(expectedGeneralFeats, pooled);
+    }
+
+    /// <summary>
+    /// Projection is per-class: the queried level replaces only the levelled class's
+    /// contribution, leaving other classes' levels intact.
+    /// </summary>
+    [Fact]
+    public void GetLevelUpFeatCount_Multiclass_ProjectsOnlyTheLevelledClass()
+    {
+        // Fighter 3 + Rogue 2 = total 5. Rogue to 3 => projected total 6 => general feat.
+        var creature = new CreatureBuilder()
+            .WithRace(6)
+            .WithClass(4, 3)
+            .WithClass(8, 2)
+            .Build();
+
+        Assert.Equal(1, _featService.GetLevelUpFeatCount(creature, 8, 3).GeneralFeats);
+        // Rogue to 4 => projected total 7 => no general feat.
+        Assert.Equal(0, _featService.GetLevelUpFeatCount(creature, 8, 4).GeneralFeats);
+    }
+
+    /// <summary>
+    /// Levelling a brand-new class adds to the existing total rather than replacing it.
+    /// </summary>
+    [Fact]
+    public void GetLevelUpFeatCount_NewClass_AddsToExistingTotal()
+    {
+        // Fighter 5, taking Rogue 1 => projected total 6 => general feat.
+        var creature = new CreatureBuilder()
+            .WithRace(6)
+            .WithClass(4, 5)
+            .Build();
+
+        var result = _featService.GetLevelUpFeatCount(creature, 8, 1);
+
+        Assert.Equal(1, result.GeneralFeats);
+        // Class level 1 of a new class is not character level 1 — no racial feat.
+        Assert.Equal(0, result.RacialBonusFeats);
+    }
+
+    #endregion
+
     #region Class Bonus Feat Pool
 
     [Fact]

--- a/Quartermaster/Quartermaster/Services/FeatService.LevelUp.cs
+++ b/Quartermaster/Quartermaster/Services/FeatService.LevelUp.cs
@@ -21,7 +21,14 @@ public partial class FeatService
     public LevelUpFeatInfo GetLevelUpFeatCount(UtcFile creature, int selectedClassId, int newClassLevel)
     {
         var result = new LevelUpFeatInfo();
-        int newTotalLevel = creature.ClassList.Sum(c => c.ClassLevel) + 1;
+
+        // Project the total level from the requested class level, not from current state (#2701).
+        // The consolidated wizard calls this once per level in a range, so deriving the level
+        // from the creature would return the same answer every iteration.
+        int currentClassLevel = creature.ClassList
+            .FirstOrDefault(c => c.Class == selectedClassId)?.ClassLevel ?? 0;
+        int newTotalLevel = creature.ClassList.Sum(c => c.ClassLevel)
+            + (newClassLevel - currentClassLevel);
 
         // D&D 3.5/NWN rule: general feat at level 1, then every 3 levels (3, 6, 9, 12...)
         // This interval is an engine rule, not configurable via 2DA


### PR DESCRIPTION
## Summary

`GetLevelUpFeatCount` ignored its `newClassLevel` parameter and derived the level from the creature's current state, so the consolidated multi-level loop got the same answer every iteration. Levelling 1 to 5 offered no general feat; 1 to 8 offered none instead of two.

It now projects the total from the requested class level:

```csharp
int newTotalLevel = creature.ClassList.Sum(c => c.ClassLevel)
    + (newClassLevel - currentClassLevel);
```

The per-class delta matters for multiclass, where the queried class level is not the character level. This matches the projection `PrepareStep3` already builds for feat prereqs, so the two agree instead of disagreeing.

`GetExpectedFeatCount` is deliberately unchanged. It takes no level parameter and audits current state, which is correct for both callers, and its `1 + totalLevel / 3` agrees with the per-level rule.

## Related Issues

- Closes #2701
- Found during verification: #2704 (Auto-Assign selects master feats without a subtype) — separate bug, not fixed here

## Tests

Seven new cases, red before the fix and green after: 1 to 5, 1 to 8, a range crossing three multiples of 3, and multiclass projection.

Worth noting for reviewers: every pre-existing test passed against the buggy code, because each was a single-level case where current + 1 coincidentally equalled the queried level. The new tests hold creature state fixed and vary only the queried level, so they can see this class of bug.

Local: 1329 passed, 0 failed. Privacy, theme, and tech-debt scans pass.

Manually verified in Quartermaster against `Bucky_lvl1.utc` (Human Rogue 1): the feat step now offers the expected general feat on a 1 to 5 pass.

## Checklist

- [x] Implementation complete
- [x] Tests added/updated
- [x] CHANGELOG updated with date
- [x] Wiki updated (#2701 was recorded as still-open)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
