### PR TITLE
[Radoub] chore: Challenge AI-generated issues in pre-warm and init-item

### DIFF
--- a/.claude/commands/init-item.md
+++ b/.claude/commands/init-item.md
@@ -86,6 +86,33 @@ ls NonPublic/Plans/*-[number]-plan.md 2>/dev/null
 If one exists, tell the user it was prepared in an earlier session and should be reviewed
 before implementation. Otherwise continue silently.
 
+### 1.5 Challenge AI-generated issues
+
+**Skip this entirely if Phase 1.4 found a plan containing a Verification Summary.** `/pre-warm`
+already challenged the claims; re-running it wastes tokens and time. Say so in the report:
+"Claims verified during pre-warm [date] — skipping re-verification."
+
+Otherwise, challenge before writing code — but only for **AI-generated tech debt or
+`/code-review` output**, identified by a `## Source` line citing `/code-review`, a
+`🤖 Generated with Claude Code` footer, or `tech-debt`/`performance` labels on a body dense with
+`file.cs:123` citations. AI-filed issues carry fabricated line numbers, invented magnitudes, and
+premises that have since gone stale.
+
+Skip it for human-written enhancements and features. A feature describes what should exist, so
+there is no premise to falsify.
+
+**How.** Dispatch `Explore` agents (one per issue, concurrently) instructed to **refute** rather
+than confirm. Require quoted code with real current line numbers, a per-claim verdict of
+CONFIRMED / WRONG / STALE / UNREACHABLE, and `git log` on cited files since the filing date. Be
+suspicious of perf claims over already-cached data, round row counts lifted from `?? fallback`
+constants, and "these two have drifted" assertions — verify those character by character.
+
+**Then act.** A materially wrong premise stops the branch: report it and ask whether to rescope,
+proceed anyway, or cancel and re-triage. Wrong details get the issue body corrected
+(`gh issue edit N --body-file NonPublic/_scratch/N-body.md`) with a dated correction note before
+implementation begins. Confirm the active identity is `LordOfMyatar` (`gh api user --jq .login`)
+before any issue edit.
+
 ## Phase 2 — Classify
 
 ### 2.1 Item type
@@ -262,6 +289,7 @@ the item in hand are still expected. Prompt before FlaUI — it takes over the m
 | Dirty working directory | Ask the user to commit or stash |
 | Branch already exists | Ask whether to check it out or create a new one |
 | Tool ambiguous | Ask the user |
+| Issue premise refuted (1.5) | Report the failed claims; ask whether to rescope, proceed, or cancel |
 | PR creation fails | Print the manual command |
 
 ## Notes

--- a/.claude/commands/pre-warm.md
+++ b/.claude/commands/pre-warm.md
@@ -55,6 +55,53 @@ dependencies between items. Use the Explore agent for open-ended sweeps.
 **Verify each item's premise.** An issue written weeks ago may describe a problem already
 fixed, or partly delivered by other work. A plan built on a stale premise wastes the sprint.
 
+### 1.4 Challenge AI-generated issues (MANDATORY)
+
+AI-filed issues carry fabricated line numbers, invented magnitudes, and premises that no
+longer hold. Challenge them before planning, not after. This step is the reason `/init-item`
+can skip its own challenge pass — record the results in the plan so the work is not repeated.
+
+**When this applies.** Challenge any issue that is AI-generated tech debt or came from a
+`/code-review` sweep — check the body for a `## Source` line citing `/code-review`, a
+`🤖 Generated with Claude Code` footer, or `tech-debt`/`performance` labels on a body full of
+`file.cs:123` citations.
+
+Skip it for human-written enhancements and feature requests. A feature describes what should
+exist, so there is no premise to falsify.
+
+**How.** Dispatch one `Explore` agent per issue, in a single message so they run concurrently.
+Instruct each to **refute**, not confirm — an agreeable verifier finds nothing. Give it the
+issue's claims as a numbered list and require:
+
+- The actual file, quoted code, and actual current line number for every claim
+- A per-claim verdict: CONFIRMED / WRONG / STALE / UNREACHABLE
+- `git log` on the cited files since the issue's filing date, since another sprint may have
+  already fixed it
+- An explicit flag when a cited line number is off by more than ~20 lines or the file does not
+  exist — that signals a fabricated citation
+
+Aim each agent at the claim most likely to be wrong. Common failure modes worth naming
+directly in the prompt:
+
+| Smell | What to check |
+|---|---|
+| A big-O or "N calls" perf claim | Whether the data is already cached — a cached lookup collapses the severity |
+| A round row count (`~2000`, `~300`) | Whether it came from a `?? fallback` constant rather than a real table |
+| "These two have drifted" | Compare character by character; the drift is often bigger or smaller than filed |
+| "X is unreachable / theoretical" | Hunt for a real guard; absence of one upgrades severity |
+| Duplicated code that "should be unified" | Whether the variants are different-by-design |
+
+**Then act on the results.** Do not plan around a claim that failed verification:
+
+- Materially wrong premise -> ask the user whether to rescope, keep, or defer the item
+- Wrong or understated details -> correct the GitHub issue body via
+  `gh issue edit N --body-file NonPublic/_scratch/N-body.md`, keeping a dated correction note
+  in the body so the next reader knows it was re-verified
+- Record every verdict in the plan's Verification Summary table
+
+Verify the active GitHub identity is `LordOfMyatar` (`gh api user --jq .login`) before editing
+any issue.
+
 ## Phase 2 — Design
 
 Invoke the `superpowers:brainstorming` skill and work through scope (in and out), approach
@@ -70,6 +117,23 @@ mkdir -p NonPublic/Plans
 Save the approved spec to `NonPublic/Plans/{YYYY-MM-DD}-{issue-number}-plan.md`, dated the day
 it was written — for example `NonPublic/Plans/2026-03-23-1901-plan.md`.
 
+The plan must open with a Verification Summary recording the Phase 1.4 results, so
+`/init-item` can confirm the challenge was done and skip its own pass:
+
+```markdown
+## Verification Summary
+
+Challenged [date] per `/pre-warm` Phase 1.4.
+
+| Issue | Verdict | Action taken |
+|---|---|---|
+| #N | CONFIRMED — all claims hold | None needed |
+| #N | Headline REFUTED | Body corrected: [what] |
+| #N | CONFIRMED but understated | Body corrected: [what] |
+```
+
+Then report:
+
 ```markdown
 ## Pre-Warm Complete
 
@@ -77,11 +141,12 @@ it was written — for example `NonPublic/Plans/2026-03-23-1901-plan.md`.
 **Plan**: `NonPublic/Plans/{date}-{number}-plan.md`
 
 ### What's Ready
-- [N] work items planned
+- [N] work items planned, [N] challenged and verified
 - Dependencies mapped
 - Implementation order defined
 - [Any item whose premise no longer holds, and why]
+- [Any GitHub issue bodies corrected]
 
 ### To Start Work
-Run `/init-item #[number]` — it detects the plan automatically.
+Run `/init-item #[number]` — it detects the plan and skips re-verification.
 ```


### PR DESCRIPTION
## Summary

AI-filed tech debt carries fabricated line numbers, invented magnitudes, and stale premises.
Pre-warming #2677 found three of five issues materially wrong, including one whose headline
perf claim collapsed once verified — the data it called uncached is cached.

`/pre-warm` Phase 1.4 and `/init-item` Phase 1.5 now dispatch Explore agents instructed to
refute rather than confirm, requiring quoted code at real line numbers and a per-claim verdict.
Wrong premises stop the work; wrong details get the issue body corrected first.

Scope is deliberately narrow: AI-generated tech debt and `/code-review` output only. Human
enhancements are exempt, since a feature describes what should exist and has no premise to
falsify. `/init-item` skips the pass when the plan already records a Verification Summary, so
the challenge runs once per item.

## Related Issues

Relates to #2677

## Tests

Documentation-only change to `.claude/commands/` — no code paths affected.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)