### PR TITLE
[Quartermaster] Sprint: Level-Up Wizard Correctness & Debt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Radoub.Formats 0.2.80-alpha] - 2026-07-21
+**Branch**: `quartermaster/issue-2677` | **PR**: #2706
+
+### Changed
+
+- `TwoDAFile.GetColumnIndex` now caches its name-to-index map instead of scanning columns on every lookup, speeding up the per-cell 2DA reads every tool performs (#2580).
+
+---
+
 ## [Radoub.Formats 0.2.79-alpha] - 2026-07-20
 **Branch**: `quartermaster/issue-2676` | **PR**: #2697
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -5,6 +5,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 ---
 
+## [0.2.142-alpha] - 2026-07-21
+**Branch**: `quartermaster/issue-2677` | **PR**: #TBD
+
+### Sprint: Level-Up Wizard Correctness & Debt (#2677)
+
+- Auto-Assign Skills now caps ranks at the final character level in multi-level level-ups, so pooled points are no longer left unspent (#2576).
+- Gaining a first level now grants the x4 skill points NWN awards at level 1 (#2578).
+- Single-level and multi-level apply share one implementation (#2575).
+- Both wizards now use the shared point-buy, feat-table, and gender services instead of their own copies (#2581).
+- Skill and feat lists update the changed row instead of rebuilding, removing search-box input lag (#2580).
+
+---
+
 ## [0.2.141-alpha] - 2026-07-20
 **Branch**: `quartermaster/issue-2701` | **PR**: #2703
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 ---
 
 ## [0.2.142-alpha] - 2026-07-21
-**Branch**: `quartermaster/issue-2677` | **PR**: #TBD
+**Branch**: `quartermaster/issue-2677` | **PR**: #2706
 
 ### Sprint: Level-Up Wizard Correctness & Debt (#2677)
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -12,7 +12,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 
 - Auto-Assign Skills now caps ranks at the final character level in multi-level level-ups, so pooled points are no longer left unspent (#2576).
 - Gaining a first level now grants the x4 skill points NWN awards at level 1 (#2578).
-- Single-level and multi-level apply share one implementation (#2575).
+- Single-level and multi-level level-up now share one span-aware apply path, and the ability-increase map is derived from a single tested source instead of three hand-synced copies (#2575).
 - The New Character wizard now uses the shared point-buy and gender services, and the four class-feat-table scans share one reader; auto-assign follows the martial-friendly priority order from #1737 (#2581).
 - Skill and feat lists update the changed row instead of rebuilding, removing search-box input lag (#2580).
 

--- a/Quartermaster/CHANGELOG.md
+++ b/Quartermaster/CHANGELOG.md
@@ -13,7 +13,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Trimmed to hig
 - Auto-Assign Skills now caps ranks at the final character level in multi-level level-ups, so pooled points are no longer left unspent (#2576).
 - Gaining a first level now grants the x4 skill points NWN awards at level 1 (#2578).
 - Single-level and multi-level apply share one implementation (#2575).
-- Both wizards now use the shared point-buy, feat-table, and gender services instead of their own copies (#2581).
+- The New Character wizard now uses the shared point-buy and gender services, and the four class-feat-table scans share one reader; auto-assign follows the martial-friendly priority order from #1737 (#2581).
 - Skill and feat lists update the changed row instead of rebuilding, removing search-box input lag (#2580).
 
 ---

--- a/Quartermaster/Quartermaster.Tests/AbilityPointBuyServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/AbilityPointBuyServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Quartermaster.Services;
 using Xunit;
 
@@ -191,6 +192,37 @@ public class AbilityPointBuyServiceTests
 
         int spent = AbilityPointBuyService.CalculatePointsSpent(result);
         Assert.True(spent <= 30, $"Should not overspend: spent {spent}");
+    }
+
+    /// <summary>
+    /// #2581: the NCW wizard kept its own copy of this order and the two drifted in all six
+    /// branches. The wizard's order (#1737 — avoid pumping WIS/CHA/INT for martial builds) is
+    /// the newer, deliberate one and is now canonical. Pinned so it cannot silently drift again.
+    /// </summary>
+    [Theory]
+    [InlineData("STR", new[] { "CON", "DEX", "INT", "WIS", "CHA" })]
+    [InlineData("DEX", new[] { "CON", "STR", "INT", "WIS", "CHA" })]
+    [InlineData("CON", new[] { "STR", "DEX", "INT", "WIS", "CHA" })]
+    [InlineData("INT", new[] { "DEX", "CON", "STR", "WIS", "CHA" })]
+    [InlineData("WIS", new[] { "CON", "DEX", "STR", "INT", "CHA" })]
+    [InlineData("CHA", new[] { "CON", "DEX", "STR", "INT", "WIS" })]
+    public void GetSecondaryPriorityOrder_MatchesCanonicalOrder(string primary, string[] expected)
+    {
+        Assert.Equal(expected, AbilityPointBuyService.GetSecondaryPriorityOrder(primary));
+    }
+
+    /// <summary>
+    /// #2581/#1737: a martial primary must favour INT over WIS among its secondaries, which is
+    /// the behavioural difference between the two drifted orders.
+    /// </summary>
+    [Fact]
+    public void GetSecondaryPriorityOrder_MartialPrimary_PrefersIntOverWis()
+    {
+        var order = AbilityPointBuyService.GetSecondaryPriorityOrder("STR");
+
+        Assert.True(
+            Array.IndexOf(order, "INT") < Array.IndexOf(order, "WIS"),
+            "STR builds should rank INT above WIS (#1737)");
     }
 
     [Fact]

--- a/Quartermaster/Quartermaster.Tests/FeatServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/FeatServiceTests.cs
@@ -290,6 +290,20 @@ public class FeatServiceTests
         Assert.DoesNotContain(45, feats);
     }
 
+    /// <summary>
+    /// #2581: the four cls_feat_*.2da scans share a skeleton but keep distinct List filters.
+    /// The bonus pool is List=1 only, and must not absorb granted (3) or creation (-1) rows.
+    /// </summary>
+    [Fact]
+    public void GetClassBonusFeatPool_Fighter_ReturnsOnlyListOneFeats()
+    {
+        var feats = _featService.GetClassBonusFeatPool(4);
+
+        Assert.Contains(5, feats);        // Blind-Fight, List=1 bonus pool
+        Assert.DoesNotContain(2, feats);  // Armor Prof Heavy, List=3 granted
+        Assert.DoesNotContain(45, feats); // Simple Weapons, List=-1 creation
+    }
+
     [Fact]
     public void GetClassGrantedFeatIds_Fighter_ReturnsAutoGrantedFeats()
     {

--- a/Quartermaster/Quartermaster.Tests/LevelUpApplicationServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/LevelUpApplicationServiceTests.cs
@@ -552,9 +552,47 @@ public class LevelUpApplicationServiceTests
         // No class yet (total level will be 0+1=1)
 
         int points = _service.CalculateLevelUpSkillPoints(creature, (int)CommonClass.Fighter);
-        // (base + intMod + racialExtra) * 4
-        // The exact value depends on mock data - just verify it's > 0 and > non-level-1
-        Assert.True(points > 0, "Level 1 should have skill points");
+
+        // Must be exactly 4x the same creature's level-2 award, not merely non-zero (#2578).
+        var atLevel1 = new CreatureBuilder()
+            .WithRace(CommonRace.Human)
+            .WithClass(CommonClass.Fighter, 1)
+            .WithAbilities(intel: 10)
+            .Build();
+        int level2Points = _service.CalculateLevelUpSkillPoints(atLevel1, (int)CommonClass.Fighter);
+
+        Assert.Equal(level2Points * 4, points);
+    }
+
+    /// <summary>
+    /// #2578: the wizard inlined the per-level formula and omitted the level-1 x4 rule, so a
+    /// level-0 creature gaining its first level got a quarter of the correct points. Both the
+    /// wizard loop and the service must go through this one function.
+    /// </summary>
+    [Theory]
+    [InlineData(1, 8, 0, 0, 32)]  // Level 1: (8 + 0 + 0) * 4 = 32
+    [InlineData(2, 8, 0, 0, 8)]   // Level 2: no multiplier
+    [InlineData(1, 8, 2, 0, 40)]  // Level 1 with INT +2: (8 + 2) * 4 = 40
+    [InlineData(1, 2, 0, 1, 12)]  // Level 1 human fighter: (2 + 0 + 1) * 4 = 12
+    [InlineData(5, 2, 0, 1, 3)]   // Level 5 human fighter: 2 + 0 + 1 = 3
+    [InlineData(2, 0, -3, 0, 1)]  // Floor of 1 applies before racial extra
+    public void CalculateSkillPointsForLevel_AppliesFirstLevelMultiplier(
+        int charLevel, int basePoints, int intMod, int racialExtra, int expected)
+    {
+        Assert.Equal(expected, LevelUpApplicationService.CalculateSkillPointsForLevel(
+            charLevel, basePoints, intMod, racialExtra));
+    }
+
+    /// <summary>
+    /// #2578: level 1 must yield exactly four times the level-2 award for the same inputs.
+    /// </summary>
+    [Fact]
+    public void CalculateSkillPointsForLevel_Level1_IsExactlyFourTimesLevel2()
+    {
+        int level1 = LevelUpApplicationService.CalculateSkillPointsForLevel(1, 8, 1, 0);
+        int level2 = LevelUpApplicationService.CalculateSkillPointsForLevel(2, 8, 1, 0);
+
+        Assert.Equal(level2 * 4, level1);
     }
 
     [Fact]

--- a/Quartermaster/Quartermaster.Tests/LevelUpApplicationServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/LevelUpApplicationServiceTests.cs
@@ -387,6 +387,95 @@ public class LevelUpApplicationServiceTests
         Assert.Equal(12, creature.Dex); // Unchanged
     }
 
+    // #2575: one span-aware ApplyLevelUp call must produce the same end state as N single-level
+    // applies for pooled quantities, applying HP/skills/spells once rather than per level.
+
+    [Fact]
+    public void ApplyLevelUp_SpanAware_PooledQuantitiesAppliedOnce()
+    {
+        var creature = new CreatureBuilder()
+            .WithClass(CommonClass.Fighter, 1)
+            .WithAbilities(14, 12, 14, 10, 10, 8)
+            .WithSkillRanks(3, 0, 2)
+            .Build();
+        creature.HitPoints = 12;
+        creature.MaxHitPoints = 12;
+        creature.CurrentHitPoints = 12;
+
+        // Level 1 -> 5 in one consolidated apply. HP/skills are pooled totals for the whole span.
+        var input = new LevelUpApplicationService.LevelUpInput
+        {
+            SelectedClassId = (int)CommonClass.Fighter,
+            NewClassLevel = 5,
+            FromClassLevel = 2,
+            SelectedFeats = new List<int> { 20, 30, 40, 50 },
+            SkillPointsAdded = new Dictionary<int, int> { { 0, 4 } }, // pooled: 4 ranks total
+            SelectedSpellsByLevel = new Dictionary<int, List<int>>(),
+            HpIncrease = 48, // pooled: 4 * 12
+            AbilityIncreasesByLevel = new Dictionary<int, int> { { 4, 0 } }, // STR +1 at char level 4
+            RecordHistory = false
+        };
+
+        _service.ApplyLevelUp(creature, input);
+
+        Assert.Single(creature.ClassList);
+        Assert.Equal(5, creature.ClassList[0].ClassLevel);
+
+        Assert.Contains((ushort)20, creature.FeatList);
+        Assert.Contains((ushort)50, creature.FeatList);
+
+        // Pooled once: skills 3 + 4 = 7, HP 12 + 48 = 60 — NOT multiplied by the 4 levels.
+        Assert.Equal(7, creature.SkillList[0]);
+        Assert.Equal(60, creature.MaxHitPoints);
+
+        // Slotted ability increase at level 4 applied exactly once.
+        Assert.Equal(15, creature.Str);
+        Assert.Equal(12, creature.Dex);
+    }
+
+    [Fact]
+    public void ApplyLevelUp_SpanAware_MatchesEquivalentSingleLevelApplies()
+    {
+        // Two creatures, same start. One leveled 1->4 by three single applies, the other by one
+        // consolidated apply with pooled totals. Class level and pooled results must match.
+        UtcFile MakeCreature() => new CreatureBuilder()
+            .WithClass(CommonClass.Fighter, 1)
+            .WithAbilities(14, 12, 14, 10, 10, 8)
+            .WithSkillRanks(0, 0, 0)
+            .Build();
+
+        var byLoop = MakeCreature();
+        byLoop.HitPoints = byLoop.MaxHitPoints = byLoop.CurrentHitPoints = 12;
+        for (int level = 2; level <= 4; level++)
+        {
+            _service.ApplyLevelUp(byLoop, new LevelUpApplicationService.LevelUpInput
+            {
+                SelectedClassId = (int)CommonClass.Fighter,
+                NewClassLevel = level,
+                SkillPointsAdded = new Dictionary<int, int> { { 0, 2 } },
+                HpIncrease = 10,
+                RecordHistory = false
+            });
+        }
+
+        var bySpan = MakeCreature();
+        bySpan.HitPoints = bySpan.MaxHitPoints = bySpan.CurrentHitPoints = 12;
+        _service.ApplyLevelUp(bySpan, new LevelUpApplicationService.LevelUpInput
+        {
+            SelectedClassId = (int)CommonClass.Fighter,
+            NewClassLevel = 4,
+            FromClassLevel = 2,
+            SkillPointsAdded = new Dictionary<int, int> { { 0, 6 } }, // 3 levels * 2
+            HpIncrease = 30, // 3 levels * 10
+            AbilityIncreasesByLevel = new Dictionary<int, int>(),
+            RecordHistory = false
+        });
+
+        Assert.Equal(byLoop.ClassList[0].ClassLevel, bySpan.ClassList[0].ClassLevel);
+        Assert.Equal(byLoop.SkillList[0], bySpan.SkillList[0]);
+        Assert.Equal(byLoop.MaxHitPoints, bySpan.MaxHitPoints);
+    }
+
     #endregion
 
     #region ApplyLevelUp Integration

--- a/Quartermaster/Quartermaster.Tests/LevelUpApplicationServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/LevelUpApplicationServiceTests.cs
@@ -243,6 +243,42 @@ public class LevelUpApplicationServiceTests
 
     #endregion
 
+    #region CalculateFinalCharacterLevel (#2576)
+
+    [Theory]
+    [InlineData(5, 1, 6)]   // Single level: 5 -> 6
+    [InlineData(5, 3, 8)]   // Multi-level: 5 +3 -> 8
+    [InlineData(0, 1, 1)]   // Level-0 creature gaining its first level
+    [InlineData(17, 3, 20)] // Near cap
+    public void CalculateFinalCharacterLevel_AddsLevelsToAdd(int currentTotal, int levelsToAdd, int expected)
+    {
+        Assert.Equal(expected, LevelUpApplicationService.CalculateFinalCharacterLevel(currentTotal, levelsToAdd));
+    }
+
+    /// <summary>
+    /// #2576: auto-assign capped ranks at currentTotal+1 while the manual +/- path and the
+    /// pooled point budget used currentTotal+_levelsToAdd, so multi-level level-ups left
+    /// pooled points unspent. Both paths must derive the same cap.
+    /// </summary>
+    [Fact]
+    public void CalculateFinalCharacterLevel_MultiLevel_MatchesManualRankCap()
+    {
+        const int currentTotal = 5;
+        const int levelsToAdd = 3;
+
+        int finalLevel = LevelUpApplicationService.CalculateFinalCharacterLevel(currentTotal, levelsToAdd);
+
+        // The manual +/- path caps class skills at final level + 3 = 11.
+        Assert.Equal(11, LevelUpApplicationService.CalculateMaxSkillRanks(true, finalLevel));
+
+        // The pre-fix auto-assign level (currentTotal + 1 = 6) capped at 9 — two ranks short.
+        Assert.NotEqual(
+            LevelUpApplicationService.CalculateMaxSkillRanks(true, currentTotal + 1),
+            LevelUpApplicationService.CalculateMaxSkillRanks(true, finalLevel));
+    }
+
+    #endregion
+
     #region CalculateRemainingSkillPoints
 
     [Fact]

--- a/Quartermaster/Quartermaster.Tests/LevelUpApplicationServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/LevelUpApplicationServiceTests.cs
@@ -333,6 +333,71 @@ public class LevelUpApplicationServiceTests
 
     #endregion
 
+    #region BuildAbilityIncreasesByLevel (#2575 / 3f)
+
+    [Fact]
+    public void BuildAbilityIncreasesByLevel_SingleIncrement_MapsToFirstSlot()
+    {
+        // STR +1 (index 0), one slot at char level 4.
+        var increments = new[] { 1, 0, 0, 0, 0, 0 };
+        var levels = new[] { 4 };
+
+        var map = LevelUpApplicationService.BuildAbilityIncreasesByLevel(increments, levels);
+
+        Assert.Single(map);
+        Assert.Equal(0, map[4]);
+    }
+
+    [Fact]
+    public void BuildAbilityIncreasesByLevel_DifferentAbilitiesAcrossSlots_SpreadsInOrder()
+    {
+        // STR +1 and CON +1, slots at levels 4 and 8. First slot -> STR, second -> CON.
+        var increments = new[] { 1, 0, 1, 0, 0, 0 };
+        var levels = new[] { 4, 8 };
+
+        var map = LevelUpApplicationService.BuildAbilityIncreasesByLevel(increments, levels);
+
+        Assert.Equal(0, map[4]); // STR
+        Assert.Equal(2, map[8]); // CON
+    }
+
+    [Fact]
+    public void BuildAbilityIncreasesByLevel_SameAbilityTwice_FillsConsecutiveSlots()
+    {
+        // STR +2, slots at 4 and 8 — both go to STR.
+        var increments = new[] { 2, 0, 0, 0, 0, 0 };
+        var levels = new[] { 4, 8 };
+
+        var map = LevelUpApplicationService.BuildAbilityIncreasesByLevel(increments, levels);
+
+        Assert.Equal(0, map[4]);
+        Assert.Equal(0, map[8]);
+    }
+
+    [Fact]
+    public void BuildAbilityIncreasesByLevel_MoreIncrementsThanSlots_LeavesOverflowUnmapped()
+    {
+        // CE mode: 3 increments but only 1 slot. Only the slot is mapped; the rest are overflow.
+        var increments = new[] { 3, 0, 0, 0, 0, 0 };
+        var levels = new[] { 4 };
+
+        var map = LevelUpApplicationService.BuildAbilityIncreasesByLevel(increments, levels);
+
+        Assert.Single(map);
+        Assert.Equal(0, map[4]);
+    }
+
+    [Fact]
+    public void BuildAbilityIncreasesByLevel_NoIncrements_ReturnsEmpty()
+    {
+        var map = LevelUpApplicationService.BuildAbilityIncreasesByLevel(
+            new[] { 0, 0, 0, 0, 0, 0 }, new[] { 4, 8 });
+
+        Assert.Empty(map);
+    }
+
+    #endregion
+
     #region Multi-Level Stacking
 
     [Fact]
@@ -413,6 +478,7 @@ public class LevelUpApplicationServiceTests
             SelectedSpellsByLevel = new Dictionary<int, List<int>>(),
             HpIncrease = 48, // pooled: 4 * 12
             AbilityIncreasesByLevel = new Dictionary<int, int> { { 4, 0 } }, // STR +1 at char level 4
+            ExtraAbilityIncreases = new List<int> { 0 }, // complete list = the one slotted STR
             RecordHistory = false
         };
 

--- a/Quartermaster/Quartermaster.Tests/SkillServiceTests.cs
+++ b/Quartermaster/Quartermaster.Tests/SkillServiceTests.cs
@@ -280,6 +280,29 @@ public class SkillServiceTests
         Assert.Equal(4, result[3]); // Discipline maxed at 4
     }
 
+    /// <summary>
+    /// #2576: in multi-level mode the wizard pools points across every level, so auto-assign
+    /// must cap at the final character level. Passing current+1 terminated the allocator
+    /// early and left pooled points unspent.
+    /// </summary>
+    [Fact]
+    public void AutoAssignSkills_MultiLevel_CapsAtFinalCharacterLevel()
+    {
+        var classSkillIds = new HashSet<int> { 3 }; // Discipline
+        int finalLevel = Services.LevelUpApplicationService.CalculateFinalCharacterLevel(5, 3); // 8
+
+        var result = _skillService.AutoAssignSkills(
+            packageId: 255,
+            classSkillIds: classSkillIds,
+            unavailableSkillIds: new HashSet<int>(),
+            totalPoints: 40,
+            totalLevel: finalLevel,
+            existingRanks: null);
+
+        // Final level 8 -> class skill cap 8+3 = 11, matching the manual +/- path.
+        Assert.Equal(11, result[3]);
+    }
+
     [Fact]
     public void AutoAssignSkills_RespectsTotalPoints()
     {

--- a/Quartermaster/Quartermaster/Services/AbilityPointBuyService.cs
+++ b/Quartermaster/Quartermaster/Services/AbilityPointBuyService.cs
@@ -161,15 +161,17 @@ public class AbilityPointBuyService
 
     /// <summary>
     /// Gets the secondary ability priority order given a primary ability.
+    /// CON and DEX are universally useful, so they lead; the rest follow the stats relevant to
+    /// the primary, avoiding needless WIS/CHA/INT investment on martial builds (#1737).
     /// </summary>
-    internal static string[] GetSecondaryPriorityOrder(string primaryAbility) => primaryAbility switch
+    public static string[] GetSecondaryPriorityOrder(string primaryAbility) => primaryAbility switch
     {
-        "STR" => new[] { "CON", "DEX", "WIS", "INT", "CHA" },
-        "DEX" => new[] { "CON", "STR", "WIS", "INT", "CHA" },
-        "CON" => new[] { "STR", "DEX", "WIS", "INT", "CHA" },
-        "INT" => new[] { "CON", "DEX", "WIS", "STR", "CHA" },
-        "WIS" => new[] { "CON", "DEX", "INT", "STR", "CHA" },
-        "CHA" => new[] { "CON", "DEX", "WIS", "INT", "STR" },
-        _ => new[] { "CON", "DEX", "WIS", "INT", "CHA" }
+        "STR" => new[] { "CON", "DEX", "INT", "WIS", "CHA" },
+        "DEX" => new[] { "CON", "STR", "INT", "WIS", "CHA" },
+        "CON" => new[] { "STR", "DEX", "INT", "WIS", "CHA" },
+        "INT" => new[] { "DEX", "CON", "STR", "WIS", "CHA" },
+        "WIS" => new[] { "CON", "DEX", "STR", "INT", "CHA" },
+        "CHA" => new[] { "CON", "DEX", "STR", "INT", "WIS" },
+        _ => new[] { "CON", "DEX", "INT", "WIS", "CHA" }
     };
 }

--- a/Quartermaster/Quartermaster/Services/FeatService.LevelUp.cs
+++ b/Quartermaster/Quartermaster/Services/FeatService.LevelUp.cs
@@ -113,7 +113,7 @@ public partial class FeatService
     {
         var result = new HashSet<int>();
 
-        ForEachClassFeatRow(classId, (featId, listType, _) =>
+        ForEachClassFeatRow(classId, (featId, listType, _, _) =>
         {
             if (listType == "1") // Bonus-only feats
                 result.Add(featId);

--- a/Quartermaster/Quartermaster/Services/FeatService.LevelUp.cs
+++ b/Quartermaster/Quartermaster/Services/FeatService.LevelUp.cs
@@ -112,24 +112,12 @@ public partial class FeatService
     public HashSet<int> GetClassBonusFeatPool(int classId)
     {
         var result = new HashSet<int>();
-        var featTable = _gameDataService.Get2DAValue("classes", classId, "FeatsTable");
-        if (string.IsNullOrEmpty(featTable) || featTable == "****")
-            return result;
 
-        int rowCount = _gameDataService.Get2DA(featTable)?.RowCount ?? 300;
-        for (int row = 0; row < rowCount; row++)
+        ForEachClassFeatRow(classId, (featId, listType, _) =>
         {
-            var featIndexStr = _gameDataService.Get2DAValue(featTable, row, "FeatIndex");
-            if (string.IsNullOrEmpty(featIndexStr) || featIndexStr == "****")
-                break;
-
-            if (int.TryParse(featIndexStr, out int featId))
-            {
-                var listType = _gameDataService.Get2DAValue(featTable, row, "List");
-                if (listType == "1") // Bonus-only feats
-                    result.Add(featId);
-            }
-        }
+            if (listType == "1") // Bonus-only feats
+                result.Add(featId);
+        });
 
         return result;
     }

--- a/Quartermaster/Quartermaster/Services/FeatService.cs
+++ b/Quartermaster/Quartermaster/Services/FeatService.cs
@@ -288,8 +288,9 @@ public partial class FeatService
     /// the scan skeleton: table resolution, the "****" terminator, and row parsing.
     /// </summary>
     /// <param name="classId">Class to read FeatsTable from</param>
-    /// <param name="onRow">Receives (featId, listType, rowIndex) for each feat row</param>
-    internal void ForEachClassFeatRow(int classId, Action<int, string?, int> onRow)
+    /// <param name="onRow">Receives (featId, listType, rowIndex, featTable) for each feat row.
+    /// featTable is the resolved, non-null cls_feat table name for reading further columns.</param>
+    internal void ForEachClassFeatRow(int classId, Action<int, string?, int, string> onRow)
     {
         var featTable = _gameDataService.Get2DAValue("classes", classId, "FeatsTable");
         if (string.IsNullOrEmpty(featTable) || featTable == "****")
@@ -305,7 +306,7 @@ public partial class FeatService
             if (!int.TryParse(featIndexStr, out int featId))
                 continue;
 
-            onRow(featId, _gameDataService.Get2DAValue(featTable, row, "List"), row);
+            onRow(featId, _gameDataService.Get2DAValue(featTable, row, "List"), row, featTable);
         }
     }
 
@@ -316,9 +317,8 @@ public partial class FeatService
     public HashSet<int> GetClassFeatsGrantedAtLevel(int classId, int classLevel)
     {
         var result = new HashSet<int>();
-        var featTable = _gameDataService.Get2DAValue("classes", classId, "FeatsTable");
 
-        ForEachClassFeatRow(classId, (featId, listType, row) =>
+        ForEachClassFeatRow(classId, (featId, listType, row, featTable) =>
         {
             // List=-1: granted at creation (class level 1 only)
             if (listType == "-1" && classLevel == 1)
@@ -358,7 +358,7 @@ public partial class FeatService
     {
         var result = new HashSet<int>();
 
-        ForEachClassFeatRow(classId, (featId, listType, _) =>
+        ForEachClassFeatRow(classId, (featId, listType, _, _) =>
         {
             if (listType == "3") // Automatic/granted feat
                 result.Add(featId);

--- a/Quartermaster/Quartermaster/Services/FeatService.cs
+++ b/Quartermaster/Quartermaster/Services/FeatService.cs
@@ -279,23 +279,23 @@ public partial class FeatService
         };
     }
 
-    /// <summary>
-    /// Gets the set of feat IDs granted by a class at all levels.
-    /// Reads from cls_feat_*.2da files.
-    /// </summary>
-    /// <summary>
-    /// Gets feats automatically granted at a specific class level.
-    /// Reads List=3 + GrantedOnLevel from cls_feat_*.2da, plus List=-1 for level 1.
-    /// </summary>
-    public HashSet<int> GetClassFeatsGrantedAtLevel(int classId, int classLevel)
-    {
-        var result = new HashSet<int>();
+    // cls_feat_*.2da row counts vary by class; used only when the table reports none.
+    private const int ClassFeatTableRowCountFallback = 300;
 
+    /// <summary>
+    /// Walks a class's cls_feat_*.2da, invoking <paramref name="onRow"/> per parsed feat row.
+    /// The four callers filter on different List values by design (#2581) — this shares only
+    /// the scan skeleton: table resolution, the "****" terminator, and row parsing.
+    /// </summary>
+    /// <param name="classId">Class to read FeatsTable from</param>
+    /// <param name="onRow">Receives (featId, listType, rowIndex) for each feat row</param>
+    internal void ForEachClassFeatRow(int classId, Action<int, string?, int> onRow)
+    {
         var featTable = _gameDataService.Get2DAValue("classes", classId, "FeatsTable");
         if (string.IsNullOrEmpty(featTable) || featTable == "****")
-            return result;
+            return;
 
-        int rowCount = _gameDataService.Get2DA(featTable)?.RowCount ?? 200;
+        int rowCount = _gameDataService.Get2DA(featTable)?.RowCount ?? ClassFeatTableRowCountFallback;
         for (int row = 0; row < rowCount; row++)
         {
             var featIndexStr = _gameDataService.Get2DAValue(featTable, row, "FeatIndex");
@@ -305,13 +305,26 @@ public partial class FeatService
             if (!int.TryParse(featIndexStr, out int featId))
                 continue;
 
-            var listType = _gameDataService.Get2DAValue(featTable, row, "List");
+            onRow(featId, _gameDataService.Get2DAValue(featTable, row, "List"), row);
+        }
+    }
 
+    /// <summary>
+    /// Gets feats automatically granted at a specific class level.
+    /// Reads List=3 + GrantedOnLevel from cls_feat_*.2da, plus List=-1 for level 1.
+    /// </summary>
+    public HashSet<int> GetClassFeatsGrantedAtLevel(int classId, int classLevel)
+    {
+        var result = new HashSet<int>();
+        var featTable = _gameDataService.Get2DAValue("classes", classId, "FeatsTable");
+
+        ForEachClassFeatRow(classId, (featId, listType, row) =>
+        {
             // List=-1: granted at creation (class level 1 only)
             if (listType == "-1" && classLevel == 1)
             {
                 result.Add(featId);
-                continue;
+                return;
             }
 
             // List=3: automatically granted at GrantedOnLevel
@@ -321,7 +334,7 @@ public partial class FeatService
                 if (int.TryParse(grantedLevelStr, out int grantedLevel) && grantedLevel == classLevel)
                     result.Add(featId);
             }
-        }
+        });
 
         return result;
     }
@@ -345,26 +358,11 @@ public partial class FeatService
     {
         var result = new HashSet<int>();
 
-        var featTable = _gameDataService.Get2DAValue("classes", classId, "FeatsTable");
-        if (string.IsNullOrEmpty(featTable) || featTable == "****")
-            return result;
-
-        int rowCount = _gameDataService.Get2DA(featTable)?.RowCount ?? 200;
-        for (int row = 0; row < rowCount; row++)
+        ForEachClassFeatRow(classId, (featId, listType, _) =>
         {
-            var featIndexStr = _gameDataService.Get2DAValue(featTable, row, "FeatIndex");
-            if (string.IsNullOrEmpty(featIndexStr) || featIndexStr == "****")
-                break;
-
-            if (int.TryParse(featIndexStr, out int featId))
-            {
-                var listType = _gameDataService.Get2DAValue(featTable, row, "List");
-                if (listType == "3") // Automatic/granted feat
-                {
-                    result.Add(featId);
-                }
-            }
-        }
+            if (listType == "3") // Automatic/granted feat
+                result.Add(featId);
+        });
 
         return result;
     }

--- a/Quartermaster/Quartermaster/Services/LevelUpApplicationService.cs
+++ b/Quartermaster/Quartermaster/Services/LevelUpApplicationService.cs
@@ -37,6 +37,18 @@ public class LevelUpApplicationService
         public int ConRetroactiveHp { get; set; } // Retroactive HP from CON modifier change
         public bool RecordHistory { get; set; }
         public LevelHistoryEncoding HistoryEncoding { get; set; } = LevelHistoryEncoding.Readable;
+
+        // Span-aware fields (#2575). FromClassLevel defaults to NewClassLevel, making the
+        // single-level case From==To with one loop iteration. AbilityIncreasesByLevel is the
+        // general form of AbilityIncrease/ExtraAbilityIncreases, keyed by character level.
+        public int? FromClassLevel { get; set; }
+        public Dictionary<int, int>? AbilityIncreasesByLevel { get; set; }
+
+        /// <summary>Number of class levels this input applies (>= 1).</summary>
+        public int LevelsToApply => NewClassLevel - EffectiveFromClassLevel + 1;
+
+        /// <summary>First class level in the range; equals NewClassLevel for a single-level apply.</summary>
+        public int EffectiveFromClassLevel => FromClassLevel ?? NewClassLevel;
     }
 
     /// <summary>
@@ -45,13 +57,43 @@ public class LevelUpApplicationService
     /// <exception cref="InvalidOperationException">If level-up cannot be applied.</exception>
     public void ApplyLevelUp(UtcFile creature, LevelUpInput input)
     {
-        ApplyClassLevel(creature, input.SelectedClassId);
-        ApplyAbilityIncrease(creature, input.AbilityIncrease);
-        // CE mode: apply additional ability increases
-        foreach (var extraAbility in input.ExtraAbilityIncreases)
-            ApplyAbilityIncrease(creature, extraAbility);
+        // Per-level: class level, that level's auto-granted feats, and any slotted ability
+        // increase. For a single-level apply From==To, so the loop runs once (#2575).
+        for (int classLevel = input.EffectiveFromClassLevel; classLevel <= input.NewClassLevel; classLevel++)
+        {
+            ApplyClassLevel(creature, input.SelectedClassId);
+            ApplyAutoGrantedFeats(creature, input.SelectedClassId, classLevel);
+
+            if (input.AbilityIncreasesByLevel is { } byLevel)
+            {
+                int charLevel = creature.ClassList.Sum(c => c.ClassLevel);
+                if (byLevel.TryGetValue(charLevel, out int abilityIdx))
+                    ApplyAbilityIncrease(creature, abilityIdx);
+            }
+        }
+
+        // Single-level compatibility: the scalar AbilityIncrease + ExtraAbilityIncreases path
+        // is used when no per-level map is supplied.
+        if (input.AbilityIncreasesByLevel is null)
+        {
+            ApplyAbilityIncrease(creature, input.AbilityIncrease);
+            foreach (var extraAbility in input.ExtraAbilityIncreases)
+                ApplyAbilityIncrease(creature, extraAbility);
+        }
+        else
+        {
+            // Multi-level CE mode: apply any increases beyond the every-fourth-level slots
+            // (#2696). "All" is the slotted increases plus the CE extras; the helper applies
+            // whatever the per-level loop did not.
+            var allIncreases = input.AbilityIncreasesByLevel.Values
+                .Concat(input.ExtraAbilityIncreases)
+                .ToList();
+            ApplyOverflowAbilityIncreases(creature, allIncreases, input.AbilityIncreasesByLevel);
+        }
+
+        // Pooled across the whole range — applied once.
         ApplyHitPoints(creature, input.HpIncrease + input.ConRetroactiveHp);
-        ApplyFeats(creature, input.SelectedClassId, input.NewClassLevel, input.SelectedFeats);
+        ApplyPlayerSelectedFeats(creature, input.SelectedFeats);
         ApplySkills(creature, input.SkillPointsAdded);
         ApplySpells(creature, input.SelectedClassId, input.SelectedSpellsByLevel);
         UpdateSavingThrows(creature);
@@ -146,25 +188,35 @@ public class LevelUpApplicationService
     /// </summary>
     public void ApplyFeats(UtcFile creature, int classId, int classLevel, List<int> selectedFeats)
     {
-        // Add player-selected feats
-        foreach (var featId in selectedFeats)
-        {
-            if (_displayService.CanFeatBeGainedMultipleTimes(featId) ||
-                !creature.FeatList.Contains((ushort)featId))
-            {
-                creature.FeatList.Add((ushort)featId);
-            }
-        }
+        ApplyPlayerSelectedFeats(creature, selectedFeats);
+        ApplyAutoGrantedFeats(creature, classId, classLevel);
+    }
 
-        // Add auto-granted class feats
-        var grantedFeats = _displayService.Feats.GetClassFeatsGrantedAtLevel(classId, classLevel);
-        foreach (var featId in grantedFeats)
+    /// <summary>
+    /// Adds player-picked feats. Pooled across a level range, so applied once (#2575).
+    /// </summary>
+    public void ApplyPlayerSelectedFeats(UtcFile creature, List<int> selectedFeats)
+    {
+        foreach (var featId in selectedFeats)
+            AddFeatIfAllowed(creature, featId);
+    }
+
+    /// <summary>
+    /// Adds the class feats auto-granted at one class level. Per-level, so called once per
+    /// level in a range (#2575).
+    /// </summary>
+    public void ApplyAutoGrantedFeats(UtcFile creature, int classId, int classLevel)
+    {
+        foreach (var featId in _displayService.Feats.GetClassFeatsGrantedAtLevel(classId, classLevel))
+            AddFeatIfAllowed(creature, featId);
+    }
+
+    private void AddFeatIfAllowed(UtcFile creature, int featId)
+    {
+        if (_displayService.CanFeatBeGainedMultipleTimes(featId) ||
+            !creature.FeatList.Contains((ushort)featId))
         {
-            if (_displayService.CanFeatBeGainedMultipleTimes(featId) ||
-                !creature.FeatList.Contains((ushort)featId))
-            {
-                creature.FeatList.Add((ushort)featId);
-            }
+            creature.FeatList.Add((ushort)featId);
         }
     }
 

--- a/Quartermaster/Quartermaster/Services/LevelUpApplicationService.cs
+++ b/Quartermaster/Quartermaster/Services/LevelUpApplicationService.cs
@@ -232,17 +232,26 @@ public class LevelUpApplicationService
         int intMod = CreatureDisplayService.CalculateAbilityBonus(creature.Int);
         int basePoints = _displayService.GetClassSkillPointBase(classId);
         int totalLevel = creature.ClassList.Sum(c => c.ClassLevel) + 1;
-
         int racialExtra = _displayService.GetRacialExtraSkillPointsPerLevel(creature.Race);
 
-        if (totalLevel == 1)
-        {
-            // Level 1 gets 4x multiplier (NWN engine rule)
-            const int FirstLevelMultiplier = 4;
-            return (Math.Max(1, basePoints + intMod) + racialExtra) * FirstLevelMultiplier;
-        }
+        return CalculateSkillPointsForLevel(totalLevel, basePoints, intMod, racialExtra);
+    }
 
-        return Math.Max(1, basePoints + intMod) + racialExtra;
+    /// <summary>
+    /// Calculates skill points awarded for gaining one character level.
+    /// D&amp;D 3.5/NWN: (basePoints + intMod) at level 2+, x4 at level 1. Racial bonus points
+    /// apply per level, and are multiplied at level 1 too.
+    /// Callers that award points across a level range must invoke this per level so the
+    /// level-1 rule cannot be skipped (#2578).
+    /// </summary>
+    public static int CalculateSkillPointsForLevel(
+        int characterLevel, int basePoints, int intMod, int racialExtra)
+    {
+        int perLevel = Math.Max(1, basePoints + intMod) + racialExtra;
+
+        // Level 1 gets 4x multiplier (NWN engine rule)
+        const int FirstLevelMultiplier = 4;
+        return characterLevel == 1 ? perLevel * FirstLevelMultiplier : perLevel;
     }
 
     /// <summary>

--- a/Quartermaster/Quartermaster/Services/LevelUpApplicationService.cs
+++ b/Quartermaster/Quartermaster/Services/LevelUpApplicationService.cs
@@ -246,6 +246,16 @@ public class LevelUpApplicationService
     }
 
     /// <summary>
+    /// Calculates the character level a level-up ends at, given the levels being added.
+    /// Multi-level level-ups pool points across the whole range, so rank caps and the point
+    /// budget must both derive from the final level rather than the next one (#2576).
+    /// </summary>
+    public static int CalculateFinalCharacterLevel(int currentTotalLevel, int levelsToAdd)
+    {
+        return currentTotalLevel + levelsToAdd;
+    }
+
+    /// <summary>
     /// Calculates max skill ranks for a skill at a given character level.
     /// Class skill: level + 3. Cross-class: (level + 3) / 2.
     /// </summary>

--- a/Quartermaster/Quartermaster/Services/LevelUpApplicationService.cs
+++ b/Quartermaster/Quartermaster/Services/LevelUpApplicationService.cs
@@ -72,23 +72,19 @@ public class LevelUpApplicationService
             }
         }
 
-        // Single-level compatibility: the scalar AbilityIncrease + ExtraAbilityIncreases path
-        // is used when no per-level map is supplied.
-        if (input.AbilityIncreasesByLevel is null)
+        if (input.AbilityIncreasesByLevel is { } increasesByLevel)
         {
-            ApplyAbilityIncrease(creature, input.AbilityIncrease);
-            foreach (var extraAbility in input.ExtraAbilityIncreases)
-                ApplyAbilityIncrease(creature, extraAbility);
+            // Map-based path (span-aware wizard). ExtraAbilityIncreases is the COMPLETE list of
+            // requested increases; the loop above applied the slotted ones, so this applies any
+            // CE overflow the slots could not hold (#2696).
+            ApplyOverflowAbilityIncreases(creature, input.ExtraAbilityIncreases, increasesByLevel);
         }
         else
         {
-            // Multi-level CE mode: apply any increases beyond the every-fourth-level slots
-            // (#2696). "All" is the slotted increases plus the CE extras; the helper applies
-            // whatever the per-level loop did not.
-            var allIncreases = input.AbilityIncreasesByLevel.Values
-                .Concat(input.ExtraAbilityIncreases)
-                .ToList();
-            ApplyOverflowAbilityIncreases(creature, allIncreases, input.AbilityIncreasesByLevel);
+            // Legacy scalar path: primary increase plus any CE extras, applied directly.
+            ApplyAbilityIncrease(creature, input.AbilityIncrease);
+            foreach (var extraAbility in input.ExtraAbilityIncreases)
+                ApplyAbilityIncrease(creature, extraAbility);
         }
 
         // Pooled across the whole range — applied once.
@@ -347,6 +343,33 @@ public class LevelUpApplicationService
     #region Consolidated Level-Up Helpers (#1645)
 
     /// <summary>
+    /// Maps each every-fourth-level ability slot to the ability being raised there (#2575, folds
+    /// in #2581's 3f). Spreads the per-ability increment counts across the available slots in
+    /// ability order, so the first slot takes the first requested increment and so on. Increments
+    /// beyond the slot count are CE-mode overflow, handled separately by
+    /// <see cref="ApplyOverflowAbilityIncreases"/>.
+    /// </summary>
+    /// <param name="abilityIncrements">Per-ability increment counts, indexed STR=0..CHA=5.</param>
+    /// <param name="abilityIncreaseLevels">Character levels that grant a slot, ascending.</param>
+    public static Dictionary<int, int> BuildAbilityIncreasesByLevel(
+        IReadOnlyList<int> abilityIncrements, IReadOnlyList<int> abilityIncreaseLevels)
+    {
+        var result = new Dictionary<int, int>();
+        int slotIdx = 0;
+        for (int ability = 0; ability < abilityIncrements.Count; ability++)
+        {
+            for (int n = 0; n < abilityIncrements[ability]; n++)
+            {
+                if (slotIdx >= abilityIncreaseLevels.Count)
+                    return result; // remaining increments are CE overflow
+                result[abilityIncreaseLevels[slotIdx]] = ability;
+                slotIdx++;
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
     /// Returns character levels within the range that get +1 ability increase (every 4th level).
     /// </summary>
     public static List<int> GetAbilityIncreaseLevels(int currentTotalLevel, int levelsToAdd)
@@ -432,24 +455,45 @@ public class LevelUpApplicationService
 
     private void RecordLevelHistory(UtcFile creature, LevelUpInput input)
     {
-        var record = new LevelRecord
-        {
-            TotalLevel = creature.ClassList.Sum(c => c.ClassLevel),
-            ClassId = input.SelectedClassId,
-            ClassLevel = input.NewClassLevel,
-            Feats = input.SelectedFeats.ToList(),
-            Skills = input.SkillPointsAdded
-                .Where(kv => kv.Value > 0)
-                .ToDictionary(kv => kv.Key, kv => kv.Value),
-            AbilityIncrease = input.AbilityIncrease
-        };
-
         var existingHistory = LevelHistoryService.Decode(creature.Comment) ?? new List<LevelRecord>();
-        existingHistory.Add(record);
+
+        // One record per level for fidelity. Pooled feat/skill selections carry no per-level
+        // attribution, so they land on the final level (#2575). Single-level (From==To) writes
+        // exactly one record, identical to the pre-span behaviour.
+        int baseCharLevel = creature.ClassList.Sum(c => c.ClassLevel);
+        for (int classLevel = input.EffectiveFromClassLevel; classLevel <= input.NewClassLevel; classLevel++)
+        {
+            int charLevelAtThisPoint = baseCharLevel - (input.NewClassLevel - classLevel);
+            bool isFinalLevel = classLevel == input.NewClassLevel;
+
+            existingHistory.Add(new LevelRecord
+            {
+                TotalLevel = charLevelAtThisPoint,
+                ClassId = input.SelectedClassId,
+                ClassLevel = classLevel,
+                Feats = isFinalLevel ? input.SelectedFeats.ToList() : new List<int>(),
+                Skills = isFinalLevel
+                    ? input.SkillPointsAdded.Where(kv => kv.Value > 0).ToDictionary(kv => kv.Key, kv => kv.Value)
+                    : new Dictionary<int, int>(),
+                AbilityIncrease = ResolveHistoryAbilityIncrease(input, charLevelAtThisPoint)
+            });
+        }
 
         creature.Comment = LevelHistoryService.AppendToComment(
             creature.Comment,
             existingHistory,
             input.HistoryEncoding);
+    }
+
+    // Per-level ability attribution: the multi-level map wins when present; single-level falls
+    // back to the scalar AbilityIncrease on the (only) final level.
+    private static int ResolveHistoryAbilityIncrease(LevelUpInput input, int charLevel)
+    {
+        if (input.AbilityIncreasesByLevel is { } byLevel)
+            return byLevel.GetValueOrDefault(charLevel, -1);
+
+        return charLevel == input.NewClassLevel || input.EffectiveFromClassLevel == input.NewClassLevel
+            ? input.AbilityIncrease
+            : -1;
     }
 }

--- a/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.AbilityScore.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.AbilityScore.cs
@@ -154,42 +154,12 @@ public partial class LevelUpWizardWindow
     /// </summary>
     private void SyncAbilityLegacyFields()
     {
-        // _selectedAbilityIncrease: set to the ability with most increments (for backward compat)
-        int maxIdx = -1;
-        int maxVal = 0;
-        for (int i = 0; i < 6; i++)
-        {
-            if (_abilityIncrements[i] > maxVal)
-            {
-                maxVal = _abilityIncrements[i];
-                maxIdx = i;
-            }
-        }
-        _selectedAbilityIncrease = maxIdx;
-
-        // _ceAbilityIncreases: populate with all abilities that have increments
-        _ceAbilityIncreases.Clear();
-        for (int i = 0; i < 6; i++)
-        {
-            for (int j = 0; j < _abilityIncrements[i]; j++)
-                _ceAbilityIncreases.Add(i);
-        }
-
-        // _abilityIncreasesByLevel: distribute increments across ability increase levels
-        // Spread them in order: first N goes to first ability with increments, etc.
-        _abilityIncreasesByLevel.Clear();
-        int levelIdx = 0;
-        for (int i = 0; i < 6; i++)
-        {
-            for (int j = 0; j < _abilityIncrements[i]; j++)
-            {
-                if (levelIdx < _abilityIncreaseLevels.Count)
-                {
-                    _abilityIncreasesByLevel[_abilityIncreaseLevels[levelIdx]] = i;
-                    levelIdx++;
-                }
-            }
-        }
+        // Keep the per-level ability map current for the skill-point (Step 4) and HP previews,
+        // built from the increment source of truth via the shared tested helper (#2575 / 3f).
+        // The old _selectedAbilityIncrease / _ceAbilityIncreases projections are gone — the apply
+        // path derives everything it needs from _abilityIncrements directly.
+        _abilityIncreasesByLevel = LevelUpApplicationService.BuildAbilityIncreasesByLevel(
+            _abilityIncrements, _abilityIncreaseLevels);
     }
 
     // Unused legacy methods kept as stubs for compatibility

--- a/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.FeatSelection.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.FeatSelection.cs
@@ -244,28 +244,14 @@ public partial class LevelUpWizardWindow
     private HashSet<int> GetClassSelectableFeatIds(int classId)
     {
         var result = new HashSet<int>();
-        var featTable = _displayService.GameDataService.Get2DAValue("classes", classId, "FeatsTable");
-        if (string.IsNullOrEmpty(featTable) || featTable == "****")
-            return result;
 
-        int rowCount = _displayService.GameDataService.Get2DA(featTable)?.RowCount ?? 300;
-        for (int row = 0; row < rowCount; row++)
+        _displayService.Feats.ForEachClassFeatRow(classId, (featId, listType, _) =>
         {
-            var featIndexStr = _displayService.GameDataService.Get2DAValue(featTable, row, "FeatIndex");
-            if (string.IsNullOrEmpty(featIndexStr) || featIndexStr == "****")
-                break;
-
-            if (int.TryParse(featIndexStr, out int featId))
-            {
-                var listType = _displayService.GameDataService.Get2DAValue(featTable, row, "List");
-                // List = 1: Bonus feat only, 2: Normal selectable, 3: Automatic/granted
-                // We want 1 and 2 for selection
-                if (listType == "1" || listType == "2")
-                {
-                    result.Add(featId);
-                }
-            }
-        }
+            // List = 1: Bonus feat only, 2: Normal selectable, 3: Automatic/granted
+            // We want 1 and 2 for selection
+            if (listType == "1" || listType == "2")
+                result.Add(featId);
+        });
 
         return result;
     }

--- a/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.FeatSelection.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.FeatSelection.cs
@@ -245,7 +245,7 @@ public partial class LevelUpWizardWindow
     {
         var result = new HashSet<int>();
 
-        _displayService.Feats.ForEachClassFeatRow(classId, (featId, listType, _) =>
+        _displayService.Feats.ForEachClassFeatRow(classId, (featId, listType, _, _) =>
         {
             // List = 1: Bonus feat only, 2: Normal selectable, 3: Automatic/granted
             // We want 1 and 2 for selection

--- a/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.SkillAllocation.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.SkillAllocation.cs
@@ -112,7 +112,8 @@ public partial class LevelUpWizardWindow
 
     private int CalculateMaxRanks(bool isClassSkill)
     {
-        int totalLevel = _creature.ClassList.Sum(c => c.ClassLevel) + _levelsToAdd;
+        int totalLevel = LevelUpApplicationService.CalculateFinalCharacterLevel(
+            _creature.ClassList.Sum(c => c.ClassLevel), _levelsToAdd);
         return LevelUpApplicationService.CalculateMaxSkillRanks(isClassSkill, totalLevel);
     }
 
@@ -173,7 +174,8 @@ public partial class LevelUpWizardWindow
 
     private void OnSkillAutoAssignClick(object? sender, RoutedEventArgs e)
     {
-        int totalLevel = _creature.ClassList.Sum(c => c.ClassLevel) + 1;
+        int totalLevel = LevelUpApplicationService.CalculateFinalCharacterLevel(
+            _creature.ClassList.Sum(c => c.ClassLevel), _levelsToAdd);
         _skillPointsAdded = _displayService.Skills.AutoAssignSkills(
             _resolvedPackageId,
             _classSkillIds,

--- a/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.SkillAllocation.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.SkillAllocation.cs
@@ -40,7 +40,8 @@ public partial class LevelUpWizardWindow
                 effectiveInt = (byte)System.Math.Min(255, effectiveInt + 1);
 
             int intMod = CreatureDisplayService.CalculateAbilityBonus(effectiveInt);
-            _skillPointsToAllocate += System.Math.Max(1, basePoints + intMod) + racialExtra;
+            _skillPointsToAllocate += LevelUpApplicationService.CalculateSkillPointsForLevel(
+                charLevel, basePoints, intMod, racialExtra);
         }
 
         _skillPointsAdded.Clear();

--- a/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.SummaryAndApply.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.SummaryAndApply.cs
@@ -22,13 +22,10 @@ public partial class LevelUpWizardWindow
 
         var className = _displayService.GetClassName(_selectedClassId);
 
-        // Build ability increases map for consolidated apply (#1645)
-        _abilityIncreasesByLevel.Clear();
-        if (_selectedAbilityIncrease >= 0)
-        {
-            foreach (var level in _abilityIncreaseLevels)
-                _abilityIncreasesByLevel[level] = _selectedAbilityIncrease;
-        }
+        // Ability map for the HP/skill preview, built from the increment source of truth via the
+        // same tested helper the apply path uses (#2575 / 3f).
+        _abilityIncreasesByLevel = LevelUpApplicationService.BuildAbilityIncreasesByLevel(
+            _abilityIncrements, _abilityIncreaseLevels);
 
         // Class summary
         if (_levelsToAdd > 1)
@@ -201,114 +198,38 @@ public partial class LevelUpWizardWindow
         var service = new LevelUpApplicationService(_displayService);
         var settings = SettingsService.Instance;
 
-        if (_levelsToAdd > 1)
+        // Build the per-level ability map straight from the increment source of truth, and the
+        // full increase list for CE overflow — no hand-synced projections (#2575 / 3f).
+        var abilityIncreasesByLevel = LevelUpApplicationService.BuildAbilityIncreasesByLevel(
+            _abilityIncrements, _abilityIncreaseLevels);
+        var allAbilityIncreases = new List<int>();
+        for (int ability = 0; ability < _abilityIncrements.Length; ability++)
+            for (int n = 0; n < _abilityIncrements[ability]; n++)
+                allAbilityIncreases.Add(ability);
+
+        // One span-aware apply path for both single- and multi-level. FromClassLevel == NewClassLevel
+        // for a single level, so the orchestrator loops once (#2575).
+        service.ApplyLevelUp(_creature, new LevelUpApplicationService.LevelUpInput
         {
-            ApplyConsolidatedLevelUp(service, settings);
-        }
-        else
-        {
-            // Existing single-level apply (unchanged)
-            service.ApplyLevelUp(_creature, new LevelUpApplicationService.LevelUpInput
-            {
-                SelectedClassId = _selectedClassId,
-                NewClassLevel = _newClassLevel,
-                IsNewClass = _isNewClass,
-                SelectedFeats = _selectedFeats,
-                SkillPointsAdded = _skillPointsAdded,
-                SelectedSpellsByLevel = _selectedSpellsByLevel,
-                AbilityIncrease = _selectedAbilityIncrease,
-                ExtraAbilityIncreases = _ceAbilityIncreases
-                    .Where(i => i != _selectedAbilityIncrease)
-                    .ToList(),
-                HpIncrease = _hpIncrease,
-                ConRetroactiveHp = _conRetroactiveHp,
-                RecordHistory = settings.RecordLevelHistory,
-                HistoryEncoding = settings.LevelHistoryEncoding
-            });
-        }
-    }
-
-    /// <summary>
-    /// Applies multiple levels in consolidated mode (#1645).
-    /// Loops class level increments, then applies pooled player selections.
-    /// </summary>
-    private void ApplyConsolidatedLevelUp(LevelUpApplicationService service, SettingsService settings)
-    {
-        // 1. Apply class levels one at a time (for auto-granted feats per level)
-        for (int lvl = _fromClassLevel; lvl <= _newClassLevel; lvl++)
-        {
-            LevelUpApplicationService.ApplyClassLevel(_creature, _selectedClassId);
-
-            // Apply ability increase at this character level (if applicable)
-            int currentCharLevel = _creature.ClassList.Sum(c => c.ClassLevel);
-            if (_abilityIncreasesByLevel.TryGetValue(currentCharLevel, out int abilityIdx))
-                LevelUpApplicationService.ApplyAbilityIncrease(_creature, abilityIdx);
-
-            // Apply auto-granted feats for this class level
-            var grantedFeats = _displayService.Feats.GetClassFeatsGrantedAtLevel(_selectedClassId, lvl);
-            foreach (var featId in grantedFeats)
-            {
-                if (_displayService.CanFeatBeGainedMultipleTimes(featId) ||
-                    !_creature.FeatList.Contains((ushort)featId))
-                    _creature.FeatList.Add((ushort)featId);
-            }
-        }
-
-        // 1.5. Apply CE increases beyond the every-fourth-level slots (#2696).
-        // _abilityIncreasesByLevel holds only what fit into those slots; the rest
-        // would otherwise be dropped on a multi-level apply.
-        LevelUpApplicationService.ApplyOverflowAbilityIncreases(
-            _creature, _ceAbilityIncreases, _abilityIncreasesByLevel);
-
-        // 2. Apply pooled HP
-        LevelUpApplicationService.ApplyHitPoints(_creature, _hpIncrease);
-
-        // 3. Apply pooled player-selected feats
-        foreach (var featId in _selectedFeats)
-        {
-            if (_displayService.CanFeatBeGainedMultipleTimes(featId) ||
-                !_creature.FeatList.Contains((ushort)featId))
-                _creature.FeatList.Add((ushort)featId);
-        }
-
-        // 4. Apply pooled skills and spells
-        LevelUpApplicationService.ApplySkills(_creature, _skillPointsAdded);
-        LevelUpApplicationService.ApplySpells(_creature, _selectedClassId, _selectedSpellsByLevel);
-
-        // 4.5. Recalculate saves from updated class levels (#1740)
-        service.UpdateSavingThrows(_creature);
-
-        // 5. Record level history — one record per level for fidelity
-        if (settings.RecordLevelHistory)
-        {
-            var existingHistory = LevelHistoryService.Decode(_creature.Comment) ?? new List<LevelRecord>();
-            int baseCharLevel = _creature.ClassList.Sum(c => c.ClassLevel);
-
-            for (int lvl = _fromClassLevel; lvl <= _newClassLevel; lvl++)
-            {
-                int charLevelAtThisPoint = baseCharLevel - (_newClassLevel - lvl);
-                var record = new LevelRecord
-                {
-                    TotalLevel = charLevelAtThisPoint,
-                    ClassId = _selectedClassId,
-                    ClassLevel = lvl,
-                    // Attribute pooled selections to the last level
-                    Feats = lvl == _newClassLevel ? _selectedFeats.ToList() : new List<int>(),
-                    Skills = lvl == _newClassLevel
-                        ? _skillPointsAdded.Where(kv => kv.Value > 0).ToDictionary(kv => kv.Key, kv => kv.Value)
-                        : new Dictionary<int, int>(),
-                    AbilityIncrease = _abilityIncreasesByLevel.GetValueOrDefault(charLevelAtThisPoint, -1)
-                };
-                existingHistory.Add(record);
-            }
-
-            _creature.Comment = LevelHistoryService.AppendToComment(
-                _creature.Comment, existingHistory, settings.LevelHistoryEncoding);
-        }
+            SelectedClassId = _selectedClassId,
+            NewClassLevel = _newClassLevel,
+            FromClassLevel = _fromClassLevel,
+            IsNewClass = _isNewClass,
+            SelectedFeats = _selectedFeats,
+            SkillPointsAdded = _skillPointsAdded,
+            SelectedSpellsByLevel = _selectedSpellsByLevel,
+            AbilityIncreasesByLevel = abilityIncreasesByLevel,
+            ExtraAbilityIncreases = allAbilityIncreases,
+            HpIncrease = _hpIncrease,
+            ConRetroactiveHp = _conRetroactiveHp,
+            RecordHistory = settings.RecordLevelHistory,
+            HistoryEncoding = settings.LevelHistoryEncoding
+        });
 
         UnifiedLogger.LogApplication(LogLevel.INFO,
-            $"Consolidated level-up: {_displayService.GetClassName(_selectedClassId)} {_fromClassLevel}-{_newClassLevel} ({_levelsToAdd} levels)");
+            $"Level-up: {_displayService.GetClassName(_selectedClassId)} {_fromClassLevel}-{_newClassLevel} ({_levelsToAdd} level(s))");
     }
+
 
     #endregion
 

--- a/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/LevelUpWizardWindow.axaml.cs
@@ -47,8 +47,6 @@ public partial class LevelUpWizardWindow : Window
     private int _skillPointsToAllocate;
     private bool _needsSpellSelection;
     private bool _needsAbilityIncrease;
-    private int _selectedAbilityIncrease = -1; // -1=none, 0=STR, 1=DEX, 2=CON, 3=INT, 4=WIS, 5=CHA
-    private readonly HashSet<int> _ceAbilityIncreases = new(); // CE mode: multiple ability increases
     private int _hpIncrease; // Pre-calculated HP gain for this level
     private int _conRetroactiveHp; // Retroactive HP from CON modifier change
     private byte _resolvedPackageId = 255;

--- a/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Abilities.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Abilities.cs
@@ -15,8 +15,10 @@ public partial class NewCharacterWizardWindow
 {
     #region Step 6: Ability Scores
 
-    private static readonly string[] AbilityNames = { "STR", "DEX", "CON", "INT", "WIS", "CHA" };
-    private static readonly string[] AbilityFullNames = { "Strength", "Dexterity", "Constitution", "Intelligence", "Wisdom", "Charisma" };
+    // Canonical order lives in AbilityPointBuyService; a divergent copy here would map racial
+    // modifiers to the wrong stat (#2581).
+    private static string[] AbilityNames => AbilityPointBuyService.AbilityNames;
+    private static string[] AbilityFullNames => AbilityPointBuyService.AbilityFullNames;
 
     private void PrepareStep6()
     {
@@ -196,9 +198,7 @@ public partial class NewCharacterWizardWindow
                 else if (tag.StartsWith("Cost_"))
                 {
                     var ability = tag[5..];
-                    int baseScore = _abilityBaseScores[ability];
-                    int costIndex = baseScore - AbilityMinBase;
-                    int cost = costIndex >= 0 && costIndex < PointBuyCosts.Length ? PointBuyCosts[costIndex] : 0;
+                    int cost = AbilityPointBuyService.GetCostForScore(_abilityBaseScores[ability]);
                     tb.Text = cost.ToString();
                 }
             }
@@ -218,11 +218,7 @@ public partial class NewCharacterWizardWindow
                         if (_validationLevel == ValidationLevel.Strict)
                         {
                             // Lawful Good: enforce point-buy budget
-                            int nextCostIndex = baseScore + 1 - AbilityMinBase;
-                            int nextCost = nextCostIndex < PointBuyCosts.Length ? PointBuyCosts[nextCostIndex] : int.MaxValue;
-                            int currentCostIndex = baseScore - AbilityMinBase;
-                            int currentCost = currentCostIndex >= 0 && currentCostIndex < PointBuyCosts.Length ? PointBuyCosts[currentCostIndex] : 0;
-                            int costDelta = nextCost - currentCost;
+                            int costDelta = AbilityPointBuyService.GetIncreaseCost(baseScore);
                             btn.IsEnabled = baseScore < AbilityMaxBase && remaining >= costDelta;
                         }
                         else
@@ -275,11 +271,7 @@ public partial class NewCharacterWizardWindow
                 if (_validationLevel == ValidationLevel.Strict)
                 {
                     // Lawful Good: enforce point-buy budget
-                    int nextCostIndex = currentScore + 1 - AbilityMinBase;
-                    int nextCost = nextCostIndex < PointBuyCosts.Length ? PointBuyCosts[nextCostIndex] : int.MaxValue;
-                    int currentCostIndex = currentScore - AbilityMinBase;
-                    int currentCost = currentCostIndex >= 0 && currentCostIndex < PointBuyCosts.Length ? PointBuyCosts[currentCostIndex] : 0;
-                    int costDelta = nextCost - currentCost;
+                    int costDelta = AbilityPointBuyService.GetIncreaseCost(currentScore);
 
                     if (GetAbilityPointsRemaining() >= costDelta)
                     {
@@ -311,92 +303,14 @@ public partial class NewCharacterWizardWindow
 
     private void OnAbilityAutoAssignClick(object? sender, RoutedEventArgs e)
     {
-        // Reset all to base 8
-        foreach (var ability in AbilityNames)
-            _abilityBaseScores[ability] = AbilityMinBase;
-
         // Read package primary ability from packages.2da Attribute column
-        string? primaryAbility = null;
-        if (_selectedPackageId != 255)
-        {
-            primaryAbility = _gameDataService.Get2DAValue("packages", _selectedPackageId, "Attribute")?.ToUpperInvariant();
-        }
+        string? primaryAbility = _selectedPackageId != 255
+            ? _gameDataService.Get2DAValue("packages", _selectedPackageId, "Attribute")?.ToUpperInvariant()
+            : null;
 
-        // Default distribution: balanced with emphasis on primary ability
-        // Strategy: primary ability gets priority, then spread remaining across useful stats
-        if (!string.IsNullOrEmpty(primaryAbility) && primaryAbility != "****" && _abilityBaseScores.ContainsKey(primaryAbility))
-        {
-            // Push primary ability to 16 (cost 10), leaves 20 points
-            _abilityBaseScores[primaryAbility] = 16;
-            int remaining = GetAbilityPointsRemaining();
-
-            // Distribute remaining points across other abilities
-            // Priority: CON > DEX > other stats
-            // Secondary ability priority: CON/DEX are universally useful,
-            // then spread across stats relevant to the primary ability.
-            // Avoid pumping WIS/CHA/INT unnecessarily for martial classes. (#1737)
-            var priorityOrder = primaryAbility switch
-            {
-                "STR" => new[] { "CON", "DEX", "INT", "WIS", "CHA" },
-                "DEX" => new[] { "CON", "STR", "INT", "WIS", "CHA" },
-                "CON" => new[] { "STR", "DEX", "INT", "WIS", "CHA" },
-                "INT" => new[] { "DEX", "CON", "STR", "WIS", "CHA" },
-                "WIS" => new[] { "CON", "DEX", "STR", "INT", "CHA" },
-                "CHA" => new[] { "CON", "DEX", "STR", "INT", "WIS" },
-                _ => new[] { "CON", "DEX", "INT", "WIS", "CHA" }
-            };
-
-            // Try to raise each secondary ability to 14 (cost 6), then 12 (cost 4)
-            foreach (var target in new[] { 14, 12 })
-            {
-                foreach (var ability in priorityOrder)
-                {
-                    while (_abilityBaseScores[ability] < target)
-                    {
-                        int currentScore = _abilityBaseScores[ability];
-                        int nextCostIndex = currentScore + 1 - AbilityMinBase;
-                        if (nextCostIndex >= PointBuyCosts.Length) break;
-                        int costDelta = PointBuyCosts[nextCostIndex] - PointBuyCosts[currentScore - AbilityMinBase];
-                        if (GetAbilityPointsRemaining() < costDelta) break;
-                        _abilityBaseScores[ability]++;
-                    }
-                }
-            }
-
-            // Spend any remaining single points
-            foreach (var ability in priorityOrder)
-            {
-                while (GetAbilityPointsRemaining() > 0 && _abilityBaseScores[ability] < AbilityMaxBase)
-                {
-                    int currentScore = _abilityBaseScores[ability];
-                    int nextCostIndex = currentScore + 1 - AbilityMinBase;
-                    if (nextCostIndex >= PointBuyCosts.Length) break;
-                    int costDelta = PointBuyCosts[nextCostIndex] - PointBuyCosts[currentScore - AbilityMinBase];
-                    if (GetAbilityPointsRemaining() < costDelta) break;
-                    _abilityBaseScores[ability]++;
-                }
-            }
-        }
-        else
-        {
-            // No primary ability: balanced spread (all 12s = 24 points, then raise STR/CON)
-            foreach (var ability in AbilityNames)
-                _abilityBaseScores[ability] = 12;
-
-            var boostOrder = new[] { "STR", "CON", "DEX", "WIS", "INT", "CHA" };
-            foreach (var ability in boostOrder)
-            {
-                while (GetAbilityPointsRemaining() > 0 && _abilityBaseScores[ability] < AbilityMaxBase)
-                {
-                    int currentScore = _abilityBaseScores[ability];
-                    int nextCostIndex = currentScore + 1 - AbilityMinBase;
-                    if (nextCostIndex >= PointBuyCosts.Length) break;
-                    int costDelta = PointBuyCosts[nextCostIndex] - PointBuyCosts[currentScore - AbilityMinBase];
-                    if (GetAbilityPointsRemaining() < costDelta) break;
-                    _abilityBaseScores[ability]++;
-                }
-            }
-        }
+        var assigned = AbilityPointBuyService.AutoAssign(_pointBuyTotal, primaryAbility);
+        foreach (var (ability, score) in assigned)
+            _abilityBaseScores[ability] = score;
 
         UpdateAbilityDisplay();
     }

--- a/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.EquipmentAndSummary.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.EquipmentAndSummary.cs
@@ -213,7 +213,7 @@ public partial class NewCharacterWizardWindow
         _summaryFileTypeLabel.Text = _isBicFile ? "Player Character (BIC)" : "Creature Blueprint (UTC)";
 
         var raceName = _displayService.GetRaceName(_selectedRaceId);
-        var genderName = _selectedGender == 0 ? "Male" : "Female";
+        var genderName = _displayService.GetGenderName(_selectedGender);
         _summaryRaceLabel.Text = $"{genderName} {raceName}";
 
         // Identity

--- a/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Navigation.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Navigation.cs
@@ -291,7 +291,7 @@ public partial class NewCharacterWizardWindow
         if (_currentStep >= 2 && _selectedRaceId != 255)
         {
             var raceName = _displayService.GetRaceName(_selectedRaceId);
-            var genderName = _selectedGender == 0 ? "Male" : "Female";
+            var genderName = _displayService.GetGenderName(_selectedGender);
             parts.Add($"{genderName} {raceName}");
         }
 

--- a/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Skills.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.Skills.cs
@@ -82,109 +82,168 @@ public partial class NewCharacterWizardWindow
     private void ApplySkillFilter()
     {
         _filteredSkills = SkillDisplayHelper.FilterByName(_allSkills, _skillSearchBox?.Text?.Trim());
+
+        // Toggle row visibility rather than rebuilding the tree (#2580).
+        var visibleIds = new HashSet<int>(_filteredSkills.Select(s => s.SkillId));
+        foreach (var (skillId, row) in _skillRowMap)
+            row.Container.IsVisible = visibleIds.Contains(skillId);
     }
+
+    // One visual row per skill, holding the controls that change on +/-. Built once per step;
+    // +/- updates only the touched row and search toggles visibility, so the whole Grid tree is
+    // no longer rebuilt on every click and keystroke (#2580).
+    private sealed class SkillRow
+    {
+        public required Grid Container { get; init; }
+        public required Button DecreaseButton { get; init; }
+        public required Button IncreaseButton { get; init; }
+        public required TextBlock RanksLabel { get; init; }
+        public required SkillDisplayItem Skill { get; init; }
+    }
+
+    private readonly Dictionary<int, SkillRow> _skillRowMap = new();
 
     private void RenderSkillRows()
     {
         _skillRowsPanel.Children.Clear();
+        _skillRowMap.Clear();
 
-        foreach (var skill in _filteredSkills)
+        foreach (var skill in _allSkills)
         {
-            var row = new Grid
-            {
-                ColumnDefinitions = ColumnDefinitions.Parse("180,50,35,35,60,60,*"),
-                Margin = new Avalonia.Thickness(12, 3, 12, 3),
-                Opacity = skill.IsUnavailable ? 0.4 : 1.0
-            };
-
-            // Skill name — class skills in green, cross-class uses theme default
-            var nameLabel = new TextBlock
-            {
-                Text = skill.Name,
-                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
-            };
-            if (skill.IsClassSkill)
-                nameLabel.Foreground = BrushManager.GetSuccessBrush(this);
-            Grid.SetColumn(nameLabel, 0);
-            row.Children.Add(nameLabel);
-
-            // Key ability
-            var keyLabel = new TextBlock
-            {
-                Text = skill.KeyAbility,
-                HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
-                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-                Foreground = this.FindResource("SystemControlForegroundBaseMediumBrush") as IBrush,
-                FontSize = this.FindResource("FontSizeSmall") as double? ?? 13
-            };
-            Grid.SetColumn(keyLabel, 1);
-            row.Children.Add(keyLabel);
-
-            // [-] button
-            var decreaseBtn = new Button
-            {
-                Content = "−",
-                Width = 28,
-                HorizontalContentAlignment = Avalonia.Layout.HorizontalAlignment.Center,
-                Tag = skill.SkillId,
-                IsEnabled = !skill.IsUnavailable && skill.AllocatedRanks > 0
-            };
-            decreaseBtn.Click += OnSkillDecrease;
-            Grid.SetColumn(decreaseBtn, 2);
-            row.Children.Add(decreaseBtn);
-
-            // [+] button
-            var increaseBtn = new Button
-            {
-                Content = "+",
-                Width = 28,
-                HorizontalContentAlignment = Avalonia.Layout.HorizontalAlignment.Center,
-                Tag = skill.SkillId,
-                IsEnabled = !skill.IsUnavailable && (_validationLevel != ValidationLevel.Strict || (skill.AllocatedRanks < skill.MaxRanks && GetSkillPointsRemaining() >= skill.Cost))
-            };
-            increaseBtn.Click += OnSkillIncrease;
-            Grid.SetColumn(increaseBtn, 3);
-            row.Children.Add(increaseBtn);
-
-            // Allocated ranks
-            var ranksLabel = new TextBlock
-            {
-                Text = skill.AllocatedRanks > 0 ? skill.AllocatedRanks.ToString() : "—",
-                HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
-                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-                FontWeight = skill.AllocatedRanks > 0 ? FontWeight.Bold : FontWeight.Normal
-            };
-            if (skill.AllocatedRanks > 0)
-                ranksLabel.Foreground = BrushManager.GetSuccessBrush(this);
-            Grid.SetColumn(ranksLabel, 4);
-            row.Children.Add(ranksLabel);
-
-            // Max ranks
-            var maxLabel = new TextBlock
-            {
-                Text = skill.IsUnavailable ? "—" : skill.MaxRanks.ToString(),
-                HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
-                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-                Foreground = this.FindResource("SystemControlForegroundBaseMediumBrush") as IBrush
-            };
-            Grid.SetColumn(maxLabel, 5);
-            row.Children.Add(maxLabel);
-
-            // Type indicator
-            var typeLabel = new TextBlock
-            {
-                Text = skill.IsUnavailable ? "Unavailable" : skill.IsClassSkill ? "Class (1 pt)" : "Cross-class (2 pts)",
-                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-                FontSize = this.FindResource("FontSizeSmall") as double? ?? 13,
-                Foreground = this.FindResource("SystemControlForegroundBaseMediumBrush") as IBrush
-            };
-            Grid.SetColumn(typeLabel, 6);
-            row.Children.Add(typeLabel);
-
-            _skillRowsPanel.Children.Add(row);
+            var row = BuildSkillRow(skill);
+            _skillRowMap[skill.SkillId] = row;
+            _skillRowsPanel.Children.Add(row.Container);
         }
 
+        ApplySkillFilter();
         UpdateSkillPointsDisplay();
+    }
+
+    private SkillRow BuildSkillRow(SkillDisplayItem skill)
+    {
+        var row = new Grid
+        {
+            ColumnDefinitions = ColumnDefinitions.Parse("180,50,35,35,60,60,*"),
+            Margin = new Avalonia.Thickness(12, 3, 12, 3),
+            Opacity = skill.IsUnavailable ? 0.4 : 1.0
+        };
+
+        // Skill name — class skills in green, cross-class uses theme default
+        var nameLabel = new TextBlock
+        {
+            Text = skill.Name,
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
+        };
+        if (skill.IsClassSkill)
+            nameLabel.Foreground = BrushManager.GetSuccessBrush(this);
+        Grid.SetColumn(nameLabel, 0);
+        row.Children.Add(nameLabel);
+
+        // Key ability
+        var keyLabel = new TextBlock
+        {
+            Text = skill.KeyAbility,
+            HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            Foreground = this.FindResource("SystemControlForegroundBaseMediumBrush") as IBrush,
+            FontSize = this.FindResource("FontSizeSmall") as double? ?? 13
+        };
+        Grid.SetColumn(keyLabel, 1);
+        row.Children.Add(keyLabel);
+
+        // [-] button
+        var decreaseBtn = new Button
+        {
+            Content = "−",
+            Width = 28,
+            HorizontalContentAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+            Tag = skill.SkillId,
+            IsEnabled = !skill.IsUnavailable && skill.AllocatedRanks > 0
+        };
+        decreaseBtn.Click += OnSkillDecrease;
+        Grid.SetColumn(decreaseBtn, 2);
+        row.Children.Add(decreaseBtn);
+
+        // [+] button
+        var increaseBtn = new Button
+        {
+            Content = "+",
+            Width = 28,
+            HorizontalContentAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+            Tag = skill.SkillId
+        };
+        increaseBtn.Click += OnSkillIncrease;
+        Grid.SetColumn(increaseBtn, 3);
+        row.Children.Add(increaseBtn);
+
+        // Allocated ranks
+        var ranksLabel = new TextBlock
+        {
+            HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
+        };
+        Grid.SetColumn(ranksLabel, 4);
+        row.Children.Add(ranksLabel);
+
+        // Max ranks
+        var maxLabel = new TextBlock
+        {
+            Text = skill.IsUnavailable ? "—" : skill.MaxRanks.ToString(),
+            HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            Foreground = this.FindResource("SystemControlForegroundBaseMediumBrush") as IBrush
+        };
+        Grid.SetColumn(maxLabel, 5);
+        row.Children.Add(maxLabel);
+
+        // Type indicator
+        var typeLabel = new TextBlock
+        {
+            Text = skill.IsUnavailable ? "Unavailable" : skill.IsClassSkill ? "Class (1 pt)" : "Cross-class (2 pts)",
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            FontSize = this.FindResource("FontSizeSmall") as double? ?? 13,
+            Foreground = this.FindResource("SystemControlForegroundBaseMediumBrush") as IBrush
+        };
+        Grid.SetColumn(typeLabel, 6);
+        row.Children.Add(typeLabel);
+
+        var built = new SkillRow
+        {
+            Container = row,
+            DecreaseButton = decreaseBtn,
+            IncreaseButton = increaseBtn,
+            RanksLabel = ranksLabel,
+            Skill = skill
+        };
+        RefreshSkillRowRankState(built);
+        return built;
+    }
+
+    // Updates the rank label and the +/- enabled state for one row from current allocation.
+    private void RefreshSkillRowRankState(SkillRow row)
+    {
+        var skill = row.Skill;
+        int ranks = skill.AllocatedRanks;
+
+        row.RanksLabel.Text = ranks > 0 ? ranks.ToString() : "—";
+        row.RanksLabel.FontWeight = ranks > 0 ? FontWeight.Bold : FontWeight.Normal;
+        if (ranks > 0)
+            row.RanksLabel.Foreground = BrushManager.GetSuccessBrush(this);
+        else
+            row.RanksLabel.ClearValue(TextBlock.ForegroundProperty);
+
+        row.DecreaseButton.IsEnabled = !skill.IsUnavailable && ranks > 0;
+        row.IncreaseButton.IsEnabled = !skill.IsUnavailable &&
+            (_validationLevel != ValidationLevel.Strict ||
+             (ranks < skill.MaxRanks && GetSkillPointsRemaining() >= skill.Cost));
+    }
+
+    // Raising one skill can exhaust the budget and disable every other + button, so the enabled
+    // state of all rows is refreshed after any allocation change — cheap property writes, no rebuild.
+    private void RefreshAllSkillRowStates()
+    {
+        foreach (var row in _skillRowMap.Values)
+            RefreshSkillRowRankState(row);
     }
 
     private void UpdateSkillPointsDisplay()
@@ -230,7 +289,8 @@ public partial class NewCharacterWizardWindow
                 int current = _skillRanksAllocated.GetValueOrDefault(skillId, 0);
                 _skillRanksAllocated[skillId] = current + 1;
                 UpdateSkillItem(skillId);
-                RenderSkillRows();
+                RefreshAllSkillRowStates();
+                UpdateSkillPointsDisplay();
             }
         }
     }
@@ -246,7 +306,8 @@ public partial class NewCharacterWizardWindow
                 if (_skillRanksAllocated[skillId] == 0)
                     _skillRanksAllocated.Remove(skillId);
                 UpdateSkillItem(skillId);
-                RenderSkillRows();
+                RefreshAllSkillRowStates();
+                UpdateSkillPointsDisplay();
             }
         }
     }
@@ -263,7 +324,6 @@ public partial class NewCharacterWizardWindow
     private void OnSkillSearchChanged(object? sender, TextChangedEventArgs e)
     {
         ApplySkillFilter();
-        RenderSkillRows();
     }
 
     private void OnSkillAutoAssignClick(object? sender, RoutedEventArgs e)
@@ -291,7 +351,8 @@ public partial class NewCharacterWizardWindow
             skill.AllocatedRanks = _skillRanksAllocated.GetValueOrDefault(skill.SkillId, 0);
         }
 
-        RenderSkillRows();
+        RefreshAllSkillRowStates();
+        UpdateSkillPointsDisplay();
     }
 
     #endregion

--- a/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.axaml.cs
+++ b/Quartermaster/Quartermaster/Views/Dialogs/NewCharacterWizardWindow.axaml.cs
@@ -97,11 +97,12 @@ public partial class NewCharacterWizardWindow : Window
         { "INT", 8 }, { "WIS", 8 }, { "CHA", 8 }
     };
     private int _pointBuyTotal = 30; // Default; updated from racialtypes.2da AbilitiesPointBuyNumber
-    private const int AbilityMinBase = 8;
-    private const int AbilityMaxBaseStrict = 18;
+    // Point-buy table and bounds are canonical in AbilityPointBuyService (#2581).
+    private const int AbilityMinBase = AbilityPointBuyService.AbilityMinBase;
     private const int AbilityMaxBaseUncapped = 99; // Chaotic Evil mode
-    private int AbilityMaxBase => _validationLevel == ValidationLevel.None ? AbilityMaxBaseUncapped : AbilityMaxBaseStrict;
-    private static readonly int[] PointBuyCosts = { 0, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16 }; // index = score - 8
+    private int AbilityMaxBase => _validationLevel == ValidationLevel.None
+        ? AbilityMaxBaseUncapped
+        : AbilityPointBuyService.AbilityMaxBase;
     private bool _step5Loaded;
 
     // Step 6: Feats

--- a/Radoub.Formats/Radoub.Formats.Tests/TwoDAFileColumnIndexTests.cs
+++ b/Radoub.Formats/Radoub.Formats.Tests/TwoDAFileColumnIndexTests.cs
@@ -1,0 +1,80 @@
+using Radoub.Formats.TwoDA;
+using Xunit;
+
+namespace Radoub.Formats.Tests;
+
+/// <summary>
+/// #2580: GetColumnIndex is on the hot path (one call per GetValue-by-name). These pin its
+/// correctness and confirm the lookup cache stays consistent when Columns is mutated.
+/// </summary>
+public class TwoDAFileColumnIndexTests
+{
+    private static TwoDAFile MakeFile(params string[] columns)
+    {
+        var file = new TwoDAFile();
+        file.Columns.AddRange(columns);
+        return file;
+    }
+
+    [Fact]
+    public void GetColumnIndex_FindsColumn_CaseInsensitive()
+    {
+        var file = MakeFile("FeatIndex", "List", "GrantedOnLevel");
+
+        Assert.Equal(0, file.GetColumnIndex("FeatIndex"));
+        Assert.Equal(1, file.GetColumnIndex("list"));
+        Assert.Equal(2, file.GetColumnIndex("GRANTEDONLEVEL"));
+    }
+
+    [Fact]
+    public void GetColumnIndex_MissingColumn_ReturnsMinusOne()
+    {
+        var file = MakeFile("FeatIndex", "List");
+
+        Assert.Equal(-1, file.GetColumnIndex("Nonexistent"));
+    }
+
+    [Fact]
+    public void GetColumnIndex_RepeatedLookups_ReturnSameIndex()
+    {
+        var file = MakeFile("A", "B", "C");
+
+        // Second and later calls must agree with the first (cache must not corrupt results).
+        Assert.Equal(1, file.GetColumnIndex("B"));
+        Assert.Equal(1, file.GetColumnIndex("B"));
+        Assert.Equal(2, file.GetColumnIndex("c"));
+    }
+
+    [Fact]
+    public void HasColumn_ReflectsColumnPresence()
+    {
+        var file = MakeFile("A", "B");
+
+        Assert.True(file.HasColumn("a"));
+        Assert.False(file.HasColumn("Z"));
+    }
+
+    [Fact]
+    public void GetColumnIndex_DuplicateColumnName_ReturnsFirstOccurrence()
+    {
+        var file = MakeFile("A", "B", "A");
+
+        // Matches the original linear scan, which returned the first match.
+        Assert.Equal(0, file.GetColumnIndex("A"));
+    }
+
+    [Fact]
+    public void GetColumnIndex_AfterColumnsChange_ReflectsNewLayout()
+    {
+        var file = MakeFile("A", "B");
+        Assert.Equal(1, file.GetColumnIndex("B")); // prime any cache
+
+        // A parser that reuses the instance and rebuilds Columns must not get stale indices.
+        file.Columns.Clear();
+        file.Columns.AddRange(new[] { "X", "B", "A" });
+
+        Assert.Equal(2, file.GetColumnIndex("A"));
+        Assert.Equal(1, file.GetColumnIndex("B"));
+        Assert.Equal(-1, file.GetColumnIndex("C"));
+    }
+}

--- a/Radoub.Formats/Radoub.Formats/TwoDA/TwoDAFile.cs
+++ b/Radoub.Formats/Radoub.Formats/TwoDA/TwoDAFile.cs
@@ -63,18 +63,30 @@ public class TwoDAFile
         return Rows[rowIndex].GetValue(columnIndex) ?? DefaultValue;
     }
 
+    // Lazily-built name -> index map. GetColumnIndex is called once per GetValue-by-name, so a
+    // per-file cache turns the hot path from an O(columns) scan into a dictionary hit (#2580).
+    // Rebuilt whenever Columns.Count changes, covering parsers that reuse an instance. A rename
+    // that keeps the same count would not invalidate, but 2DA columns are built once and never
+    // renamed in place, so that case does not arise.
+    private Dictionary<string, int>? _columnIndexCache;
+    private int _columnIndexCacheCount = -1;
+
     /// <summary>
     /// Get the column index for a column name (case-insensitive).
     /// Returns -1 if not found.
     /// </summary>
     public int GetColumnIndex(string columnName)
     {
-        for (int i = 0; i < Columns.Count; i++)
+        if (_columnIndexCache is null || _columnIndexCacheCount != Columns.Count)
         {
-            if (Columns[i].Equals(columnName, StringComparison.OrdinalIgnoreCase))
-                return i;
+            var cache = new Dictionary<string, int>(Columns.Count, StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < Columns.Count; i++)
+                cache.TryAdd(Columns[i], i); // first occurrence wins, matching the old linear scan
+            _columnIndexCache = cache;
+            _columnIndexCacheCount = Columns.Count;
         }
-        return -1;
+
+        return _columnIndexCache.TryGetValue(columnName, out int index) ? index : -1;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Corrects the remaining level-up math errors and retires the duplicated logic that causes them.
Five items, sequenced so the correctness fixes land before the refactors.

Every claim was challenged against HEAD during pre-warm before planning. Three issue bodies
needed correction first: #2580's headline ("~600k uncached 2DA reads") was refuted — the 2DA
layer already caches, and its row counts came from `?? fallback` constants — so it is rescoped
to the real hot spots. #2581 understated itself: all six auto-assign priority branches have
drifted, not one. #2578 was upgraded to confirmed-reachable.

## Work Items

- ✅ #2576 — Auto-Assign Skills caps ranks at the final level, not current+1
- ✅ #2578 — Level-1 x4 skill-point multiplier, delegated to the shared service
- ✅ #2581 — NCW routed through the point-buy and gender services; one shared class-feat-table reader; #1737 priority order made canonical (derived-projection cleanup landed with #2575)
- 🔄 #2580 — NCW skill rows update incrementally; `TwoDAFile` column-index cache. LUW feat re-sort and the class-feat HashSet are deferred, tracked in #2580
- ✅ #2575 — one span-aware apply path (single + multi-level); ability map derived by a unit-tested helper, three hand-synced projections retired

## Related Issues

- Closes #2677 (sprint), #2576, #2578, #2581, #2575
- Relates to #2580 (partial — remainder stays open), #2571 (parent epic), #2696, #2128

## Checklist

- [ ] Implementation complete
- [ ] Tests added/updated
- [ ] CHANGELOG updated with date
- [ ] Manual spot-checks verified

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

